### PR TITLE
fix: use PAT for release creation so cd.yml is triggered

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,10 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Must use a PAT here — releases created via GITHUB_TOKEN do not
+          # trigger other workflows (GitHub's anti-loop safety measure), so
+          # the release: published event in cd.yml would never fire.
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: |
           gh release create "release-${{ github.sha }}" \
             --title "Build ${{ github.sha }}" \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -379,6 +379,10 @@ GitHub Actions runs all three suites (`common`, `backend`, `web`) in parallel on
 
 These rules apply to all autonomous agents (issue agent, PR agent) working in this repository, as well as interactive sessions that are prompted to "create a commit" or "create a PR" by the user.
 
+### Linking to PRs and issues
+
+Always refer to PRs and issues as Markdown links using the full URL, e.g. `[shaoster/glaze#55](https://github.com/shaoster/glaze/pull/55)` for PRs and `[shaoster/glaze#42](https://github.com/shaoster/glaze/issues/42)` for issues. Never use bold text (e.g. **shaoster/glaze#55**) as a substitute for a link.
+
 ### Branch naming
 
 Name branches `issue/<N>-short-slug` when opening a branch in response to a GitHub issue (e.g. `issue/42-fix-glazed-transition`). For other work use `<type>/short-slug` (`fix/`, `feat/`, `docs/`, etc.).


### PR DESCRIPTION
## Summary

- `gh release create` in `ci.yml` was using `GITHUB_TOKEN`, which GitHub silently prevents from triggering other workflows (anti-loop protection)
- Switches to `RELEASE_PAT` (a fine-grained PAT with Contents: Read and Write on this repo only) so the `release: published` event propagates normally and fires `cd.yml`

## Test plan

- [ ] Merge to `main` → CI passes → Docker image published → GitHub Release created → `cd.yml` deploy job fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)