### PR TITLE
Fix four UI bugs in GlazeCombinationPicker

### DIFF
--- a/docs/agents/typescript-react-vite.md
+++ b/docs/agents/typescript-react-vite.md
@@ -95,6 +95,8 @@ function useAsync<T>(asyncFunction: () => Promise<T>, immediate = true) {
 - Use `slotProps={{ htmlInput: { ... } }}` on MUI `TextField` — the `inputProps` prop is deprecated in MUI v7.
 - Module-level constants should be named in `ALL_CAPS_SNAKE_CASE`. This applies to both exported constants and internal ones.
 - All HTTP calls should go through a shared API module. This is the single place where wire types (ISO date strings, etc.) are mapped to domain types. Components must never perform their own serialization or deserialization — they receive fully-typed domain objects and call API functions to write data.
+- When passing references to backend API calls, always use the object's `id`/`pk` rather than a human-readable name field. Names are not stable identifiers and can collide across scopes (e.g. public vs. private objects). Reserve names only for display.
+- MUI `Dialog` components should have a fixed size derived from the viewport (e.g. `PaperProps={{ sx: { height: '80vh' } }}`), not a size that expands and contracts with dynamic content. Fix the height and let the scrollable content region (`DialogContent` with `overflowY: 'auto'`) adapt. Exception: lightbox-style dialogs where the container is inherently sized to a static image or caption.
 - Configure Axios with `axios.create({ baseURL: import.meta.env.VITE_API_URL })` rather than constructing URLs ad hoc. Use interceptors for cross-cutting concerns (auth headers, error normalisation) rather than repeating that logic at each call site.
 - Use `lazy` + `Suspense` for route-level code splitting to keep the initial bundle small:
   ```tsx

--- a/web/src/components/GlazeCombinationPicker.tsx
+++ b/web/src/components/GlazeCombinationPicker.tsx
@@ -103,7 +103,7 @@ export default function GlazeCombinationPicker({ open, onClose, onSelect }: Glaz
     useEffect(() => {
         if (!open) return
         fetchGlobalEntries('glaze_type')
-            .then((entries) => setAllGlazeTypes(entries.map((e) => ({ id: e.name, name: e.name }))))
+            .then((entries) => setAllGlazeTypes(entries.map((e) => ({ id: e.id, name: e.name }))))
             .catch(() => {})
         fetchGlobalEntries('firing_temperature')
             .then((entries) => setAllFiringTemperatures(entries.map((e) => ({ id: e.id, name: e.name }))))
@@ -151,9 +151,16 @@ export default function GlazeCombinationPicker({ open, onClose, onSelect }: Glaz
     const visible = filters.onlyFavorites ? combinations.filter((c) => c.isFavorite) : combinations
 
     return (
-        <Dialog open={open} onClose={handleClose} maxWidth="md" fullWidth>
+        <Dialog
+            open={open}
+            onClose={handleClose}
+            maxWidth="md"
+            fullWidth
+            PaperProps={{ sx: { height: '85vh', display: 'flex', flexDirection: 'column' } }}
+        >
             <DialogTitle>Browse Glaze Combinations</DialogTitle>
-            <DialogContent>
+            {/* Filters — sticky, never scroll away */}
+            <Box sx={{ px: 3, pt: 1, pb: 2, flexShrink: 0, borderBottom: 1, borderColor: 'divider' }}>
                 <Stack spacing={2}>
                     {/* Glaze type filter */}
                     <Autocomplete
@@ -180,35 +187,40 @@ export default function GlazeCombinationPicker({ open, onClose, onSelect }: Glaz
                         size="small"
                     />
 
-                    {/* Boolean property filters */}
-                    <FormGroup row sx={{ gap: 1 }}>
+                    {/* Boolean property filters — each field has its own labelled group */}
+                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
                         {(Object.entries(BOOL_FILTER_LABELS) as [NullableBoolField, string][]).map(
                             ([field, label]) => (
-                                <Box key={field} sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                                    <FormControlLabel
-                                        label={`${label}: yes`}
-                                        control={
-                                            <Checkbox
-                                                size="small"
-                                                checked={filters[field] === true}
-                                                onChange={(e) => handleBoolFilter(field, e.target.checked, true)}
-                                            />
-                                        }
-                                    />
-                                    <FormControlLabel
-                                        label="no"
-                                        control={
-                                            <Checkbox
-                                                size="small"
-                                                checked={filters[field] === false}
-                                                onChange={(e) => handleBoolFilter(field, e.target.checked, false)}
-                                            />
-                                        }
-                                    />
+                                <Box key={field}>
+                                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.25 }}>
+                                        {label}
+                                    </Typography>
+                                    <FormGroup row>
+                                        <FormControlLabel
+                                            label="Yes"
+                                            control={
+                                                <Checkbox
+                                                    size="small"
+                                                    checked={filters[field] === true}
+                                                    onChange={(e) => handleBoolFilter(field, e.target.checked, true)}
+                                                />
+                                            }
+                                        />
+                                        <FormControlLabel
+                                            label="No"
+                                            control={
+                                                <Checkbox
+                                                    size="small"
+                                                    checked={filters[field] === false}
+                                                    onChange={(e) => handleBoolFilter(field, e.target.checked, false)}
+                                                />
+                                            }
+                                        />
+                                    </FormGroup>
                                 </Box>
                             )
                         )}
-                    </FormGroup>
+                    </Box>
 
                     {/* Only favorites toggle */}
                     <FormControlLabel
@@ -222,19 +234,22 @@ export default function GlazeCombinationPicker({ open, onClose, onSelect }: Glaz
                         }
                         label="Only favorites"
                     />
+                </Stack>
+            </Box>
 
-                    {/* Results */}
-                    {loading ? (
-                        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
-                            <CircularProgress />
-                        </Box>
-                    ) : visible.length === 0 ? (
-                        <Typography color="text.secondary" sx={{ py: 2, textAlign: 'center' }}>
-                            No combinations match the current filters.
-                        </Typography>
-                    ) : (
-                        <Stack spacing={1}>
-                            {visible.map((combo) => (
+            {/* Scrollable results */}
+            <DialogContent sx={{ flex: 1, overflowY: 'auto', pt: 2 }}>
+                {loading ? (
+                    <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+                        <CircularProgress />
+                    </Box>
+                ) : visible.length === 0 ? (
+                    <Typography color="text.secondary" sx={{ py: 2, textAlign: 'center' }}>
+                        No combinations match the current filters.
+                    </Typography>
+                ) : (
+                    <Stack spacing={1}>
+                        {visible.map((combo) => (
                                 <Box
                                     key={combo.id}
                                     onClick={() => {
@@ -315,7 +330,6 @@ export default function GlazeCombinationPicker({ open, onClose, onSelect }: Glaz
                             ))}
                         </Stack>
                     )}
-                </Stack>
             </DialogContent>
             <DialogActions>
                 <Button onClick={handleClose}>Cancel</Button>


### PR DESCRIPTION
## Summary

- **Fixed scrolling**: Dialog is now `85vh` tall with a flex column layout. Filters are pinned in a sticky section; only the results list scrolls.
- **Fixed label occlusion**: Filter controls were moved out of `DialogContent` into a dedicated `Box`, so the MUI floating label on the glaze type input no longer gets clipped by the dialog title.
- **Improved boolean grouping**: Each boolean filter (`Food safe`, `Runs`, etc.) now renders as its own group with a caption label above and clearly labelled **Yes** / **No** checkboxes below, instead of a flat undifferentiated run.
- **Fixed glaze type filter**: `allGlazeTypes` was mapping `e.name` as the `id`, so the frontend was sending glaze type names to the backend instead of PKs. The backend's `layers__glaze_type_id` filter expects PKs — changed to `e.id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
