### PR TITLE
fix: prevent uncommitted text from being saved in GlobalFieldPicker

### DIFF
--- a/web/src/components/GlobalFieldPicker.tsx
+++ b/web/src/components/GlobalFieldPicker.tsx
@@ -103,6 +103,14 @@ export default function GlobalFieldPicker({
     const [internalEntries, setInternalEntries] = useState<GlobalEntry[]>([])
     const [creating, setCreating] = useState(false)
     const [error, setError] = useState<string | null>(null)
+    // Tracks what is shown in the text field while the user is typing.
+    // Separate from `value` so that partially-typed text is never committed.
+    const [inputValue, setInputValue] = useState(value)
+
+    // Keep the displayed text in sync when the committed value changes externally.
+    useEffect(() => {
+        setInputValue(value)
+    }, [value])
 
     const entries = optionsProp ?? internalEntries
 
@@ -153,8 +161,19 @@ export default function GlobalFieldPicker({
         <Autocomplete
             freeSolo={canCreate}
             options={displayOptions}
-            inputValue={value}
-            onInputChange={(_e, val) => onChange(val)}
+            inputValue={inputValue}
+            onInputChange={(_e, val, reason) => {
+                setInputValue(val)
+                // 'reset' fires when the user clears the field or an option is
+                // selected; 'input' fires on every keystroke. Only propagate on
+                // 'reset' (i.e. clear) — actual selections are handled by onChange.
+                if (reason === 'reset' && val === '') onChange('')
+            }}
+            onBlur={() => {
+                // If the user typed something but never made a selection, discard
+                // the partial text and restore the last committed value.
+                setInputValue(value)
+            }}
             onChange={(_e, val) => handleChange(val ?? null)}
             filterOptions={(opts, params) => {
                 const filtered = FILTER(opts, params)

--- a/web/src/components/__tests__/GlobalFieldPicker.test.tsx
+++ b/web/src/components/__tests__/GlobalFieldPicker.test.tsx
@@ -172,6 +172,34 @@ describe('GlobalFieldPicker', () => {
         })
     })
 
+    describe('uncommitted text', () => {
+        it('does not call onChange while the user is typing', async () => {
+            const onChange = vi.fn()
+            render(<GlobalFieldPicker {...defaultProps} onChange={onChange} canCreate />)
+            await userEvent.type(screen.getByLabelText('Location'), 'New Studio')
+            expect(onChange).not.toHaveBeenCalled()
+        })
+
+        it('resets the input to the committed value on blur when nothing was selected', async () => {
+            render(<Controlled canCreate options={[entry('Studio A')]} />)
+            const input = screen.getByLabelText('Location')
+            await userEvent.type(input, 'something partial')
+            fireEvent.blur(input)
+            await waitFor(() => expect(input).toHaveValue(''))
+        })
+
+        it('preserves the input after a successful create', async () => {
+            vi.mocked(api.createGlobalEntry).mockResolvedValue('New Studio')
+            render(<Controlled canCreate />)
+            await userEvent.type(screen.getByLabelText('Location'), 'New Studio')
+            await waitFor(() =>
+                expect(screen.getByRole('option', { name: 'Create "New Studio"' })).toBeInTheDocument()
+            )
+            fireEvent.click(screen.getByRole('option', { name: 'Create "New Studio"' }))
+            await waitFor(() => expect(screen.getByLabelText('Location')).toHaveValue('New Studio'))
+        })
+    })
+
     describe('public/private disambiguation', () => {
         it('appends (public) suffix to a public entry that shares a name with a private entry', async () => {
             render(

--- a/web/src/components/__tests__/NewPieceDialog.test.tsx
+++ b/web/src/components/__tests__/NewPieceDialog.test.tsx
@@ -194,8 +194,14 @@ describe('NewPieceDialog', () => {
 
         it('sends location when provided', async () => {
             vi.mocked(api.createPiece).mockResolvedValue(makePieceDetail())
+            vi.mocked(api.fetchGlobalEntries).mockResolvedValue([{ id: '1', name: 'Studio 7', isPublic: false }])
             render(<NewPieceDialog {...defaultProps} />)
-            fireEvent.change(screen.getByLabelText('Location'), { target: { value: 'Studio 7' } })
+            await userEvent.type(screen.getByLabelText('Location'), 'Studio 7')
+            await waitFor(() =>
+                expect(screen.getByRole('option', { name: 'Studio 7' })).toBeInTheDocument()
+            )
+            fireEvent.click(screen.getByRole('option', { name: 'Studio 7' }))
+            await waitFor(() => expect(screen.getByLabelText('Location')).toHaveValue('Studio 7'))
             await userEvent.type(screen.getByTestId('name-input'), 'Bowl')
             await userEvent.click(screen.getByTestId('save-button'))
             await waitFor(() => {

--- a/web/src/components/__tests__/PieceDetail.test.tsx
+++ b/web/src/components/__tests__/PieceDetail.test.tsx
@@ -108,12 +108,18 @@ describe('PieceDetail', () => {
 
     it('saves location updates when confirmed', async () => {
         const updated = makePiece({ current_location: 'Studio 7' })
+        vi.mocked(api.fetchGlobalEntries).mockResolvedValue([{ id: '1', name: 'Studio 7', isPublic: false }])
         vi.mocked(api.updateCurrentState).mockResolvedValue(updated)
         vi.mocked(api.updatePiece).mockResolvedValue(updated)
         const onPieceUpdated = vi.fn()
         renderPieceDetail(undefined, onPieceUpdated)
         const input = screen.getByLabelText('Current location')
         await userEvent.type(input, 'Studio 7')
+        await waitFor(() =>
+            expect(screen.getByRole('option', { name: 'Studio 7' })).toBeInTheDocument()
+        )
+        fireEvent.click(screen.getByRole('option', { name: 'Studio 7' }))
+        await waitFor(() => expect(input).toHaveValue('Studio 7'))
         await userEvent.click(screen.getByTestId('save-button'))
         await waitFor(() =>
             expect(api.updatePiece).toHaveBeenCalledWith('piece-id-1', { current_location: 'Studio 7' })

--- a/web/src/components/__tests__/WorkflowState.test.tsx
+++ b/web/src/components/__tests__/WorkflowState.test.tsx
@@ -309,6 +309,7 @@ describe('WorkflowState', () => {
         const updated = makePieceDetail()
         vi.mocked(api.updateCurrentState).mockResolvedValue(updated)
         vi.mocked(api.updatePiece).mockRejectedValue(new Error('Network error'))
+        vi.mocked(api.fetchGlobalEntries).mockResolvedValue([{ id: '1', name: 'Shelf Z', isPublic: false }])
         render(
             <WorkflowState
                 {...defaultProps}
@@ -317,6 +318,11 @@ describe('WorkflowState', () => {
         )
         const input = screen.getByLabelText('Current location')
         await userEvent.type(input, 'Shelf Z')
+        await waitFor(() =>
+            expect(screen.getByRole('option', { name: 'Shelf Z' })).toBeInTheDocument()
+        )
+        fireEvent.click(screen.getByRole('option', { name: 'Shelf Z' }))
+        await waitFor(() => expect(input).toHaveValue('Shelf Z'))
         await userEvent.click(screen.getByTestId('save-button'))
         await waitFor(() => expect(screen.getByText('Failed to save. Please try again.')).toBeInTheDocument())
         expect(screen.getByTestId('unsaved-indicator')).toBeInTheDocument()


### PR DESCRIPTION
## Summary

- `GlobalFieldPicker` previously propagated every keystroke to the parent via `onInputChange → onChange`, so partially-typed text that was never selected or created could be saved as the field value
- Added internal `inputValue` state separate from the committed `value` prop — keystrokes update display only, not the parent
- `onBlur` resets the input to the last committed value when the user types without making a selection
- `onChange` (dropdown selection or "Create '...'" sentinel) remains the sole path for committing a real value

## Test plan

- [ ] Type in a `GlobalFieldPicker` with `canCreate`, blur without selecting — input resets, value is not saved
- [ ] Select an existing option — value commits correctly
- [ ] Type a new name and select "Create '...'" — entry is created and value commits
- [ ] Clear the field (×) — value commits as empty
- [ ] `npm test` passes (one pre-existing `App.test.tsx` failure unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
