### PR TITLE
Cloudinary image upload and WorkflowState image management overhaul

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Glaze local development environment template.
+# Copy to `.env.local` at the repo root, then fill your own values.
+
+# Cloudinary backend-signed upload (recommended for web + mobile)
+CLOUDINARY_CLOUD_NAME=
+CLOUDINARY_API_KEY=
+CLOUDINARY_API_SECRET=
+CLOUDINARY_UPLOAD_FOLDER=glaze
+CLOUDINARY_UPLOAD_PRESET=
+
+# Mobile API base URL (Expo)
+# EXPO_PUBLIC_API_BASE_URL=http://localhost:8080/api/

--- a/.gitignore
+++ b/.gitignore
@@ -146,12 +146,17 @@ celerybeat.pid
 # Environments
 .env
 .envrc
+.env.local
+.env.local.*
 .venv
 env/
 venv/
 ENV/
 env.bak/
 venv.bak/
+
+# Commit template env files, but never local secrets.
+!**/.env.example
 
 # Spyder project settings
 .spyderproject

--- a/README.md
+++ b/README.md
@@ -38,6 +38,22 @@ Source the file to load all shortcuts into your shell:
 source env.sh
 ```
 
+### Local secrets and config (git-safe)
+Keep local-only settings in `.env.local` files; they are gitignored by default:
+
+- `.env.local` (repo-wide defaults)
+- `web/.env.local` (web-only overrides)
+- `mobile/.env.local` (mobile-only overrides)
+
+`source env.sh` automatically loads all three (in that order) so you can inject Cloudinary/API config without committing secrets.
+Use the checked-in templates:
+
+```bash
+cp .env.example .env.local
+cp web/.env.example web/.env.local
+cp mobile/.env.example mobile/.env.local
+```
+
 ### Setup
 
 | Command | Description |
@@ -124,6 +140,21 @@ cd web
 npm test              # single run (CI) — 101 tests across 6 files
 npm run test:watch    # watch mode
 ```
+
+## Cloudinary image uploads (web)
+Recommended: use backend-signed uploads so Cloudinary secrets never ship to the browser.
+Set these in `.env.local` before starting Django:
+
+```bash
+export CLOUDINARY_CLOUD_NAME=<your-cloud-name>
+export CLOUDINARY_API_KEY=<your-api-key>
+export CLOUDINARY_API_SECRET=<your-api-secret>
+export CLOUDINARY_UPLOAD_FOLDER=glaze         # optional
+export CLOUDINARY_UPLOAD_PRESET=<your-upload-preset>  # optional
+```
+
+`WorkflowState` calls `POST /api/uploads/cloudinary/signature/` and uploads with the signed payload.
+`CLOUDINARY_API_SECRET` stays server-only and is never returned to the client.
 
 ### What is tested
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -64,7 +64,7 @@ class PieceSummarySerializer(serializers.ModelSerializer):
             raise ValueError(f'Piece {obj.id} has no states — data integrity error')
         return {'state': cs.state}
 
-    @extend_schema_field(serializers.CharField(allow_null=True))
+    @extend_schema_field(serializers.CharField(allow_null=True, required=False))
     def get_current_location(self, obj: Piece) -> str | None:
         return obj.current_location.name if obj.current_location else None
 

--- a/api/tests/test_cloudinary_upload_signature.py
+++ b/api/tests/test_cloudinary_upload_signature.py
@@ -1,0 +1,45 @@
+import hashlib
+
+import pytest
+
+
+@pytest.mark.django_db
+class TestCloudinaryUploadSignature:
+    def test_returns_503_when_not_configured(self, client, monkeypatch):
+        monkeypatch.delenv('CLOUDINARY_CLOUD_NAME', raising=False)
+        monkeypatch.delenv('CLOUDINARY_API_KEY', raising=False)
+        monkeypatch.delenv('CLOUDINARY_API_SECRET', raising=False)
+
+        response = client.post('/api/uploads/cloudinary/signature/', {}, format='json')
+
+        assert response.status_code == 503
+        assert response.json()['detail'] == 'Cloudinary is not configured on the server.'
+
+    def test_returns_signed_upload_payload(self, client, monkeypatch):
+        monkeypatch.setenv('CLOUDINARY_CLOUD_NAME', 'demo-cloud')
+        monkeypatch.setenv('CLOUDINARY_API_KEY', 'public-api-key')
+        monkeypatch.setenv('CLOUDINARY_API_SECRET', 'super-secret')
+        monkeypatch.setenv('CLOUDINARY_UPLOAD_FOLDER', 'glaze')
+        monkeypatch.setenv('CLOUDINARY_UPLOAD_PRESET', 'glaze_signed')
+
+        with monkeypatch.context() as m:
+            m.setattr('api.views.time.time', lambda: 1_700_000_000)
+            response = client.post('/api/uploads/cloudinary/signature/', {}, format='json')
+
+        assert response.status_code == 200
+        data = response.json()
+
+        expected_signing_string = 'folder=glaze&timestamp=1700000000&upload_preset=glaze_signed'
+        expected_signature = hashlib.sha1(
+            f'{expected_signing_string}super-secret'.encode('utf-8')
+        ).hexdigest()
+
+        assert data == {
+            'cloud_name': 'demo-cloud',
+            'api_key': 'public-api-key',
+            'timestamp': 1700000000,
+            'signature': expected_signature,
+            'upload_url': 'https://api.cloudinary.com/v1_1/demo-cloud/image/upload',
+            'folder': 'glaze',
+            'upload_preset': 'glaze_signed',
+        }

--- a/api/urls.py
+++ b/api/urls.py
@@ -8,4 +8,9 @@ urlpatterns = [
     path('pieces/<uuid:piece_id>/states/', views.piece_states, name='piece-states'),
     path('pieces/<uuid:piece_id>/state/', views.piece_current_state, name='piece-current-state'),
     path('globals/<str:global_name>/', views.global_entries, name='global-entries'),
+    path(
+        'uploads/cloudinary/signature/',
+        views.cloudinary_upload_signature,
+        name='cloudinary-upload-signature',
+    ),
 ]

--- a/api/views.py
+++ b/api/views.py
@@ -1,3 +1,7 @@
+import hashlib
+import os
+import time
+
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.decorators import api_view
@@ -116,3 +120,63 @@ def global_entries(request: Request, global_name: str) -> Response:
     obj, created = model_cls.objects.get_or_create(**{field: value})
     status_code = status.HTTP_201_CREATED if created else status.HTTP_200_OK
     return Response({'id': str(obj.pk), 'name': getattr(obj, display_field)}, status=status_code)
+
+
+@extend_schema(
+    request=None,
+    responses={
+        200: {
+            'type': 'object',
+            'properties': {
+                'cloud_name': {'type': 'string'},
+                'api_key': {'type': 'string'},
+                'timestamp': {'type': 'integer'},
+                'signature': {'type': 'string'},
+                'upload_url': {'type': 'string'},
+                'folder': {'type': 'string'},
+                'upload_preset': {'type': 'string'},
+            },
+            'required': ['cloud_name', 'api_key', 'timestamp', 'signature', 'upload_url'],
+        }
+    },
+)
+@api_view(['POST'])
+def cloudinary_upload_signature(request: Request) -> Response:
+    cloud_name = os.environ.get('CLOUDINARY_CLOUD_NAME')
+    api_key = os.environ.get('CLOUDINARY_API_KEY')
+    api_secret = os.environ.get('CLOUDINARY_API_SECRET')
+    folder = os.environ.get('CLOUDINARY_UPLOAD_FOLDER', '').strip()
+    upload_preset = os.environ.get('CLOUDINARY_UPLOAD_PRESET', '').strip()
+
+    if not cloud_name or not api_key or not api_secret:
+        return Response(
+            {'detail': 'Cloudinary is not configured on the server.'},
+            status=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    timestamp = int(time.time())
+    params_to_sign: dict[str, str | int] = {'timestamp': timestamp}
+    if folder:
+        params_to_sign['folder'] = folder
+    if upload_preset:
+        params_to_sign['upload_preset'] = upload_preset
+
+    # Cloudinary signature format: sorted key=value params joined by '&',
+    # then append API secret and SHA1 hash the resulting string.
+    signing_string = '&'.join(
+        f'{key}={params_to_sign[key]}' for key in sorted(params_to_sign.keys())
+    )
+    signature = hashlib.sha1(f'{signing_string}{api_secret}'.encode('utf-8')).hexdigest()
+
+    payload = {
+        'cloud_name': cloud_name,
+        'api_key': api_key,
+        'timestamp': timestamp,
+        'signature': signature,
+        'upload_url': f'https://api.cloudinary.com/v1_1/{cloud_name}/image/upload',
+    }
+    if folder:
+        payload['folder'] = folder
+    if upload_preset:
+        payload['upload_preset'] = upload_preset
+    return Response(payload)

--- a/env.sh
+++ b/env.sh
@@ -60,6 +60,21 @@ _gz_ensure_node() {
     nvm use 20
 }
 
+_gz_load_env_file() {  # _gz_load_env_file <path>
+    local path="$1"
+    [[ -f "$path" ]] || return 0
+    set -a
+    # shellcheck disable=SC1090
+    source "$path"
+    set +a
+}
+
+_gz_load_local_env() {
+    _gz_load_env_file "$GLAZE_ROOT/.env.local"
+    _gz_load_env_file "$GLAZE_ROOT/web/.env.local"
+    _gz_load_env_file "$GLAZE_ROOT/mobile/.env.local"
+}
+
 # ---------------------------------------------------------------------------
 # Setup
 # ---------------------------------------------------------------------------
@@ -149,7 +164,7 @@ gz_test() {
 
 gz_backend() {
     _gz_start backend "$_GLAZE_LOGS/backend.log" \
-        bash -c "source '$GLAZE_ROOT/.venv/bin/activate' && cd '$GLAZE_ROOT' && python manage.py runserver 8080"
+        bash -c "source '$GLAZE_ROOT/.venv/bin/activate' && cd '$GLAZE_ROOT' && set -a && [ -f '$GLAZE_ROOT/.env.local' ] && source '$GLAZE_ROOT/.env.local'; set +a && python manage.py runserver 8080"
 }
 
 gz_web() {
@@ -273,6 +288,7 @@ gz_help() {
 # ---------------------------------------------------------------------------
 
 echo "Glaze dev helpers loaded."
+_gz_load_local_env
 for entry in "${_GZ_SHORTCUTS[@]}"; do
     echo "  $entry"
 done

--- a/frontend_common/src/api.ts
+++ b/frontend_common/src/api.ts
@@ -23,6 +23,16 @@ if (expoBaseUrl) {
     client.defaults.baseURL = expoBaseUrl
 }
 
+type CloudinarySignedUploadPayload = {
+    cloud_name: string
+    api_key: string
+    timestamp: number
+    signature: string
+    upload_url: string
+    folder?: string
+    upload_preset?: string
+}
+
 // ---------------------------------------------------------------------------
 // Wire<T> — converts domain types back to the raw format Axios delivers.
 // The generated types declare dates as Date (via the date-time transform),
@@ -161,4 +171,36 @@ export async function createGlobalEntry(globalName: string, field: string, value
         value,
     })
     return data.name
+}
+
+export function hasCloudinaryUploadConfig(): boolean {
+    // Signed uploads are configured on the backend, so keep the UI control
+    // visible and let the signature endpoint decide availability.
+    return true
+}
+
+export async function uploadImageToCloudinary(file: Blob): Promise<string> {
+    const { data } = await client.post<CloudinarySignedUploadPayload>('uploads/cloudinary/signature/', {})
+    const signedData = new FormData()
+    signedData.append('file', file)
+    signedData.append('api_key', data.api_key)
+    signedData.append('timestamp', String(data.timestamp))
+    signedData.append('signature', data.signature)
+    if (data.folder) {
+        signedData.append('folder', data.folder)
+    }
+    if (data.upload_preset) {
+        signedData.append('upload_preset', data.upload_preset)
+    }
+    const uploadResponse = await axios.post<{ secure_url?: string; url?: string }>(
+        data.upload_url,
+        signedData
+    )
+    const uploadedUrl = uploadResponse.data.secure_url ?? uploadResponse.data.url
+    if (!uploadedUrl) {
+        throw new Error('Cloudinary upload did not return a URL')
+    }
+    // Insert f_auto so Cloudinary converts HEIC and other formats to the best
+    // type for each client (WebP/JPEG) at delivery time.
+    return uploadedUrl.replace('/image/upload/', '/image/upload/f_auto/')
 }

--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -1,0 +1,4 @@
+# Mobile-only local development env template.
+# Copy to `mobile/.env.local` (or root `.env.local`) and set values.
+
+EXPO_PUBLIC_API_BASE_URL=http://localhost:8080/api/

--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -22,6 +22,10 @@ expo-env.d.ts
 .env.test.local
 .env.production.local
 
+# codex local artifacts
+.codex
+.codex/*
+
 # macOS / editor artifacts
 .DS_Store
 .vscode/

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -39,13 +39,32 @@ EXPO_PUBLIC_API_BASE_URL=http://10.0.2.2:8080/api/ npm run android
 
 Use a device-reachable host when running on a phone/emulator (for Android emulator, `10.0.2.2` maps to host localhost).
 
+## Local secrets and config (git-safe)
+
+Create `mobile/.env.local` from the template:
+
+```bash
+cp mobile/.env.example mobile/.env.local
+```
+
+These files are gitignored, so Cloudinary/API values are safe for local use and won't be committed.
+If you use `source env.sh`, it also auto-loads `.env.local`, `web/.env.local`, and `mobile/.env.local`.
+
+For Cloudinary uploads, prefer backend-signed config in root `.env.local`:
+
+- `CLOUDINARY_CLOUD_NAME`
+- `CLOUDINARY_API_KEY`
+- `CLOUDINARY_API_SECRET`
+
+This keeps secrets out of the mobile/web client bundles.
+
 ## Shared web modules
 
-Mobile imports shared modules from `web/src`:
+Mobile imports shared modules from `frontend_common/src`:
 
-- `web/src/api.ts`
-- `web/src/types.ts`
-- `web/src/workflow.ts`
-- `web/src/yaml.d.ts`
+- `frontend_common/src/api.ts`
+- `frontend_common/src/types.ts`
+- `frontend_common/src/workflow.ts`
+- `frontend_common/src/yaml.d.ts`
 
 This keeps API contracts, workflow field behavior, and types in one place for both web and mobile.

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,2 @@
+# Web-only local development env template.
+# Cloudinary signing is backend-driven; define CLOUDINARY_* in root `.env.local`.

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -26,3 +26,8 @@ dist-ssr
 *.sw?
 venv/
 node_modules/
+
+# Local env files
+.env.local
+.env.local.*
+!.env.example

--- a/web/README.md
+++ b/web/README.md
@@ -1,5 +1,16 @@
 # React + TypeScript + Vite
 
+## Local env config (git-safe)
+
+Use `.env.local` for local-only values. It is gitignored.
+Start from the committed template:
+
+```bash
+cp .env.example .env.local
+```
+
+Cloudinary uploads are signed by Django; set `CLOUDINARY_*` in root `.env.local` so the API secret never appears in browser code.
+
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
 Currently, two official plugins are available:

--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -1,18 +1,24 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react'
 import {
     Box,
     Button,
     CircularProgress,
+    Divider,
     IconButton,
     List,
     ListItem,
     ListItemText,
     MenuItem,
+    Modal,
     TextField,
+    ToggleButton,
+    ToggleButtonGroup,
     Typography,
 } from '@mui/material'
 import type { PieceDetail, PieceState } from '@common/types'
 import {
+    hasCloudinaryUploadConfig,
+    uploadImageToCloudinary,
     updateCurrentState,
     updatePiece,
 } from '@common/api'
@@ -126,6 +132,13 @@ export default function WorkflowState({
     const [images, setImages] = useState<ImageEntry[]>(stateImages(pieceState))
     const [newImageUrl, setNewImageUrl] = useState('')
     const [newImageCaption, setNewImageCaption] = useState('')
+    const [uploadingImage, setUploadingImage] = useState(false)
+    const [uploadError, setUploadError] = useState<string | null>(null)
+    const [imageInputMode, setImageInputMode] = useState<'url' | 'upload'>(
+        () => hasCloudinaryUploadConfig() ? 'upload' : 'url'
+    )
+    const [editingCaptionIndex, setEditingCaptionIndex] = useState<number | null>(null)
+    const [editingCaptionValue, setEditingCaptionValue] = useState('')
     const [saving, setSaving] = useState(false)
     const [saveError, setSaveError] = useState<string | null>(null)
     const [currentLocation, setCurrentLocation] = useState(currentLocationProp)
@@ -147,6 +160,32 @@ export default function WorkflowState({
         JSON.stringify(normalizedAdditionalFields) !== JSON.stringify(normalizedBaseAdditionalFields)
     const locationDirty = currentLocation.trim() !== currentLocationProp.trim()
 
+    // Upload preview load state
+    const [uploadPreviewLoaded, setUploadPreviewLoaded] = useState(false)
+    useEffect(() => { setUploadPreviewLoaded(false) }, [newImageUrl])
+
+    // Lightbox state
+    const [lightboxIndex, setLightboxIndex] = useState<number | null>(null)
+    const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0
+    const touchStartX = useRef<number | null>(null)
+
+    function openLightbox(index: number) { setLightboxIndex(index) }
+    function closeLightbox() { setLightboxIndex(null) }
+    function lightboxPrev() { setLightboxIndex((i) => (i !== null && i > 0 ? i - 1 : i)) }
+    function lightboxNext() { setLightboxIndex((i) => (i !== null && i < images.length - 1 ? i + 1 : i)) }
+
+    function handleLightboxTouchStart(e: React.TouchEvent) {
+        touchStartX.current = e.touches[0].clientX
+    }
+    function handleLightboxTouchEnd(e: React.TouchEvent) {
+        if (touchStartX.current === null) return
+        const delta = e.changedTouches[0].clientX - touchStartX.current
+        if (delta > 50) lightboxPrev()
+        else if (delta < -50) lightboxNext()
+        touchStartX.current = null
+    }
+    const canUploadToCloudinary = hasCloudinaryUploadConfig()
+
     // Reset form when pieceState changes (e.g. after a state transition)
     useEffect(() => {
         setNotes(pieceState.notes)
@@ -155,10 +194,11 @@ export default function WorkflowState({
         setCurrentLocation(currentLocationProp)
     }, [pieceState, baseAdditionalFieldInputs, currentLocationProp])
 
-    const originalImages = stateImages(pieceState)
+    const [savingImage, setSavingImage] = useState(false)
+    const [imageError, setImageError] = useState<string | null>(null)
+
     const isDirty =
         notes !== pieceState.notes ||
-        JSON.stringify(images) !== JSON.stringify(originalImages) ||
         additionalFieldsDirty ||
         locationDirty
 
@@ -172,7 +212,7 @@ export default function WorkflowState({
         try {
             const payload = {
                 notes,
-                images,
+                images,  // always in sync with server after each image operation
                 additional_fields: normalizedAdditionalFields,
             }
             const result = await updateCurrentState(pieceId, payload)
@@ -191,21 +231,88 @@ export default function WorkflowState({
         }
     }
 
-    function addImage() {
+    async function addImage() {
         if (!newImageUrl.trim()) return
-        setImages((prev) => [
-            ...prev,
-            {
-                url: newImageUrl.trim(),
-                caption: newImageCaption.trim(),
-            },
-        ])
-        setNewImageUrl('')
-        setNewImageCaption('')
+        const updatedImages = [...images, { url: newImageUrl.trim(), caption: newImageCaption.trim() }]
+        setSavingImage(true)
+        setImageError(null)
+        try {
+            const result = await updateCurrentState(pieceId, {
+                notes,
+                images: updatedImages,
+                additional_fields: normalizedAdditionalFields,
+            })
+            onSaved(result)
+            setNewImageUrl('')
+            setNewImageCaption('')
+        } catch {
+            setImageError('Failed to save image. Please try again.')
+        } finally {
+            setSavingImage(false)
+        }
     }
 
-    function removeImage(index: number) {
-        setImages((prev) => prev.filter((_, i) => i !== index))
+    async function removeImage(index: number) {
+        if (!window.confirm('Remove this image?')) return
+        const updatedImages = images.filter((_, i) => i !== index)
+        setSavingImage(true)
+        setImageError(null)
+        try {
+            const result = await updateCurrentState(pieceId, {
+                notes,
+                images: updatedImages,
+                additional_fields: normalizedAdditionalFields,
+            })
+            onSaved(result)
+        } catch {
+            setImageError('Failed to remove image. Please try again.')
+        } finally {
+            setSavingImage(false)
+        }
+    }
+
+    function startEditingCaption(index: number) {
+        setEditingCaptionIndex(index)
+        setEditingCaptionValue(images[index].caption)
+    }
+
+    async function commitCaptionEdit(index: number, value: string) {
+        setEditingCaptionIndex(null)
+        const newCaption = value.trim()
+        if (newCaption === images[index].caption) return
+        const updatedImages = images.map((img, i) => i === index ? { ...img, caption: newCaption } : img)
+        setSavingImage(true)
+        setImageError(null)
+        try {
+            const result = await updateCurrentState(pieceId, {
+                notes,
+                images: updatedImages,
+                additional_fields: normalizedAdditionalFields,
+            })
+            onSaved(result)
+        } catch {
+            setImageError('Failed to save caption. Please try again.')
+        } finally {
+            setSavingImage(false)
+        }
+    }
+
+    async function handleCloudinaryUpload(event: ChangeEvent<HTMLInputElement>) {
+        const file = event.target.files?.[0]
+        if (!file) {
+            return
+        }
+        setUploadingImage(true)
+        setUploadError(null)
+        try {
+            const uploadedUrl = await uploadImageToCloudinary(file)
+            setNewImageUrl(uploadedUrl)
+        } catch {
+            setUploadError('Failed to upload image. Check Cloudinary config and try again.')
+        } finally {
+            setUploadingImage(false)
+            event.target.value = ''
+        }
     }
 
     function handleAdditionalFieldChange(name: string, value: string) {
@@ -352,77 +459,6 @@ export default function WorkflowState({
                 </Box>
             )}
 
-            {/* Images */}
-            <Box>
-                <Typography variant="subtitle2" sx={{ color: 'text.secondary', mb: 1 }}>
-                    Images
-                </Typography>
-                {images.length > 0 && (
-                    <List dense disablePadding>
-                        {images.map((img, i) => (
-                            <ListItem
-                                key={i}
-                                disableGutters
-                                secondaryAction={
-                                    <IconButton
-                                        edge="end"
-                                        aria-label="remove image"
-                                        onClick={() => removeImage(i)}
-                                        size="small"
-                                    >
-                                        ✕
-                                    </IconButton>
-                                }
-                            >
-                                <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flexWrap: 'wrap', pr: 6 }}>
-                                    <img
-                                        src={img.url}
-                                        alt={img.caption || 'Pottery image'}
-                                        style={{ height: 64, width: 64, objectFit: 'cover', borderRadius: 4 }}
-                                    />
-                                    <ListItemText
-                                        primary={img.caption || '(no caption)'}
-                                        slotProps={{
-                                            primary: { sx: { color: 'text.primary' } },
-                                        }}
-                                    />
-                                </Box>
-                            </ListItem>
-                        ))}
-                    </List>
-                )}
-                <Box sx={{ display: 'flex', gap: 1, mt: 1, flexWrap: 'wrap' }}>
-                    <TextField
-                        label="Image URL"
-                        value={newImageUrl}
-                        onChange={(e) => setNewImageUrl(e.target.value)}
-                        size="small"
-                        sx={{ flex: 2, minWidth: 200 }}
-                        onKeyDown={(e) => {
-                            if (e.key === 'Enter') { e.preventDefault(); addImage() }
-                        }}
-                    />
-                    <TextField
-                        label="Caption"
-                        value={newImageCaption}
-                        onChange={(e) => setNewImageCaption(e.target.value)}
-                        size="small"
-                        sx={{ flex: 1, minWidth: 120 }}
-                        onKeyDown={(e) => {
-                            if (e.key === 'Enter') { e.preventDefault(); addImage() }
-                        }}
-                    />
-                    <Button
-                        variant="outlined"
-                        onClick={addImage}
-                        disabled={!newImageUrl.trim()}
-                        size="small"
-                    >
-                        + Add Image
-                    </Button>
-                </Box>
-            </Box>
-
             {/* Save controls */}
             {saveError && (
                 <Typography color="error" variant="body2">
@@ -446,6 +482,220 @@ export default function WorkflowState({
                     </Typography>
                 )}
             </Box>
+
+            {/* Images */}
+            <Box>
+                <Typography variant="subtitle2" sx={{ color: 'text.secondary', mb: 1 }}>
+                    Images
+                </Typography>
+                {images.length > 0 && (
+                    <List dense disablePadding>
+                        {images.map((img, i) => (
+                            <ListItem key={i} disableGutters>
+                                <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', width: '100%' }}>
+                                    <IconButton
+                                        aria-label="remove image"
+                                        onClick={() => removeImage(i)}
+                                        size="small"
+                                    >
+                                        ✕
+                                    </IconButton>
+                                    <Box
+                                        component="button"
+                                        onClick={() => openLightbox(i)}
+                                        aria-label={`View image ${i + 1}`}
+                                        sx={{
+                                            p: 0, border: 'none', background: 'none', cursor: 'pointer',
+                                            borderRadius: 0.5, display: 'block', flexShrink: 0,
+                                        }}
+                                    >
+                                        <img
+                                            src={img.url}
+                                            alt={img.caption || 'Pottery image'}
+                                            style={{ height: 64, width: 64, objectFit: 'cover', borderRadius: 4, display: 'block' }}
+                                        />
+                                    </Box>
+                                    {editingCaptionIndex === i ? (
+                                        <TextField
+                                            value={editingCaptionValue}
+                                            onChange={(e) => setEditingCaptionValue(e.target.value)}
+                                            onBlur={() => commitCaptionEdit(i, editingCaptionValue)}
+                                            onKeyDown={(e) => {
+                                                if (e.key === 'Enter') { e.preventDefault(); commitCaptionEdit(i, editingCaptionValue) }
+                                                if (e.key === 'Escape') { e.preventDefault(); setEditingCaptionIndex(null) }
+                                            }}
+                                            size="small"
+                                            autoFocus
+                                            sx={{ flex: 1 }}
+                                            slotProps={{ htmlInput: { 'aria-label': 'Edit caption' } }}
+                                        />
+                                    ) : (
+                                        <>
+                                            <ListItemText
+                                                primary={img.caption || '(no caption)'}
+                                                slotProps={{ primary: { sx: { color: 'text.primary' } } }}
+                                            />
+                                            <IconButton
+                                                aria-label="edit caption"
+                                                onClick={() => startEditingCaption(i)}
+                                                size="small"
+                                                sx={{ ml: 'auto', flexShrink: 0 }}
+                                            >
+                                                ✏
+                                            </IconButton>
+                                        </>
+                                    )}
+                                </Box>
+                            </ListItem>
+                        ))}
+                    </List>
+                )}
+                <Divider sx={{ my: 1 }} />
+                <Box>
+                  {canUploadToCloudinary && (
+                      <ToggleButtonGroup
+                          value={imageInputMode}
+                          exclusive
+                          onChange={(_, val) => { if (val) { setImageInputMode(val); setNewImageUrl('') } }}
+                          size="small"
+                          sx={{ mb: 1 }}
+                      >
+                          <ToggleButton value="url">Paste URL</ToggleButton>
+                          <ToggleButton value="upload">Upload</ToggleButton>
+                      </ToggleButtonGroup>
+                  )}
+                  <Box sx={{ display: 'flex', gap: 1, mt: 1, flexWrap: 'wrap', alignItems: 'center' }}>
+                      {imageInputMode === 'upload' ? (
+                          newImageUrl ? (
+                              <>
+                                  {!uploadPreviewLoaded && <CircularProgress size={40} />}
+                                  <img
+                                      src={newImageUrl}
+                                      alt="Uploaded preview"
+                                      data-testid="upload-preview"
+                                      style={{ height: 64, width: 64, objectFit: 'cover', borderRadius: 4, flexShrink: 0, display: uploadPreviewLoaded ? 'block' : 'none' }}
+                                      onLoad={() => setUploadPreviewLoaded(true)}
+                                  />
+                              </>
+                          ) : (
+                              <Button
+                                  component="label"
+                                  variant="outlined"
+                                  size="small"
+                                  disabled={uploadingImage}
+                              >
+                                  {uploadingImage ? 'Uploading...' : 'Upload Image'}
+                                  <input
+                                      hidden
+                                      type="file"
+                                      accept="image/*"
+                                      onChange={handleCloudinaryUpload}
+                                  />
+                              </Button>
+                          )
+                      ) : (
+                          <TextField
+                              label="Image URL"
+                              value={newImageUrl}
+                              onChange={(e) => setNewImageUrl(e.target.value)}
+                              size="small"
+                              sx={{ flex: 2, minWidth: 200 }}
+                              onKeyDown={(e) => {
+                                  if (e.key === 'Enter') { e.preventDefault(); addImage() }
+                              }}
+                          />
+                      )}
+                      <TextField
+                          label="Caption"
+                          value={newImageCaption}
+                          onChange={(e) => setNewImageCaption(e.target.value)}
+                          size="small"
+                          sx={{ flex: 1, minWidth: 120 }}
+                          onKeyDown={(e) => {
+                              if (e.key === 'Enter') { e.preventDefault(); addImage() }
+                          }}
+                      />
+                      <Button
+                          variant="outlined"
+                          onClick={addImage}
+                          disabled={!newImageUrl.trim() || savingImage}
+                          size="small"
+                          startIcon={savingImage ? <CircularProgress size={14} color="inherit" /> : undefined}
+                      >
+                          + Add Image
+                      </Button>
+                  </Box>
+                  {(uploadError || imageError) && (
+                      <Typography color="error" variant="body2" sx={{ mt: 1 }}>
+                          {uploadError ?? imageError}
+                      </Typography>
+                  )}
+              </Box>
+            </Box>
+            {/* Lightbox */}
+            <Modal
+                open={lightboxIndex !== null}
+                onClose={closeLightbox}
+                slotProps={{ backdrop: { sx: { backgroundColor: 'rgba(0,0,0,0.92)' } } }}
+            >
+                <Box
+                    onClick={closeLightbox}
+                    onTouchStart={handleLightboxTouchStart}
+                    onTouchEnd={handleLightboxTouchEnd}
+                    sx={{
+                        position: 'fixed', inset: 0,
+                        display: 'flex', flexDirection: 'column',
+                        alignItems: 'center', justifyContent: 'center',
+                        gap: 2, outline: 'none',
+                    }}
+                >
+                    {lightboxIndex !== null && (
+                        <>
+                            <img
+                                src={images[lightboxIndex].url}
+                                alt={images[lightboxIndex].caption || 'Pottery image'}
+                                style={{
+                                    maxWidth: '90vw', maxHeight: '80vh',
+                                    objectFit: 'contain', borderRadius: 4,
+                                    userSelect: 'none',
+                                }}
+                            />
+                            {images[lightboxIndex].caption && (
+                                <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.8)' }}>
+                                    {images[lightboxIndex].caption}
+                                </Typography>
+                            )}
+                            {!isTouchDevice && images.length > 1 && (
+                                <Box
+                                    onClick={(e) => e.stopPropagation()}
+                                    sx={{ display: 'flex', gap: 2 }}
+                                >
+                                    <IconButton
+                                        onClick={lightboxPrev}
+                                        disabled={lightboxIndex === 0}
+                                        sx={{ color: 'white', fontSize: '1.5rem' }}
+                                        aria-label="previous image"
+                                    >
+                                        ←
+                                    </IconButton>
+                                    <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.6)', alignSelf: 'center' }}>
+                                        {lightboxIndex + 1} / {images.length}
+                                    </Typography>
+                                    <IconButton
+                                        onClick={lightboxNext}
+                                        disabled={lightboxIndex === images.length - 1}
+                                        sx={{ color: 'white', fontSize: '1.5rem' }}
+                                        aria-label="next image"
+                                    >
+                                        →
+                                    </IconButton>
+                                </Box>
+                            )}
+                        </>
+                    )}
+                </Box>
+            </Modal>
+
         </Box>
     )
 }

--- a/web/src/components/__tests__/PieceDetail.test.tsx
+++ b/web/src/components/__tests__/PieceDetail.test.tsx
@@ -12,6 +12,8 @@ vi.mock('@common/api', () => ({
     addPieceState: vi.fn(),
     updatePiece: vi.fn(),
     createGlobalEntry: vi.fn(),
+    hasCloudinaryUploadConfig: vi.fn().mockReturnValue(false),
+    uploadImageToCloudinary: vi.fn(),
 }))
 
 function makeState(overrides: Partial<PieceState> = {}): PieceState {

--- a/web/src/components/__tests__/WorkflowState.test.tsx
+++ b/web/src/components/__tests__/WorkflowState.test.tsx
@@ -11,6 +11,8 @@ vi.mock('@common/api', () => ({
     updateCurrentState: vi.fn(),
     updatePiece: vi.fn(),
     createGlobalEntry: vi.fn(),
+    hasCloudinaryUploadConfig: vi.fn().mockReturnValue(false),
+    uploadImageToCloudinary: vi.fn(),
 }))
 
 function makeState(overrides: Partial<PieceState> = {}): PieceState {
@@ -36,6 +38,7 @@ function makePieceDetail(overrides: Partial<PieceDetail> = {}): PieceDetail {
         last_modified: new Date('2024-01-15T10:00:00Z'),
         thumbnail: '',
         current_state: state,
+        current_location: '',
         history: [state],
         ...overrides,
     }
@@ -286,12 +289,140 @@ describe('WorkflowState', () => {
         expect(onDirtyChange).toHaveBeenLastCalledWith(false)
     })
 
-    it('adds an image entry', () => {
+    it('adds an image entry', async () => {
+        const updated = makePieceDetail({ current_state: makeState({ images: [{ url: 'http://example.com/img.jpg', caption: 'A test image', created: new Date() }] }) })
+        vi.mocked(api.updateCurrentState).mockResolvedValue(updated)
         render(<WorkflowState {...defaultProps} />)
         fireEvent.change(screen.getByLabelText('Image URL'), { target: { value: 'http://example.com/img.jpg' } })
         fireEvent.change(screen.getByLabelText('Caption'), { target: { value: 'A test image' } })
         fireEvent.click(screen.getByText('+ Add Image'))
-        expect(screen.getByText('A test image')).toBeInTheDocument()
+        await waitFor(() => expect(api.updateCurrentState).toHaveBeenCalled())
+    })
+
+    it('prompts for confirmation before removing an image and removes on confirm', async () => {
+        vi.spyOn(window, 'confirm').mockReturnValue(true)
+        const updated = makePieceDetail({ current_state: makeState({ images: [] }) })
+        vi.mocked(api.updateCurrentState).mockResolvedValue(updated)
+        render(<WorkflowState {...defaultProps} pieceState={makeState({ images: [{ url: 'http://example.com/img.jpg', caption: 'To delete', created: new Date() }] })} />)
+        fireEvent.click(screen.getByRole('button', { name: 'remove image' }))
+        expect(window.confirm).toHaveBeenCalledWith('Remove this image?')
+        await waitFor(() => expect(api.updateCurrentState).toHaveBeenCalled())
+    })
+
+    it('clicking the pencil icon makes the caption editable', () => {
+        render(<WorkflowState {...defaultProps} pieceState={makeState({ images: [{ url: 'http://example.com/img.jpg', caption: 'My caption', created: new Date() }] })} />)
+        fireEvent.click(screen.getByRole('button', { name: 'edit caption' }))
+        expect(screen.getByRole('textbox', { name: 'Edit caption' })).toBeInTheDocument()
+        expect(screen.queryByText('My caption')).not.toBeInTheDocument()
+    })
+
+    it('persists caption change on blur and exits edit mode', async () => {
+        const updated = makePieceDetail()
+        vi.mocked(api.updateCurrentState).mockResolvedValue(updated)
+        render(<WorkflowState {...defaultProps} pieceState={makeState({ images: [{ url: 'http://example.com/img.jpg', caption: 'Old', created: new Date() }] })} />)
+        fireEvent.click(screen.getByRole('button', { name: 'edit caption' }))
+        const input = screen.getByRole('textbox', { name: 'Edit caption' })
+        fireEvent.change(input, { target: { value: 'New caption' } })
+        fireEvent.blur(input)
+        await waitFor(() => expect(api.updateCurrentState).toHaveBeenCalledWith(
+            'test-piece-id',
+            expect.objectContaining({ images: expect.arrayContaining([expect.objectContaining({ caption: 'New caption' })]) })
+        ))
+        expect(screen.queryByRole('textbox', { name: 'Edit caption' })).not.toBeInTheDocument()
+    })
+
+    it('skips server call when caption is unchanged on blur', () => {
+        render(<WorkflowState {...defaultProps} pieceState={makeState({ images: [{ url: 'http://example.com/img.jpg', caption: 'Same', created: new Date() }] })} />)
+        fireEvent.click(screen.getByRole('button', { name: 'edit caption' }))
+        const input = screen.getByRole('textbox', { name: 'Edit caption' })
+        fireEvent.blur(input)
+        expect(api.updateCurrentState).not.toHaveBeenCalled()
+    })
+
+    it('pressing Escape exits edit mode without saving', () => {
+        render(<WorkflowState {...defaultProps} pieceState={makeState({ images: [{ url: 'http://example.com/img.jpg', caption: 'Keep', created: new Date() }] })} />)
+        fireEvent.click(screen.getByRole('button', { name: 'edit caption' }))
+        const input = screen.getByRole('textbox', { name: 'Edit caption' })
+        fireEvent.change(input, { target: { value: 'Changed' } })
+        fireEvent.keyDown(input, { key: 'Escape' })
+        expect(api.updateCurrentState).not.toHaveBeenCalled()
+        expect(screen.queryByRole('textbox', { name: 'Edit caption' })).not.toBeInTheDocument()
+    })
+
+    it('does not remove image when confirmation is cancelled', () => {
+        vi.spyOn(window, 'confirm').mockReturnValue(false)
+        render(<WorkflowState {...defaultProps} pieceState={makeState({ images: [{ url: 'http://example.com/img.jpg', caption: 'Keep me', created: new Date() }] })} />)
+        fireEvent.click(screen.getByRole('button', { name: 'remove image' }))
+        expect(screen.getByText('Keep me')).toBeInTheDocument()
+    })
+
+    it('shows mode toggle when Cloudinary is configured', () => {
+        vi.mocked(api.hasCloudinaryUploadConfig).mockReturnValue(true)
+        render(<WorkflowState {...defaultProps} />)
+        expect(screen.getByRole('button', { name: 'Paste URL' })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Upload' })).toBeInTheDocument()
+    })
+
+    it('does not show mode toggle when Cloudinary is not configured', () => {
+        vi.mocked(api.hasCloudinaryUploadConfig).mockReturnValue(false)
+        render(<WorkflowState {...defaultProps} />)
+        expect(screen.queryByRole('button', { name: 'Paste URL' })).not.toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: 'Upload' })).not.toBeInTheDocument()
+    })
+
+    it('defaults to upload mode: hides URL field and shows upload button', () => {
+        vi.mocked(api.hasCloudinaryUploadConfig).mockReturnValue(true)
+        render(<WorkflowState {...defaultProps} />)
+        expect(screen.queryByLabelText('Image URL')).not.toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Upload Image' })).toBeInTheDocument()
+    })
+
+    it('switching to URL mode shows URL field and hides upload button', () => {
+        vi.mocked(api.hasCloudinaryUploadConfig).mockReturnValue(true)
+        render(<WorkflowState {...defaultProps} />)
+        fireEvent.click(screen.getByRole('button', { name: 'Paste URL' }))
+        expect(screen.getByLabelText('Image URL')).toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: 'Upload Image' })).not.toBeInTheDocument()
+    })
+
+    it('switching modes clears the preview', async () => {
+        vi.mocked(api.hasCloudinaryUploadConfig).mockReturnValue(true)
+        vi.mocked(api.uploadImageToCloudinary).mockResolvedValue('https://res.cloudinary.com/demo/image/upload/sample.jpg')
+        render(<WorkflowState {...defaultProps} />)
+        fireEvent.change(document.querySelector('input[type="file"]') as HTMLInputElement, { target: { files: [new File(['img'], 'test.png', { type: 'image/png' })] } })
+        await waitFor(() => expect(screen.getByTestId('upload-preview')).toBeInTheDocument())
+        fireEvent.click(screen.getByRole('button', { name: 'Paste URL' }))
+        expect(screen.queryByTestId('upload-preview')).not.toBeInTheDocument()
+        expect(screen.getByLabelText('Image URL')).toHaveValue('')
+    })
+
+    it('replaces upload button with preview image after successful upload', async () => {
+        vi.mocked(api.hasCloudinaryUploadConfig).mockReturnValue(true)
+        vi.mocked(api.uploadImageToCloudinary).mockResolvedValue('https://res.cloudinary.com/demo/image/upload/sample.jpg')
+        render(<WorkflowState {...defaultProps} />)
+        fireEvent.change(document.querySelector('input[type="file"]') as HTMLInputElement, { target: { files: [new File(['img'], 'test.png', { type: 'image/png' })] } })
+        await waitFor(() => expect(api.uploadImageToCloudinary).toHaveBeenCalled())
+        await waitFor(() => {
+            expect(screen.queryByRole('button', { name: 'Upload Image' })).not.toBeInTheDocument()
+            const preview = screen.getByTestId('upload-preview') as HTMLImageElement
+            expect(preview.src).toBe('https://res.cloudinary.com/demo/image/upload/sample.jpg')
+        })
+    })
+
+    it('shows spinner while upload preview image is loading, then hides it on load', async () => {
+        vi.mocked(api.hasCloudinaryUploadConfig).mockReturnValue(true)
+        vi.mocked(api.uploadImageToCloudinary).mockResolvedValue('https://res.cloudinary.com/demo/image/upload/sample.jpg')
+        render(<WorkflowState {...defaultProps} />)
+        fireEvent.change(document.querySelector('input[type="file"]') as HTMLInputElement, { target: { files: [new File(['img'], 'test.png', { type: 'image/png' })] } })
+        await waitFor(() => expect(screen.getByTestId('upload-preview')).toBeInTheDocument())
+
+        const preview = screen.getByTestId('upload-preview')
+        expect(screen.getByRole('progressbar')).toBeInTheDocument()
+        expect(preview).toHaveStyle({ display: 'none' })
+
+        fireEvent.load(preview)
+        expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+        expect(preview).toHaveStyle({ display: 'block' })
     })
 
     it('accepts any valid workflow state', () => {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,19 +3,23 @@ import react, { reactCompilerPreset } from '@vitejs/plugin-react'
 import babel from '@rolldown/plugin-babel'
 import yaml from '@rollup/plugin-yaml'
 import { fileURLToPath } from 'node:url'
+import path from 'node:path'
 
 // https://vite.dev/config/
 export default defineConfig({
+  resolve: {
+    // frontend_common is outside web/, so bare imports inside it resolve from
+    // the repo root upward (not web/node_modules). Pin axios to web's install.
+    alias: {
+      axios: path.resolve(__dirname, 'node_modules/axios'),
+      '@common': fileURLToPath(new URL('../frontend_common/src', import.meta.url)),
+    },
+  },
   plugins: [
     yaml(),
     react(),
     babel({ presets: [reactCompilerPreset()] })
   ],
-  resolve: {
-    alias: {
-      '@common': fileURLToPath(new URL('../frontend_common/src', import.meta.url)),
-    },
-  },
   server: {
     fs: {
       allow: ['..'],


### PR DESCRIPTION
## Summary

- **Cloudinary signed upload backend**: new `POST /api/uploads/cloudinary/signature/` endpoint; `env.sh` fixed to load `.env.local` into the Django process; `current_location` marked optional in the OpenAPI schema
- **Frontend upload client**: `uploadImageToCloudinary` in `api.ts` fetches a signed payload, posts to Cloudinary, and rewrites the returned URL with `f_auto` for automatic HEIC→WebP/JPEG conversion at delivery time
- **WorkflowState image management overhaul**:
  - URL / Upload tab toggle (ToggleButtonGroup); defaults to Upload when Cloudinary is configured
  - Upload preview replaces the button after a successful upload; spinner while the browser loads the image
  - Image add and remove persist immediately to the server and are excluded from dirty state; `+ Add Image` shows a spinner during save
  - Inline caption editing via pencil icon (✏); blur or Enter persists, Escape cancels
  - Lightbox modal with touch-swipe and arrow-button navigation
  - Delete confirmation, divider between list and add form, Save button moved above the image section
- **Vite axios alias**: pins `axios` in `web/vite.config.ts` so imports from `frontend_common` (outside Vite root) resolve correctly

## Test plan

- [x] `gz_test` passes (common + backend + web)
- [x] Set `CLOUDINARY_*` vars in `.env.local`, start with `gz_start`, open a piece and upload a HEIC photo from an iPhone — confirm it appears as WebP/JPEG in the lightbox
- [x] Verify upload button disappears and preview renders after upload; spinner shown while loading
- [x] Confirm image add/remove save immediately without requiring the Save button
- [x] Edit a caption inline, blur away — confirm persisted; Escape — confirm cancelled
- [x] Confirm Save button is above the image section and only enables for notes/location/field changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)