### PR TITLE
Add landing tabs for pieces and analysis

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -49,6 +49,7 @@ const MOCK_USER = {
 describe('App auth flow', () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        window.history.pushState({}, '', '/')
         // Reset fetchCurrentUser to return null by default
         vi.mocked(fetchCurrentUser).mockResolvedValue(null)
     })
@@ -103,5 +104,48 @@ describe('App auth flow', () => {
             expect(screen.getByText('Pat Potter')).toBeInTheDocument()
             expect(screen.getByText('Piece List Content')).toBeInTheDocument()
         })
+
+        expect(screen.getByRole('tab', { name: 'Pieces' })).toHaveAttribute('aria-selected', 'true')
+        expect(screen.getByRole('tab', { name: 'Analyze' })).toHaveAttribute('aria-selected', 'false')
+    })
+
+    it('switches between landing tabs and keeps the URL in sync', async () => {
+        vi.mocked(fetchCurrentUser).mockResolvedValue(MOCK_USER)
+
+        render(<App />)
+
+        await waitFor(() => {
+            expect(screen.getByText('Pottery Pieces')).toBeInTheDocument()
+        })
+
+        await userEvent.click(screen.getByRole('tab', { name: 'Analyze' }))
+
+        await waitFor(() => {
+            expect(screen.getByText('Coming soon')).toBeInTheDocument()
+            expect(window.location.pathname).toBe('/analyze')
+        })
+
+        expect(screen.getByRole('tab', { name: 'Analyze' })).toHaveAttribute('aria-selected', 'true')
+
+        await userEvent.click(screen.getByRole('tab', { name: 'Pieces' }))
+
+        await waitFor(() => {
+            expect(screen.getByText('Pottery Pieces')).toBeInTheDocument()
+            expect(window.location.pathname).toBe('/')
+        })
+    })
+
+    it('activates the analyze tab on direct navigation to /analyze', async () => {
+        vi.mocked(fetchCurrentUser).mockResolvedValue(MOCK_USER)
+        window.history.pushState({}, '', '/analyze')
+
+        render(<App />)
+
+        await waitFor(() => {
+            expect(screen.getByText('Coming soon')).toBeInTheDocument()
+        })
+
+        expect(screen.getByRole('tab', { name: 'Analyze' })).toHaveAttribute('aria-selected', 'true')
+        expect(screen.getByRole('tab', { name: 'Pieces' })).toHaveAttribute('aria-selected', 'false')
     })
 })

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import {
   RouterProvider,
   createBrowserRouter,
   createRoutesFromElements,
+  useLocation,
   useNavigate,
   useParams,
 } from 'react-router-dom'
@@ -25,6 +26,8 @@ import {
   MenuItem,
   Paper,
   Stack,
+  Tab,
+  Tabs,
   TextField,
   Typography,
 } from '@mui/material'
@@ -288,6 +291,31 @@ function PieceDetailPage() {
   )
 }
 
+function AnalyzePage() {
+  return <Typography>Coming soon</Typography>
+}
+
+function LandingPage() {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const currentTab = location.pathname === '/analyze' ? '/analyze' : '/'
+
+  return (
+    <>
+      <Tabs
+        value={currentTab}
+        onChange={(_event, nextTab: string) => navigate(nextTab)}
+        aria-label="Landing page navigation"
+        sx={{ mb: 3 }}
+      >
+        <Tab label="Pieces" value="/" />
+        <Tab label="Analyze" value="/analyze" />
+      </Tabs>
+      <Outlet />
+    </>
+  )
+}
+
 function AppShell({
   currentUser,
   onLogout,
@@ -347,7 +375,10 @@ function AuthenticatedApp({
       createBrowserRouter(
         createRoutesFromElements(
           <Route element={<AppShell currentUser={currentUser} onLogout={onLogout} />}>
-            <Route path="/" element={<PieceListPage />} />
+            <Route path="/" element={<LandingPage />}>
+              <Route index element={<PieceListPage />} />
+              <Route path="analyze" element={<AnalyzePage />} />
+            </Route>
             <Route path="/pieces/:id" element={<PieceDetailPage />} />
             <Route path="*" element={<Navigate to="/" replace />} />
           </Route>,


### PR DESCRIPTION
## Summary
- add a landing-page tab bar that keeps the Pieces and Analyze tabs synced with `/` and `/analyze`
- add an `AnalyzePage` placeholder stub for future analysis views
- extend the app test coverage for default landing state, tab navigation, and direct `/analyze` deep links

## Testing
- `npm test -- --runInBand` *(fails in this environment: WSL 1 is not supported / Could not determine Node.js install directory)*
- `npx tsc --noEmit` *(fails in this environment: WSL 1 is not supported / Could not determine Node.js install directory)*
- `pytest tests/` *(not available in this environment: `pytest: command not found`)*
- `pytest api/` *(not available in this environment: `pytest: command not found`)*
- `./build.sh` *(not available in this environment: `pip: command not found`)*

Closes #92
