### PR TITLE
Bump GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/claude-issue-agent.yml
+++ b/.github/workflows/claude-issue-agent.yml
@@ -22,7 +22,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: anthropics/claude-code-action@v1
         id: claude
         with:

--- a/.github/workflows/claude-pr-agent.yml
+++ b/.github/workflows/claude-pr-agent.yml
@@ -30,7 +30,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: anthropics/claude-code-action@v1
@@ -53,7 +53,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,9 +10,9 @@ jobs:
     name: Common (workflow schema)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: pip
@@ -27,9 +27,9 @@ jobs:
     name: Backend (pytest)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: pip
@@ -47,9 +47,9 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: npm
@@ -65,14 +65,14 @@ jobs:
     name: Web (build)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: pip
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: npm
@@ -111,17 +111,17 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -139,7 +139,7 @@ jobs:
       group: deploy-production
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up SSH
         run: |


### PR DESCRIPTION
## Summary

- `actions/checkout` v4 → v5
- `actions/setup-python` v5 → v6
- `actions/setup-node` v4 → v5
- `docker/login-action` v3 → v4
- `docker/build-push-action` v6 → v7

Fixes Node.js 20 deprecation warnings across all six workflow jobs. Node.js 20 actions will be forced to Node.js 24 starting June 2, 2026, and removed entirely on September 16, 2026.

## Test plan

- [ ] Verify CI jobs pass after merge (no code changes, purely action version bumps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)