### PR TITLE
Migrate CD trigger from GitHub Release to workflow_run

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,21 +1,26 @@
 name: CD
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
 
 jobs:
   deploy:
     name: Deploy to droplet
     runs-on: ubuntu-latest
     environment: glaze-tailscale
+    if: github.event.workflow_run.conclusion == 'success'
     concurrency:
       group: deploy-production
-      cancel-in-progress: true
+      cancel-in-progress: false
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.release.target_commitish }}
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Set up SSH
         run: |
@@ -26,3 +31,12 @@ jobs:
 
       - name: Deploy
         run: ./deploy.sh "${{ vars.DEPLOY_HOST }}"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "release-${{ github.event.workflow_run.head_sha }}" \
+            --title "Build ${{ github.event.workflow_run.head_sha }}" \
+            --notes "Docker image: \`ghcr.io/shaoster/glaze:${{ github.event.workflow_run.head_sha }}\`" \
+            --latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,6 @@ jobs:
     needs: [common, backend, web, web-build]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
-      contents: write
       packages: write
     steps:
       - uses: actions/checkout@v5
@@ -143,15 +142,3 @@ jobs:
             VITE_GOOGLE_CLIENT_ID=${{ secrets.VITE_GOOGLE_CLIENT_ID }}
           labels: |
             org.opencontainers.image.revision=${{ github.sha }}
-
-      - name: Create GitHub Release
-        env:
-          # Must use a PAT here — releases created via GITHUB_TOKEN do not
-          # trigger other workflows (GitHub's anti-loop safety measure), so
-          # the release: published event in cd.yml would never fire.
-          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
-        run: |
-          gh release create "release-${{ github.sha }}" \
-            --title "Build ${{ github.sha }}" \
-            --notes "Docker image published: \`ghcr.io/shaoster/glaze:${{ github.sha }}\`" \
-            --latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,7 +363,7 @@ fireEvent.click(screen.getByTestId('save-button'))  // may miss queued microtask
 
 ### CI
 
-GitHub Actions runs all three suites (`common`, `backend`, `web`) in parallel on every push and pull request — see [`.github/workflows/ci-cd.yml`](.github/workflows/ci-cd.yml). A PR should not be merged if any job is red.
+GitHub Actions runs all three suites (`common`, `backend`, `web`) in parallel on every push and pull request — see [`.github/workflows/ci.yml`](.github/workflows/ci.yml). A PR should not be merged if any job is red.
 
 ### What to test
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ The repo ships a [`Dockerfile`](Dockerfile) and [`docker-compose.yml`](docker-co
 
 **How it works:**
 
-- Every push to `main` that passes all tests triggers a GitHub Actions `publish` job that builds the Docker image (with `VITE_GOOGLE_CLIENT_ID` baked in from a GitHub Actions secret) and pushes it to `ghcr.io/shaoster/glaze:latest`.
+- Every push to `main` that passes all tests triggers a GitHub Actions `publish` job ([`ci.yml`](.github/workflows/ci.yml)) that builds the Docker image (with `VITE_GOOGLE_CLIENT_ID` baked in from a GitHub Actions secret) and pushes it to `ghcr.io/shaoster/glaze:latest`. On success, [`cd.yml`](.github/workflows/cd.yml) automatically deploys the new image to the droplet and creates a GitHub release marking the deployed SHA.
 - The droplet never needs git, Node, or Python build tools — it just pulls the pre-built image.
 - Migrations run automatically inside the container on every start (via [`docker-entrypoint.sh`](docker-entrypoint.sh)).
 - Runtime secrets (`SECRET_KEY`, `DATABASE_URL`, `CLOUDINARY_*`, etc.) live only in `.env` on the droplet and are never part of the image.


### PR DESCRIPTION
## Summary

- Replaces the `release: published` trigger in `cd.yml` with `workflow_run` on CI completion, eliminating the `RELEASE_PAT` requirement — `GITHUB_TOKEN` is sufficient since `cd.yml` no longer listens for release events (no loop risk)
- Removes release creation and `contents: write` permission from `ci.yml`; `ci.yml` now only builds and pushes the Docker image
- Moves release creation to the end of the deploy job in `cd.yml`, so a GitHub release now means "successfully deployed" rather than "image published"
- Sets `cancel-in-progress: false` to prevent a concurrent `workflow_run` from cancelling an in-progress SSH deploy session mid-flight
- Fixes stale `ci-cd.yml` link in `AGENTS.md` and updates `README.md` to describe the two-workflow pipeline

## Cleanup

The `RELEASE_PAT` secret can be deleted from **Settings → Secrets and variables → Actions** — it is no longer referenced anywhere.

## Test plan

- [ ] Merge to main triggers CI (`ci.yml`), which on success triggers CD (`cd.yml`)
- [ ] CD deploys to droplet and creates a GitHub release using `GITHUB_TOKEN`
- [ ] A failed CI run does not trigger deployment (guarded by `conclusion == 'success'`)
- [ ] Two rapid merges to main queue deploys sequentially rather than cancelling mid-SSH

🤖 Generated with [Claude Code](https://claude.com/claude-code)