### PR TITLE
CI/CD: rename workflow, skip docs pushes, harden Claude PR agent

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,8 +1,19 @@
-name: Tests
+name: CI/CD
 
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - '.gitignore'
+      - '.gitattributes'
+      - '.gitmodules'
+      - '.mailmap'
+      - '.editorconfig'
+      - '.vscode/**'
+      - '.idea/**'
+      - 'LICENSE'
+      - 'LICENSE.*'
   pull_request:
 
 jobs:

--- a/.github/workflows/claude-pr-agent.yml
+++ b/.github/workflows/claude-pr-agent.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   respond-to-comment:
-    # Run when a PR comment mentions @claude
+    # Run when a PR comment mentions @claude AND the PR was created by Claude
     if: |
       !endsWith(github.actor, '[bot]') &&
       (
@@ -17,11 +17,13 @@ jobs:
           (
             github.event_name == 'pull_request_review_comment' ||
             (github.event_name == 'issue_comment' && github.event.issue.pull_request)
-          )
+          ) &&
+          endsWith(github.event.issue.user.login, '[bot]')
         ) ||
         (
           github.event_name == 'pull_request_review' &&
-          github.event.review.state == 'changes_requested'
+          github.event.review.state == 'changes_requested' &&
+          endsWith(github.event.pull_request.user.login, '[bot]')
         )
       )
     runs-on: ubuntu-latest
@@ -41,12 +43,50 @@ jobs:
           claude_args: "--dangerously-skip-permissions"
           show_full_output: "true"
 
+  decline-non-claude-pr:
+    # When @claude is mentioned on a PR Claude did NOT create, respond to the comment
+    # without making code changes — Claude can answer questions but must not modify files.
+    if: |
+      !endsWith(github.actor, '[bot]') &&
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '@claude') &&
+      !endsWith(github.event.issue.user.login, '[bot]')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: "--dangerously-skip-permissions"
+          show_full_output: "true"
+          prompt: |
+            A user has mentioned @claude in a comment on pull request #${{ github.event.issue.number }},
+            but this PR was not opened by you — it was opened by @${{ github.event.issue.user.login }}.
+
+            The comment was:
+            ${{ github.event.comment.body }}
+
+            You may read the code and PR context to give a helpful response, but you MUST NOT modify,
+            create, or delete any files. Post a comment addressing the user's question or request,
+            and explain that you can only make code changes on pull requests you opened yourself.
+            If their request requires code changes, suggest they ask the PR author or open a new
+            issue (labelled `claude`) for you to handle.
+
   address-review-changes:
-    # Run when a reviewer requests changes — Claude implements the feedback and pushes a new commit
+    # Run when a reviewer requests changes on a PR Claude created
     if: |
       !endsWith(github.actor, '[bot]') &&
       github.event_name == 'pull_request_review' &&
-      github.event.review.state == 'changes_requested'
+      github.event.review.state == 'changes_requested' &&
+      endsWith(github.event.pull_request.user.login, '[bot]')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,7 +155,7 @@ PieceSummary & {
 - API auth is session-based (`SessionAuthentication`) with CSRF protection.
 - User data isolation is mandatory: lists must scope to `request.user`, and object lookups must use user-filtered querysets.
 - When a user requests another user's object ID, return `404` (not `403`) so object existence is not leaked.
-- User-owned globals (like `Location`) are isolated per user; keep per-user uniqueness constraints intact.
+- User-owned globals (`Location`, `ClayBody`, `GlazeType`, `GlazeMethod`) are isolated per user; keep per-user uniqueness constraints intact.
 
 **API endpoints:**
 - `GET /api/auth/csrf/` → set CSRF cookie
@@ -308,7 +308,7 @@ The test environment is jsdom; setup file is [`web/src/test-setup.ts`](web/src/t
 
 ### CI
 
-GitHub Actions runs all three suites (`common`, `backend`, `web`) in parallel on every push and pull request — see [`.github/workflows/tests.yml`](.github/workflows/tests.yml). A PR should not be merged if any job is red.
+GitHub Actions runs all three suites (`common`, `backend`, `web`) in parallel on every push and pull request — see [`.github/workflows/ci-cd.yml`](.github/workflows/ci-cd.yml). A PR should not be merged if any job is red.
 
 ### What to test
 

--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ The workflow state machine and all valid transitions are defined in [`workflow.y
 
 `workflow.yml` also contains two optional sections beyond the state list:
 
-- **`globals`** — named domain types backed by Django models (e.g. `location`, `piece`), registered so they can be referenced from `additional_fields` and verified against `api/models.py` by the test suite.
+- **`globals`** — named domain types backed by Django models (`location`, `piece`, `clay_body`, `glaze_type`, `glaze_method`), registered so they can be referenced from `additional_fields` and verified against `api/models.py` by the test suite.
 - **`additional_fields`** (per-state) — state-specific fields declared using the embedded DSL. See the “Authoring `additional_fields`” section below for the exact syntax and how the web renders the inputs.
 
 ### Authoring `additional_fields`


### PR DESCRIPTION
## Summary

- **Rename `tests.yml` → `ci-cd.yml`** and update the workflow `name` to `CI/CD` — the file has always handled build, publish, and deploy, not just tests.
- **Scope the push trigger with `paths-ignore`** so doc-only and metadata-only pushes to `main` (Markdown files, `.gitignore`, `.editorconfig`, IDE config, `LICENSE`) skip the full pipeline including Docker build and deploy.
- **Harden the Claude PR agent** so it only iterates on PRs it opened:
  - `respond-to-comment` and `address-review-changes` now guard on `endsWith(pr.user.login, '[bot]')`.
  - New `decline-non-claude-pr` job: when `@claude` is mentioned on a PR Claude did not open, invokes Claude to post a meaningful reply without modifying any files.
- **Docs**: update globals examples in `AGENTS.md` and `README.md` to list all five registered globals (`location`, `piece`, `clay_body`, `glaze_type`, `glaze_method`).

## Test plan

- [ ] Push a docs-only change to `main` and verify the CI/CD workflow does not trigger
- [ ] Push a code change to `main` and verify the full pipeline (tests → publish → deploy) runs
- [ ] Mention `@claude` on a PR opened by a human and verify it posts a comment but makes no file changes
- [ ] Request changes on a Claude-opened PR and verify Claude addresses them
- [ ] Request changes on a human-opened PR and verify the `address-review-changes` job is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)