### PR TITLE
[codex] Add mobile PWA support for landing page

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,9 +3,23 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.svg" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
     <meta name="referrer" content="origin" />
-    <title>web</title>
+    <meta name="theme-color" content="#121212" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Glaze" />
+    <meta
+      name="description"
+      content="Track every pottery piece through your workflow."
+    />
+    <title>Glaze</title>
     <!-- Cloudinary Upload Widget (loaded globally so openUploadWidget is available at runtime) -->
     <script src="https://upload-widget.cloudinary.com/latest/global/all.js" type="text/javascript"></script>
   </head>

--- a/web/public/apple-touch-icon.svg
+++ b/web/public/apple-touch-icon.svg
@@ -1,0 +1,15 @@
+<svg width="180" height="180" viewBox="0 0 180 180" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <rect width="180" height="180" rx="44" fill="#121212" />
+  <rect x="16" y="16" width="148" height="148" rx="34" fill="#1F1F1F" />
+  <g transform="translate(90 90) scale(1.72) translate(-64 -64)">
+    <ellipse cx="64" cy="93.2143" rx="42" ry="12" fill="#E6C3A0" stroke="#8A3F1D" stroke-width="1.5" />
+    <path
+      d="M42 29.2143 L86 29.2143 L86 93.2143 C86 99.2143 42 99.2143 42 93.2143 Z"
+      fill="#C66A3D"
+      stroke="#8A3F1D"
+      stroke-width="1.5"
+      stroke-linejoin="round"
+    />
+    <ellipse cx="64" cy="29.2143" rx="22.5" ry="6.4286" fill="#8A3F1D" />
+  </g>
+</svg>

--- a/web/public/mask-icon.svg
+++ b/web/public/mask-icon.svg
@@ -1,0 +1,11 @@
+<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <rect width="512" height="512" rx="140" fill="#121212" />
+  <g transform="translate(256 256) scale(5.9) translate(-64 -64)">
+    <ellipse cx="64" cy="93.2143" rx="42" ry="12" fill="#E6C3A0" />
+    <path
+      d="M42 29.2143 L86 29.2143 L86 93.2143 C86 99.2143 42 99.2143 42 93.2143 Z"
+      fill="#C66A3D"
+    />
+    <ellipse cx="64" cy="29.2143" rx="22.5" ry="6.4286" fill="#8A3F1D" />
+  </g>
+</svg>

--- a/web/public/pwa-icon.svg
+++ b/web/public/pwa-icon.svg
@@ -1,0 +1,15 @@
+<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="none">
+  <rect width="512" height="512" rx="120" fill="#121212" />
+  <rect x="48" y="48" width="416" height="416" rx="96" fill="#1F1F1F" />
+  <g transform="translate(256 256) scale(5.25) translate(-64 -64)">
+    <ellipse cx="64" cy="93.2143" rx="42" ry="12" fill="#E6C3A0" stroke="#8A3F1D" stroke-width="1.5" />
+    <path
+      d="M42 29.2143 L86 29.2143 L86 93.2143 C86 99.2143 42 99.2143 42 93.2143 Z"
+      fill="#C66A3D"
+      stroke="#8A3F1D"
+      stroke-width="1.5"
+      stroke-linejoin="round"
+    />
+    <ellipse cx="64" cy="29.2143" rx="22.5" ry="6.4286" fill="#8A3F1D" />
+  </g>
+</svg>

--- a/web/public/site.webmanifest
+++ b/web/public/site.webmanifest
@@ -1,0 +1,25 @@
+{
+  "name": "Glaze",
+  "short_name": "Glaze",
+  "description": "Track every pottery piece through your workflow.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "portrait",
+  "background_color": "#121212",
+  "theme_color": "#121212",
+  "icons": [
+    {
+      "src": "/pwa-icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/mask-icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -1,0 +1,83 @@
+const CACHE_NAME = 'glaze-shell-v1'
+const APP_SHELL = [
+  '/',
+  '/index.html',
+  '/site.webmanifest',
+  '/favicon.svg',
+  '/pwa-icon.svg',
+  '/mask-icon.svg',
+  '/apple-touch-icon.svg',
+]
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(APP_SHELL)),
+  )
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((cacheNames) =>
+      Promise.all(
+        cacheNames
+          .filter((cacheName) => cacheName !== CACHE_NAME)
+          .map((cacheName) => caches.delete(cacheName)),
+      ),
+    ),
+  )
+  self.clients.claim()
+})
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event
+
+  if (request.method !== 'GET') {
+    return
+  }
+
+  const url = new URL(request.url)
+  if (url.origin !== self.location.origin) {
+    return
+  }
+
+  if (
+    url.pathname.startsWith('/api') ||
+    url.pathname.startsWith('/admin') ||
+    url.pathname.startsWith('/static')
+  ) {
+    return
+  }
+
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          const responseClone = response.clone()
+          caches.open(CACHE_NAME).then((cache) => cache.put('/index.html', responseClone))
+          return response
+        })
+        .catch(async () => {
+          const cachedResponse = await caches.match('/index.html')
+          return cachedResponse ?? Response.error()
+        }),
+    )
+    return
+  }
+
+  event.respondWith(
+    caches.match(request).then((cachedResponse) => {
+      const networkFetch = fetch(request)
+        .then((response) => {
+          if (response.ok) {
+            const responseClone = response.clone()
+            caches.open(CACHE_NAME).then((cache) => cache.put(request, responseClone))
+          }
+          return response
+        })
+        .catch(() => cachedResponse)
+
+      return cachedResponse ?? networkFetch
+    }),
+  )
+})

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -119,22 +119,40 @@ function AuthLanding({
   }
 
   return (
-    <>
-      <Container maxWidth="sm" sx={{ minHeight: '100vh', display: 'grid', placeItems: 'center' }}>
-        <Paper sx={{ width: '100%', p: 4 }}>
+    <Container
+      maxWidth="sm"
+      sx={{
+        minHeight: '100dvh',
+        display: 'grid',
+        placeItems: 'center',
+        px: { xs: 2, sm: 3 },
+        py: {
+          xs: 'max(16px, env(safe-area-inset-top))',
+          sm: 3,
+        },
+      }}
+    >
+      <Paper
+        sx={{
+          width: '100%',
+          p: { xs: 2.5, sm: 4 },
+          borderRadius: { xs: 3, sm: 4 },
+        }}
+      >
           <Stack spacing={2}>
-            <Typography variant="h4" component="h1">
+            <Typography variant="h4" component="h1" sx={{ fontSize: { xs: '2rem', sm: '2.5rem' } }}>
               Glaze
             </Typography>
             <Typography color="text.secondary">
               Track every pottery piece through your workflow.
             </Typography>
 
-            <Box sx={{ display: 'flex', gap: 1 }}>
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={1}>
               <Button
                 variant={mode === 'login' ? 'contained' : 'outlined'}
                 onClick={() => setMode('login')}
                 disabled={submitting}
+                fullWidth
               >
                 Log In
               </Button>
@@ -142,10 +160,11 @@ function AuthLanding({
                 variant={mode === 'register' ? 'contained' : 'outlined'}
                 onClick={() => setMode('register')}
                 disabled={submitting || !SIGN_UP_ENABLED}
+                fullWidth
               >
                 Sign Up
               </Button>
-            </Box>
+            </Stack>
             {!SIGN_UP_ENABLED && (
               <Typography variant="body2" color="text.secondary">
                 Sign up is temporarily disabled. Ask an admin to create your account.
@@ -198,7 +217,7 @@ function AuthLanding({
             {GOOGLE_CLIENT_ID && (
               <>
                 <Divider>or</Divider>
-                <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+                <Box sx={{ display: 'flex', justifyContent: 'center', overflowX: 'auto' }}>
                   <GoogleLogin
                     theme="outline"
                     onSuccess={async ({ credential }) => {
@@ -220,9 +239,8 @@ function AuthLanding({
               </>
             )}
           </Stack>
-        </Paper>
-      </Container>
-    </>
+      </Paper>
+    </Container>
   )
 }
 
@@ -241,8 +259,28 @@ function AppShell({
   }, [currentUser])
 
   return (
-    <Container maxWidth="lg" sx={{ py: 2 }}>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 0 }}>
+    <Container
+      maxWidth="lg"
+      sx={{
+        minHeight: '100dvh',
+        py: 2,
+        px: {
+          xs: 'max(16px, env(safe-area-inset-left))',
+          sm: 3,
+        },
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          gap: 1.5,
+          mb: 0,
+          flexDirection: 'row',
+          flexWrap: 'nowrap',
+        }}
+      >
         <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1}}>
           <Typography variant="h6" component="p" color="text.primary" display="inline">
             PotterDoc
@@ -255,7 +293,7 @@ function AppShell({
           onClick={(e) => setMenuAnchor(e.currentTarget)}
           onDelete={(e) => setMenuAnchor(e.currentTarget)}
           deleteIcon={<ExpandMoreIcon />}
-          sx={{ cursor: 'pointer' }}
+          sx={{ cursor: 'pointer', flexShrink: 0 }}
         />
         <Menu
           anchorEl={menuAnchor}
@@ -335,7 +373,7 @@ export default function App() {
       <ThemeProvider theme={DARK_THEME}>
         <CssBaseline />
         {loading ? (
-          <Container maxWidth="sm" sx={{ minHeight: '100vh', display: 'grid', placeItems: 'center' }}>
+          <Container maxWidth="sm" sx={{ minHeight: '100dvh', display: 'grid', placeItems: 'center' }}>
             <CircularProgress />
           </Container>
         ) : currentUser ? (

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,6 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 
+if (import.meta.env.PROD && 'serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    void navigator.serviceWorker.register('/sw.js')
+  })
+}
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />

--- a/web/src/pages/LandingPage.tsx
+++ b/web/src/pages/LandingPage.tsx
@@ -1,5 +1,5 @@
 import { useLocation, useNavigate, Outlet } from 'react-router-dom'
-import { Tab, Tabs } from '@mui/material'
+import { Box, Tab, Tabs } from '@mui/material'
 
 export default function LandingPage() {
   const location = useLocation()
@@ -7,17 +7,26 @@ export default function LandingPage() {
   const currentTab = location.pathname === '/analyze' ? '/analyze' : '/'
 
   return (
-    <>
+    <Box sx={{ pb: 2 }}>
       <Tabs
         value={currentTab}
         onChange={(_event, nextTab: string) => navigate(nextTab)}
         aria-label="Landing page navigation"
-        sx={{ mb: 3 }}
+        variant="fullWidth"
+        sx={{
+          mb: 2.5,
+          minHeight: 52,
+          '& .MuiTab-root': {
+            minHeight: 52,
+            textTransform: 'none',
+            fontSize: { xs: '0.95rem', sm: '1rem' },
+          },
+        }}
       >
         <Tab label="Pieces" value="/" />
         <Tab label="Analyze" value="/analyze" />
       </Tabs>
       <Outlet />
-    </>
+    </Box>
   )
 }


### PR DESCRIPTION
## Summary
- add a web app manifest, install icons, and a small service worker so the landing page can be installed as a PWA on iOS and Android
- register the service worker in production and add mobile web app metadata to the HTML shell
- tighten the landing/auth shell layout for smaller screens while preserving the existing PotterDoc header and inline user menu

## Why
The landing page was not installable as a mobile web app and needed a few viewport and layout adjustments to display more reliably on phones.

## Validation
- `source env.sh && gz_test_common`
- `source env.sh && gz_test_backend`
- `source env.sh && gz_test_web`
- `source env.sh && gz_build`

## Notes
- `gz_build` completed successfully, but its helper logged that the temporary backend did not become ready in time before the frontend build step continued.