### PR TITLE
Potentially fix bug with iOS image caching in CloudinaryImage

### DIFF
--- a/web/src/components/CloudinaryImage.tsx
+++ b/web/src/components/CloudinaryImage.tsx
@@ -19,7 +19,7 @@ import { auto as autoQuality } from '@cloudinary/url-gen/qualifiers/quality'
 import { autoGravity } from '@cloudinary/url-gen/qualifiers/gravity'
 import { AdvancedImage } from '@cloudinary/react'
 import { Box, CircularProgress } from '@mui/material'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 const CLOUDINARY_HOSTNAME = 'res.cloudinary.com'
 const THUMBNAIL_SIZE = 64
@@ -111,9 +111,28 @@ export default function CloudinaryImage({
     'data-testid': testId,
 }: CloudinaryImageProps) {
     const [isLoading, setIsLoading] = useState(true)
+    const imageRef = useRef<HTMLImageElement | null>(null)
+    const advancedImageRef = useRef<AdvancedImage | null>(null)
 
     useEffect(() => {
         setIsLoading(true)
+    }, [url, cloudinary_public_id, context])
+
+    useEffect(() => {
+        function syncLoadedStateFromDom() {
+            const image = imageRef.current ?? advancedImageRef.current?.imageRef?.current ?? null
+            if (image?.complete && image.naturalWidth > 0) {
+                setIsLoading(false)
+            }
+        }
+
+        syncLoadedStateFromDom()
+        window.addEventListener('pageshow', syncLoadedStateFromDom)
+        document.addEventListener('visibilitychange', syncLoadedStateFromDom)
+        return () => {
+            window.removeEventListener('pageshow', syncLoadedStateFromDom)
+            document.removeEventListener('visibilitychange', syncLoadedStateFromDom)
+        }
     }, [url, cloudinary_public_id, context])
 
     function handleLoad(event: React.SyntheticEvent<HTMLImageElement>) {
@@ -191,6 +210,7 @@ export default function CloudinaryImage({
                     </Box>
                 )}
                 <AdvancedImage
+                    ref={advancedImageRef}
                     cldImg={img}
                     alt={alt}
                     style={imageStyle}
@@ -212,6 +232,7 @@ export default function CloudinaryImage({
                 </Box>
             )}
             <img
+                ref={imageRef}
                 src={url}
                 alt={alt}
                 style={imageStyle}

--- a/web/src/components/__tests__/CloudinaryImage.test.tsx
+++ b/web/src/components/__tests__/CloudinaryImage.test.tsx
@@ -1,25 +1,42 @@
 import { fireEvent, render, screen } from '@testing-library/react'
+import { forwardRef, useImperativeHandle, useRef } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import CloudinaryImage from '../CloudinaryImage'
 
 vi.mock('@cloudinary/react', () => ({
-    AdvancedImage: ({ alt, className, 'data-testid': testId, onError, onLoad, style }: {
-        alt?: string
-        className?: string
-        'data-testid'?: string
-        onError?: React.ReactEventHandler<HTMLImageElement>
-        onLoad?: React.ReactEventHandler<HTMLImageElement>
-        style?: React.CSSProperties
-    }) => (
-        <img
-            alt={alt}
-            className={className}
-            data-testid={testId}
-            onError={onError}
-            onLoad={onLoad}
-            style={style}
-        />
-    ),
+    AdvancedImage: forwardRef(function MockAdvancedImage(
+        {
+            alt,
+            className,
+            'data-testid': testId,
+            onError,
+            onLoad,
+            style,
+        }: {
+            alt?: string
+            className?: string
+            'data-testid'?: string
+            onError?: React.ReactEventHandler<HTMLImageElement>
+            onLoad?: React.ReactEventHandler<HTMLImageElement>
+            style?: React.CSSProperties
+        },
+        ref: React.ForwardedRef<{ imageRef: React.RefObject<HTMLImageElement | null> }>
+    ) {
+        const imageRef = useRef<HTMLImageElement>(null)
+        useImperativeHandle(ref, () => ({ imageRef }), [])
+
+        return (
+            <img
+                ref={imageRef}
+                alt={alt}
+                className={className}
+                data-testid={testId}
+                onError={onError}
+                onLoad={onLoad}
+                style={style}
+            />
+        )
+    }),
 }))
 
 vi.mock('@cloudinary/url-gen', () => ({
@@ -107,5 +124,18 @@ describe('CloudinaryImage', () => {
         fireEvent.load(image)
 
         expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+    })
+
+    it('hides the spinner when the browser restores a cached image without a new load event', () => {
+        render(<CloudinaryImage url="https://example.com/pot.jpg" alt="Pot" context="thumbnail" />)
+
+        const image = screen.getByAltText('Pot')
+        Object.defineProperty(image, 'complete', { configurable: true, get: () => true })
+        Object.defineProperty(image, 'naturalWidth', { configurable: true, get: () => 64 })
+
+        fireEvent(document, new Event('visibilitychange'))
+
+        expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+        expect(image).toHaveStyle({ opacity: '1' })
     })
 })

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -60,7 +60,7 @@ describe('PieceList', () => {
         it('name cell links to piece detail page', async () => {
             renderPieceList([makePiece()])
             const link = screen.getByRole('navigation', { name: 'Clay Bowl' })
-            expect(link.attributes.href.value).toBe('/pieces/aaaaaaaa-0000-0000-0000-000000000001')
+            expect(link.getAttribute('href')).toBe('/pieces/aaaaaaaa-0000-0000-0000-000000000001')
         })
 
         it('renders tags as chips', () => {


### PR DESCRIPTION
From ChatGPT:

```
I ran some debugging using safari devtools:
1. No console errors.
2. I see the successful web requests for the images. They are successfully retrieved from cloudinary and loaded.
3. Only the spinner isn't swapped back to the image after the successful load.
7:58 PM

That Safari evidence is much stronger, and it changes the confidence level a lot.

If the Cloudinary requests succeed and the image bytes load, then the bug is almost certainly not:

a failed network request
a bad Cloudinary URL
a navigation/router issue by itself
It narrows the problem to UI state: the spinner state in CloudinaryImage is not being reconciled back to “loaded” after the page is restored. That fits the old implementation exactly, because in CloudinaryImage.tsx the spinner only disappeared when our React handlers saw onLoad or onError. If Safari standalone restores the page with the image already loaded, but the component never gets a fresh load callback, then:

the image can be present
the request can be successful
isLoading can still stay true
the image remains visually hidden because opacity stays at 0
So your debugging is strong evidence for the underlying bug class: stale loading state after restore.

On the “don’t break existing features” concern, your new findings actually suggest an even safer version of the fix than the one I started with:

The important fix is not “replace AdvancedImage with <img>”.
The important fix is “stop relying solely on React onLoad to clear loading state”.
Given that, the lowest-risk approach is:

Keep the existing Cloudinary rendering path as intact as possible.
Add a state reconciliation path that checks whether the underlying image is already complete after pageshow / visibility restore.
Only clear the spinner if the DOM image is actually loaded (complete && naturalWidth > 0).
That means your evidence supports the DOM complete part directly. It does not specifically prove that replacing AdvancedImage is necessary.

So if we want to be extra conservative, I would revise the patch like this:

Keep AdvancedImage if we can reliably inspect the underlying <img> or otherwise force a remount/recheck on restore.
If AdvancedImage makes that hard, then switching to a plain <img src={img.toURL()}> becomes a compatibility tradeoff, not the primary fix.
Why I thought the <img> switch was reasonable:

In this codebase we aren’t using Cloudinary React plugins or AdvancedImage-specific features.
We are already generating the transformed Cloudinary URL ourselves.
So a plain <img> is functionally close.
But you’re right to separate:

proven bug mechanism: stale spinner/loading state
implementation choice: whether to keep AdvancedImage or not
With your new evidence, I’d describe the safest path as:

proven target: fix stale loading state after iPhone PWA restore
safest implementation: preserve current rendering behavior as much as possible, add restore-time loaded-state reconciliation
only use the plain <img> path if AdvancedImage prevents us from doing that cleanly
If you want, I can adjust the code to make it more conservative:

keep Cloudinary behavior as-is where possible
focus only on spinner-state recovery after restore
then reopen the PR flow from that version
```