### PR TITLE
fix: prune stopped containers and unused images after deploy

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -36,6 +36,12 @@ echo "--- restarting services ---"
 # Migrations run automatically in docker-entrypoint.sh on container start.
 docker compose up -d
 
+echo "--- pruning stopped containers and unused images ---"
+# Remove stopped containers (old versions) so their images become reclaimable.
+docker container prune -f
+# Remove dangling images (old pulled layers no longer tagged or referenced).
+docker image prune -f
+
 echo "--- deploy complete ---"
 docker compose ps
 REMOTE


### PR DESCRIPTION
## Summary

- After `docker compose up -d` detaches, old containers are stopped but not removed, which keeps their image layers referenced on disk.
- Adds `docker container prune -f` to remove those stopped containers immediately after the new services come up.
- Adds `docker image prune -f` to then remove the now-dangling old image layers.

This keeps disk usage in check on the droplet automatically after each deploy.

## Test plan

- [ ] Deploy to a droplet and verify `docker ps -a` shows no stopped glaze containers after deploy
- [ ] Verify `docker images` shows no dangling (`<none>`) image layers after deploy
- [ ] Verify new containers are running correctly after pruning

🤖 Generated with [Claude Code](https://claude.ai/claude-code)