### PR TITLE
Fix Vite proxy to forward /admin and /static to Django

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -40,6 +40,8 @@ export default defineConfig({
     },
     proxy: {
       '/api': 'http://localhost:8080',
+      '/admin': 'http://localhost:8080',
+      '/static': 'http://localhost:8080',
     },
   },
 })


### PR DESCRIPTION
## Summary

- The Vite dev server only proxied `/api` to Django, so navigating to `/admin/` was caught by React Router's `path="*"` catch-all and redirected to `/`
- Add `/admin` and `/static` proxy entries in `web/vite.config.ts` so the Django admin UI and its static assets are reachable at `localhost:5173/admin/` during development

## Test plan

- [ ] Start Django on port 8080 and the Vite dev server
- [ ] Navigate to `http://localhost:5173/admin/` — should reach the Django admin login page
- [ ] Confirm `/static/` assets (admin CSS/JS) load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)