### PR TITLE
Standardize on American English spelling

### DIFF
--- a/.github/workflows/claude-pr-agent.yml
+++ b/.github/workflows/claude-pr-agent.yml
@@ -69,7 +69,7 @@ jobs:
             responding to the user's question or request. You MUST NOT modify, create, or
             delete any files — this PR does not have the 'claude' label. If their request
             requires code changes, let them know they can add the 'claude' label to this
-            PR to give you edit access, or open a new issue labelled 'claude' for you to
+            PR to give you edit access, or open a new issue labeled 'claude' for you to
             handle in a fresh PR.
 
   address-review-changes:

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ After setup, the app is reachable at `https://<droplet-name>.tail<id>.ts.net` fr
 | [`frontend_common/src/workflow.test.ts`](frontend_common/src/workflow.test.ts) | `formatWorkflowFieldLabel`, `getGlobalDisplayField`, `getAdditionalFieldDefinitions` (inline, state ref, global ref) — decoupled from real `workflow.yml` via `vi.mock` |
 | [`__tests__/GlobalFieldPicker.test.tsx`](web/src/components/__tests__/GlobalFieldPicker.test.tsx) | Rendering, internal fetch, provided options, create sentinel, inline creation (success/error), selecting existing |
 | [`__tests__/PieceList.test.tsx`](web/src/components/__tests__/PieceList.test.tsx) | Column headers, empty state, per-row data, links |
-| [`__tests__/NewPieceDialog.test.tsx`](web/src/components/__tests__/NewPieceDialog.test.tsx) | Rendering, name/notes/location/thumbnail, save/cancel behaviour |
+| [`__tests__/NewPieceDialog.test.tsx`](web/src/components/__tests__/NewPieceDialog.test.tsx) | Rendering, name/notes/location/thumbnail, save/cancel behavior |
 | [`__tests__/WorkflowState.test.tsx`](web/src/components/__tests__/WorkflowState.test.tsx) | Notes, additional fields (inline, state ref, global ref), location, save button, unsaved indicator |
 | [`__tests__/PieceDetail.test.tsx`](web/src/components/__tests__/PieceDetail.test.tsx) | Rendering, state transitions, confirmation dialog, location editing |
 

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ docker compose up -d
 
 Note: `VITE_GOOGLE_CLIENT_ID` is **not** set here — it is baked into the JS bundle at CI build time via the GitHub Actions secret.
 
-**Local overrides:** create `docker-compose.override.yml` (gitignored) to customise port bindings or mount volumes during local Docker testing without touching the main compose file.
+**Local overrides:** create `docker-compose.override.yml` (gitignored) to customize port bindings or mount volumes during local Docker testing without touching the main compose file.
 
 **Setting up Nginx + SSL (one-time, after first `docker compose up -d`):**
 

--- a/api/tests/test_glaze_combination_admin.py
+++ b/api/tests/test_glaze_combination_admin.py
@@ -1,8 +1,8 @@
-"""Tests for GlazeCombinationLayerInline admin behaviour.
+"""Tests for GlazeCombinationLayerInline admin behavior.
 
 Covers order assignment for new layers and reordering of existing layers via the
 adminsortable2-backed inline.  Tests use CustomInlineFormSet (the real formset
-class used by SortableInlineAdminMixin) to match runtime behaviour exactly.
+class used by SortableInlineAdminMixin) to match runtime behavior exactly.
 """
 import pytest
 from django.forms.models import inlineformset_factory

--- a/api/tests/test_globals.py
+++ b/api/tests/test_globals.py
@@ -198,7 +198,7 @@ class TestGlobalEntriesClayBody:
 
 
 # ---------------------------------------------------------------------------
-# Generic /api/globals/ endpoint — shared behaviour
+# Generic /api/globals/ endpoint — shared behavior
 # ---------------------------------------------------------------------------
 
 @pytest.mark.django_db

--- a/api/views.py
+++ b/api/views.py
@@ -292,7 +292,7 @@ def global_entries(request: Request, global_name: str) -> Response:
 )
 @api_view(['GET'])
 def cloudinary_widget_config(request: Request) -> Response:
-    """Return Cloudinary config needed to initialise the Upload Widget."""
+    """Return Cloudinary config needed to initialize the Upload Widget."""
     cloud_name = os.environ.get('CLOUDINARY_CLOUD_NAME')
     api_key = os.environ.get('CLOUDINARY_API_KEY')
     folder = os.environ.get('CLOUDINARY_UPLOAD_FOLDER', '').strip()

--- a/docs/agents/dev.md
+++ b/docs/agents/dev.md
@@ -26,7 +26,7 @@ All vars are optional. The app runs without any of them; each missing group degr
 
 **`.env.local`** (loaded by `source env.sh`, read by Django):
 
-| Variable | Absent behaviour |
+| Variable | Absent behavior |
 |---|---|
 | `CLOUDINARY_CLOUD_NAME` | `/api/uploads/cloudinary/widget-config/` returns 503; UI falls back to URL-paste mode |
 | `CLOUDINARY_API_KEY` | same as above |
@@ -36,7 +36,7 @@ All vars are optional. The app runs without any of them; each missing group degr
 
 **`web/.env.local`** (read by Vite, injected into the frontend bundle):
 
-| Variable | Absent behaviour |
+| Variable | Absent behavior |
 |---|---|
 | `VITE_GOOGLE_CLIENT_ID` | Google Sign-In button is not rendered; must match `GOOGLE_OAUTH_CLIENT_ID` |
 

--- a/docs/agents/django-drf-python.md
+++ b/docs/agents/django-drf-python.md
@@ -39,7 +39,7 @@ Django, Django REST Framework, SQLite (dev), django-cors-headers
 
 ## Production environment variables and settings
 
-Gate dev/prod behaviour on a single `IS_PRODUCTION` flag derived from one env var, rather than scattering `os.environ` checks throughout `settings.py`:
+Gate dev/prod behavior on a single `IS_PRODUCTION` flag derived from one env var, rather than scattering `os.environ` checks throughout `settings.py`:
 
 ```python
 IS_PRODUCTION = bool(os.environ.get('PRODUCTION', ''))
@@ -54,7 +54,7 @@ IS_PRODUCTION = bool(os.environ.get('PRODUCTION', ''))
 - Never add a new setting that requires a value in production without either gating it on `IS_PRODUCTION` or providing a safe, non-functional dev default (e.g. an empty string that disables the feature).
 - Optional integrations (OAuth, third-party APIs) should read from `os.environ.get('VAR', '')` and degrade gracefully when absent, so the dev environment works without credentials.
 
-See the project domain guide for the specific env vars and their per-environment behaviours in this codebase.
+See the project domain guide for the specific env vars and their per-environment behaviors in this codebase.
 
 ## Django admin customisation
 
@@ -116,7 +116,7 @@ import re
 print(re.findall(r'id="[^"]*-group"', html))
 ```
 
-**Check the extension's documentation first** — before scanning source code or guessing at behaviour, look up the relevant section in the library's docs. Many non-obvious constraints are documented explicitly. For example, adminsortable2 documents that unique constraints on ordering fields cause swap failures on SQLite and MySQL, and Django's admin docs explain the `formfield_for_dbfield` / `formfield_for_foreignkey` call order. Reading the docs first avoids a long debugging loop that the author has already solved.
+**Check the extension's documentation first** — before scanning source code or guessing at behavior, look up the relevant section in the library's docs. Many non-obvious constraints are documented explicitly. For example, adminsortable2 documents that unique constraints on ordering fields cause swap failures on SQLite and MySQL, and Django's admin docs explain the `formfield_for_dbfield` / `formfield_for_foreignkey` call order. Reading the docs first avoids a long debugging loop that the author has already solved.
 
 **Tracing a `formfield_for_*` method** — if you're not sure whether your override is being called, or what widget type it's actually receiving, monkey-patch it before making the request:
 
@@ -156,4 +156,4 @@ pytest api/
 
 - Every new API endpoint or serializer change → add or update tests.
 - Pure helper functions → unit test with `monkeypatch` to decouple from real data files or configuration.
-- Prefer the API client (`client.post(...)`) for tests that exercise request/response behaviour over creating objects directly via the ORM.
+- Prefer the API client (`client.post(...)`) for tests that exercise request/response behavior over creating objects directly via the ORM.

--- a/docs/agents/glaze-domain.md
+++ b/docs/agents/glaze-domain.md
@@ -2,7 +2,7 @@
 
 ## Language
 
-Use American English spelling throughout — in code, comments, documentation, and UI strings. For example: "behavior" not "behavior", "initialize" not "initialise", "labeled" not "labelled", "analyze" not "analyse".
+Use American English spelling throughout — in code, comments, documentation, and UI strings. For example: "behavior" not "behaviour", "initialize" not "initialise", "labeled" not "labelled", "analyze" not "analyse".
 
 ## Project Overview
 

--- a/docs/agents/glaze-domain.md
+++ b/docs/agents/glaze-domain.md
@@ -1,5 +1,9 @@
 # Glaze — Domain Logic
 
+## Language
+
+Use American English spelling throughout — in code, comments, documentation, and UI strings. For example: "behavior" not "behavior", "initialize" not "initialise", "labeled" not "labelled", "analyze" not "analyse".
+
 ## Project Overview
 
 Glaze is a pottery workflow tracking application. Users log each pottery piece and record state transitions as the piece moves through the production lifecycle — from throwing or handbuilding through firing, glazing, and finishing. The history of state transitions is the primary data product; it can be analyzed per-piece or in aggregate.
@@ -158,9 +162,9 @@ These supplement the generic Django/DRF conventions.
 
 All API endpoints are registered in `backend/urls.py`.
 
-**Production environment variables** — `settings.py` gates dev/prod behaviour on `IS_PRODUCTION = bool(os.environ.get('PRODUCTION', ''))`. The full env var reference:
+**Production environment variables** — `settings.py` gates dev/prod behavior on `IS_PRODUCTION = bool(os.environ.get('PRODUCTION', ''))`. The full env var reference:
 
-| Setting | Env var | Dev behaviour | Prod behaviour |
+| Setting | Env var | Dev behavior | Prod behavior |
 |---|---|---|---|
 | `SECRET_KEY` | `SECRET_KEY` | Falls back to an insecure hardcoded default | **Required** — raises `KeyError` if absent |
 | `DEBUG` | *(derived from `PRODUCTION`)* | `True` | `False` |
@@ -216,10 +220,10 @@ Name uniqueness for public globals is enforced with two conditional DB constrain
 - Updates user profile (name, picture) from Google on each login and creates a Django session.
 
 **Backend testing — Glaze-specific guidance:**
-- The `piece` fixture in `api/tests/conftest.py` creates a piece via the ORM directly; prefer the API client (`client.post(...)`) for tests that exercise request/response behaviour.
+- The `piece` fixture in `api/tests/conftest.py` creates a piece via the ORM directly; prefer the API client (`client.post(...)`) for tests that exercise request/response behavior.
 - Every new API endpoint or serializer change → add or update a test under `api/tests/`.
 - Every new or modified `api/workflow.py` helper → add or update a test in `api/tests/test_workflow_helpers.py`, patching `_STATE_MAP` / `_GLOBALS_MAP` via `monkeypatch`.
-- **New global domain models**: adding a new concrete `GlobalModel` subclass automatically enrolls it in the parameterised test suites in `api/tests/test_globals.py`. No manual test additions needed for registry invariants — focus new tests on model-specific constraints and API behaviour instead.
+- **New global domain models**: adding a new concrete `GlobalModel` subclass automatically enrolls it in the parameterised test suites in `api/tests/test_globals.py`. No manual test additions needed for registry invariants — focus new tests on model-specific constraints and API behavior instead.
 
 ---
 

--- a/frontend_common/src/workflow.ts
+++ b/frontend_common/src/workflow.ts
@@ -2,7 +2,7 @@
  * Shared web/mobile interface to the workflow.yml configuration.
  *
  * This module loads workflow.yml at build time and exposes typed helpers that
- * the web and mobile apps use to drive dynamic behaviour — field definitions
+ * the web and mobile apps use to drive dynamic behavior — field definitions
  * for per-state forms, display labels, and global type metadata. It is the
  * shared-app counterpart to the backend's `_STATE_MAP` / `_GLOBALS_MAP` in
  * `api/models.py`. Neither the state list nor the globals map should be

--- a/web/src/components/GlobalFieldPicker.tsx
+++ b/web/src/components/GlobalFieldPicker.tsx
@@ -12,7 +12,7 @@ const PUBLIC_SUFFIX = ' (public)'
 
 /**
  * Returns the display label for a global entry. When a public entry shares its
- * name with a private entry in the same list, the public entry is labelled with
+ * name with a private entry in the same list, the public entry is labeled with
  * a "(public)" suffix so users can distinguish the two.
  */
 function buildDisplayOptions(entries: GlobalEntry[]): string[] {

--- a/web/src/components/__tests__/ImageLightbox.test.tsx
+++ b/web/src/components/__tests__/ImageLightbox.test.tsx
@@ -125,7 +125,7 @@ describe('ImageLightbox', () => {
         })
     })
 
-    describe('close behaviour', () => {
+    describe('close behavior', () => {
         it('calls onClose when backdrop is clicked', () => {
             const { onClose } = renderLightbox(THREE_IMAGES, 0)
             // The outer Box has onClick={onClose}; click parent of the <img>

--- a/web/src/components/__tests__/NewPieceDialog.test.tsx
+++ b/web/src/components/__tests__/NewPieceDialog.test.tsx
@@ -117,7 +117,7 @@ describe('NewPieceDialog', () => {
         })
     })
 
-    describe('cancel / close behaviour', () => {
+    describe('cancel / close behavior', () => {
         it('calls onClose immediately when no changes have been made', async () => {
             render(<NewPieceDialog {...defaultProps} />)
             await userEvent.click(screen.getByRole('button', { name: 'Cancel' }))


### PR DESCRIPTION
## Summary

- Add a "Language" section to `docs/agents/glaze-domain.md` stating that American English spelling should be used throughout — in code, comments, docs, and UI strings
- Scan the codebase for British spellings and fix all occurrences found: `behaviour` → `behavior`, `initialise` → `initialize`, `labelled` → `labeled`

## Files changed

| File | Change |
|---|---|
| `docs/agents/glaze-domain.md` | Added American English rule; fixed `behaviour` |
| `docs/agents/dev.md` | `behaviour` → `behavior` |
| `docs/agents/django-drf-python.md` | `behaviour` → `behavior` |
| `README.md` | `behaviour` → `behavior` |
| `api/views.py` | `initialise` → `initialize` |
| `api/tests/test_glaze_combination_admin.py` | `behaviour` → `behavior` |
| `api/tests/test_globals.py` | `behaviour` → `behavior` |
| `frontend_common/src/workflow.ts` | `behaviour` → `behavior` |
| `web/src/components/GlobalFieldPicker.tsx` | `labelled` → `labeled` |
| `web/src/components/__tests__/NewPieceDialog.test.tsx` | `behaviour` → `behavior` |
| `web/src/components/__tests__/ImageLightbox.test.tsx` | `behaviour` → `behavior` |
| `.github/workflows/claude-pr-agent.yml` | `labelled` → `labeled` |

## Test plan

- [ ] No functional changes — spelling fixes only in comments, docs, and string literals
- [ ] All test suites (`pytest tests/`, `pytest api/`, `npm test`) still pass

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)
