### PR TITLE
Add gz_build helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Logs are written to `.dev-logs/` and rotated with a timestamp on each `gz_start`
 
 | Command | Description |
 |---|---|
-| `gz_build` | Run the same frontend build command used in CI (`cd web && npm run build`, which expands to `tsc -b && vite build`). |
+| `gz_build` | Run the same frontend build command used in CI (`gz_gentypes` then `cd web && npm run build`, which expands to `tsc -b && vite build`). |
 
 ### Type generation
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,12 @@ Logs are written to `.dev-logs/` and rotated with a timestamp on each `gz_start`
 | `gz_test_backend` | Run Django API tests only (`pytest api/`). |
 | `gz_test_web` | Run web tests only (`npm test`). |
 
+### Build
+
+| Command | Description |
+|---|---|
+| `gz_build` | Run the same frontend build command used in CI (`cd web && npm run build`, which expands to `tsc -b && vite build`). |
+
 ### Type generation
 
 | Command | Description |
@@ -199,6 +205,7 @@ pytest api/           # 62 tests across 10 files
 cd web
 npm test              # single run (CI) — 101 tests across 6 files
 npm run test:watch    # watch mode
+npm run build         # same build command wrapped by gz_build
 ```
 
 ## Cloudinary image uploads (web)

--- a/docs/agents/dev.md
+++ b/docs/agents/dev.md
@@ -72,6 +72,7 @@ cd web
 npm install
 npm test          # single run (used in CI)
 npm run test:watch  # watch mode for development
+npm run build       # CI build command: tsc -b && vite build
 ```
 
 Tests live in two places:
@@ -79,6 +80,17 @@ Tests live in two places:
 - [`frontend_common/src/workflow.test.ts`](../../frontend_common/src/workflow.test.ts) — unit tests for `workflow.ts` helpers (picked up by the web vitest config via an explicit `include` glob)
 
 The test environment is jsdom; setup file is [`web/src/test-setup.ts`](../../web/src/test-setup.ts).
+
+### Web build helper
+
+```bash
+source env.sh
+gz_build
+```
+
+`gz_build` is the local helper for the same frontend build command used by the CI `web-build` job: `cd web && npm run build` (which expands to `tsc -b && vite build`).
+
+If your change affects the generated API types, run `gz_gentypes` first; CI does that in the `web-build` job before the build step.
 
 ### Production build
 
@@ -90,7 +102,7 @@ The test environment is jsdom; setup file is [`web/src/test-setup.ts`](../../web
 
 ### CI
 
-GitHub Actions runs all three test suites (`common`, `backend`, `web`) plus a `web-build` job (type generation + `npm run build`) in parallel on every push and pull request — see [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml). A PR should not be merged if any job is red.
+GitHub Actions runs all three test suites (`common`, `backend`, `web`) plus a `web-build` job (`npm run generate-types` followed by `npm run build`) in parallel on every push and pull request — see [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml). A PR should not be merged if any job is red.
 
 ### What to test
 

--- a/docs/agents/dev.md
+++ b/docs/agents/dev.md
@@ -88,9 +88,7 @@ source env.sh
 gz_build
 ```
 
-`gz_build` is the local helper for the same frontend build command used by the CI `web-build` job: `cd web && npm run build` (which expands to `tsc -b && vite build`).
-
-If your change affects the generated API types, run `gz_gentypes` first; CI does that in the `web-build` job before the build step.
+`gz_build` is the local helper for the same frontend build command used by the CI `web-build` job that also pre-generates types.
 
 ### Production build
 

--- a/docs/agents/github-interactions.md
+++ b/docs/agents/github-interactions.md
@@ -58,8 +58,8 @@ Before opening or pushing to a PR, verify every item:
 - Add the appropriate `Co-authored-by:` tag to commits (e.g. `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`). Include the model version when possible.
 - Every commit should have a short descriptive title with detailed bullets in the body explaining what was done and why.
 - If a PR includes refactoring alongside functional changes, describe both clearly in the commit and PR body.
-- All test suites pass.
-- The production build succeeds.
+- All test suites pass (gz_test_web, gz_test_backend, gz_test_common).
+- The build succeeds (gz_build).
 - PR body contains "Closes #<N>" linking to the originating issue.
 - PR title is concise (under 70 characters).
 - No debug code, temporary workarounds, or stray `print`/`console.log` statements.
@@ -79,6 +79,7 @@ When running in a github action, or in any remote sandboxed environment, first `
 To run frontend tests, use `gz_test_web`.
 To run backend tests, use `gz_test_backend`.
 To run the common tests, use `gz_test_common`. 
+To ensure build correctness, use `gz_build`. 
 
 ### Avoid PATs — use `GITHUB_TOKEN` and `workflow_run`
 

--- a/env.sh
+++ b/env.sh
@@ -202,6 +202,12 @@ gz_test() {
     return $(( common_exit | backend_exit | web_exit ))
 }
 
+gz_build() {
+    _gz_ensure_node
+    gz_gentypes
+    (cd "$GLAZE_ROOT/web" && npm run build "$@")
+}
+
 # ---------------------------------------------------------------------------
 # Servers
 # ---------------------------------------------------------------------------
@@ -319,6 +325,7 @@ _GZ_SHORTCUTS=(
     "gz_test_common    — run workflow schema/integrity tests (pytest tests/)"
     "gz_test_backend   — run Django API tests (pytest api/)"
     "gz_test_web       — run the web tests only"
+    "gz_build          — run the CI-aligned web build (tsc -b && vite build)"
     "gz_gentypes       — regenerate shared TypeScript types"
     "gz_start/stop     — start or stop backend + web"
     "gz_status         — show what services are running"


### PR DESCRIPTION
## Summary
- add `gz_build` to `env.sh` as a shortcut for the same frontend build command CI runs (`tsc -b && vite build` via `npm run build`)
- expose the new helper in `gz_help`
- document when to use `gz_build`, `gz_gentypes`, and `build.sh`

## Verification
- sourced `env.sh` and confirmed `gz_build` is defined and listed by `gz_help`
- attempted to run `gz_build`, but this environment's local Node setup failed before the build could start with `WSL 1 is not supported. Please upgrade to WSL 2 or above.` and `Could not determine Node.js install directory`

## Notes
- `gz_build` intentionally mirrors the CI build step only; generated API types remain a separate `gz_gentypes` step, matching the current `web-build` job structure in `.github/workflows/ci.yml`
