### PR TITLE
feat: skip autonomous agent actions on closed PRs and issues

### DIFF
--- a/.github/workflows/claude-issue-agent.yml
+++ b/.github/workflows/claude-issue-agent.yml
@@ -11,6 +11,7 @@ jobs:
     # Run when the 'claude' label is present; skip bot comments to prevent loops
     if: |
       !endsWith(github.actor, '[bot]') &&
+      github.event.issue.state != 'closed' &&
       contains(github.event.issue.labels.*.name, 'claude') &&
       (
         github.event_name == 'issues' ||

--- a/.github/workflows/claude-pr-agent.yml
+++ b/.github/workflows/claude-pr-agent.yml
@@ -14,6 +14,7 @@ jobs:
       !endsWith(github.actor, '[bot]') &&
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request != null &&
+      github.event.issue.state != 'closed' &&
       contains(github.event.comment.body, '@claude') &&
       contains(github.event.issue.labels.*.name, 'claude')
     runs-on: ubuntu-latest
@@ -77,6 +78,7 @@ jobs:
       !endsWith(github.actor, '[bot]') &&
       github.event_name == 'pull_request_review' &&
       github.event.review.state == 'changes_requested' &&
+      github.event.pull_request.state != 'closed' &&
       contains(github.event.pull_request.labels.*.name, 'claude')
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

- `respond-to-comment` (PR with `claude` label): skip when PR is closed/merged — no value in iterating on code that can't be merged
- `address-review-changes`: skip when PR is closed/merged — stale change-request reviews should not trigger autonomous code changes
- `claude-issue-agent`: skip when issue is closed — agent should not create PRs or post clarifying questions on closed issues
- `decline-non-claude-pr` is intentionally unrestricted — it's read-only, so answering questions on closed PRs remains fine

## Test plan

- [ ] Comment mentioning `@claude` on a closed PR with `claude` label → `respond-to-comment` job should be skipped
- [ ] Comment mentioning `@claude` on a closed PR without `claude` label → `decline-non-claude-pr` job should still run
- [ ] Change-request review submitted on a closed PR with `claude` label → `address-review-changes` job should be skipped
- [ ] Label `claude` applied to a closed issue → `claude-issue-agent` job should be skipped
- [ ] Comment on a closed issue with `claude` label → `claude-issue-agent` job should be skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)