### PR TITLE
Add filterable/favoritable/compose_from workflow engine helpers

### DIFF
--- a/api/tests/test_workflow_helpers.py
+++ b/api/tests/test_workflow_helpers.py
@@ -119,6 +119,32 @@ _MOCK_GLOBALS_MAP = {
             'name': {'type': 'string'},
         },
     },
+    'glaze_combination': {
+        'model': 'GlazeCombination',
+        'public': True,
+        'private': True,
+        'favoritable': True,
+        'compose_from': {
+            'glaze_types': {
+                'global': 'glaze_type',
+                'ordered': True,
+            },
+        },
+        'fields': {
+            'name': {'type': 'string'},
+            'is_food_safe': {'type': 'boolean', 'filterable': True},
+            'runs': {'type': 'boolean', 'filterable': True},
+            'test_tile_image': {'type': 'image'},
+        },
+    },
+    'glaze_type': {
+        'model': 'GlazeType',
+        'public': True,
+        'private': True,
+        'fields': {
+            'name': {'type': 'string'},
+        },
+    },
 }
 
 
@@ -214,17 +240,28 @@ def test_is_private_global_defaults_to_true_for_unknown_global(monkeypatch):
 
 def test_get_public_global_models_returns_models_for_public_globals(monkeypatch):
     clay_model = Mock(name='ClayBodyModel')
+    glaze_combination_model = Mock(name='GlazeCombinationModel')
+    glaze_type_model = Mock(name='GlazeTypeModel')
     admin_only_model = Mock(name='AdminOnlyModel')
-    get_model = Mock(side_effect=lambda app, name: clay_model if name == 'ClayBody' else admin_only_model)
+
+    def _get_model(app, name):
+        return {
+            'ClayBody': clay_model,
+            'GlazeCombination': glaze_combination_model,
+            'GlazeType': glaze_type_model,
+        }.get(name, admin_only_model)
+
     monkeypatch.setattr(workflow_module, '_GLOBALS_MAP', _MOCK_GLOBALS_MAP)
-    monkeypatch.setattr(workflow_module.apps, 'get_model', get_model)
+    monkeypatch.setattr(workflow_module.apps, 'get_model', _get_model)
 
     result = workflow_module.get_public_global_models()
 
-    # clay_body and admin_only_type both have public: true in _MOCK_GLOBALS_MAP.
+    # clay_body, admin_only_type, glaze_combination, and glaze_type all have public: true.
     assert clay_model in result
+    assert glaze_combination_model in result
+    assert glaze_type_model in result
     assert admin_only_model in result
-    assert len(result) == 2
+    assert len(result) == 4
 
 
 def test_get_image_fields_for_global_model_returns_image_fields(monkeypatch):
@@ -301,3 +338,67 @@ def test_build_additional_fields_schema_resolves_state_refs_recursively(monkeypa
         },
         'additionalProperties': False,
     }
+
+
+# ---------------------------------------------------------------------------
+# get_filterable_fields
+# ---------------------------------------------------------------------------
+
+def test_get_filterable_fields_returns_filterable_fields(monkeypatch):
+    monkeypatch.setattr(workflow_module, '_GLOBALS_MAP', _MOCK_GLOBALS_MAP)
+    result = workflow_module.get_filterable_fields('glaze_combination')
+    assert set(result) == {'is_food_safe', 'runs'}
+
+
+def test_get_filterable_fields_returns_empty_when_no_filterable_fields(monkeypatch):
+    monkeypatch.setattr(workflow_module, '_GLOBALS_MAP', _MOCK_GLOBALS_MAP)
+    assert workflow_module.get_filterable_fields('location') == []
+
+
+def test_get_filterable_fields_returns_empty_for_unknown_global(monkeypatch):
+    monkeypatch.setattr(workflow_module, '_GLOBALS_MAP', _MOCK_GLOBALS_MAP)
+    assert workflow_module.get_filterable_fields('does_not_exist') == []
+
+
+# ---------------------------------------------------------------------------
+# is_favoritable_global
+# ---------------------------------------------------------------------------
+
+def test_is_favoritable_global_returns_true_when_flag_set(monkeypatch):
+    monkeypatch.setattr(workflow_module, '_GLOBALS_MAP', _MOCK_GLOBALS_MAP)
+    assert workflow_module.is_favoritable_global('glaze_combination') is True
+
+
+def test_is_favoritable_global_returns_false_when_flag_absent(monkeypatch):
+    monkeypatch.setattr(workflow_module, '_GLOBALS_MAP', _MOCK_GLOBALS_MAP)
+    assert workflow_module.is_favoritable_global('location') is False
+
+
+def test_is_favoritable_global_returns_false_for_unknown_global(monkeypatch):
+    monkeypatch.setattr(workflow_module, '_GLOBALS_MAP', _MOCK_GLOBALS_MAP)
+    assert workflow_module.is_favoritable_global('does_not_exist') is False
+
+
+# ---------------------------------------------------------------------------
+# get_compose_from
+# ---------------------------------------------------------------------------
+
+def test_get_compose_from_returns_declaration_when_present(monkeypatch):
+    monkeypatch.setattr(workflow_module, '_GLOBALS_MAP', _MOCK_GLOBALS_MAP)
+    result = workflow_module.get_compose_from('glaze_combination')
+    assert result == {
+        'glaze_types': {
+            'global': 'glaze_type',
+            'ordered': True,
+        },
+    }
+
+
+def test_get_compose_from_returns_none_when_absent(monkeypatch):
+    monkeypatch.setattr(workflow_module, '_GLOBALS_MAP', _MOCK_GLOBALS_MAP)
+    assert workflow_module.get_compose_from('location') is None
+
+
+def test_get_compose_from_returns_none_for_unknown_global(monkeypatch):
+    monkeypatch.setattr(workflow_module, '_GLOBALS_MAP', _MOCK_GLOBALS_MAP)
+    assert workflow_module.get_compose_from('does_not_exist') is None

--- a/api/workflow.py
+++ b/api/workflow.py
@@ -117,6 +117,43 @@ def get_image_fields_for_global_model(model_cls: type[django_models.Model]) -> l
     return []
 
 
+def get_filterable_fields(global_name: str) -> list[str]:
+    """Return field names declared as filterable: true for a given global.
+
+    Used by the generic filter view logic to discover which fields to accept
+    as query-param filter criteria for a global type's list endpoint.
+    Returns an empty list for unknown globals or globals with no filterable fields.
+    """
+    config = _GLOBALS_MAP.get(global_name, {})
+    return [
+        field_name
+        for field_name, field_def in config.get('fields', {}).items()
+        if field_def.get('filterable', False)
+    ]
+
+
+def is_favoritable_global(global_name: str) -> bool:
+    """Return True if the global declares favoritable: true.
+
+    Favoritable globals support per-user favorites via
+    POST/DELETE /api/globals/<global_name>/<pk>/favorite/.
+    """
+    config = _GLOBALS_MAP.get(global_name, {})
+    return bool(config.get('favoritable', False))
+
+
+def get_compose_from(global_name: str) -> dict | None:
+    """Return the compose_from declaration for a global, or None.
+
+    compose_from declares ordered M2M composition relationships — e.g.
+    GlazeCombination is composed from an ordered list of GlazeTypes.
+    Used by model/admin generation and frontend composition pickers.
+    Returns None if the global is unknown or has no compose_from key.
+    """
+    config = _GLOBALS_MAP.get(global_name, {})
+    return config.get('compose_from') or None
+
+
 def _resolve_field_def(field_def: dict) -> dict:
     """Recursively resolve a DSL field_def to its effective JSON Schema property dict.
 

--- a/frontend_common/src/workflow.test.ts
+++ b/frontend_common/src/workflow.test.ts
@@ -34,11 +34,15 @@ vi.mock('../../workflow.yml', () => ({
             },
             glaze_combination: {
                 model: 'GlazeCombination',
+                favoritable: true,
                 compose_from: {
                     glaze_types: { global: 'glaze_type' },
                 },
                 fields: {
                     name: { type: 'string' },
+                    is_food_safe: { type: 'boolean', filterable: true },
+                    runs: { type: 'boolean', filterable: true },
+                    test_tile_image: { type: 'image' },
                 },
             },
         },
@@ -127,8 +131,10 @@ vi.mock('../../workflow.yml', () => ({
 import {
     formatWorkflowFieldLabel,
     getAdditionalFieldDefinitions,
+    getFilterableFields,
     getGlobalComposeFrom,
     getGlobalDisplayField,
+    isFavoritableGlobal,
 } from './workflow'
 
 describe('formatWorkflowFieldLabel', () => {
@@ -258,5 +264,41 @@ describe('getAdditionalFieldDefinitions', () => {
             const fields = getAdditionalFieldDefinitions('submitted_to_bisque_fire')
             expect(fields.find((f) => f.name === 'kiln_location')!.isStateRef).toBe(false)
         })
+    })
+})
+
+describe('getFilterableFields', () => {
+    it('returns names of fields with filterable: true', () => {
+        expect(getFilterableFields('glaze_combination')).toEqual(
+            expect.arrayContaining(['is_food_safe', 'runs'])
+        )
+    })
+
+    it('does not include non-filterable fields', () => {
+        const fields = getFilterableFields('glaze_combination')
+        expect(fields).not.toContain('name')
+        expect(fields).not.toContain('test_tile_image')
+    })
+
+    it('returns an empty array when no fields are filterable', () => {
+        expect(getFilterableFields('location')).toEqual([])
+    })
+
+    it('returns an empty array for an unknown global', () => {
+        expect(getFilterableFields('nonexistent')).toEqual([])
+    })
+})
+
+describe('isFavoritableGlobal', () => {
+    it('returns true for a global with favoritable: true', () => {
+        expect(isFavoritableGlobal('glaze_combination')).toBe(true)
+    })
+
+    it('returns false for a global without the favoritable flag', () => {
+        expect(isFavoritableGlobal('location')).toBe(false)
+    })
+
+    it('returns false for an unknown global', () => {
+        expect(isFavoritableGlobal('nonexistent')).toBe(false)
     })
 })

--- a/frontend_common/src/workflow.ts
+++ b/frontend_common/src/workflow.ts
@@ -17,6 +17,7 @@ interface InlineFieldDef {
     description?: string
     required?: boolean
     enum?: string[]
+    filterable?: boolean
 }
 
 interface StateRefFieldDef {
@@ -49,6 +50,7 @@ export interface ComposeFromEntry {
 interface WorkflowGlobalDefinition {
     model: string
     description?: string
+    favoritable?: boolean
     compose_from?: Record<string, ComposeFromEntry>
     fields: Record<string, InlineFieldDef | GlobalRefFieldDef>
 }
@@ -89,6 +91,28 @@ export type ResolvedAdditionalField = {
  */
 export function getGlobalComposeFrom(globalName: string): Record<string, ComposeFromEntry> | undefined {
     return GLOBALS_MAP[globalName]?.compose_from
+}
+
+/**
+ * Returns the field names declared as filterable: true for a given global.
+ * Used by pickers (e.g. GlazeCombinationPicker) to discover which fields to
+ * expose as filter controls without hardcoding them in the component.
+ * Mirrors the backend's `get_filterable_fields` helper.
+ */
+export function getFilterableFields(globalName: string): string[] {
+    const fields = GLOBALS_MAP[globalName]?.fields ?? {}
+    return Object.entries(fields)
+        .filter(([, def]) => 'filterable' in def && (def as InlineFieldDef).filterable)
+        .map(([name]) => name)
+}
+
+/**
+ * Returns true if the global declares favoritable: true — i.e. it supports
+ * per-user favorites via POST/DELETE /api/globals/<name>/<pk>/favorite/.
+ * Mirrors the backend's `is_favoritable_global` helper.
+ */
+export function isFavoritableGlobal(globalName: string): boolean {
+    return !!(GLOBALS_MAP[globalName] as WorkflowGlobalDefinition | undefined)?.favoritable
 }
 
 /**

--- a/workflow.schema.yml
+++ b/workflow.schema.yml
@@ -70,6 +70,13 @@ $defs:
           Whether this global type supports user-private instances.
           Private objects are owned by a specific user and invisible to others.
         default: true
+      favoritable:
+        type: boolean
+        description: |
+          Whether this global type supports per-user favorites. When true,
+          authenticated users can mark individual entries as favorites via
+          POST/DELETE /api/globals/<global_name>/<pk>/favorite/.
+        default: false
       compose_from:
         type: object
         description: |
@@ -204,6 +211,13 @@ $defs:
         minItems: 1
         items: {}
         uniqueItems: true
+      filterable:
+        type: boolean
+        description: |
+          Whether this field can be used as a filter criterion in list views.
+          Intended for boolean fields; consumers use get_filterable_fields() /
+          getFilterableFields() to discover which fields to expose as filter controls.
+        default: false
 
   state_ref_field:
     type: object

--- a/workflow.yml
+++ b/workflow.yml
@@ -171,6 +171,7 @@ globals:
     description: An ordered combination of one or more glaze layers with shared application properties.
     public: true
     private: true
+    favoritable: true
     compose_from:
       glaze_types:
         global: glaze_type
@@ -193,15 +194,19 @@ globals:
       is_food_safe:
         type: boolean
         description: Whether this glaze combination is food safe.
+        filterable: true
       runs:
         type: boolean
         description: Whether this combination runs during firing.
+        filterable: true
       highlights_grooves:
         type: boolean
         description: Whether this combination highlights surface grooves and texture.
+        filterable: true
       is_different_on_white_and_brown_clay:
         type: boolean
         description: Whether the combination appears different on white versus brown clay.
+        filterable: true
 
 # Built-in states for standard workflow.
 states:


### PR DESCRIPTION
## Summary

- Adds `filterable: true` to boolean filter fields on `glaze_combination` in `workflow.yml` (`is_food_safe`, `runs`, `highlights_grooves`, `is_different_on_white_and_brown_clay`) and `favoritable: true` on the global itself; both new keys are validated by `workflow.schema.yml`.
- Adds three new helpers to `api/workflow.py`: `get_filterable_fields(global_name)`, `is_favoritable_global(global_name)`, `get_compose_from(global_name)`.
- Adds two new exports to `frontend_common/src/workflow.ts`: `getFilterableFields(globalName)`, `isFavoritableGlobal(globalName)`.
- All new helpers are covered by tests in `api/tests/test_workflow_helpers.py` and `frontend_common/src/workflow.test.ts` using the existing monkeypatch/vi.mock patterns.

Note: `build_additional_fields_schema` (already in `api/workflow.py`) satisfies the `get_additional_field_schema` checklist item; `getGlobalComposeFrom` (already in `workflow.ts`) satisfies the `getComposeFrom` checklist item. No renames — callers already use the existing names.

## Test plan

- [x] `pytest tests/ api/` — 282 passed
- [x] `vitest run` (web) — 182 passed across 10 test files

Closes #97
