### PR TITLE
Fix flaky async assertions in frontend component tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -348,6 +348,19 @@ The test environment is jsdom; setup file is [`web/src/test-setup.ts`](web/src/t
 
 **Component tests** that involve typing into a controlled MUI Autocomplete must use a stateful wrapper (see `Controlled` in `GlobalFieldPicker.test.tsx`) because `inputValue={value}` means the mock `onChange: vi.fn()` never updates the value, so the component never sees the typed text.
 
+**Avoiding flaky async assertions:** Never make a bare assertion immediately after a `waitFor` block — state updates triggered by async events may not have propagated yet. Wrap the follow-on assertion in its own `waitFor` call. Similarly, prefer `await userEvent.click(...)` over `fireEvent.click(...)` when the click handler triggers state updates, because `userEvent` dispatches the full browser event sequence and awaits its completion. The pattern to follow:
+```ts
+// ✅ correct
+await waitFor(() => expect(api.someCall).toHaveBeenCalled())
+await waitFor(() => expect(element).toHaveValue('expected'))
+await userEvent.click(screen.getByTestId('save-button'))
+
+// ❌ flaky — bare assertion after async work
+await waitFor(() => expect(api.someCall).toHaveBeenCalled())
+expect(element).toHaveValue('expected')             // may run before state update
+fireEvent.click(screen.getByTestId('save-button'))  // may miss queued microtasks
+```
+
 ### CI
 
 GitHub Actions runs all three suites (`common`, `backend`, `web`) in parallel on every push and pull request — see [`.github/workflows/ci-cd.yml`](.github/workflows/ci-cd.yml). A PR should not be merged if any job is red.

--- a/web/src/components/__tests__/NewPieceDialog.test.tsx
+++ b/web/src/components/__tests__/NewPieceDialog.test.tsx
@@ -71,7 +71,7 @@ describe('NewPieceDialog', () => {
             await waitFor(() =>
                 expect(api.createGlobalEntry).toHaveBeenCalledWith('location', 'name', 'Studio K')
             )
-            expect(locationInput).toHaveValue('Studio K')
+            await waitFor(() => expect(locationInput).toHaveValue('Studio K'))
         })
 
         it('renders the location field', () => {

--- a/web/src/components/__tests__/PieceDetail.test.tsx
+++ b/web/src/components/__tests__/PieceDetail.test.tsx
@@ -98,6 +98,7 @@ describe('PieceDetail', () => {
         await waitFor(() =>
             expect(api.createGlobalEntry).toHaveBeenCalledWith('location', 'name', 'Studio K')
         )
+        await waitFor(() => expect(input).toHaveValue('Studio K'))
         fireEvent.click(screen.getByTestId('save-button'))
         await waitFor(() =>
             expect(api.updatePiece).toHaveBeenCalledWith('piece-id-1', { current_location: 'Studio K' })
@@ -113,7 +114,7 @@ describe('PieceDetail', () => {
         renderPieceDetail(undefined, onPieceUpdated)
         const input = screen.getByLabelText('Current location')
         await userEvent.type(input, 'Studio 7')
-        fireEvent.click(screen.getByTestId('save-button'))
+        await userEvent.click(screen.getByTestId('save-button'))
         await waitFor(() =>
             expect(api.updatePiece).toHaveBeenCalledWith('piece-id-1', { current_location: 'Studio 7' })
         )
@@ -175,6 +176,7 @@ describe('PieceDetail', () => {
         const onPieceUpdated = vi.fn()
         renderPieceDetail(makePiece(), onPieceUpdated)
         fireEvent.click(screen.getByRole('button', { name: 'Wheel Thrown' }))
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument())
         fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
         await waitFor(() => expect(api.addPieceState).toHaveBeenCalledWith('piece-id-1', { state: 'wheel_thrown' }))
         await waitFor(() => expect(onPieceUpdated).toHaveBeenCalledWith(updated))

--- a/web/src/components/__tests__/WorkflowState.test.tsx
+++ b/web/src/components/__tests__/WorkflowState.test.tsx
@@ -317,7 +317,7 @@ describe('WorkflowState', () => {
         )
         const input = screen.getByLabelText('Current location')
         await userEvent.type(input, 'Shelf Z')
-        fireEvent.click(screen.getByTestId('save-button'))
+        await userEvent.click(screen.getByTestId('save-button'))
         await waitFor(() => expect(screen.getByText('Failed to save. Please try again.')).toBeInTheDocument())
         expect(screen.getByTestId('unsaved-indicator')).toBeInTheDocument()
         expect(screen.getByTestId('save-button')).not.toBeDisabled()


### PR DESCRIPTION
## Summary

- Wrap follow-on assertions in their own `waitFor` so they don't fire before React state updates propagate (NewPieceDialog, PieceDetail, WorkflowState)
- Replace `fireEvent.click` with `await userEvent.click` on save-button interactions so the full event sequence completes before the next assertion (PieceDetail, WorkflowState)
- Add a `waitFor` guard before clicking the Confirm transition button in PieceDetail so the button is in the DOM before the click fires

Also documents the correct pattern in AGENTS.md under **"Avoiding flaky async assertions"** to prevent recurrence.

## Test plan

- [x] `cd web && node_modules/.bin/vitest run` — 157 tests pass across 9 files
- [x] No changes to production code

🤖 Generated with [Claude Code](https://claude.ai/claude-code)