### PR TITLE
[codex] Clean up PieceList layout

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -120,7 +120,7 @@ describe('App auth flow', () => {
         render(<App />)
 
         await waitFor(() => {
-            expect(screen.getByText('+ New Piece')).toBeInTheDocument()
+            expect(screen.getByRole('button', { name: /new piece/i })).toBeInTheDocument()
         })
 
         await userEvent.click(screen.getByRole('tab', { name: 'Analyze' }))
@@ -135,7 +135,7 @@ describe('App auth flow', () => {
         await userEvent.click(screen.getByRole('tab', { name: 'Pieces' }))
 
         await waitFor(() => {
-            expect(screen.getByText('+ New Piece')).toBeInTheDocument()
+            expect(screen.getByRole('button', { name: /new piece/i })).toBeInTheDocument()
             expect(window.location.pathname).toBe('/')
         })
     })
@@ -147,7 +147,7 @@ describe('App auth flow', () => {
         render(<App />)
 
         await waitFor(() => {
-            expect(screen.getByText('+ New Piece')).toBeInTheDocument()
+            expect(screen.getByRole('button', { name: /new piece/i })).toBeInTheDocument()
         })
 
         // Open the user menu and click log out

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -1,18 +1,22 @@
 import { useMemo, useState } from "react";
+import type { ReactNode } from 'react'
+import Autocomplete from "@mui/material/Autocomplete";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import FilterListIcon from "@mui/icons-material/FilterList";
+import LabelIcon from "@mui/icons-material/Label";
 import {
   Box,
+  Button,
   Card,
   CardActionArea,
   CardContent,
   CardHeader,
-  Checkbox,
-  FormControl,
+  Chip,
+  Collapse,
   Grid,
-  InputLabel,
-  ListItemText,
-  MenuItem,
-  Select,
-  type SelectChangeEvent,
+  Stack,
+  TextField,
+  Typography,
 } from "@mui/material";
 import type { PieceSummary, TagEntry } from '@common/types'
 import { formatState, getStateDescription, isTerminalState, SUCCESSORS } from '@common/types'
@@ -25,7 +29,23 @@ const DEFAULT_THUMBNAIL = '/thumbnails/question-mark.svg'
 
 type FilterCategory = 'wip' | 'completed' | 'discarded'
 
-const FILTER_OPTIONS: { value: FilterCategory; label: string }[] = [
+interface FilterOption {
+  value: FilterCategory
+  label: string
+}
+
+interface SelectorPanelProps {
+  title: string
+  expanded: boolean
+  count: number
+  emptyLabel: string
+  icon: ReactNode
+  onToggle: () => void
+  summary: ReactNode
+  children: ReactNode
+}
+
+const FILTER_OPTIONS: FilterOption[] = [
   { value: 'wip', label: 'Work in Progress' },
   { value: 'completed', label: 'Completed' },
   { value: 'discarded', label: 'Discarded' },
@@ -40,6 +60,86 @@ function matchesFilter(piece: PieceSummary, filter: FilterCategory): boolean {
   return false
 }
 
+function SelectorPanel({
+  title,
+  expanded,
+  count,
+  emptyLabel,
+  icon,
+  onToggle,
+  summary,
+  children,
+}: SelectorPanelProps) {
+  const compactSummary = count > 0 ? (
+    <Box sx={{ minWidth: 0, flex: 1, overflow: 'hidden' }}>{summary}</Box>
+  ) : (
+    <Typography variant="body2" color="text.secondary" sx={{ whiteSpace: 'nowrap' }}>
+      {emptyLabel}
+    </Typography>
+  )
+
+  return (
+    <Box
+      sx={{
+        border: 1,
+        borderColor: 'divider',
+        borderRadius: 2,
+        p: expanded ? 1.5 : 1,
+        backgroundColor: 'background.paper',
+      }}
+    >
+      <Stack direction="row" spacing={1} alignItems="center" justifyContent="space-between">
+        <Stack
+          direction="row"
+          spacing={1}
+          alignItems="center"
+          sx={{
+            minWidth: 0,
+            flex: 1,
+            overflow: 'hidden',
+          }}
+        >
+          {icon}
+          {count > 0 && <Chip label={count} size="small" color="primary" sx={{ flexShrink: 0 }} />}
+          {expanded ? (
+            <Stack spacing={0.75} sx={{ minWidth: 0, flex: 1 }}>
+              {count > 0 ? (
+                <Box sx={{ minWidth: 0 }}>{summary}</Box>
+              ) : (
+                <Typography variant="body2" color="text.secondary">
+                  {emptyLabel}
+                </Typography>
+              )}
+            </Stack>
+          ) : (
+            compactSummary
+          )}
+        </Stack>
+        <Button
+          size="small"
+          variant="text"
+          sx={{ flexShrink: 0, minWidth: 0, px: 1 }}
+          onClick={onToggle}
+          aria-expanded={expanded}
+          aria-label={expanded ? `Hide ${title.toLowerCase()}` : `Show ${title.toLowerCase()}`}
+        >
+          <ExpandMoreIcon
+            sx={{
+              transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
+              transition: 'transform 0.2s ease',
+            }}
+          />
+        </Button>
+      </Stack>
+      <Collapse in={expanded} unmountOnExit>
+        <Box sx={{ pt: 1.5 }}>
+          {children}
+        </Box>
+      </Collapse>
+    </Box>
+  )
+}
+
 type PieceListItemProps = {
   piece: PieceSummary
 };
@@ -52,7 +152,7 @@ const PieceListItem = (props: PieceListItemProps) => {
     <Grid size={{xs: 6, sm: 4, md: 3, lg: 2}} sx={{ display: "flex", flexDirection: "column" }} role="row">
       <Card
         sx={{ cursor: 'pointer', padding: 0, margin: 0, height: '100%' }}
-        data-state={piece.current_state.state} 
+        data-state={piece.current_state.state}
       >
         <CardActionArea
           sx={{
@@ -66,7 +166,7 @@ const PieceListItem = (props: PieceListItemProps) => {
         >
           <CardHeader
             title={<h4 style={{ margin: 0 }}>{piece.name}</h4>}
-            avatar={<CloudinaryImage 
+            avatar={<CloudinaryImage
               url={piece.thumbnail?.url ?? DEFAULT_THUMBNAIL}
               cloudinary_public_id={piece.thumbnail?.cloudinary_public_id}
               context="thumbnail"
@@ -98,8 +198,13 @@ const PieceList = (props: PieceListingProps) => {
   const { pieces } = props;
   const [activeFilters, setActiveFilters] = useState<FilterCategory[]>([])
   const [activeTags, setActiveTags] = useState<TagEntry[]>([])
-  const filterDesktopColumns = activeFilters.length === 0 ? 2 : 4
-  const tagDesktopColumns = activeTags.length === 0 ? 2 : 4
+  const [filtersExpanded, setFiltersExpanded] = useState(false)
+  const [tagsExpanded, setTagsExpanded] = useState(false)
+
+  const activeFilterOptions = useMemo(
+    () => FILTER_OPTIONS.filter((option) => activeFilters.includes(option.value)),
+    [activeFilters]
+  )
 
   const availableTags = useMemo(() => {
     const deduped = new Map<string, TagEntry>()
@@ -121,62 +226,75 @@ const PieceList = (props: PieceListingProps) => {
     })
   }, [pieces, activeFilters, activeTags])
 
-  function handleFilterChange(event: SelectChangeEvent<FilterCategory[]>) {
-    setActiveFilters(event.target.value as FilterCategory[])
-  }
-
   return (
     <>
       <Box
         sx={{
           mb: 2,
           display: 'grid',
-          gap: 2,
-          gridTemplateColumns: { xs: '1fr', sm: 'repeat(4, minmax(0, 1fr))' },
+          gap: 1.5,
+          gridTemplateColumns: { xs: '1fr', lg: 'repeat(2, minmax(0, 1fr))' },
           alignItems: 'start',
         }}
       >
-        <Box
-          data-testid="piece-list-filter-control"
-          data-desktop-columns={filterDesktopColumns}
-          sx={{
-            gridColumn: { xs: '1 / -1', sm: `span ${filterDesktopColumns}` },
-            minWidth: 0,
-          }}
-        >
-          <FormControl
-            size="small"
-            fullWidth
-          >
-            <InputLabel id="piece-filter-label">Filter</InputLabel>
-            <Select
-              labelId="piece-filter-label"
-              label="Filter"
-              multiple
-              value={activeFilters}
-              onChange={handleFilterChange}
-              renderValue={(selected) =>
-                selected
-                  .map((v) => FILTER_OPTIONS.find((o) => o.value === v)?.label ?? v)
-                  .join(', ')
-              }
-            >
-              {FILTER_OPTIONS.map((option) => (
-                <MenuItem key={option.value} value={option.value}>
-                  <Checkbox checked={activeFilters.includes(option.value)} />
-                  <ListItemText primary={option.label} />
-                </MenuItem>
+        <SelectorPanel
+          title="Filters"
+          expanded={filtersExpanded}
+          count={activeFilterOptions.length}
+          emptyLabel="No status filters applied."
+          icon={<FilterListIcon fontSize="small" color="action" />}
+          onToggle={() => setFiltersExpanded((prev) => !prev)}
+          summary={
+            <Stack direction="row" spacing={0.75} useFlexGap flexWrap="wrap">
+              {activeFilterOptions.map((option) => (
+                <Chip
+                  key={option.value}
+                  label={option.label}
+                  size="small"
+                  onDelete={() => setActiveFilters((prev) => prev.filter((value) => value !== option.value))}
+                />
               ))}
-            </Select>
-          </FormControl>
-        </Box>
-        <Box
-          data-testid="piece-list-tags-control"
-          data-desktop-columns={tagDesktopColumns}
-          sx={{
-            gridColumn: { xs: '1 / -1', sm: `span ${tagDesktopColumns}` },
-            minWidth: 0,
-          }}
+            </Stack>
+          }
+        >
+          <Autocomplete
+            multiple
+            disableCloseOnSelect
+            size="small"
+            options={FILTER_OPTIONS}
+            value={activeFilterOptions}
+            onChange={(_event, nextValue) => {
+              setActiveFilters(nextValue.map((option) => option.value))
+            }}
+            getOptionLabel={(option) => option.label}
+            isOptionEqualToValue={(option, selected) => option.value === selected.value}
+            renderTags={(selected, getTagProps) =>
+              selected.map((option, index) => (
+                <Chip
+                  {...getTagProps({ index })}
+                  key={option.value}
+                  label={option.label}
+                  size="small"
+                />
+              ))
+            }
+            renderInput={(params) => (
+              <TextField
+                {...params}
+                label="Filters"
+                fullWidth
+              />
+            )}
+          />
+        </SelectorPanel>
+        <SelectorPanel
+          title="Tags"
+          expanded={tagsExpanded}
+          count={activeTags.length}
+          emptyLabel="No tags selected."
+          icon={<LabelIcon fontSize="small" color="action" />}
+          onToggle={() => setTagsExpanded((prev) => !prev)}
+          summary={<TagChipList tags={activeTags} />}
         >
           <TagAutocomplete
             label="Tags"
@@ -185,7 +303,7 @@ const PieceList = (props: PieceListingProps) => {
             onChange={setActiveTags}
             sx={{ minWidth: 0 }}
           />
-        </Box>
+        </SelectorPanel>
       </Box>
       <Grid container spacing={1} alignItems="stretch" role="rowgroup">
         {filteredPieces.map((piece) => <PieceListItem key={piece.id} piece={piece} />)}

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -1,10 +1,9 @@
 import { describe, it, expect, vi } from 'vitest'
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import PieceList from '../PieceList'
 import type { PieceSummary } from '@common/types'
-import { act } from 'react'
 
 vi.mock('../CloudinaryImage', () => ({
     default: ({ url, alt }: { url: string; alt?: string }) => <img src={url} alt={alt ?? ''} />,
@@ -107,16 +106,12 @@ describe('PieceList', () => {
     })
 
     describe('filter dropdown', () => {
-        it('renders the filter dropdown', () => {
+        it('renders filter and tag summaries in a compact state', () => {
             renderPieceList([])
-            expect(screen.getByLabelText('Filter')).toBeInTheDocument()
-        })
-
-        it('keeps empty filter and tag controls at two desktop columns each', () => {
-            renderPieceList([])
-
-            expect(screen.getByTestId('piece-list-filter-control')).toHaveAttribute('data-desktop-columns', '2')
-            expect(screen.getByTestId('piece-list-tags-control')).toHaveAttribute('data-desktop-columns', '2')
+            expect(screen.getByText('No status filters applied.')).toBeInTheDocument()
+            expect(screen.getByText('No tags selected.')).toBeInTheDocument()
+            expect(screen.queryByLabelText('Filters')).not.toBeInTheDocument()
+            expect(screen.queryByLabelText('Tags')).not.toBeInTheDocument()
         })
 
         it('shows all pieces when no filter is selected', () => {
@@ -140,14 +135,15 @@ describe('PieceList', () => {
             ]
             renderPieceList(pieces)
 
-            await user.click(screen.getByLabelText('Filter'))
+            await user.click(screen.getByRole('button', { name: /show filters/i }))
+            await user.click(screen.getByLabelText('Filters'))
             await user.click(screen.getByRole('option', { name: 'Work in Progress' }))
             await user.keyboard('{Escape}')
 
             expect(screen.getByText('Bowl')).toBeInTheDocument()
             expect(screen.queryByText('Mug')).not.toBeInTheDocument()
             expect(screen.queryByText('Vase')).not.toBeInTheDocument()
-            expect(screen.getByTestId('piece-list-filter-control')).toHaveAttribute('data-desktop-columns', '4')
+            expect(screen.getAllByText('Work in Progress').length).toBeGreaterThan(0)
         })
 
         it('filters to completed pieces only', async () => {
@@ -159,7 +155,8 @@ describe('PieceList', () => {
             ]
             renderPieceList(pieces)
 
-            await user.click(screen.getByLabelText('Filter'))
+            await user.click(screen.getByRole('button', { name: /show filters/i }))
+            await user.click(screen.getByLabelText('Filters'))
             await user.click(screen.getByRole('option', { name: 'Completed' }))
             await user.keyboard('{Escape}')
 
@@ -177,7 +174,8 @@ describe('PieceList', () => {
             ]
             renderPieceList(pieces)
 
-            await user.click(screen.getByLabelText('Filter'))
+            await user.click(screen.getByRole('button', { name: /show filters/i }))
+            await user.click(screen.getByLabelText('Filters'))
             await user.click(screen.getByRole('option', { name: 'Discarded' }))
             await user.keyboard('{Escape}')
 
@@ -195,7 +193,8 @@ describe('PieceList', () => {
             ]
             renderPieceList(pieces)
 
-            await user.click(screen.getByLabelText('Filter'))
+            await user.click(screen.getByRole('button', { name: /show filters/i }))
+            await user.click(screen.getByLabelText('Filters'))
             await user.click(screen.getByRole('option', { name: 'Completed' }))
             await user.click(screen.getByRole('option', { name: 'Discarded' }))
             await user.keyboard('{Escape}')
@@ -214,13 +213,14 @@ describe('PieceList', () => {
             renderPieceList(pieces)
 
             // Apply filter
-            await user.click(screen.getByLabelText('Filter'))
+            await user.click(screen.getByRole('button', { name: /show filters/i }))
+            await user.click(screen.getByLabelText('Filters'))
             await user.click(screen.getByRole('option', { name: 'Completed' }))
             await user.keyboard('{Escape}')
             expect(screen.queryByText('Bowl')).not.toBeInTheDocument()
 
             // Remove filter by clicking the same option again
-            await user.click(screen.getByLabelText('Filter'))
+            await user.click(screen.getByLabelText('Filters'))
             await user.click(screen.getByRole('option', { name: 'Completed' }))
             await user.keyboard('{Escape}')
             expect(screen.getByText('Bowl')).toBeInTheDocument()
@@ -248,6 +248,7 @@ describe('PieceList', () => {
             ]
             renderPieceList(pieces)
 
+            await user.click(screen.getByRole('button', { name: /show tags/i }))
             await user.click(screen.getByLabelText('Tags'))
             await user.click(screen.getByRole('option', { name: 'Gift' }))
             await user.click(screen.getByLabelText('Tags'))
@@ -256,7 +257,28 @@ describe('PieceList', () => {
 
             expect(screen.getByText('Bowl')).toBeInTheDocument()
             expect(screen.queryByText('Mug')).not.toBeInTheDocument()
-            expect(screen.getByTestId('piece-list-tags-control')).toHaveAttribute('data-desktop-columns', '4')
+            expect(screen.getAllByText('For Sale').length).toBeGreaterThan(0)
+        })
+
+        it('can hide the selectors again after expanding them', async () => {
+            const user = userEvent.setup()
+            renderPieceList([])
+
+            await user.click(screen.getByRole('button', { name: /show filters/i }))
+            expect(screen.getByLabelText('Filters')).toBeInTheDocument()
+
+            await user.click(screen.getByRole('button', { name: /hide filters/i }))
+            await waitFor(() => {
+                expect(screen.queryByLabelText('Filters')).not.toBeInTheDocument()
+            })
+
+            await user.click(screen.getByRole('button', { name: /show tags/i }))
+            expect(screen.getByLabelText('Tags')).toBeInTheDocument()
+
+            await user.click(screen.getByRole('button', { name: /hide tags/i }))
+            await waitFor(() => {
+                expect(screen.queryByLabelText('Tags')).not.toBeInTheDocument()
+            })
         })
     })
 })

--- a/web/src/pages/PieceListPage.tsx
+++ b/web/src/pages/PieceListPage.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react'
-import { Box, Button, CircularProgress, Typography } from '@mui/material'
+import AddIcon from '@mui/icons-material/Add'
+import { Box, Button, CircularProgress, Fab, Typography, useMediaQuery } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
 import { fetchPieces } from '@common/api'
 import { useAsync } from '../util/useAsync'
 import NewPieceDialog from '../components/NewPieceDialog'
@@ -9,6 +11,8 @@ import type { PieceDetail, PieceSummary } from '@common/types'
 export default function PieceListPage() {
   const { data: pieces, loading, error, setData: setPieces } = useAsync<PieceSummary[]>(fetchPieces)
   const [dialogOpen, setDialogOpen] = useState(false)
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
 
   function handleCreated(piece: PieceDetail) {
     setPieces(prev => [piece, ...(prev ?? [])])
@@ -16,11 +20,27 @@ export default function PieceListPage() {
 
   return (
     <>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
-        <Button variant="contained" onClick={() => setDialogOpen(true)}>
-          + New Piece
-        </Button>
-      </Box>
+      {isMobile ? (
+        <Fab
+          color="primary"
+          aria-label="New Piece"
+          onClick={() => setDialogOpen(true)}
+          sx={{
+            position: 'fixed',
+            right: 16,
+            bottom: 16,
+            zIndex: (muiTheme) => muiTheme.zIndex.speedDial,
+          }}
+        >
+          <AddIcon />
+        </Fab>
+      ) : (
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 2 }}>
+          <Button variant="contained" startIcon={<AddIcon />} onClick={() => setDialogOpen(true)}>
+            New Piece
+          </Button>
+        </Box>
+      )}
       {loading && (
         <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
           <CircularProgress />


### PR DESCRIPTION
## What changed
- reworked the PieceList controls so Filters and Tags use the same expandable selector pattern
- made the collapsed state much denser by reducing the closed controls to icon-and-summary rows
- moved the New Piece action to a more compact desktop placement and a floating mobile action button
- updated PieceList and app tests to cover the new control behavior

## Why
The old layout used mismatched controls and spent too much vertical space, especially before a user interacted with the list. This keeps the default list view tighter while still allowing the full selectors to expand when needed.

## Validation
- `source env.sh && gz_test_web`
- `source env.sh && gz_build`
- earlier in this branch, `source env.sh && gz_test` passed before the final copy-tightening pass; the follow-up changes were web-only and were revalidated with the web test/build commands