### PR TITLE
Rename toggleFavoriteGlazeCombination to generic toggleGlobalEntryFavorite

### DIFF
--- a/frontend_common/src/api.ts
+++ b/frontend_common/src/api.ts
@@ -255,14 +255,11 @@ export async function fetchGlazeCombinations(
     return data
 }
 
-// TODO(#82): replace with a generic toggleGlobalEntryFavorite(globalName, id, favorite)
-// that constructs the URL from globalName rather than hardcoding 'glaze_combination'.
-// https://github.com/shaoster/glaze/issues/82
-export async function toggleFavoriteGlazeCombination(id: string, favorite: boolean): Promise<void> {
+export async function toggleGlobalEntryFavorite(globalName: string, id: string, favorite: boolean): Promise<void> {
     if (favorite) {
-        await client.post(`globals/glaze_combination/${id}/favorite/`)
+        await client.post(`globals/${globalName}/${id}/favorite/`)
     } else {
-        await client.delete(`globals/glaze_combination/${id}/favorite/`)
+        await client.delete(`globals/${globalName}/${id}/favorite/`)
     }
 }
 

--- a/web/src/components/GlazeCombinationPicker.tsx
+++ b/web/src/components/GlazeCombinationPicker.tsx
@@ -21,7 +21,7 @@ import TextField from '@mui/material/TextField'
 import {
     fetchGlazeCombinations,
     fetchGlobalEntries,
-    toggleFavoriteGlazeCombination,
+    toggleGlobalEntryFavorite,
     type GlazeCombinationEntry,
     type GlazeCombinationFilters,
     type GlazeTypeRef,
@@ -126,7 +126,7 @@ export default function GlazeCombinationPicker({ open, onClose, onSelect }: Glaz
     async function handleToggleFavorite(combo: GlazeCombinationEntry) {
         setTogglingId(combo.id)
         try {
-            await toggleFavoriteGlazeCombination(combo.id, !combo.is_favorite)
+            await toggleGlobalEntryFavorite('glaze_combination', combo.id, !combo.is_favorite)
             setCombinations((prev) =>
                 prev.map((c) => (c.id === combo.id ? { ...c, is_favorite: !c.is_favorite } : c))
             )

--- a/web/src/components/__tests__/GlazeCombinationPicker.test.tsx
+++ b/web/src/components/__tests__/GlazeCombinationPicker.test.tsx
@@ -8,7 +8,7 @@ import type { GlazeCombinationEntry } from '@common/api'
 vi.mock('@common/api', () => ({
     fetchGlazeCombinations: vi.fn(),
     fetchGlobalEntries: vi.fn(),
-    toggleFavoriteGlazeCombination: vi.fn(),
+    toggleGlobalEntryFavorite: vi.fn(),
 }))
 
 vi.mock('../CloudinaryImage', () => ({
@@ -55,7 +55,7 @@ beforeEach(() => {
         }
         return Promise.resolve([])
     })
-    vi.mocked(api.toggleFavoriteGlazeCombination).mockResolvedValue(undefined)
+    vi.mocked(api.toggleGlobalEntryFavorite).mockResolvedValue(undefined)
 })
 
 describe('GlazeCombinationPicker', () => {
@@ -126,22 +126,22 @@ describe('GlazeCombinationPicker', () => {
             await waitFor(() => expect(screen.getByLabelText('Remove from favorites')).toBeInTheDocument())
         })
 
-        it('calls toggleFavoriteGlazeCombination with correct args when favoriting', async () => {
+        it('calls toggleGlobalEntryFavorite with correct args when favoriting', async () => {
             render(<GlazeCombinationPicker {...defaultProps} />)
             await waitFor(() => expect(screen.getByLabelText('Add to favorites')).toBeInTheDocument())
             await userEvent.click(screen.getByLabelText('Add to favorites'))
             await waitFor(() =>
-                expect(api.toggleFavoriteGlazeCombination).toHaveBeenCalledWith('1', true)
+                expect(api.toggleGlobalEntryFavorite).toHaveBeenCalledWith('glaze_combination', '1', true)
             )
         })
 
-        it('calls toggleFavoriteGlazeCombination with false when unfavoriting', async () => {
+        it('calls toggleGlobalEntryFavorite with false when unfavoriting', async () => {
             vi.mocked(api.fetchGlazeCombinations).mockResolvedValue([makeCombo({ is_favorite: true })])
             render(<GlazeCombinationPicker {...defaultProps} />)
             await waitFor(() => expect(screen.getByLabelText('Remove from favorites')).toBeInTheDocument())
             await userEvent.click(screen.getByLabelText('Remove from favorites'))
             await waitFor(() =>
-                expect(api.toggleFavoriteGlazeCombination).toHaveBeenCalledWith('1', false)
+                expect(api.toggleGlobalEntryFavorite).toHaveBeenCalledWith('glaze_combination', '1', false)
             )
         })
 


### PR DESCRIPTION
Renames `toggleFavoriteGlazeCombination` to the generic `toggleGlobalEntryFavorite(globalName, id, favorite)` that constructs the URL from `globalName` rather than hardcoding `'glaze_combination'`. This unblocks adding favorites support to a second global type without adding another bespoke function.

The backend already uses a registry-based `make_global_entry_favorite_view` / `_FAVORITES_REGISTRY` pattern — this brings the frontend API layer to the same level of generality.

## Changes

- `frontend_common/src/api.ts`: rename function, add `globalName` as first parameter
- `web/src/components/GlazeCombinationPicker.tsx`: update import and call site (`'glaze_combination', combo.id, …`)
- `web/src/components/__tests__/GlazeCombinationPicker.test.tsx`: update mock name and expected call args

## Test plan

- [x] All 183 frontend tests pass (`vitest run`)
- [x] No TypeScript errors

Closes #82
