### PR TITLE
fix: Add authentication to cloudinary endpoints

### DIFF
--- a/api/tests/test_cloudinary_image_widget.py
+++ b/api/tests/test_cloudinary_image_widget.py
@@ -1,5 +1,3 @@
-import pytest
-
 from api.admin import (
     CloudinaryImageWidget,
     _cloudinary_lightbox_url,

--- a/api/tests/test_cloudinary_upload_signature.py
+++ b/api/tests/test_cloudinary_upload_signature.py
@@ -13,6 +13,15 @@ class TestCloudinaryWidgetConfig:
         assert response.status_code == 503
         assert response.json()['detail'] == 'Cloudinary is not configured on the server.'
 
+    def test_returns_403_when_not_authenticated(self, client, monkeypatch):
+        monkeypatch.delenv('CLOUDINARY_CLOUD_NAME', raising=False)
+        monkeypatch.delenv('CLOUDINARY_API_KEY', raising=False)
+        client.force_authenticate(user=None)
+        response = client.get('/api/uploads/cloudinary/widget-config/')
+
+        assert response.status_code == 403
+        assert response.json()['detail'] == 'Authentication credentials were not provided.'
+
     def test_returns_config_without_folder(self, client, monkeypatch):
         monkeypatch.setenv('CLOUDINARY_CLOUD_NAME', 'demo-cloud')
         monkeypatch.setenv('CLOUDINARY_API_KEY', 'public-api-key')
@@ -59,6 +68,19 @@ class TestCloudinaryWidgetSign:
 
         assert response.status_code == 503
         assert response.json()['detail'] == 'Cloudinary is not configured on the server.'
+
+    def test_returns_403_when_not_authenticated(self, client, monkeypatch):
+        monkeypatch.delenv('CLOUDINARY_API_SECRET', raising=False)
+        client.force_authenticate(user=None)
+        response = client.post(
+            '/api/uploads/cloudinary/widget-signature/',
+            {'params_to_sign': {}},
+            format='json',
+        )
+
+        assert response.status_code == 403
+        assert response.json()['detail'] == 'Authentication credentials were not provided.'
+
 
     def test_returns_signature(self, client, monkeypatch):
         monkeypatch.setenv('CLOUDINARY_API_SECRET', 'super-secret')

--- a/api/views.py
+++ b/api/views.py
@@ -378,7 +378,6 @@ def make_global_entry_favorite_view(global_name: str):
     return view
 
 
-
 @extend_schema(
     request=None,
     responses={
@@ -394,6 +393,7 @@ def make_global_entry_favorite_view(global_name: str):
     },
 )
 @api_view(['GET'])
+@permission_classes([IsAuthenticated])
 def cloudinary_widget_config(request: Request) -> Response:
     """Return Cloudinary config needed to initialize the Upload Widget."""
     cloud_name = os.environ.get('CLOUDINARY_CLOUD_NAME')
@@ -432,6 +432,7 @@ def cloudinary_widget_config(request: Request) -> Response:
     },
 )
 @api_view(['POST'])
+@permission_classes([IsAuthenticated])
 def cloudinary_widget_sign(request: Request) -> Response:
     """Sign the params_to_sign dict provided by the Cloudinary Upload Widget."""
     api_secret = os.environ.get('CLOUDINARY_API_SECRET')


### PR DESCRIPTION
Prior to this fix, if users knew how to get around the UI, they could send unauthenticated requests to the backend to get upload tokens to our cloudinary bucket.

This change patches that hole and adds tests to ensure requests to the cloudinary endpoints are now authenticated.

Closes #63