### PR TITLE
Derive filterable field metadata from workflow.yml (closes #81)

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -13,6 +13,7 @@ from .workflow import (
     VALID_STATES,
     WORKFLOW_VERSION,
     build_additional_fields_schema,
+    get_filterable_fields,
     get_global_model_and_field,
     get_state_ref_fields,
 )
@@ -350,14 +351,13 @@ class GlazeCombination(GlobalModel):
             GlazeCombinationLayer.objects.create(combination=obj, glaze_type=gt, order=order)
 
     # Declares which fields are exposed as query-param filters in the global_entries view.
-    # - boolean fields: filtered by ?field=true or ?field=false
-    # - m2m_id fields: filtered by ?param=id1,id2,... (combination must contain ALL listed IDs)
-    # TODO: derive this from workflow.yml field metadata (https://github.com/shaoster/glaze/issues/81)
+    # Boolean fields are derived from workflow.yml (filterable: true entries).
+    # Relational filters (m2m_id, fk_id) use ORM lookups not expressible in workflow.yml
+    # and are declared explicitly here.
     filterable_fields: dict[str, dict] = {
-        'is_food_safe': {'type': 'boolean'},
-        'runs': {'type': 'boolean'},
-        'highlights_grooves': {'type': 'boolean'},
-        'is_different_on_white_and_brown_clay': {'type': 'boolean'},
+        # Derived from workflow.yml — boolean property filters.
+        **{k: {'type': 'boolean'} for k in get_filterable_fields('glaze_combination')},
+        # Relational filters that require custom ORM lookups and param names.
         'layers__glaze_type_id': {'type': 'm2m_id', 'param': 'glaze_type_ids'},
         'firing_temperature_id': {'type': 'fk_id', 'param': 'firing_temperature_id'},
     }

--- a/api/tests/test_workflow_helpers.py
+++ b/api/tests/test_workflow_helpers.py
@@ -132,8 +132,8 @@ _MOCK_GLOBALS_MAP = {
         },
         'fields': {
             'name': {'type': 'string'},
-            'is_food_safe': {'type': 'boolean', 'filterable': True},
-            'runs': {'type': 'boolean', 'filterable': True},
+            'is_food_safe': {'type': 'boolean', 'filterable': True, 'label': 'Food safe'},
+            'runs': {'type': 'boolean', 'filterable': True, 'label': 'Runs'},
             'test_tile_image': {'type': 'image'},
         },
     },
@@ -347,17 +347,19 @@ def test_build_additional_fields_schema_resolves_state_refs_recursively(monkeypa
 def test_get_filterable_fields_returns_filterable_fields(monkeypatch):
     monkeypatch.setattr(workflow_module, '_GLOBALS_MAP', _MOCK_GLOBALS_MAP)
     result = workflow_module.get_filterable_fields('glaze_combination')
-    assert set(result) == {'is_food_safe', 'runs'}
+    assert set(result.keys()) == {'is_food_safe', 'runs'}
+    assert result['is_food_safe'] == {'type': 'boolean', 'label': 'Food safe'}
+    assert result['runs'] == {'type': 'boolean', 'label': 'Runs'}
 
 
 def test_get_filterable_fields_returns_empty_when_no_filterable_fields(monkeypatch):
     monkeypatch.setattr(workflow_module, '_GLOBALS_MAP', _MOCK_GLOBALS_MAP)
-    assert workflow_module.get_filterable_fields('location') == []
+    assert workflow_module.get_filterable_fields('location') == {}
 
 
 def test_get_filterable_fields_returns_empty_for_unknown_global(monkeypatch):
     monkeypatch.setattr(workflow_module, '_GLOBALS_MAP', _MOCK_GLOBALS_MAP)
-    assert workflow_module.get_filterable_fields('does_not_exist') == []
+    assert workflow_module.get_filterable_fields('does_not_exist') == {}
 
 
 # ---------------------------------------------------------------------------

--- a/api/workflow.py
+++ b/api/workflow.py
@@ -117,19 +117,25 @@ def get_image_fields_for_global_model(model_cls: type[django_models.Model]) -> l
     return []
 
 
-def get_filterable_fields(global_name: str) -> list[str]:
-    """Return field names declared as filterable: true for a given global.
+def get_filterable_fields(global_name: str) -> dict[str, dict]:
+    """Return filterable field metadata for a given global.
 
-    Used by the generic filter view logic to discover which fields to accept
-    as query-param filter criteria for a global type's list endpoint.
-    Returns an empty list for unknown globals or globals with no filterable fields.
+    Returns a dict mapping field_name -> {type, label} for every field
+    declared with filterable: true in workflow.yml. Used by:
+    - the generic filter view logic (discover which query-params to accept)
+    - model classes (derive filterable_fields without hardcoding)
+
+    Returns an empty dict for unknown globals or globals with no filterable fields.
     """
     config = _GLOBALS_MAP.get(global_name, {})
-    return [
-        field_name
+    return {
+        field_name: {
+            k: v for k, v in field_def.items()
+            if k in ('type', 'label')
+        }
         for field_name, field_def in config.get('fields', {}).items()
         if field_def.get('filterable', False)
-    ]
+    }
 
 
 def is_favoritable_global(global_name: str) -> bool:

--- a/frontend_common/src/workflow.test.ts
+++ b/frontend_common/src/workflow.test.ts
@@ -40,8 +40,8 @@ vi.mock('../../workflow.yml', () => ({
                 },
                 fields: {
                     name: { type: 'string' },
-                    is_food_safe: { type: 'boolean', filterable: true },
-                    runs: { type: 'boolean', filterable: true },
+                    is_food_safe: { type: 'boolean', filterable: true, label: 'Food safe' },
+                    runs: { type: 'boolean', filterable: true, label: 'Runs' },
                     test_tile_image: { type: 'image' },
                 },
             },
@@ -268,16 +268,24 @@ describe('getAdditionalFieldDefinitions', () => {
 })
 
 describe('getFilterableFields', () => {
-    it('returns names of fields with filterable: true', () => {
-        expect(getFilterableFields('glaze_combination')).toEqual(
-            expect.arrayContaining(['is_food_safe', 'runs'])
-        )
+    it('returns metadata for fields with filterable: true', () => {
+        const fields = getFilterableFields('glaze_combination')
+        const names = fields.map((f) => f.name)
+        expect(names).toEqual(expect.arrayContaining(['is_food_safe', 'runs']))
+    })
+
+    it('includes type and label for each filterable field', () => {
+        const fields = getFilterableFields('glaze_combination')
+        const foodSafe = fields.find((f) => f.name === 'is_food_safe')!
+        expect(foodSafe.type).toBe('boolean')
+        expect(foodSafe.label).toBe('Food safe')
     })
 
     it('does not include non-filterable fields', () => {
         const fields = getFilterableFields('glaze_combination')
-        expect(fields).not.toContain('name')
-        expect(fields).not.toContain('test_tile_image')
+        const names = fields.map((f) => f.name)
+        expect(names).not.toContain('name')
+        expect(names).not.toContain('test_tile_image')
     })
 
     it('returns an empty array when no fields are filterable', () => {

--- a/frontend_common/src/workflow.ts
+++ b/frontend_common/src/workflow.ts
@@ -18,6 +18,7 @@ interface InlineFieldDef {
     required?: boolean
     enum?: string[]
     filterable?: boolean
+    label?: string
 }
 
 interface StateRefFieldDef {
@@ -93,17 +94,26 @@ export function getGlobalComposeFrom(globalName: string): Record<string, Compose
     return GLOBALS_MAP[globalName]?.compose_from
 }
 
+export interface FilterableFieldDef {
+    name: string
+    type: FieldType
+    label: string
+}
+
 /**
- * Returns the field names declared as filterable: true for a given global.
+ * Returns metadata for fields declared as filterable: true for a given global.
  * Used by pickers (e.g. GlazeCombinationPicker) to discover which fields to
- * expose as filter controls without hardcoding them in the component.
+ * expose as filter controls without hardcoding labels or field names in the component.
  * Mirrors the backend's `get_filterable_fields` helper.
  */
-export function getFilterableFields(globalName: string): string[] {
+export function getFilterableFields(globalName: string): FilterableFieldDef[] {
     const fields = GLOBALS_MAP[globalName]?.fields ?? {}
     return Object.entries(fields)
         .filter(([, def]) => 'filterable' in def && (def as InlineFieldDef).filterable)
-        .map(([name]) => name)
+        .map(([name, def]) => {
+            const inline = def as InlineFieldDef
+            return { name, type: inline.type, label: inline.label ?? formatWorkflowFieldLabel(name) }
+        })
 }
 
 /**

--- a/web/src/components/GlazeCombinationPicker.tsx
+++ b/web/src/components/GlazeCombinationPicker.tsx
@@ -26,7 +26,10 @@ import {
     type GlazeCombinationFilters,
     type GlazeTypeRef,
 } from '@common/api'
+import { getFilterableFields } from '@common/workflow'
 import CloudinaryImage from './CloudinaryImage'
+
+const BOOL_FILTERABLE_FIELDS = getFilterableFields('glaze_combination')
 
 export interface GlazeCombinationPickerProps {
     open: boolean
@@ -40,54 +43,40 @@ interface FiringTemperatureOption {
     name: string
 }
 
+// TODO(#83): make this component generic (GlobalEntryPicker) accepting a globalName prop.
+// The filter UI, API calls, and favorites support should all be derived from workflow
+// metadata and generic API functions rather than being hardcoded to glaze_combination.
+// Depends on #82 (generic favorite toggle). https://github.com/shaoster/glaze/issues/83
+
 interface FilterState {
     glazeTypes: GlazeTypeRef[]
     firingTemperature: FiringTemperatureOption | null
-    isFoodSafe: boolean | null
-    runs: boolean | null
-    highlightsGrooves: boolean | null
-    isDifferentOnWhiteAndBrownClay: boolean | null
+    // Boolean filters keyed by snake_case field name from workflow.yml.
+    boolFilters: Record<string, boolean | null>
     onlyFavorites: boolean
 }
 
 const EMPTY_FILTERS: FilterState = {
     glazeTypes: [],
     firingTemperature: null,
-    isFoodSafe: null,
-    runs: null,
-    highlightsGrooves: null,
-    isDifferentOnWhiteAndBrownClay: null,
+    boolFilters: Object.fromEntries(BOOL_FILTERABLE_FIELDS.map((f) => [f.name, null])),
     onlyFavorites: false,
 }
 
-// TODO(#83): make this component generic (GlobalEntryPicker) accepting a globalName prop.
-// The filter UI, API calls, and favorites support should all be derived from workflow
-// metadata and generic API functions rather than being hardcoded to glaze_combination.
-// Depends on #81 (filterable fields in workflow.yml) and #82 (generic favorite toggle).
-// https://github.com/shaoster/glaze/issues/83
-//
-// TODO(#81): replace NullableBoolField and BOOL_FILTER_LABELS with filterable field
-// metadata imported from getFilterableFields('glaze_combination') in workflow.ts once
-// filter metadata is declared in workflow.yml.
-// https://github.com/shaoster/glaze/issues/81
-type NullableBoolField = 'isFoodSafe' | 'runs' | 'highlightsGrooves' | 'isDifferentOnWhiteAndBrownClay'
-
-const BOOL_FILTER_LABELS: Record<NullableBoolField, string> = {
-    isFoodSafe: 'Food safe',
-    runs: 'Runs',
-    highlightsGrooves: 'Highlights grooves',
-    isDifferentOnWhiteAndBrownClay: 'Different on white/brown clay',
+function snakeToCamel(s: string): string {
+    return s.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase())
 }
 
 function filtersToApi(f: FilterState): GlazeCombinationFilters {
     const out: GlazeCombinationFilters = {}
     if (f.glazeTypes.length) out.glazeTypeIds = f.glazeTypes.map((gt) => gt.id)
     if (f.firingTemperature !== null) out.firingTemperatureId = f.firingTemperature.id
-    if (f.isFoodSafe !== null) out.isFoodSafe = f.isFoodSafe
-    if (f.runs !== null) out.runs = f.runs
-    if (f.highlightsGrooves !== null) out.highlightsGrooves = f.highlightsGrooves
-    if (f.isDifferentOnWhiteAndBrownClay !== null)
-        out.isDifferentOnWhiteAndBrownClay = f.isDifferentOnWhiteAndBrownClay
+    for (const [field, value] of Object.entries(f.boolFilters)) {
+        if (value !== null) {
+            // GlazeCombinationFilters uses camelCase keys matching the snake_case field names.
+            (out as Record<string, unknown>)[snakeToCamel(field)] = value
+        }
+    }
     return out
 }
 
@@ -124,10 +113,13 @@ export default function GlazeCombinationPicker({ open, onClose, onSelect }: Glaz
         loadCombinations(filters)
     }, [open, filters, loadCombinations])
 
-    function handleBoolFilter(field: NullableBoolField, checked: boolean, value: boolean) {
+    function handleBoolFilter(field: string, checked: boolean, value: boolean) {
         setFilters((prev) => ({
             ...prev,
-            [field]: checked ? value : prev[field] === value ? null : prev[field],
+            boolFilters: {
+                ...prev.boolFilters,
+                [field]: checked ? value : prev.boolFilters[field] === value ? null : prev.boolFilters[field],
+            },
         }))
     }
 
@@ -187,39 +179,37 @@ export default function GlazeCombinationPicker({ open, onClose, onSelect }: Glaz
                         size="small"
                     />
 
-                    {/* Boolean property filters — each field has its own labelled group */}
+                    {/* Boolean property filters — derived from workflow.yml filterable fields */}
                     <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
-                        {(Object.entries(BOOL_FILTER_LABELS) as [NullableBoolField, string][]).map(
-                            ([field, label]) => (
-                                <Box key={field}>
-                                    <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.25 }}>
-                                        {label}
-                                    </Typography>
-                                    <FormGroup row>
-                                        <FormControlLabel
-                                            label="Yes"
-                                            control={
-                                                <Checkbox
-                                                    size="small"
-                                                    checked={filters[field] === true}
-                                                    onChange={(e) => handleBoolFilter(field, e.target.checked, true)}
-                                                />
-                                            }
-                                        />
-                                        <FormControlLabel
-                                            label="No"
-                                            control={
-                                                <Checkbox
-                                                    size="small"
-                                                    checked={filters[field] === false}
-                                                    onChange={(e) => handleBoolFilter(field, e.target.checked, false)}
-                                                />
-                                            }
-                                        />
-                                    </FormGroup>
-                                </Box>
-                            )
-                        )}
+                        {BOOL_FILTERABLE_FIELDS.map(({ name, label }) => (
+                            <Box key={name}>
+                                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.25 }}>
+                                    {label}
+                                </Typography>
+                                <FormGroup row>
+                                    <FormControlLabel
+                                        label="Yes"
+                                        control={
+                                            <Checkbox
+                                                size="small"
+                                                checked={filters.boolFilters[name] === true}
+                                                onChange={(e) => handleBoolFilter(name, e.target.checked, true)}
+                                            />
+                                        }
+                                    />
+                                    <FormControlLabel
+                                        label="No"
+                                        control={
+                                            <Checkbox
+                                                size="small"
+                                                checked={filters.boolFilters[name] === false}
+                                                onChange={(e) => handleBoolFilter(name, e.target.checked, false)}
+                                            />
+                                        }
+                                    />
+                                </FormGroup>
+                            </Box>
+                        ))}
                     </Box>
 
                     {/* Only favorites toggle */}

--- a/workflow.schema.yml
+++ b/workflow.schema.yml
@@ -218,6 +218,12 @@ $defs:
           Intended for boolean fields; consumers use get_filterable_fields() /
           getFilterableFields() to discover which fields to expose as filter controls.
         default: false
+      label:
+        type: string
+        description: |
+          Human-readable label for the field in filter UIs. Used by pickers to
+          render filter controls without hardcoding labels in components.
+          Most useful when filterable: true.
 
   state_ref_field:
     type: object

--- a/workflow.schema.yml
+++ b/workflow.schema.yml
@@ -221,10 +221,10 @@ $defs:
       label:
         type: string
         description: |
-          Human-readable label for the field in filter UIs. Used by pickers to
-          render filter controls without hardcoding labels in components.
-          Most useful when filterable: true.
-
+          Human-readable label for the field in UIs. Used to render human
+          readable controls without hardcoding labels in components.
+          If not provided, the field name is converted to title case and used as a label.
+          E.g. "firing_temperature" → "Firing Temperature".
   state_ref_field:
     type: object
     required: [$ref]

--- a/workflow.yml
+++ b/workflow.yml
@@ -195,18 +195,22 @@ globals:
         type: boolean
         description: Whether this glaze combination is food safe.
         filterable: true
+        label: "Food safe"
       runs:
         type: boolean
         description: Whether this combination runs during firing.
         filterable: true
+        label: "Runs"
       highlights_grooves:
         type: boolean
         description: Whether this combination highlights surface grooves and texture.
         filterable: true
+        label: "Highlights grooves"
       is_different_on_white_and_brown_clay:
         type: boolean
         description: Whether the combination appears different on white versus brown clay.
         filterable: true
+        label: "Different on white/brown clay"
 
 # Built-in states for standard workflow.
 states:


### PR DESCRIPTION
- workflow.yml: add `label` to each filterable boolean field on glaze_combination
- workflow.schema.yml: allow optional `label` key on inline field entries
- api/workflow.py: expand get_filterable_fields() return type from list[str] to dict[str, dict] carrying {type, label} — mirrors what consumers need
- api/models.py: derive GlazeCombination boolean filterable_fields from get_filterable_fields() at class definition time; relational filters (m2m_id, fk_id) remain explicit as they use ORM lookups not in workflow.yml
- frontend_common/src/workflow.ts: expand getFilterableFields() return type from string[] to FilterableFieldDef[] ({name, type, label}); falls back to formatWorkflowFieldLabel(name) when label is absent
- GlazeCombinationPicker: remove NullableBoolField union type and BOOL_FILTER_LABELS constant; FilterState.boolFilters is now a Record<string, boolean|null> keyed by snake_case field name; render loop iterates BOOL_FILTERABLE_FIELDS from getFilterableFields()
- Update all tests for the new return shapes