### PR TITLE
[codex] Start PotterDoc rebrand

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Glaze — Agent Guide
 
+`PotterDoc` is the external product/brand name. `glaze` remains the internal repository and project name for code, paths, and internal documentation unless a task explicitly changes those identifiers too.
+
 @docs/agents/glaze-domain.md
 @docs/agents/django-drf-python.md
 @docs/agents/typescript-react-vite.md

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Glaze
+# PotterDoc
+
+PotterDoc is the external product name for this app. The repository, internal code identifiers, and some contributor documentation still use `glaze` as the internal project name during the transition.
 
 A pottery workflow tracking application. Log pieces and record state transitions as work moves through throwing, bisque firing, glazing, and finishing.
 
@@ -22,7 +24,7 @@ While the UI is similar at a surface level to other craft journaling application
 
 ## Authentication and Data Isolation
 
-Glaze now runs as a user-scoped application with session authentication.
+PotterDoc now runs as a user-scoped application with session authentication.
 
 - Auth is session/cookie-based (Django + DRF `SessionAuthentication`).
 - The web client fetches a CSRF cookie from `GET /api/auth/csrf/` before login/logout/register writes.
@@ -36,7 +38,7 @@ Glaze now runs as a user-scoped application with session authentication.
 
 ### Google OAuth Flow
 
-Glaze supports Google Sign-In using OAuth 2.0 with OpenID Connect. The flow works as follows:
+PotterDoc supports Google Sign-In using OAuth 2.0 with OpenID Connect. The flow works as follows:
 
 1. **Frontend**: The web app uses `@react-oauth/google` to display a Google Sign-In button when `VITE_GOOGLE_CLIENT_ID` is configured.
 2. **Google Authentication**: User clicks the button, Google handles authentication and returns a JWT credential.
@@ -231,7 +233,7 @@ export CLOUDINARY_UPLOAD_FOLDER=glaze   # optional; images are placed in this fo
 Cloudinary is optional — if the env vars are not set, the config endpoint returns 503 and the UI falls back to URL-paste mode.
 
 ## Google OAuth (web)
-Glaze supports Google Sign-In using OAuth 2.0 with OpenID Connect. To enable the Google sign-in button in the web UI:
+PotterDoc supports Google Sign-In using OAuth 2.0 with OpenID Connect. To enable the Google sign-in button in the web UI:
 
 1. **Create Google OAuth credentials:**
    - Go to [Google Cloud Console](https://console.cloud.google.com/)
@@ -259,7 +261,7 @@ Glaze supports Google Sign-In using OAuth 2.0 with OpenID Connect. To enable the
 
 ## Deployment
 
-Glaze supports Docker Compose (self-hosted on any VPS/droplet).
+PotterDoc supports Docker Compose (self-hosted on any VPS/droplet).
 
 ### Docker Compose (self-hosted)
 

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -81,7 +81,7 @@ REST_FRAMEWORK = {
 }
 
 SPECTACULAR_SETTINGS = {
-    'TITLE': 'Glaze API',
+    'TITLE': 'PotterDoc API',
     'DESCRIPTION': 'Pottery workflow tracking API',
     'VERSION': '0.0.1',
 }

--- a/docs/agents/glaze-domain.md
+++ b/docs/agents/glaze-domain.md
@@ -1,5 +1,9 @@
 # Glaze — Domain Logic
 
+## Branding
+
+`PotterDoc` is the external product name. `glaze` remains the internal repository/project name for code identifiers, paths, and domain documentation during the rebrand unless a task explicitly calls for renaming internals too.
+
 ## Language
 
 Use American English spelling throughout — in code, comments, documentation, and UI strings. For example: "behavior" not "behaviour", "initialize" not "initialise", "labeled" not "labelled", "analyze" not "analyse".

--- a/web/index.html
+++ b/web/index.html
@@ -14,7 +14,7 @@
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="apple-mobile-web-app-title" content="Glaze" />
+    <meta name="apple-mobile-web-app-title" content="PotterDoc" />
     <meta
       name="description"
       content="Track every pottery piece through your workflow."

--- a/web/public/site.webmanifest
+++ b/web/public/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "Glaze",
-  "short_name": "Glaze",
+  "name": "PotterDoc",
+  "short_name": "PotterDoc",
   "description": "Track every pottery piece through your workflow.",
   "start_url": "/",
   "scope": "/",

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -68,6 +68,8 @@ describe('App auth flow', () => {
             expect(screen.getByText('Track every pottery piece through your workflow.')).toBeInTheDocument()
         })
 
+        expect(screen.getByRole('img', { name: 'PotterDoc icon' })).toBeInTheDocument()
+
         // Verify we can find an input field (email input)
         const inputs = screen.getAllByRole('textbox')
         expect(inputs.length).toBeGreaterThan(0)
@@ -110,6 +112,7 @@ describe('App auth flow', () => {
             expect(screen.getByText('Piece List Content')).toBeInTheDocument()
         })
 
+        expect(screen.getByRole('img', { name: 'PotterDoc app icon' })).toBeInTheDocument()
         expect(screen.getByRole('tab', { name: 'Pieces' })).toHaveAttribute('aria-selected', 'true')
         expect(screen.getByRole('tab', { name: 'Analyze' })).toHaveAttribute('aria-selected', 'false')
     })

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -140,9 +140,22 @@ function AuthLanding({
         }}
       >
           <Stack spacing={2}>
-            <Typography variant="h4" component="h1" sx={{ fontSize: { xs: '2rem', sm: '2.5rem' } }}>
-              Glaze
-            </Typography>
+            <Stack direction="row" spacing={1.25} alignItems="center">
+              <Box
+                component="img"
+                src="/favicon.svg"
+                alt="PotterDoc icon"
+                sx={{
+                  width: { xs: 32, sm: 36 },
+                  height: { xs: 32, sm: 36 },
+                  flexShrink: 0,
+                  display: 'block',
+                }}
+              />
+              <Typography variant="h4" component="h1" sx={{ fontSize: { xs: '2rem', sm: '2.5rem' }, lineHeight: 1.1 }}>
+                PotterDoc
+              </Typography>
+            </Stack>
             <Typography color="text.secondary">
               Track every pottery piece through your workflow.
             </Typography>
@@ -281,7 +294,18 @@ function AppShell({
           flexWrap: 'nowrap',
         }}
       >
-        <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1}}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1}}>
+          <Box
+            component="img"
+            src="/favicon.svg"
+            alt="PotterDoc app icon"
+            sx={{
+              width: 22,
+              height: 22,
+              flexShrink: 0,
+              display: 'block',
+            }}
+          />
           <Typography variant="h6" component="p" color="text.primary" display="inline">
             PotterDoc
           </Typography>


### PR DESCRIPTION
## What changed
- renamed key external-facing product labels from `Glaze` to `PotterDoc`
- documented that `glaze` remains the internal repo/project name during the transition
- added the PotterDoc icon next to the app name on both the unauthenticated landing screen and the authenticated app header
- updated the landing-page auth test to assert the icon treatment is present

## Why
This starts the rebrand without forcing an internal identifier rename yet. The user-facing product can move to `PotterDoc` now while code paths, docs structure, and internal references continue to use `glaze` until later follow-up work.

## Impact
- users now see `PotterDoc` in the app shell, auth landing screen, install metadata, and API schema title
- contributors now have explicit guidance about the external brand vs. internal project name split
- the authenticated app header now carries the product icon as part of the visible brand

## Validation
- `source env.sh && gz_test_common`
- `source env.sh && gz_test_backend`
- `source env.sh && gz_test_web`
- `source env.sh && gz_build`