### PR TITLE
[codex] Add workflow-authored state labels and chips

### DIFF
--- a/docs/agents/glaze-domain.md
+++ b/docs/agents/glaze-domain.md
@@ -97,7 +97,7 @@ Each state in [`workflow.yml`](../../workflow.yml) must declare a `friendly_name
 | `designed` | `Designing` | Piece conceived/designed — universal entry point |
 | `wheel_thrown` | `Throwing` | Piece created on the wheel |
 | `handbuilt` | `Handbuilding` | Piece hand-sculpted |
-| `trimmed` | `Decorating` | Wheel-thrown piece trimmed |
+| `trimmed` | `Trimming` | Wheel-thrown piece trimmed |
 | `slip_applied` | `Adding Slip` | Decorative slip added |
 | `carved` | `Carving` | Surface carved or decorated |
 | `submitted_to_bisque_fire` | `Queued → Bisque` | Ready for initial firing |

--- a/docs/agents/glaze-domain.md
+++ b/docs/agents/glaze-domain.md
@@ -32,10 +32,10 @@ The source of truth for piece states is [`workflow.yml`](../../workflow.yml) at 
 
 **`globals` section:** The optional top-level `globals` map registers named domain types backed by Django models. Each entry declares the model class name (PascalCase, verified against `api/models.py` by tests) and a subset of its fields exposed to the field DSL. `api/models.py` remains the authoritative source of truth — `globals` is a DSL-level view of those models, kept in sync by tests.
 
-**What belongs in `workflow.yml` vs. what does not:** `workflow.yml` is for domain structure and business rules that both backend and frontend must agree on: state IDs, transitions, field existence, requiredness, persistence shape, and domain constraints that affect validation or query behavior. It is not a home for presentation defaults, styling choices, or convenience UI metadata.
+**What belongs in `workflow.yml` vs. what does not:** `workflow.yml` is for domain structure and business rules that both backend and frontend must agree on: state IDs, required state `friendly_name` labels, required state descriptions, transitions, field existence, requiredness, persistence shape, and domain constraints that affect validation or query behavior. It is not a home for presentation defaults, styling choices, or convenience UI metadata.
 
-- **Belongs in `workflow.yml`:** lifecycle states, successor relationships, whether a field/global exists at all, whether it is required, whether a global is public/private/favoritable/taggable, and true domain constraints where the allowed values are part of the business model.
-- **Does not belong in `workflow.yml`:** default colors, color palettes, icon choices, display order chosen only for UX, wording tweaks for labels, component layout, and other presentation-layer defaults that the backend does not need in order to validate or persist the data.
+- **Belongs in `workflow.yml`:** lifecycle states, required `friendly_name` labels and descriptions for those states, successor relationships, whether a field/global exists at all, whether it is required, whether a global is public/private/favoritable/taggable, and true domain constraints where the allowed values are part of the business model.
+- **Does not belong in `workflow.yml`:** default colors, color palettes, icon choices, display order chosen only for UX, component layout, and other presentation-layer defaults that the backend does not need in order to validate or persist the data.
 - **Rule of thumb:** if changing the value should require a migration, backend validation change, API contract change, or data cleanup plan, it may belong in `workflow.yml`. If changing it should only affect how the UI looks or which default the user sees first, it belongs in frontend code instead.
 - **Example:** a `Tag` having a persisted `color` field can be valid domain data if users explicitly choose and save a color. But a built-in palette of suggested colors, or a default initial color shown in the create form, is presentation logic and should live in the web layer, not in `workflow.yml`.
 - **Capability pattern:** use `workflow.yml` to opt models into generic capabilities such as `favoritable: true` or `taggable: true`, not to encode one-off wiring details that generated backend/frontend code can infer.
@@ -90,23 +90,25 @@ Referential rules enforced by `TestAdditionalFieldsDSL`:
 
 **States** (in rough lifecycle order):
 
-| State | Description |
-|---|---|
-| `designed` | Piece conceived/designed — universal entry point |
-| `wheel_thrown` | Piece created on the wheel |
-| `handbuilt` | Piece hand-sculpted |
-| `trimmed` | Wheel-thrown piece trimmed |
-| `slip_applied` | Decorative slip added |
-| `carved` | Surface carved or decorated |
-| `submitted_to_bisque_fire` | Ready for initial firing |
-| `bisque_fired` | Initial bisque fire complete |
-| `waxed` | Wax resist applied before glazing |
-| `glazed` | Glaze applied |
-| `submitted_to_glaze_fire` | Ready for glaze firing |
-| `glaze_fired` | Glaze fire complete |
-| `sanded` | Final sanding/finishing |
-| `completed` | Terminal — finished piece |
-| `recycled` | Terminal — piece discarded or clay reclaimed |
+Each state in [`workflow.yml`](../../workflow.yml) must declare a `friendly_name` and a `description`. Clients use the authored label directly and do not derive a fallback from the snake_case state ID.
+
+| State | Friendly name | Description |
+|---|---|---|
+| `designed` | `Designing` | Piece conceived/designed — universal entry point |
+| `wheel_thrown` | `Throwing` | Piece created on the wheel |
+| `handbuilt` | `Handbuilding` | Piece hand-sculpted |
+| `trimmed` | `Decorating` | Wheel-thrown piece trimmed |
+| `slip_applied` | `Adding Slip` | Decorative slip added |
+| `carved` | `Carving` | Surface carved or decorated |
+| `submitted_to_bisque_fire` | `Queued → Bisque` | Ready for initial firing |
+| `bisque_fired` | `Planning → Glaze` | Initial bisque fire complete |
+| `waxed` | `Waxing` | Wax resist applied before glazing |
+| `glazed` | `Glazing` | Glaze applied |
+| `submitted_to_glaze_fire` | `Queued → Glaze` | Ready for glaze firing |
+| `glaze_fired` | `Touching Up` | Glaze fire complete |
+| `sanded` | `Sanding` | Final sanding/finishing |
+| `completed` | `Completed` | Terminal — finished piece |
+| `recycled` | `Recycled` | Terminal — piece discarded or clay reclaimed |
 
 **Rules:**
 - `designed` is the single entry point for all new pieces — `POST /api/pieces/` always creates a piece in the `designed` state.
@@ -307,6 +309,30 @@ All data-fetching components must render a loading spinner (`<CircularProgress /
 - [`WorkflowState.tsx`](../../web/src/components/WorkflowState.tsx) — edits the current `PieceState`: notes, location, additional fields, images (upload or URL), caption editing, lightbox launch
 - [`CloudinaryImage.tsx`](../../web/src/components/CloudinaryImage.tsx) — renders a `CaptionedImage` via `@cloudinary/url-gen` + `@cloudinary/react` when available; falls back to a plain `<img>`. Sizing context: `thumbnail`/`preview` (64×64 fill), `lightbox` (90vw×80vh fit).
 - [`ImageLightbox.tsx`](../../web/src/components/ImageLightbox.tsx) — full-screen modal image viewer with caption and keyboard/touch navigation
+- [`StateChip.tsx`](../../web/src/components/StateChip.tsx) — shared workflow-state token. Takes `variant: 'current' | 'past' | 'future'` plus `isTerminal` and optional interaction hooks so list/detail/timeline UIs stay in one visual family.
+
+**Visual design system — state chips and state flow:**
+- Treat workflow-state tokens as a dedicated UI language, not as interchangeable tag chips or generic MUI buttons. Tags represent user-authored metadata; state chips represent the pottery workflow itself and should stay visually distinct.
+- Keep state-chip color rules in frontend code, not in [`workflow.yml`](../../workflow.yml). The workflow file defines which states exist and which successors are valid; the web layer owns presentation decisions such as chip color, dot treatment, connector lines, hover fills, and emphasis.
+- The current state in [`PieceDetail.tsx`](../../web/src/components/PieceDetail.tsx) should read as the anchor of the flow: solid outline, lightly filled background, and a filled status dot on the left. It may be slightly larger than successor chips, but it should still feel related to them.
+- Valid successor states should render as actionable state chips, not CTA-style buttons. They should size to their content, use dotted or dashed outlines plus outlined dots by default, and become visually "promoted" on hover by filling the background, solidifying the outline, and filling the dot.
+- Hovering a valid successor should also temporarily de-emphasize the current state with a muted gray treatment. This creates a preview of "if you clicked this, the hovered successor would become the new current state."
+- Use semantic state colors consistently across the app. Current conventions in `PieceDetail` are:
+- `completed` → green
+- `recycled` → red
+- all other active workflow states → the shared warm clay accent (`oklch(0.66 0.17 35)`)
+- When the UI needs to show a branch from one current state to multiple valid successors, use an explicit connector treatment rather than text labels like "Current" or "Next". [`PieceDetail.tsx`](../../web/src/components/PieceDetail.tsx) currently uses a small SVG branch connector between the current-state chip and the vertical list of successors.
+- Past states are sealed historical records, not available actions. When rendered as chips in future history or timeline views, they should stay in the same visual family as state chips but with clearly reduced emphasis: read-only, no hover preview, no interactive affordance, and a lower-contrast or muted treatment that distinguishes them from both the current state and valid successors.
+- Do not restyle state chips to match tags, favorites, filter pills, or upload buttons for convenience. If a new screen needs workflow states, prefer extracting or extending a shared state-chip component rather than recreating an ad hoc variant.
+- If the state-flow styling changes in a meaningful way, update this section alongside the implementation so future agents do not reintroduce tag-like current states or button-like successor states by accident.
+
+**State-flow screenshots:**
+- There are currently no repo-hosted screenshots for this pattern.
+- When adding them, store them under a stable docs path such as `docs/images/state-flow/` and link them here with ordinary Markdown image links so the screenshots travel with the repository history.
+- Suggested captures:
+- `PieceDetail` showing one current state with multiple valid successors
+- `PieceDetail` showing a hovered valid successor and the muted current-state preview
+- a history or timeline view once past-state chips exist as a first-class pattern
 
 **Auth UI flow (`App.tsx`):**
 - On load, calls `fetchCurrentUser()` (`GET /api/auth/me/`).

--- a/frontend_common/src/types.ts
+++ b/frontend_common/src/types.ts
@@ -1,7 +1,15 @@
 import type { components } from './generated-types'
 import workflow from '../../workflow.yml'
+export { formatState, getStateDescription, getStateMetadata, isTerminalState } from './workflow'
 
-type WorkflowState = { id: string; visible: boolean; successors?: string[]; terminal?: boolean }
+type WorkflowState = {
+    id: string
+    visible: boolean
+    friendly_name: string
+    description: string
+    successors?: string[]
+    terminal?: boolean
+}
 
 // Runtime constants derived from workflow.json.
 // STATES preserves lifecycle order; SUCCESSORS encodes the transition graph.
@@ -78,10 +86,4 @@ export type GlazeCombinationImagePiece = {
 export type GlazeCombinationImageEntry = {
     glaze_combination: GlazeCombinationEntry
     pieces: GlazeCombinationImagePiece[]
-}
-
-// Convert a snake_case state id to a human-readable label.
-// e.g. "wheel_thrown" → "Wheel Thrown", "designed" → "Designed"
-export function formatState(state: string): string {
-    return state.split('_').map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join(' ')
 }

--- a/frontend_common/src/workflow.test.ts
+++ b/frontend_common/src/workflow.test.ts
@@ -94,7 +94,7 @@ vi.mock('../../workflow.yml', () => ({
             {
                 id: 'trimmed',
                 visible: true,
-                friendly_name: 'Decorating',
+                friendly_name: 'Trimming',
                 description: 'Ready for surface work.',
                 successors: ['submitted_to_bisque_fire', 'recycled'],
                 fields: {

--- a/frontend_common/src/workflow.test.ts
+++ b/frontend_common/src/workflow.test.ts
@@ -57,11 +57,15 @@ vi.mock('../../workflow.yml', () => ({
             {
                 id: 'designed',
                 visible: true,
+                friendly_name: 'Designing',
+                description: 'Dreaming it up.',
                 successors: ['wheel_thrown', 'handbuilt'],
             },
             {
                 id: 'wheel_thrown',
                 visible: true,
+                friendly_name: 'Throwing',
+                description: 'Fresh off the wheel.',
                 successors: ['trimmed', 'recycled'],
                 fields: {
                     clay_weight_grams: {
@@ -77,6 +81,8 @@ vi.mock('../../workflow.yml', () => ({
             {
                 id: 'submitted_to_bisque_fire',
                 visible: true,
+                friendly_name: 'Queued → Bisque',
+                description: 'Waiting on the kiln...',
                 successors: ['bisque_fired', 'recycled'],
                 fields: {
                     kiln_location: {
@@ -88,6 +94,8 @@ vi.mock('../../workflow.yml', () => ({
             {
                 id: 'trimmed',
                 visible: true,
+                friendly_name: 'Decorating',
+                description: 'Ready for surface work.',
                 successors: ['submitted_to_bisque_fire', 'recycled'],
                 fields: {
                     trimmed_weight_grams: {
@@ -102,6 +110,8 @@ vi.mock('../../workflow.yml', () => ({
             {
                 id: 'bisque_fired',
                 visible: true,
+                friendly_name: 'Planning → Glaze',
+                description: 'Done with the first firing!',
                 successors: ['glazed', 'recycled'],
                 fields: {
                     kiln_temperature_c: {
@@ -116,6 +126,8 @@ vi.mock('../../workflow.yml', () => ({
             {
                 id: 'glaze_fired',
                 visible: true,
+                friendly_name: 'Touching Up',
+                description: 'Final cleanup stretch.',
                 successors: ['completed', 'recycled'],
                 fields: {
                     kiln_temperature_c: {
@@ -129,6 +141,8 @@ vi.mock('../../workflow.yml', () => ({
             {
                 id: 'recycled',
                 visible: true,
+                friendly_name: 'Recycled',
+                description: 'Oops! Next time.',
                 terminal: true,
             },
         ],
@@ -136,7 +150,9 @@ vi.mock('../../workflow.yml', () => ({
 }))
 
 import {
+    formatState,
     formatWorkflowFieldLabel,
+    getStateDescription,
     getAdditionalFieldDefinitions,
     getFilterableFields,
     getGlobalComposeFrom,
@@ -152,6 +168,22 @@ describe('formatWorkflowFieldLabel', () => {
 
     it('converts a multi-word snake_case name to Title Case', () => {
         expect(formatWorkflowFieldLabel('clay_weight_grams')).toBe('Clay Weight Grams')
+    })
+})
+
+describe('formatState', () => {
+    it('uses the workflow-authored friendly_name', () => {
+        expect(formatState('submitted_to_bisque_fire')).toBe('Queued → Bisque')
+    })
+
+    it('returns an empty string for an unknown state instead of synthesizing a fallback', () => {
+        expect(formatState('unknown_state')).toBe('')
+    })
+})
+
+describe('getStateDescription', () => {
+    it('returns the workflow-authored state description', () => {
+        expect(getStateDescription('bisque_fired')).toBe('Done with the first firing!')
     })
 })
 

--- a/frontend_common/src/workflow.ts
+++ b/frontend_common/src/workflow.ts
@@ -41,6 +41,8 @@ type FieldDefinition = InlineFieldDef | StateRefFieldDef | GlobalRefFieldDef
 interface WorkflowStateDefinition {
     id: string
     visible: boolean
+    friendly_name: string
+    description: string
     terminal?: boolean
     successors?: string[]
     fields?: Record<string, FieldDefinition>
@@ -75,6 +77,13 @@ const STATE_MAP = new Map<string, WorkflowStateDefinition>(
 )
 const GLOBALS_MAP = workflowDef.globals ?? {}
 
+function toTitleWords(value: string): string {
+    return value
+        .split('_')
+        .map((word) => (word ? word.charAt(0).toUpperCase() + word.slice(1) : ''))
+        .join(' ')
+}
+
 export type ResolvedAdditionalField = {
     name: string
     type: FieldType
@@ -86,6 +95,13 @@ export type ResolvedAdditionalField = {
     canCreate?: boolean
     globalName?: string
     globalField?: string
+}
+
+export interface WorkflowStateMetadata {
+    id: string
+    friendlyName: string
+    description: string
+    isTerminal: boolean
 }
 
 /**
@@ -248,10 +264,37 @@ export function getAdditionalFieldDefinitions(stateId: string): ResolvedAddition
  * additional field names are shown in the UI.
  */
 export function formatWorkflowFieldLabel(fieldName: string): string {
-    return fieldName
-        .split('_')
-        .map((word) => (word ? word.charAt(0).toUpperCase() + word.slice(1) : ''))
-        .join(' ')
+    return toTitleWords(fieldName)
+}
+
+/**
+ * Converts a state ID into the shared display label used throughout the UI.
+ * State labels are required in workflow.yml; this helper intentionally does not
+ * synthesize a fallback label from the state ID.
+ */
+export function formatState(stateId: string): string {
+    return STATE_MAP.get(stateId)?.friendly_name ?? ''
+}
+
+export function getStateDescription(stateId: string): string {
+    return STATE_MAP.get(stateId)?.description ?? ''
+}
+
+export function isTerminalState(stateId: string): boolean {
+    return !!STATE_MAP.get(stateId)?.terminal
+}
+
+export function getStateMetadata(stateId: string): WorkflowStateMetadata | null {
+    const state = STATE_MAP.get(stateId)
+    if (!state) {
+        return null
+    }
+    return {
+        id: state.id,
+        friendlyName: state.friendly_name,
+        description: state.description,
+        isTerminal: !!state.terminal,
+    }
 }
 
 function isStateRefField(def: FieldDefinition): boolean {

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -106,6 +106,18 @@ def _all_inline_fields(workflow):
                 yield f"global '{global_name}'", field_name, field_def
 
 
+def _state(state_id, **overrides):
+    """Build a minimal valid state fixture for schema tests."""
+    state = {
+        "id": state_id,
+        "visible": True,
+        "friendly_name": state_id.title(),
+        "description": f"{state_id} description",
+    }
+    state.update(overrides)
+    return state
+
+
 # ---------------------------------------------------------------------------
 # Schema validation
 # ---------------------------------------------------------------------------
@@ -116,7 +128,7 @@ class TestSchemaValidation:
         jsonschema.validate(instance=workflow, schema=schema)
 
     def test_missing_version_fails(self, schema):
-        bad = {"states": [{"id": "a", "visible": True}, {"id": "b", "visible": True, "terminal": True}]}
+        bad = {"states": [_state("a"), _state("b", terminal=True)]}
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(instance=bad, schema=schema)
 
@@ -126,14 +138,14 @@ class TestSchemaValidation:
             jsonschema.validate(instance=bad, schema=schema)
 
     def test_invalid_version_format_fails(self, schema):
-        bad = {"version": "v1", "states": [{"id": "a", "visible": True}, {"id": "b", "visible": True, "terminal": True}]}
+        bad = {"version": "v1", "states": [_state("a"), _state("b", terminal=True)]}
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(instance=bad, schema=schema)
 
     def test_invalid_state_id_format_fails(self, schema):
         bad = {
             "version": "1.0.0",
-            "states": [{"id": "Bad-ID", "visible": True}, {"id": "b", "visible": True, "terminal": True}],
+            "states": [_state("Bad-ID"), _state("b", terminal=True)],
         }
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(instance=bad, schema=schema)
@@ -142,22 +154,44 @@ class TestSchemaValidation:
         bad = {
             "version": "1.0.0",
             "states": [
-                {"id": "a", "visible": True, "successors": ["b", "b"]},
-                {"id": "b", "visible": True, "terminal": True},
+                _state("a", successors=["b", "b"]),
+                _state("b", terminal=True),
             ],
         }
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(instance=bad, schema=schema)
 
     def test_extra_top_level_key_fails(self, schema):
-        bad = {"version": "1.0.0", "states": [{"id": "a", "visible": True}], "extra": True}
+        bad = {"version": "1.0.0", "states": [_state("a")], "extra": True}
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(instance=bad, schema=schema)
 
     def test_extra_state_key_fails(self, schema):
         bad = {
             "version": "1.0.0",
-            "states": [{"id": "a", "visible": True, "unknown_field": "x"}],
+            "states": [_state("a", unknown_field="x")],
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=bad, schema=schema)
+
+    def test_missing_friendly_name_fails(self, schema):
+        bad = {
+            "version": "1.0.0",
+            "states": [
+                {"id": "a", "visible": True, "description": "desc", "successors": ["b"]},
+                _state("b", terminal=True),
+            ],
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=bad, schema=schema)
+
+    def test_missing_description_fails(self, schema):
+        bad = {
+            "version": "1.0.0",
+            "states": [
+                {"id": "a", "visible": True, "friendly_name": "A", "successors": ["b"]},
+                _state("b", terminal=True),
+            ],
         }
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(instance=bad, schema=schema)
@@ -176,8 +210,8 @@ class TestSchemaValidation:
                 }
             },
             "states": [
-                {"id": "a", "visible": True, "successors": ["b"]},
-                {"id": "b", "visible": True, "terminal": True},
+                _state("a", successors=["b"]),
+                _state("b", terminal=True),
             ],
         }
         jsonschema.validate(instance=valid, schema=schema)
@@ -193,8 +227,8 @@ class TestSchemaValidation:
                 }
             },
             "states": [
-                {"id": "a", "visible": True, "successors": ["b"]},
-                {"id": "b", "visible": True, "terminal": True},
+                _state("a", successors=["b"]),
+                _state("b", terminal=True),
             ],
         }
         with pytest.raises(jsonschema.ValidationError):
@@ -212,8 +246,8 @@ class TestSchemaValidation:
                 }
             },
             "states": [
-                {"id": "a", "visible": True, "successors": ["b"]},
-                {"id": "b", "visible": True, "terminal": True},
+                _state("a", successors=["b"]),
+                _state("b", terminal=True),
             ],
         }
         jsonschema.validate(instance=valid, schema=schema)
@@ -230,8 +264,8 @@ class TestSchemaValidation:
                 }
             },
             "states": [
-                {"id": "a", "visible": True, "successors": ["b"]},
-                {"id": "b", "visible": True, "terminal": True},
+                _state("a", successors=["b"]),
+                _state("b", terminal=True),
             ],
         }
         jsonschema.validate(instance=valid, schema=schema)
@@ -248,14 +282,13 @@ class TestSchemaValidation:
             },
             "states": [
                 {
-                    "id": "a",
-                    "visible": True,
+                    **_state("a"),
                     "successors": ["b"],
                     "fields": {
                         "kiln": {"$ref": "@location.name"},
                     },
                 },
-                {"id": "b", "visible": True, "terminal": True},
+                _state("b", terminal=True),
             ],
         }
         jsonschema.validate(instance=valid, schema=schema)
@@ -272,14 +305,13 @@ class TestSchemaValidation:
             },
             "states": [
                 {
-                    "id": "a",
-                    "visible": True,
+                    **_state("a"),
                     "successors": ["b"],
                     "fields": {
                         "kiln": {"$ref": "@location.name", "can_create": True},
                     },
                 },
-                {"id": "b", "visible": True, "terminal": True},
+                _state("b", terminal=True),
             ],
         }
         jsonschema.validate(instance=valid, schema=schema)
@@ -290,22 +322,20 @@ class TestSchemaValidation:
             "version": "1.0.0",
             "states": [
                 {
-                    "id": "a",
-                    "visible": True,
+                    **_state("a"),
                     "successors": ["b"],
                     "fields": {
                         "x": {"type": "number"},
                     },
                 },
                 {
-                    "id": "b",
-                    "visible": True,
+                    **_state("b"),
                     "successors": ["c"],
                     "fields": {
                         "y": {"$ref": "a.x", "can_create": True},
                     },
                 },
-                {"id": "c", "visible": True, "terminal": True},
+                _state("c", terminal=True),
             ],
         }
         with pytest.raises(jsonschema.ValidationError):
@@ -317,14 +347,13 @@ class TestSchemaValidation:
             "version": "1.0.0",
             "states": [
                 {
-                    "id": "a",
-                    "visible": True,
+                    **_state("a"),
                     "successors": ["b"],
                     "fields": {
                         "x": {"type": "number", "can_create": True},
                     },
                 },
-                {"id": "b", "visible": True, "terminal": True},
+                _state("b", terminal=True),
             ],
         }
         with pytest.raises(jsonschema.ValidationError):
@@ -336,12 +365,11 @@ class TestSchemaValidation:
             "version": "1.0.0",
             "states": [
                 {
-                    "id": "a",
-                    "visible": True,
+                    **_state("a"),
                     "successors": ["b"],
                     "fields": {"x": {"$ref": "not-valid"}},
                 },
-                {"id": "b", "visible": True, "terminal": True},
+                _state("b", terminal=True),
             ],
         }
         with pytest.raises(jsonschema.ValidationError):
@@ -351,7 +379,7 @@ class TestSchemaValidation:
         bad = {
             "version": "1.0.0",
             "globals": {"location": {"fields": {"name": {"type": "string"}}}},
-            "states": [{"id": "a", "visible": True}, {"id": "b", "visible": True, "terminal": True}],
+            "states": [_state("a"), _state("b", terminal=True)],
         }
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(instance=bad, schema=schema)
@@ -360,7 +388,7 @@ class TestSchemaValidation:
         bad = {
             "version": "1.0.0",
             "globals": {"location": {"model": "Location", "fields": {}}},
-            "states": [{"id": "a", "visible": True}, {"id": "b", "visible": True, "terminal": True}],
+            "states": [_state("a"), _state("b", terminal=True)],
         }
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(instance=bad, schema=schema)
@@ -382,7 +410,7 @@ class TestSchemaValidation:
                     },
                 },
             },
-            "states": [{"id": "a", "visible": True}, {"id": "b", "visible": True, "terminal": True}],
+            "states": [_state("a"), _state("b", terminal=True)],
         }
         jsonschema.validate(instance=valid, schema=schema)
 
@@ -399,7 +427,7 @@ class TestSchemaValidation:
                     },
                 },
             },
-            "states": [{"id": "a", "visible": True}, {"id": "b", "visible": True, "terminal": True}],
+            "states": [_state("a"), _state("b", terminal=True)],
         }
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(instance=bad, schema=schema)
@@ -417,7 +445,7 @@ class TestSchemaValidation:
                     },
                 },
             },
-            "states": [{"id": "a", "visible": True}, {"id": "b", "visible": True, "terminal": True}],
+            "states": [_state("a"), _state("b", terminal=True)],
         }
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(instance=bad, schema=schema)
@@ -452,7 +480,7 @@ class TestSchemaValidation:
                     },
                 },
             },
-            "states": [{"id": "a", "visible": True}, {"id": "b", "visible": True, "terminal": True}],
+            "states": [_state("a"), _state("b", terminal=True)],
         }
         jsonschema.validate(instance=valid, schema=schema)
 
@@ -469,7 +497,7 @@ class TestSchemaValidation:
                     },
                 },
             },
-            "states": [{"id": "a", "visible": True}, {"id": "b", "visible": True, "terminal": True}],
+            "states": [_state("a"), _state("b", terminal=True)],
         }
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(instance=bad, schema=schema)
@@ -492,7 +520,7 @@ class TestSchemaValidation:
                     },
                 },
             },
-            "states": [{"id": "a", "visible": True}, {"id": "b", "visible": True, "terminal": True}],
+            "states": [_state("a"), _state("b", terminal=True)],
         }
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(instance=bad, schema=schema)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -241,7 +241,7 @@ function AppShell({
   }, [currentUser])
 
   return (
-    <Container maxWidth="lg" sx={{ py: 4 }}>
+    <Container maxWidth="lg" sx={{ py: 2 }}>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 0 }}>
         <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1}}>
           <Typography variant="h6" component="p" color="text.primary" display="inline">

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -24,10 +24,11 @@ import CheckIcon from '@mui/icons-material/Check'
 import CloseIcon from '@mui/icons-material/Close'
 import { useBlocker } from 'react-router-dom'
 import type { CaptionedImage, PieceDetail as PieceDetailType, TagEntry } from '@common/types'
-import { formatState, SUCCESSORS } from '@common/types'
+import { formatState, getStateDescription, isTerminalState, SUCCESSORS } from '@common/types'
 import { addPieceState, createTagEntry, fetchGlobalEntries, updatePiece } from '@common/api'
 import ImageLightbox from './ImageLightbox'
 import CloudinaryImage from './CloudinaryImage'
+import StateChip from './StateChip'
 import WorkflowState from './WorkflowState'
 import { pickDefaultTagColor } from './tagPalette'
 import TagAutocomplete from './TagAutocomplete'
@@ -36,135 +37,22 @@ import TagChipList from './TagChipList'
 
 const DUPLICATE_TAG_ERROR = 'A tag with that name already exists. Choose the existing tag or enter a different name.'
 const TAG_ATTACH_SNACKBAR_ERROR = 'Failed to attach the selected tag. Please check your connection and try again.'
-const DEFAULT_STATE_COLOR = 'oklch(0.66 0.17 35)'
-const COMPLETED_STATE_COLOR = 'oklch(0.72 0.17 145)'
-const RECYCLED_STATE_COLOR = 'oklch(0.63 0.23 25)'
 
 type PieceDetailProps = {
     piece: PieceDetailType
     onPieceUpdated: (updated: PieceDetailType) => void
 }
 
-type StateChipProps = {
-    state: string
-    label: string
-    current?: boolean
-    muted?: boolean
-    onClick?: () => void
-    disabled?: boolean
-    onHoverStart?: () => void
-    onHoverEnd?: () => void
-}
-
-function getStateColor(state: string): string {
-    if (state === 'completed') {
-        return COMPLETED_STATE_COLOR
-    }
-    if (state === 'recycled') {
-        return RECYCLED_STATE_COLOR
-    }
-    return DEFAULT_STATE_COLOR
-}
-
-function StateChip({
-    state,
-    label,
-    current = false,
-    muted = false,
-    onClick,
-    disabled = false,
-    onHoverStart,
-    onHoverEnd,
-}: StateChipProps) {
-    const color = getStateColor(state)
-    const mutedColor = 'oklch(0.62 0 0)'
-    const outlineColor = current && muted ? `color-mix(in oklab, ${mutedColor} 55%, transparent)` : color
-    const backgroundColor = current
-        ? muted
-            ? `color-mix(in oklab, ${mutedColor} 14%, transparent)`
-            : `color-mix(in oklab, ${color} 18%, transparent)`
-        : 'transparent'
-    const dotFillColor = current ? (muted ? `color-mix(in oklab, ${mutedColor} 45%, white)` : color) : 'transparent'
-    const stateChipSx = {
-        borderRadius: 999,
-        border: '1px solid',
-        borderColor: outlineColor,
-        display: 'inline-flex',
-        alignItems: 'center',
-        gap: 0.75,
-        fontWeight: 500,
-        lineHeight: 1,
-        minHeight: current ? 28 : 24,
-        px: current ? 1.25 : 1,
-        py: current ? 0.5 : 0.25,
-        textTransform: 'none',
-        whiteSpace: 'nowrap',
-        width: 'fit-content',
-        color: current && muted ? `color-mix(in oklab, ${mutedColor} 80%, black)` : color,
-        backgroundColor,
-        borderStyle: current ? 'solid' : 'dashed',
-        fontSize: current ? '0.85rem' : '0.8125rem',
-        boxShadow: 'none',
-    }
-    const dot = (
-        <Box
-            component="span"
-            className="state-chip-dot"
-            sx={{
-                width: 8,
-                height: 8,
-                borderRadius: '50%',
-                border: `1.5px solid ${outlineColor}`,
-                backgroundColor: dotFillColor,
-                flexShrink: 0,
-            }}
-        />
-    )
-    const content = (
-        <>
-            {dot}
-            <Box component="span">{label}</Box>
-        </>
-    )
-
-    if (onClick) {
-        return (
-            <Button
-                onClick={onClick}
-                disabled={disabled}
-                variant="text"
-                sx={{
-                    ...stateChipSx,
-                    justifyContent: 'flex-start',
-                    minWidth: 0,
-                    '&:hover': {
-                        borderStyle: 'solid',
-                        borderColor: color,
-                        backgroundColor: `color-mix(in oklab, ${color} 18%, transparent)`,
-                        '& .state-chip-dot': {
-                            backgroundColor: color,
-                        },
-                    },
-                    '&.Mui-disabled': {
-                        color: `color-mix(in oklab, ${color} 55%, white)`,
-                        borderColor: `color-mix(in oklab, ${color} 55%, white)`,
-                    },
-                }}
-                onMouseEnter={onHoverStart}
-                onMouseLeave={onHoverEnd}
-                onFocus={onHoverStart}
-                onBlur={onHoverEnd}
-            >
-                {content}
-            </Button>
-        )
-    }
-
-    return (
-        <Box component="span" sx={stateChipSx}>
-            {content}
-        </Box>
-    )
+function sortSuccessorsForDisplay(successors: string[]): string[] {
+    const standardSuccessors = successors.filter((state) => state !== 'completed' && state !== 'recycled')
+    const trailingSuccessors = successors.filter((state) => state === 'completed' || state === 'recycled')
+    trailingSuccessors.sort((left, right) => {
+        if (left === right) return 0
+        if (left === 'completed') return -1
+        if (right === 'completed') return 1
+        return 0
+    })
+    return [...standardSuccessors, ...trailingSuccessors]
 }
 
 type StateBranchConnectorProps = {
@@ -234,7 +122,7 @@ export default function PieceDetail({ piece, onPieceUpdated }: PieceDetailProps)
     const [hoveredSuccessor, setHoveredSuccessor] = useState<string | null>(null)
     const nameInputRef = useRef<HTMLInputElement>(null)
     const currentState = piece.current_state
-    const successors = SUCCESSORS[currentState.state] ?? []
+    const successors = sortSuccessorsForDisplay(SUCCESSORS[currentState.state] ?? [])
     const isTerminal = successors.length === 0
     const pastHistory = piece.history.slice(0, -1) // all except current (last)
     // Flat list of all images across all past states, in history order.
@@ -391,7 +279,7 @@ export default function PieceDetail({ piece, onPieceUpdated }: PieceDetailProps)
     return (
         <Box sx={{ textAlign: 'left' }}>
             {/* Header */}
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 1 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 0 }}>
                 {piece.thumbnail && (
                     <CloudinaryImage
                         url={piece.thumbnail.url}
@@ -401,146 +289,160 @@ export default function PieceDetail({ piece, onPieceUpdated }: PieceDetailProps)
                         style={{ objectFit: 'cover', borderRadius: 4 }}
                     />
                 )}
-                <Box sx={{ minWidth: 0 }}>
-                    {editingName ? (
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                            <TextField
-                                inputRef={nameInputRef}
-                                value={nameValue}
-                                onChange={(e) => setNameValue(e.target.value)}
-                                onKeyDown={(e) => {
-                                    if (e.key === 'Enter') saveName()
-                                    if (e.key === 'Escape') cancelEditingName()
-                                }}
-                                size="small"
-                                error={!!nameError}
-                                helperText={nameError}
-                                disabled={nameSaving}
-                                slotProps={{ htmlInput: { 'aria-label': 'Piece name', maxLength: 255 } }}
-                                sx={{ minWidth: 200 }}
-                            />
-                            <IconButton
-                                aria-label="Save name"
-                                onClick={saveName}
-                                disabled={nameSaving}
-                                size="small"
-                                color="primary"
-                            >
-                                <CheckIcon fontSize="small" />
-                            </IconButton>
-                            <IconButton
-                                aria-label="Cancel name edit"
-                                onClick={cancelEditingName}
-                                disabled={nameSaving}
-                                size="small"
-                            >
-                                <CloseIcon fontSize="small" />
-                            </IconButton>
-                        </Box>
-                    ) : (
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                            <Typography variant="h5" component="h2">
-                                {piece.name}
-                            </Typography>
-                            <IconButton
-                                aria-label="Edit piece name"
-                                onClick={startEditingName}
-                                size="small"
-                                sx={{ color: 'text.secondary' }}
-                            >
-                                <EditIcon fontSize="small" />
-                            </IconButton>
-                        </Box>
-                    )}
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', width: '100%', alignItems: 'center' }}>
+                  <Box sx={{ minWidth: 0, flexBasis: '100%' }}>
+                      {editingName ? (
+                          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                              <TextField
+                                  inputRef={nameInputRef}
+                                  value={nameValue}
+                                  onChange={(e) => setNameValue(e.target.value)}
+                                  onKeyDown={(e) => {
+                                      if (e.key === 'Enter') saveName()
+                                      if (e.key === 'Escape') cancelEditingName()
+                                  }}
+                                  size="small"
+                                  error={!!nameError}
+                                  helperText={nameError}
+                                  disabled={nameSaving}
+                                  slotProps={{ htmlInput: { 'aria-label': 'Piece name', maxLength: 255 } }}
+                                  sx={{ minWidth: 200 }}
+                              />
+                              <IconButton
+                                  aria-label="Save name"
+                                  onClick={saveName}
+                                  disabled={nameSaving}
+                                  size="small"
+                                  color="primary"
+                              >
+                                  <CheckIcon fontSize="small" />
+                              </IconButton>
+                              <IconButton
+                                  aria-label="Cancel name edit"
+                                  onClick={cancelEditingName}
+                                  disabled={nameSaving}
+                                  size="small"
+                              >
+                                  <CloseIcon fontSize="small" />
+                              </IconButton>
+                          </Box>
+                      ) : (
+                          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                              <Typography variant="h5" component="h2">
+                                  {piece.name}
+                              </Typography>
+                              <IconButton
+                                  aria-label="Edit piece name"
+                                  onClick={startEditingName}
+                                  size="small"
+                                  sx={{ color: 'text.secondary' }}
+                              >
+                                  <EditIcon fontSize="small" />
+                              </IconButton>
+                          </Box>
+                      )}
+                </Box>
+                <Box sx={{ flexBasis: "100%" }}>
+                {editingTags ? (
+                    <Box sx={{ mb: 2 }}>
                     <Box
-                        aria-label="State flow"
-                        role="group"
                         sx={{
-                            mt: 1,
-                            display: 'flex',
-                            alignItems: 'center',
-                            gap: 1.25,
+                            display: 'grid',
+                            gap: 1,
+                            gridTemplateColumns: { xs: '1fr', sm: 'minmax(0, 1fr) auto' },
+                            alignItems: 'start',
                         }}
                     >
-                        <StateChip
-                            state={currentState.state}
-                            label={formatState(currentState.state)}
-                            current
-                            muted={hoveredSuccessor !== null}
+                        <TagAutocomplete
+                            label="Tags"
+                            options={availableTags}
+                            value={draftTags}
+                            onChange={setDraftTags}
+                            disabled={tagSaving}
+                            sx={{ minWidth: 0 }}
                         />
-                        {!isTerminal && <StateBranchConnector count={successors.length} />}
-                        {!isTerminal && (
-                            <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 0.75 }}>
-                                {successors.map((next) => (
-                                    <StateChip
-                                        key={next}
-                                        state={next}
-                                        label={formatState(next)}
-                                        onClick={() => openTransitionDialog(next)}
-                                        disabled={isDirty || transitioning}
-                                        onHoverStart={() => setHoveredSuccessor(next)}
-                                        onHoverEnd={() => setHoveredSuccessor((value) => (value === next ? null : value))}
-                                    />
-                                ))}
-                            </Box>
-                        )}
+                        <Button
+                            variant="outlined"
+                            size="small"
+                            onClick={() => setTagDialogOpen(true)}
+                            disabled={tagSaving}
+                            sx={{ minWidth: { sm: 88 } }}
+                        >
+                          New
+                        </Button>
                     </Box>
-                </Box>
-            </Box>
-            {editingTags ? (
-                <Box sx={{ mb: 2 }}>
-                <Box
-                    sx={{
-                        display: 'grid',
-                        gap: 1,
-                        gridTemplateColumns: { xs: '1fr', sm: 'minmax(0, 1fr) auto' },
-                        alignItems: 'start',
-                    }}
-                >
-                    <TagAutocomplete
-                        label="Tags"
-                        options={availableTags}
-                        value={draftTags}
-                        onChange={setDraftTags}
-                        disabled={tagSaving}
-                        sx={{ minWidth: 0 }}
-                    />
                     <Button
-                        variant="outlined"
+                        variant="contained"
                         size="small"
-                        onClick={() => setTagDialogOpen(true)}
+                        onClick={() => void saveTags(draftTags)}
                         disabled={tagSaving}
-                        sx={{ width: { xs: '100%', sm: 'auto' }, minWidth: { sm: 88 } }}
+                        aria-label="Save tags"
+                        sx={{ mt: 1 }}
                     >
-                      New
+                        Save
                     </Button>
+                    </Box>
+                ) : (
+                    <Box sx={{ mb: 2, display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
+                        {selectedTags.length > 0 ? (
+                            <TagChipList tags={selectedTags} />
+                        ) : (
+                            <Typography variant="body2" sx={{ color: 'text.secondary', mr: 0}}>
+                              Add some tags!
+                            </Typography>
+                        )}
+                        <IconButton
+                            aria-label="Edit tags"
+                            onClick={startEditingTags}
+                            disabled={tagSaving}
+                            size="small"
+                            sx={{ color: 'text.secondary' }}
+                        >
+                            <EditIcon fontSize="small" />
+                        </IconButton>
+                    </Box>
+                )}
                 </Box>
-                <Button
-                    variant="contained"
-                    size="small"
-                    onClick={() => void saveTags(draftTags)}
-                    disabled={tagSaving}
-                    aria-label="Save tags"
-                    sx={{ mt: 1 }}
-                >
-                    Save
-                </Button>
-                </Box>
-            ) : (
-                <Box sx={{ mb: 2, display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
-                    <TagChipList tags={selectedTags} />
-                    <IconButton
-                        aria-label="Edit tags"
-                        onClick={startEditingTags}
-                        disabled={tagSaving}
-                        size="small"
-                        sx={{ color: 'text.secondary' }}
-                    >
-                        <EditIcon fontSize="small" />
-                    </IconButton>
-                </Box>
-            )}
-            <Divider sx={{ mb: 3 }} />
+              </Box>
+            </Box>
+            <Box
+                aria-label="State flow"
+                role="group"
+                sx={{
+                    mb: 1.5,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1.25,
+                }}
+            >
+                <StateChip
+                    state={currentState.state}
+                    label={formatState(currentState.state)}
+                    description={getStateDescription(currentState.state)}
+                    variant="current"
+                    isTerminal={isTerminalState(currentState.state)}
+                    muted={hoveredSuccessor !== null}
+                />
+                {!isTerminal && <StateBranchConnector count={successors.length} />}
+                {!isTerminal && (
+                    <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 0.75 }}>
+                        {successors.map((next) => (
+                            <StateChip
+                                key={next}
+                                state={next}
+                                label={formatState(next)}
+                                description={getStateDescription(next)}
+                                variant="future"
+                                isTerminal={isTerminalState(next)}
+                                onClick={() => openTransitionDialog(next)}
+                                disabled={isDirty || transitioning}
+                                onHoverStart={() => setHoveredSuccessor(next)}
+                                onHoverEnd={() => setHoveredSuccessor((value) => (value === next ? null : value))}
+                            />
+                        ))}
+                    </Box>
+                )}
+            </Box>
 
             {/* Current state form */}
             <WorkflowState

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -17,8 +17,9 @@ import {
 } from "@mui/material";
 import { Link, useNavigate } from "react-router-dom";
 import type { PieceSummary, TagEntry } from '@common/types'
-import { SUCCESSORS } from '@common/types'
+import { formatState, getStateDescription, isTerminalState, SUCCESSORS } from '@common/types'
 import CloudinaryImage from './CloudinaryImage'
+import StateChip from './StateChip'
 import TagAutocomplete from './TagAutocomplete'
 import TagChipList from './TagChipList'
 
@@ -75,7 +76,13 @@ const PieceListItem = (props: PieceListItemProps) => {
         </Link>
       </TableCell>
       <TableCell sx={{ color: 'text.primary' }}>
-        {piece.current_state.state}
+        <StateChip
+          state={piece.current_state.state}
+          label={formatState(piece.current_state.state)}
+          description={getStateDescription(piece.current_state.state)}
+          variant="current"
+          isTerminal={isTerminalState(piece.current_state.state)}
+        />
       </TableCell>
       <TableCell sx={{ color: 'text.primary' }}>
         <TagChipList tags={piece.tags ?? []} />

--- a/web/src/components/StateChip.tsx
+++ b/web/src/components/StateChip.tsx
@@ -1,0 +1,159 @@
+import { Box, ButtonBase, type SxProps, type Theme } from '@mui/material'
+
+const DEFAULT_STATE_COLOR = 'oklch(0.66 0.17 35)'
+const COMPLETED_STATE_COLOR = 'oklch(0.72 0.17 145)'
+const RECYCLED_STATE_COLOR = 'oklch(0.63 0.23 25)'
+const PAST_STATE_COLOR = 'oklch(0.62 0 0)'
+
+export type StateChipVariant = 'current' | 'past' | 'future'
+
+export interface StateChipProps {
+    state: string
+    label: string
+    description?: string
+    variant: StateChipVariant
+    isTerminal: boolean
+    muted?: boolean
+    disabled?: boolean
+    onClick?: () => void
+    onHoverStart?: () => void
+    onHoverEnd?: () => void
+}
+
+function getStateColor(state: string, isTerminal: boolean): string {
+    if (isTerminal && state === 'completed') {
+        return COMPLETED_STATE_COLOR
+    }
+    if (isTerminal && state === 'recycled') {
+        return RECYCLED_STATE_COLOR
+    }
+    return DEFAULT_STATE_COLOR
+}
+
+export default function StateChip({
+    state,
+    label,
+    description,
+    variant,
+    isTerminal,
+    muted = false,
+    disabled = false,
+    onClick,
+    onHoverStart,
+    onHoverEnd,
+}: StateChipProps) {
+    const interactive = variant === 'future' && !!onClick
+    const baseColor = variant === 'past' ? PAST_STATE_COLOR : getStateColor(state, isTerminal)
+    const outlineColor = muted
+        ? `color-mix(in oklab, ${PAST_STATE_COLOR} 55%, transparent)`
+        : baseColor
+
+    const backgroundColor = (() => {
+        if (variant === 'current') {
+            return muted
+                ? `color-mix(in oklab, ${PAST_STATE_COLOR} 14%, transparent)`
+                : `color-mix(in oklab, ${baseColor} 18%, transparent)`
+        }
+        if (variant === 'past') {
+            return `color-mix(in oklab, ${PAST_STATE_COLOR} 10%, transparent)`
+        }
+        return 'transparent'
+    })()
+
+    const dotFillColor = (() => {
+        if (variant === 'current') {
+            return muted ? `color-mix(in oklab, ${PAST_STATE_COLOR} 45%, white)` : baseColor
+        }
+        if (variant === 'past') {
+            return `color-mix(in oklab, ${PAST_STATE_COLOR} 18%, white)`
+        }
+        return 'transparent'
+    })()
+
+    const chipSx: SxProps<Theme> = {
+        borderRadius: 999,
+        border: '1px solid',
+        borderColor: outlineColor,
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 0.75,
+        fontWeight: 500,
+        lineHeight: 1,
+        minHeight: variant === 'current' ? 28 : 24,
+        px: variant === 'current' ? 1.25 : 1,
+        py: variant === 'current' ? 0.5 : 0.25,
+        textTransform: 'none',
+        whiteSpace: 'nowrap',
+        width: 'fit-content',
+        color: muted ? `color-mix(in oklab, ${PAST_STATE_COLOR} 80%, black)` : baseColor,
+        backgroundColor,
+        borderStyle: variant === 'future' ? 'dashed' : 'solid',
+        fontSize: variant === 'current' ? '0.85rem' : '0.8125rem',
+        boxShadow: 'none',
+        opacity: disabled ? 0.6 : 1,
+        transition: 'background-color 120ms ease, border-color 120ms ease, color 120ms ease',
+        ...(interactive ? {
+            '&:hover': {
+                backgroundColor: `color-mix(in oklab, ${baseColor} 16%, transparent)`,
+                borderStyle: 'solid',
+                '.state-chip-dot': {
+                    backgroundColor: baseColor,
+                },
+            },
+        } : {}),
+    }
+
+    const content = (
+        <>
+            <Box
+                component="span"
+                className="state-chip-dot"
+                sx={{
+                    width: 8,
+                    height: 8,
+                    borderRadius: '50%',
+                    border: `1.5px solid ${outlineColor}`,
+                    backgroundColor: dotFillColor,
+                    flexShrink: 0,
+                    transition: 'background-color 120ms ease, border-color 120ms ease',
+                }}
+            />
+            <Box component="span">{label}</Box>
+        </>
+    )
+
+    if (interactive) {
+        return (
+            <ButtonBase
+                onClick={onClick}
+                onMouseEnter={onHoverStart}
+                onMouseLeave={onHoverEnd}
+                onFocus={onHoverStart}
+                onBlur={onHoverEnd}
+                disabled={disabled}
+                title={description}
+                data-state={state}
+                data-variant={variant}
+                data-terminal={isTerminal}
+                sx={chipSx}
+            >
+                {content}
+            </ButtonBase>
+        )
+    }
+
+    return (
+        <Box
+            component="span"
+            onMouseEnter={onHoverStart}
+            onMouseLeave={onHoverEnd}
+            title={description}
+            data-state={state}
+            data-variant={variant}
+            data-terminal={isTerminal}
+            sx={chipSx}
+        >
+            {content}
+        </Box>
+    )
+}

--- a/web/src/components/__tests__/PieceDetail.test.tsx
+++ b/web/src/components/__tests__/PieceDetail.test.tsx
@@ -71,7 +71,7 @@ describe('PieceDetail', () => {
 
     it('renders current state label', async () => {
         await renderPieceDetail()
-        expect(screen.getAllByText('Designed').length).toBeGreaterThan(0)
+        expect(screen.getAllByText('Designing').length).toBeGreaterThan(0)
     })
 
     it('renders thumbnail image', async () => {
@@ -135,9 +135,19 @@ describe('PieceDetail', () => {
         await renderPieceDetail()
         // 'designed' has successors: wheel_thrown, handbuilt
         const stateFlow = screen.getByRole('group', { name: 'State flow' })
-        expect(within(stateFlow).getByText('Designed')).toBeInTheDocument()
-        expect(within(stateFlow).getByRole('button', { name: 'Wheel Thrown' })).toBeInTheDocument()
-        expect(within(stateFlow).getByRole('button', { name: 'Handbuilt' })).toBeInTheDocument()
+        expect(within(stateFlow).getByText('Designing')).toBeInTheDocument()
+        expect(within(stateFlow).getByRole('button', { name: 'Throwing' })).toBeInTheDocument()
+        expect(within(stateFlow).getByRole('button', { name: 'Handbuilding' })).toBeInTheDocument()
+    })
+
+    it('renders completed before recycled at the end of the successor list', async () => {
+        const piece = makePiece({ current_state: makeState({ state: 'glaze_fired' }) })
+        await renderPieceDetail(piece)
+
+        const stateFlow = screen.getByRole('group', { name: 'State flow' })
+        const buttons = within(stateFlow).getAllByRole('button')
+
+        expect(buttons.map((button) => button.textContent)).toEqual(['Sanding', 'Completed', 'Recycled'])
     })
 
     it('shows terminal state alert for terminal states', async () => {
@@ -149,33 +159,33 @@ describe('PieceDetail', () => {
     it('shows no transition buttons for terminal states', async () => {
         const piece = makePiece({ current_state: makeState({ state: 'completed' }), history: [makeState({ state: 'completed' })] })
         await renderPieceDetail(piece)
-        expect(screen.queryByRole('button', { name: 'Wheel Thrown' })).not.toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: 'Throwing' })).not.toBeInTheDocument()
     })
 
     it('transition buttons disabled when there are unsaved changes', async () => {
         await renderPieceDetail()
         fireEvent.change(screen.getByLabelText('Notes'), { target: { value: 'Dirty notes' } })
-        const transitionBtn = screen.getByRole('button', { name: 'Wheel Thrown' })
+        const transitionBtn = screen.getByRole('button', { name: 'Throwing' })
         expect(transitionBtn).toBeDisabled()
     })
 
     it('clicking transition button opens confirmation dialog', async () => {
         await renderPieceDetail()
-        fireEvent.click(screen.getByRole('button', { name: 'Wheel Thrown' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Throwing' }))
         expect(screen.getByText(/Confirm State Transition/i)).toBeInTheDocument()
     })
 
     it('confirmation dialog shows from/to states', async () => {
         await renderPieceDetail()
-        fireEvent.click(screen.getByRole('button', { name: 'Wheel Thrown' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Throwing' }))
         // The dialog body contains both state names (human-readable)
-        expect(screen.getAllByText(/Designed/).length).toBeGreaterThan(0)
-        expect(screen.getAllByText(/Wheel Thrown/).length).toBeGreaterThan(0)
+        expect(screen.getAllByText(/Designing/).length).toBeGreaterThan(0)
+        expect(screen.getAllByText(/Throwing/).length).toBeGreaterThan(0)
     })
 
     it('cancelling confirmation closes dialog', async () => {
         await renderPieceDetail()
-        fireEvent.click(screen.getByRole('button', { name: 'Wheel Thrown' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Throwing' }))
         fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
         await waitFor(() =>
             expect(screen.queryByText(/Confirm State Transition/i)).not.toBeInTheDocument()
@@ -187,7 +197,7 @@ describe('PieceDetail', () => {
         vi.mocked(api.addPieceState).mockResolvedValue(updated)
         const onPieceUpdated = vi.fn()
         await renderPieceDetail(makePiece(), onPieceUpdated)
-        fireEvent.click(screen.getByRole('button', { name: 'Wheel Thrown' }))
+        fireEvent.click(screen.getByRole('button', { name: 'Throwing' }))
         await waitFor(() => expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument())
         fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
         await waitFor(() => expect(api.addPieceState).toHaveBeenCalledWith('piece-id-1', { state: 'wheel_thrown' }))
@@ -213,7 +223,7 @@ describe('PieceDetail', () => {
         })
         await renderPieceDetail(piece)
         fireEvent.click(screen.getByRole('button', { name: /show history/i }))
-        expect(screen.getByText('Designed')).toBeInTheDocument()
+        expect(screen.getByText('Designing')).toBeInTheDocument()
     })
 
     it('no history panel when piece has only one state', async () => {
@@ -417,7 +427,6 @@ describe('PieceDetail', () => {
                 id: 'sale',
                 name: 'For Sale',
                 color: '#4FC3F7',
-                isPublic: false,
             })
 
             await renderPieceDetail()

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -61,7 +61,7 @@ describe('PieceList', () => {
 
         it('renders the current state', () => {
             renderPieceList([makePiece({ current_state: { state: 'bisque_fired' } })])
-            expect(screen.getByText('bisque_fired')).toBeInTheDocument()
+            expect(screen.getByText('Planning → Glaze')).toBeInTheDocument()
         })
 
         it('renders the thumbnail image with correct src', () => {
@@ -124,9 +124,9 @@ describe('PieceList', () => {
             const rows = screen.getAllByRole('row')
             // rows[0] is the header row
             expect(within(rows[1]).getByText('Bowl')).toBeInTheDocument()
-            expect(within(rows[1]).getByText('designed')).toBeInTheDocument()
+            expect(within(rows[1]).getByText('Designing')).toBeInTheDocument()
             expect(within(rows[2]).getByText('Mug')).toBeInTheDocument()
-            expect(within(rows[2]).getByText('glazed')).toBeInTheDocument()
+            expect(within(rows[2]).getByText('Glazing')).toBeInTheDocument()
         })
     })
 

--- a/web/src/components/__tests__/StateChip.test.tsx
+++ b/web/src/components/__tests__/StateChip.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import StateChip from '../StateChip'
+
+describe('StateChip', () => {
+    it('renders a non-interactive current chip with description metadata', () => {
+        render(
+            <StateChip
+                state="designed"
+                label="Designing"
+                description="Dreaming it up."
+                variant="current"
+                isTerminal={false}
+            />
+        )
+
+        const chip = screen.getByText('Designing').closest('[data-state="designed"]')
+        expect(chip).toHaveAttribute('data-variant', 'current')
+        expect(chip).toHaveAttribute('title', 'Dreaming it up.')
+    })
+
+    it('renders a clickable future chip', () => {
+        const onClick = vi.fn()
+        render(
+            <StateChip
+                state="glazing"
+                label="Glazing"
+                variant="future"
+                isTerminal={false}
+                onClick={onClick}
+            />
+        )
+
+        fireEvent.click(screen.getByRole('button', { name: 'Glazing' }))
+        expect(onClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('marks terminal chips in the data attributes', () => {
+        render(
+            <StateChip
+                state="completed"
+                label="Completed"
+                variant="past"
+                isTerminal
+            />
+        )
+
+        expect(screen.getByText('Completed').closest('[data-state="completed"]')).toHaveAttribute('data-terminal', 'true')
+    })
+})

--- a/web/src/pages/PieceDetailPage.tsx
+++ b/web/src/pages/PieceDetailPage.tsx
@@ -18,7 +18,7 @@ export default function PieceDetailPage() {
     <>
       <Box sx={{ mb: 2, textAlign: 'left' }}>
         <Button variant="text" onClick={() => navigate('/')} sx={{ px: 0 }}>
-          ← Back to Pottery Pieces
+          ← Back to Pieces
         </Button>
       </Box>
       {loading && (

--- a/workflow.schema.yml
+++ b/workflow.schema.yml
@@ -179,7 +179,7 @@ $defs:
 
   state:
     type: object
-    required: [id, visible]
+    required: [id, visible, friendly_name, description]
     additionalProperties: false
     properties:
       id:
@@ -189,6 +189,18 @@ $defs:
       visible:
         type: boolean
         description: Whether this state is shown in the default UI.
+      friendly_name:
+        type: string
+        description: |
+          Human-friendly label for this state, used by clients when displaying
+          workflow state names. This is required so every visible state label is
+          authored explicitly in workflow.yml rather than synthesized from the ID.
+      description:
+        type: string
+        description: |
+          Required short description of the state's current meaning, written for
+          humans. Clients may use this text for tooltips, helper copy, or other
+          contextual explanations of the workflow step.
       terminal:
         type: boolean
         description: If true, no outgoing transitions are allowed.

--- a/workflow.yml
+++ b/workflow.yml
@@ -244,12 +244,16 @@ globals:
 states:
   - id: designed
     visible: true
+    friendly_name: Designing
+    description: Dreaming it up and deciding how this piece wants to begin.
     successors:
       - wheel_thrown
       - handbuilt
 
   - id: wheel_thrown
     visible: true
+    friendly_name: Throwing
+    description: Fresh off the wheel and drying toward trimming.
     successors:
       - recycled
       - trimmed
@@ -267,6 +271,8 @@ states:
 
   - id: trimmed
     visible: true
+    friendly_name: Decorating
+    description: Trimmed and ready for carving, slip, or a straight shot to bisque.
     successors:
       - recycled
       - slip_applied
@@ -282,6 +288,8 @@ states:
 
   - id: handbuilt
     visible: true
+    friendly_name: Handbuilding
+    description: Built by hand and settling in before decoration or the bisque queue.
     successors:
       - recycled
       - slip_applied
@@ -295,6 +303,8 @@ states:
 
   - id: slip_applied
     visible: true
+    friendly_name: Adding Slip
+    description: Slip is going on for color, contrast, and future carving fun.
     successors:
       - recycled
       - carved
@@ -302,6 +312,8 @@ states:
 
   - id: carved
     visible: true
+    friendly_name: Carving
+    description: Carving time. A little more surface work and then off to bisque.
     successors:
       - recycled
       - slip_applied
@@ -309,6 +321,8 @@ states:
 
   - id: submitted_to_bisque_fire
     visible: true
+    friendly_name: "Queued → Bisque"
+    description: Waiting on the kiln...
     successors:
       - recycled
       - bisque_fired
@@ -320,6 +334,8 @@ states:
 
   - id: bisque_fired
     visible: true
+    friendly_name: "Planning → Glaze"
+    description: Done with the first firing! Glazing comes next...
     successors:
       - recycled
       - waxed
@@ -335,12 +351,16 @@ states:
 
   - id: waxed
     visible: true
+    friendly_name: Waxing
+    description: Wax resist is going on so the glaze behaves itself.
     successors:
       - recycled
       - glazed
 
   - id: glazed
     visible: true
+    friendly_name: Glazing
+    description: Glaze is on and the glaze kiln is up next.
     successors:
       - recycled
       - submitted_to_glaze_fire
@@ -352,6 +372,8 @@ states:
 
   - id: submitted_to_glaze_fire
     visible: true
+    friendly_name: "Queued → Glaze"
+    description: Lined up for the glaze firing. Fingers crossed for kiln luck.
     successors:
       - recycled
       - glaze_fired
@@ -363,6 +385,8 @@ states:
 
   - id: glaze_fired
     visible: true
+    friendly_name: Touching Up
+    description: Out of the glaze kiln and into the final cleanup stretch.
     successors:
       - recycled
       - sanded
@@ -380,14 +404,20 @@ states:
 
   - id: sanded
     visible: true
+    friendly_name: Sanding
+    description: Almost there. Smoothing the last rough spots before calling it done.
     successors:
       - recycled
       - completed
 
   - id: completed
     visible: true
+    friendly_name: Completed
+    description: All done and ready to admire.
     terminal: true
 
   - id: recycled
     visible: true
+    friendly_name: Recycled
+    description: "Oops! Next time things will go better. :)"
     terminal: true

--- a/workflow.yml
+++ b/workflow.yml
@@ -253,7 +253,7 @@ states:
   - id: wheel_thrown
     visible: true
     friendly_name: Throwing
-    description: Fresh off the wheel and drying toward trimming.
+    description: The initial shaping on the wheel. Infinite possibilities ahead!
     successors:
       - recycled
       - trimmed
@@ -271,8 +271,8 @@ states:
 
   - id: trimmed
     visible: true
-    friendly_name: Decorating
-    description: Trimmed and ready for carving, slip, or a straight shot to bisque.
+    friendly_name: Trimming 
+    description: Getting that shape just right.
     successors:
       - recycled
       - slip_applied
@@ -289,7 +289,7 @@ states:
   - id: handbuilt
     visible: true
     friendly_name: Handbuilding
-    description: Built by hand and settling in before decoration or the bisque queue.
+    description: Building by hand for that uniquely organic feel. No wheel required!
     successors:
       - recycled
       - slip_applied
@@ -322,7 +322,7 @@ states:
   - id: submitted_to_bisque_fire
     visible: true
     friendly_name: "Queued → Bisque"
-    description: Waiting on the kiln...
+    description: Ready for the first firing. Just waiting on the kiln...
     successors:
       - recycled
       - bisque_fired
@@ -360,7 +360,7 @@ states:
   - id: glazed
     visible: true
     friendly_name: Glazing
-    description: Glaze is on and the glaze kiln is up next.
+    description: Applying glaze and getting ready for the final firing. The piece is really coming to life now!
     successors:
       - recycled
       - submitted_to_glaze_fire
@@ -373,7 +373,7 @@ states:
   - id: submitted_to_glaze_fire
     visible: true
     friendly_name: "Queued → Glaze"
-    description: Lined up for the glaze firing. Fingers crossed for kiln luck.
+    description: Lined up for the glaze firing. Time to pray to the kiln gods!
     successors:
       - recycled
       - glaze_fired


### PR DESCRIPTION
## What changed
- require every workflow state to declare an authored `friendly_name` and `description`
- update the built-in state catalog to use gerund-style labels for active states, plus light-hearted helper descriptions
- add a reusable `StateChip` component and refactor `PieceDetail` and `PieceList` to use it
- keep `Completed` ahead of `Recycled` at the end of successor lists in `PieceDetail`
- document the workflow/state-chip contract in `docs/agents/glaze-domain.md`

## Why
State labels and helper copy now live in `workflow.yml` as explicit shared metadata instead of being synthesized in the UI, and the chip presentation/behavior is centralized so list/detail views stay consistent.

## Validation
- `source env.sh && gz_setup`
- `source env.sh && gz_test_common`
- `source env.sh && gz_test_backend`
- `source env.sh && gz_test_web`
- `source env.sh && gz_build`

## Notes
`gz_build` completed successfully, although its helper reported that the temporary backend never became ready before the frontend build continued.
