### PR TITLE
Add loading spinner to CloudinaryImage

### DIFF
--- a/web/src/components/CloudinaryImage.tsx
+++ b/web/src/components/CloudinaryImage.tsx
@@ -174,7 +174,7 @@ export default function CloudinaryImage({
             img.resize(fit().width(vw).height(vh))
         } else {
             // thumbnail or preview — 64×64 fill with auto gravity
-            img.resize(fill().width(64).height(64).gravity(autoGravity()))
+            img.resize(fill().width(THUMBNAIL_SIZE).height(THUMBNAIL_SIZE).gravity(autoGravity()))
         }
 
         img.delivery(format(autoFormat()))

--- a/web/src/components/CloudinaryImage.tsx
+++ b/web/src/components/CloudinaryImage.tsx
@@ -18,8 +18,13 @@ import { auto as autoFormat } from '@cloudinary/url-gen/qualifiers/format'
 import { auto as autoQuality } from '@cloudinary/url-gen/qualifiers/quality'
 import { autoGravity } from '@cloudinary/url-gen/qualifiers/gravity'
 import { AdvancedImage } from '@cloudinary/react'
+import { Box, CircularProgress } from '@mui/material'
+import { useEffect, useState } from 'react'
 
 const CLOUDINARY_HOSTNAME = 'res.cloudinary.com'
+const THUMBNAIL_SIZE = 64
+const LIGHTBOX_MAX_WIDTH = '90vw'
+const LIGHTBOX_MAX_HEIGHT = '80vh'
 
 /**
  * Parse cloud_name and public_id from a Cloudinary delivery URL.
@@ -105,6 +110,55 @@ export default function CloudinaryImage({
     onLoad,
     'data-testid': testId,
 }: CloudinaryImageProps) {
+    const [isLoading, setIsLoading] = useState(true)
+
+    useEffect(() => {
+        setIsLoading(true)
+    }, [url, cloudinary_public_id, context])
+
+    function handleLoad(event: React.SyntheticEvent<HTMLImageElement>) {
+        setIsLoading(false)
+        onLoad?.(event)
+    }
+
+    function handleError() {
+        setIsLoading(false)
+    }
+
+    const wrapperStyle: React.CSSProperties = context === 'lightbox'
+        ? {
+            position: 'relative',
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: LIGHTBOX_MAX_WIDTH,
+            height: LIGHTBOX_MAX_HEIGHT,
+            maxWidth: LIGHTBOX_MAX_WIDTH,
+            maxHeight: LIGHTBOX_MAX_HEIGHT,
+        }
+        : {
+            position: 'relative',
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: THUMBNAIL_SIZE,
+            height: THUMBNAIL_SIZE,
+            flexShrink: 0,
+        }
+    const spinnerStyle: React.CSSProperties = {
+        position: 'absolute',
+        inset: 0,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        pointerEvents: 'none',
+    }
+
+    const imageStyle: React.CSSProperties = {
+        ...style,
+        opacity: isLoading ? 0 : 1,
+    }
+
     // Resolve cloud_name + publicId. Prefer the stored prop; fall back to URL parse.
     const parsed = parseCloudinaryUrl(url)
     const cloudName = parsed?.cloudName ?? null
@@ -127,26 +181,42 @@ export default function CloudinaryImage({
         img.delivery(quality(autoQuality()))
 
         return (
-            <AdvancedImage
-                cldImg={img}
-                alt={alt}
-                style={style}
-                className={className}
-                onLoad={onLoad}
-                data-testid={testId}
-            />
+            <Box style={wrapperStyle}>
+                {isLoading && (
+                    <Box style={spinnerStyle}>
+                        <CircularProgress size={24} />
+                    </Box>
+                )}
+                <AdvancedImage
+                    cldImg={img}
+                    alt={alt}
+                    style={imageStyle}
+                    className={className}
+                    onLoad={handleLoad}
+                    onError={handleError}
+                    data-testid={testId}
+                />
+            </Box>
         )
     }
 
     // No Cloudinary identity available — plain img fallback.
     return (
-        <img
-            src={url}
-            alt={alt}
-            style={style}
-            className={className}
-            onLoad={onLoad}
-            data-testid={testId}
-        />
+        <Box style={wrapperStyle}>
+            {isLoading && (
+                <Box style={spinnerStyle}>
+                    <CircularProgress size={24} />
+                </Box>
+            )}
+            <img
+                src={url}
+                alt={alt}
+                style={imageStyle}
+                className={className}
+                onLoad={handleLoad}
+                onError={handleError}
+                data-testid={testId}
+            />
+        </Box>
     )
 }

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -21,7 +21,7 @@ import type { CaptionedImage, PieceDetail as PieceDetailType } from '@common/typ
 import { formatState, SUCCESSORS } from '@common/types'
 import { addPieceState } from '@common/api'
 import ImageLightbox from './ImageLightbox'
-import CloudinaryImage from './CloudinaryImage'
+import CloudinaryImage, { THUMBNAIL_SIZE } from './CloudinaryImage'
 import WorkflowState from './WorkflowState'
 
 type PieceDetailProps = {
@@ -84,7 +84,7 @@ export default function PieceDetail({ piece, onPieceUpdated }: PieceDetailProps)
                 <img
                     src={piece.thumbnail}
                     alt={piece.name}
-                    style={{ height: 64, width: 64, objectFit: 'cover', borderRadius: 4 }}
+                    style={{ height: THUMBNAIL_SIZE, width: THUMBNAIL_SIZE, objectFit: 'cover', borderRadius: 4 }}
                 />
             )}
             <Box>
@@ -190,7 +190,7 @@ export default function PieceDetail({ piece, onPieceUpdated }: PieceDetailProps)
                                                                 cloudinary_public_id={img.cloudinary_public_id}
                                                                 alt={img.caption || ''}
                                                                 context="thumbnail"
-                                                                style={{ width: 64, height: 64, objectFit: 'cover', borderRadius: 4 }}
+                                                                style={{ objectFit: 'cover', borderRadius: 4 }}
                                                             />
                                                             {img.caption && (
                                                                 <Typography variant="caption" sx={{ color: 'text.secondary', textAlign: 'center', wordBreak: 'break-word' }}>

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -24,8 +24,6 @@ import ImageLightbox from './ImageLightbox'
 import CloudinaryImage from './CloudinaryImage'
 import WorkflowState from './WorkflowState'
 
-const PIECE_THUMBNAIL_SIZE = 64
-
 type PieceDetailProps = {
     piece: PieceDetailType
     onPieceUpdated: (updated: PieceDetailType) => void
@@ -83,10 +81,11 @@ export default function PieceDetail({ piece, onPieceUpdated }: PieceDetailProps)
             {/* Header */}
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 3 }}>
             {piece.thumbnail && (
-                <img
-                    src={piece.thumbnail}
+                <CloudinaryImage
+                    url={piece.thumbnail}
                     alt={piece.name}
-                    style={{ height: PIECE_THUMBNAIL_SIZE, width: PIECE_THUMBNAIL_SIZE, objectFit: 'cover', borderRadius: 4 }}
+                    context="thumbnail"
+                    style={{ objectFit: 'cover', borderRadius: 4 }}
                 />
             )}
             <Box>

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -21,8 +21,10 @@ import type { CaptionedImage, PieceDetail as PieceDetailType } from '@common/typ
 import { formatState, SUCCESSORS } from '@common/types'
 import { addPieceState } from '@common/api'
 import ImageLightbox from './ImageLightbox'
-import CloudinaryImage, { THUMBNAIL_SIZE } from './CloudinaryImage'
+import CloudinaryImage from './CloudinaryImage'
 import WorkflowState from './WorkflowState'
+
+const PIECE_THUMBNAIL_SIZE = 64
 
 type PieceDetailProps = {
     piece: PieceDetailType
@@ -84,7 +86,7 @@ export default function PieceDetail({ piece, onPieceUpdated }: PieceDetailProps)
                 <img
                     src={piece.thumbnail}
                     alt={piece.name}
-                    style={{ height: THUMBNAIL_SIZE, width: THUMBNAIL_SIZE, objectFit: 'cover', borderRadius: 4 }}
+                    style={{ height: PIECE_THUMBNAIL_SIZE, width: PIECE_THUMBNAIL_SIZE, objectFit: 'cover', borderRadius: 4 }}
                 />
             )}
             <Box>

--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -516,7 +516,7 @@ export default function WorkflowState({
                                             cloudinary_public_id={img.cloudinary_public_id}
                                             alt={img.caption || 'Pottery image'}
                                             context="thumbnail"
-                                            style={{ height: 64, width: 64, objectFit: 'cover', borderRadius: 4, display: 'block' }}
+                                            style={{ objectFit: 'cover', borderRadius: 4, display: 'block' }}
                                         />
                                     </Box>
                                     {editingCaptionIndex === i ? (

--- a/web/src/components/__tests__/CloudinaryImage.test.tsx
+++ b/web/src/components/__tests__/CloudinaryImage.test.tsx
@@ -1,0 +1,110 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import CloudinaryImage from '../CloudinaryImage'
+
+vi.mock('@cloudinary/react', () => ({
+    AdvancedImage: ({ alt, className, 'data-testid': testId, onError, onLoad, style }: {
+        alt?: string
+        className?: string
+        'data-testid'?: string
+        onError?: React.ReactEventHandler<HTMLImageElement>
+        onLoad?: React.ReactEventHandler<HTMLImageElement>
+        style?: React.CSSProperties
+    }) => (
+        <img
+            alt={alt}
+            className={className}
+            data-testid={testId}
+            onError={onError}
+            onLoad={onLoad}
+            style={style}
+        />
+    ),
+}))
+
+vi.mock('@cloudinary/url-gen', () => ({
+    Cloudinary: class {
+        image(publicId: string) {
+            return {
+                publicId,
+                resize() { return this },
+                delivery() { return this },
+            }
+        }
+    },
+}))
+
+vi.mock('@cloudinary/url-gen/actions/resize', () => ({
+    fill: () => ({
+        width() { return this },
+        height() { return this },
+        gravity() { return this },
+    }),
+    fit: () => ({
+        width() { return this },
+        height() { return this },
+    }),
+}))
+
+vi.mock('@cloudinary/url-gen/actions/delivery', () => ({
+    format: vi.fn(),
+    quality: vi.fn(),
+}))
+
+vi.mock('@cloudinary/url-gen/qualifiers/format', () => ({
+    auto: vi.fn(),
+}))
+
+vi.mock('@cloudinary/url-gen/qualifiers/quality', () => ({
+    auto: vi.fn(),
+}))
+
+vi.mock('@cloudinary/url-gen/qualifiers/gravity', () => ({
+    autoGravity: vi.fn(),
+}))
+
+describe('CloudinaryImage', () => {
+    it('shows a spinner until a fallback image loads', () => {
+        render(<CloudinaryImage url="https://example.com/pot.jpg" alt="Pot" context="thumbnail" />)
+
+        const image = screen.getByAltText('Pot')
+        expect(screen.getByRole('progressbar')).toBeInTheDocument()
+        expect(image).toHaveStyle({ opacity: '0' })
+
+        fireEvent.load(image)
+
+        expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+        expect(image).toHaveStyle({ opacity: '1' })
+    })
+
+    it('shows the spinner again when the image source changes', () => {
+        const { rerender } = render(<CloudinaryImage url="https://example.com/first.jpg" alt="Pot" context="thumbnail" />)
+
+        const image = screen.getByAltText('Pot')
+        fireEvent.load(image)
+        expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+
+        rerender(<CloudinaryImage url="https://example.com/second.jpg" alt="Pot" context="thumbnail" />)
+
+        expect(screen.getByRole('progressbar')).toBeInTheDocument()
+        expect(screen.getByAltText('Pot')).toHaveStyle({ opacity: '0' })
+    })
+
+    it('shows a spinner for Cloudinary-backed images until they load', () => {
+        render(
+            <CloudinaryImage
+                url="https://res.cloudinary.com/demo/image/upload/v1/pottery/sample.jpg"
+                cloudinary_public_id="pottery/sample"
+                alt="Cloudinary pot"
+                context="preview"
+            />
+        )
+
+        const image = screen.getByAltText('Cloudinary pot')
+        expect(screen.getByRole('progressbar')).toBeInTheDocument()
+
+        fireEvent.load(image)
+
+        expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+    })
+})

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -32,6 +32,7 @@
   },
   "include": [
     "src",
+    "../frontend_common/src/generated-types.ts",
     "../frontend_common/src/types.ts",
     "../frontend_common/src/api.ts",
     "../frontend_common/src/workflow.ts"

--- a/web/tsconfig.test.json
+++ b/web/tsconfig.test.json
@@ -8,6 +8,7 @@
   },
   "include": [
     "src",
+    "../frontend_common/src/generated-types.ts",
     "../frontend_common/src/types.ts",
     "../frontend_common/src/api.ts",
     "../frontend_common/src/workflow.ts"


### PR DESCRIPTION
## Summary

- show a spinner in `CloudinaryImage` while the browser is still loading the backing image
- keep image containers sized for thumbnail, preview, and lightbox contexts to avoid layout jump
- add focused component tests for fallback images, Cloudinary-backed images, and reload-on-src-change behavior

## Testing

- `/home/phil/.nvm/versions/node/v25.5.0/bin/node node_modules/vitest/vitest.mjs run src/components/__tests__/CloudinaryImage.test.tsx src/components/__tests__/ImageLightbox.test.tsx src/components/__tests__/WorkflowState.test.tsx`