### PR TITLE
feat: split ci-cd.yml into ci.yml + cd.yml with release-gated deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,7 +22,7 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -H $(echo "${{ secrets.DEPLOY_HOST }}" | cut -d@ -f2) >> ~/.ssh/known_hosts
+          ssh-keyscan -H $(echo "${{ vars.DEPLOY_HOST }}" | cut -d@ -f2) >> ~/.ssh/known_hosts
 
       - name: Deploy
-        run: ./deploy.sh "${{ secrets.DEPLOY_HOST }}"
+        run: ./deploy.sh "${{ vars.DEPLOY_HOST }}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,28 @@
+name: CD
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    name: Deploy to droplet
+    runs-on: ubuntu-latest
+    environment: glaze-tailscale
+    concurrency:
+      group: deploy-production
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.release.target_commitish }}
+
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H $(echo "${{ secrets.DEPLOY_HOST }}" | cut -d@ -f2) >> ~/.ssh/known_hosts
+
+      - name: Deploy
+        run: ./deploy.sh "${{ secrets.DEPLOY_HOST }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI/CD
+name: CI
 
 on:
   push:
@@ -119,7 +119,7 @@ jobs:
     needs: [common, backend, web, web-build]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
-      contents: read
+      contents: write
       packages: write
     steps:
       - uses: actions/checkout@v5
@@ -136,28 +136,19 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/shaoster/glaze:latest
+          tags: |
+            ghcr.io/shaoster/glaze:latest
+            ghcr.io/shaoster/glaze:${{ github.sha }}
           build-args: |
             VITE_GOOGLE_CLIENT_ID=${{ secrets.VITE_GOOGLE_CLIENT_ID }}
           labels: |
             org.opencontainers.image.revision=${{ github.sha }}
 
-  deploy:
-    name: Deploy to droplet
-    runs-on: ubuntu-latest
-    needs: [publish]
-    concurrency:
-      group: deploy-production
-      cancel-in-progress: true
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Set up SSH
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -H $(echo "${{ secrets.DEPLOY_HOST }}" | cut -d@ -f2) >> ~/.ssh/known_hosts
-
-      - name: Deploy
-        run: ./deploy.sh "${{ secrets.DEPLOY_HOST }}"
+          gh release create "release-${{ github.sha }}" \
+            --title "Build ${{ github.sha }}" \
+            --notes "Docker image published: \`ghcr.io/shaoster/glaze:${{ github.sha }}\`" \
+            --latest


### PR DESCRIPTION
## Summary

- **Rename** `ci-cd.yml` → `ci.yml`; removes the `deploy` job from CI entirely
- **Docker tagging**: the `publish` job now tags images as both `:latest` and `:<sha>`, so every build is addressable by commit
- **GitHub Release**: after a successful image push, `ci.yml` creates a Release (`release-<sha>`) via `gh release create`, registering the build in the repo's Releases page
- **`cd.yml`**: new workflow triggered on `release: published`; the `deploy` job runs under the `glaze-tailscale` environment (secrets scoped there) and checks out the release's target commit before calling `deploy.sh`

## Test plan

- [ ] Push to `main` → CI jobs pass → Docker image pushed with `:latest` + `:<sha>` tags → GitHub Release created automatically
- [ ] Newly created Release triggers `cd.yml` → deploy job runs (requires `glaze-tailscale` environment to be configured — see below)
- [ ] PRs continue to run only CI jobs (no publish, no deploy)

## Repository settings required

1. **Create the `glaze-tailscale` environment**
   - Go to **Settings → Environments → New environment**, name it `glaze-tailscale`
   - Optionally add required reviewers or deployment branch restrictions

2. **Move deploy secrets into that environment**
   - Under the new environment, add `DEPLOY_SSH_KEY` and `DEPLOY_HOST` as **environment secrets** (they can be removed from repo-level secrets once the environment is set up)

3. **Verify Actions write permissions**
   - Go to **Settings → Actions → General → Workflow permissions**
   - Ensure "Read and write permissions" is selected (needed for `gh release create` and `packages: write`)

Closes #N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)