### PR TITLE
feat: Glaze Import Tool for bulk public library seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,3 +612,36 @@ gz_dump_public_library --output path/to/custom.json
 # Inspect the export without writing a file:
 gz_dump_public_library --output -
 ```
+
+## Glaze Import Tool
+
+The **Glaze Import Tool** at `/tools/glaze-import` is a browser-based admin workflow for seeding the public `GlazeType` and `GlazeCombination` libraries from physical test-tile photographs (JPEG, PNG, or HEIC via Cloudinary). It replaces manual admin entry for bulk imports.
+
+> Only staff users (`is_staff = True`) can access this tool.
+
+### The five-step flow
+
+1. **Upload** — drag-and-drop or select source images from disk, or use the Cloudinary widget for HEIC/HEIF files (Cloudinary converts them to JPEG automatically).
+2. **Crop** — draw a rotatable square crop box over each image. The box may extend beyond the image boundary; overflow becomes transparent. A live preview updates after 200 ms of inactivity.
+3. **OCR** — optionally draw a rotatable OCR region box on the crop preview to focus text extraction. Click **Run OCR For All Records** — Tesseract reads each region and auto-fills the name, glaze kind, first/second glaze, runs, and food-safe fields. OCR understands structured labels (`1st Glaze: …` / `2nd Glaze: …`) and annotation lines (`CAUTION: RUNS`, `NOT FOOD SAFE`).
+4. **Review** — verify and correct each record's parsed fields, then check the **Reviewed** box. Combination names are auto-computed as `<first>!<second>` and are read-only.
+5. **Import** — sends all reviewed records and compressed crop images to the backend. A per-record progress list tracks each file; results show admin links to every created object.
+
+If any records are skipped as duplicates, a **6. Reconcile** tab appears with the scraped fields and a direct link to the existing admin record.
+
+### What the import creates
+
+| Record kind | Created objects |
+|-------------|----------------|
+| `glaze_type` | Public `GlazeType` + a matching single-layer public `GlazeCombination` |
+| `glaze_combination` | Public `GlazeCombination` with two ordered layers (both referenced `GlazeType` rows must already exist as public records) |
+
+`runs` and `is_food_safe` parsed from OCR are written to both `GlazeType` and `GlazeCombination` on creation.
+
+After a successful import, export and deploy the updated library:
+
+```bash
+gz_dump_public_library
+git add fixtures/public_library.json
+git commit -m "Update public library after glaze import"
+```

--- a/api/management/commands/import_test_tile_images.py
+++ b/api/management/commands/import_test_tile_images.py
@@ -1,0 +1,370 @@
+"""Import public glaze library entries from the local issue-146 test-tile images."""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import cloudinary
+import cloudinary.uploader
+import requests
+from cloudinary.utils import cloudinary_url
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from PIL import Image
+from pillow_heif import register_heif_opener
+
+from api.models import GlazeCombination, GlazeCombinationLayer, GlazeType
+
+register_heif_opener()
+
+
+@dataclass(frozen=True)
+class TileImportSpec:
+    filename: str
+    name: str
+    crop_box: tuple[int, int, int, int]
+    first_glaze: str | None = None
+    second_glaze: str | None = None
+
+
+_ROOT = Path(settings.BASE_DIR)
+_TYPES_DIR = _ROOT / 'Test Tile Images' / 'Glaze Type Test Tiles'
+_COMBOS_DIR = _ROOT / 'Test Tile Images' / 'Glaze Combination Test Tiles'
+_DEFAULT_INSPECTION_DIR = _ROOT / 'tmp' / 'issue_146' / 'inspection'
+_DEFAULT_CROP_DIR = _ROOT / 'tmp' / 'issue_146' / 'crops'
+_DEFAULT_MANIFEST = _ROOT / 'tmp' / 'issue_146' / 'manifest.json'
+
+# Keep the full centered tile and the lower label, with a slightly loose crop.
+_TYPE_CROP_BOX = (350, 200, 2650, 4032)
+_COMBO_CROP_BOX = (900, 500, 2850, 3900)
+# Use the full source width and anchor to the bottom edge for tiles whose labels
+# and right/left tile edges were being clipped by narrower custom crops.
+_FULL_WIDTH_BOTTOM_4X5_CROP_BOX = (0, 252, 3024, 4032)
+_SHARED_GLAZE_FIELDS = (
+    'test_tile_image',
+    'is_food_safe',
+    'runs',
+    'highlights_grooves',
+    'is_different_on_white_and_brown_clay',
+    'apply_thin',
+)
+
+_GLAZE_TYPE_SPECS = [
+    # File-specific overrides where the generic box either clipped the label,
+    # clipped a tile edge, or produced an unnecessarily skinny crop.
+    TileImportSpec('2026-04-22 14.36.47.heic', 'Turquoise', _FULL_WIDTH_BOTTOM_4X5_CROP_BOX),
+    TileImportSpec('2026-04-22 14.37.09.heic', 'Dragon Green', _TYPE_CROP_BOX),
+    TileImportSpec('2026-04-22 14.37.12.heic', 'French Blue', _TYPE_CROP_BOX),
+    TileImportSpec('2026-04-22 14.37.14.heic', 'French Green', _FULL_WIDTH_BOTTOM_4X5_CROP_BOX),
+    TileImportSpec('2026-04-22 14.37.16.heic', 'Gloss White', _TYPE_CROP_BOX),
+    TileImportSpec('2026-04-22 14.37.19.heic', 'Hee Soo Clear Crackle', _TYPE_CROP_BOX),
+    TileImportSpec('2026-04-22 14.37.32.heic', 'Choy', _FULL_WIDTH_BOTTOM_4X5_CROP_BOX),
+    TileImportSpec('2026-04-22 14.37.36.heic', 'Clear Crackle', _FULL_WIDTH_BOTTOM_4X5_CROP_BOX),
+    TileImportSpec('2026-04-22 14.37.38.heic', 'Cornwall', _FULL_WIDTH_BOTTOM_4X5_CROP_BOX),
+    TileImportSpec('2026-04-22 14.37.50.heic', 'Celadon', _FULL_WIDTH_BOTTOM_4X5_CROP_BOX),
+    TileImportSpec('2026-04-22 14.37.53.heic', 'Cobalt Blue Green', _TYPE_CROP_BOX),
+    TileImportSpec('2026-04-22 14.37.59.heic', 'Breakthrough White', _TYPE_CROP_BOX),
+    TileImportSpec('2026-04-22 14.38.02.heic', 'Breakthrough Blue', _TYPE_CROP_BOX),
+    TileImportSpec('2026-04-22 14.38.07.heic', 'Albany Blue Slip', _TYPE_CROP_BOX),
+    TileImportSpec('2026-04-22 14.38.11.heic', 'Albany Green Slip', _TYPE_CROP_BOX),
+    TileImportSpec('2026-04-22 14.38.14.heic', 'Albany Manganese Slip', _TYPE_CROP_BOX),
+]
+_GLAZE_COMBINATION_SPECS = [
+    TileImportSpec(
+        '2026-04-22 14.36.16.heic',
+        'Albany Blue Slip!French Green',
+        _COMBO_CROP_BOX,
+        first_glaze='Albany Blue Slip',
+        second_glaze='French Green',
+    ),
+]
+
+
+def _configure_cloudinary() -> None:
+    cloud_name = os.environ.get('CLOUDINARY_CLOUD_NAME', '').strip()
+    api_key = os.environ.get('CLOUDINARY_API_KEY', '').strip()
+    api_secret = os.environ.get('CLOUDINARY_API_SECRET', '').strip()
+    if not cloud_name or not api_key or not api_secret:
+        raise CommandError('CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY, and CLOUDINARY_API_SECRET are required.')
+    cloudinary.config(cloud_name=cloud_name, api_key=api_key, api_secret=api_secret, secure=True)
+
+
+def _load_image(path: Path) -> Image.Image:
+    image = Image.open(path)
+    if image.mode != 'RGB':
+        image = image.convert('RGB')
+    return image
+
+
+def _save_crop(src: Path, dst: Path, crop_box: tuple[int, int, int, int]) -> None:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    with _load_image(src) as image:
+        cropped = image.crop(crop_box)
+        cropped.save(dst, 'JPEG', quality=95)
+
+
+def _upload_file(path: Path, public_id: str, folder: str | None = None) -> dict:
+    upload_kwargs = {
+        'public_id': public_id,
+        'overwrite': True,
+        'resource_type': 'image',
+    }
+    if folder:
+        upload_kwargs['folder'] = folder
+    return cloudinary.uploader.upload(str(path), **upload_kwargs)
+
+
+def _download_file(url: str, dst: Path) -> None:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    response = requests.get(url, timeout=60)
+    response.raise_for_status()
+    dst.write_bytes(response.content)
+
+
+def _ensure_single_layer_combination(glaze_type: GlazeType) -> GlazeCombination:
+    combo_props = {field: getattr(glaze_type, field) for field in _SHARED_GLAZE_FIELDS}
+    combo, _ = GlazeCombination.objects.get_or_create(
+        user=None,
+        name=glaze_type.name,
+        defaults=combo_props,
+    )
+    for field, value in combo_props.items():
+        setattr(combo, field, value)
+    combo.save(update_fields=list(_SHARED_GLAZE_FIELDS))
+    layers = list(combo.layers.select_related('glaze_type').order_by('order'))
+    if len(layers) != 1 or layers[0].glaze_type_id != glaze_type.id:
+        combo.layers.all().delete()
+        GlazeCombinationLayer.objects.create(combination=combo, glaze_type=glaze_type, order=0)
+    return combo
+
+
+def _ensure_combination_layers(combo: GlazeCombination, glaze_types: list[GlazeType]) -> None:
+    existing = list(combo.layers.select_related('glaze_type').order_by('order'))
+    expected_ids = [glaze_type.id for glaze_type in glaze_types]
+    existing_ids = [layer.glaze_type_id for layer in existing]
+    if existing_ids == expected_ids and [layer.order for layer in existing] == list(range(len(glaze_types))):
+        return
+    combo.layers.all().delete()
+    for order, glaze_type in enumerate(glaze_types):
+        GlazeCombinationLayer.objects.create(combination=combo, glaze_type=glaze_type, order=order)
+
+
+class Command(BaseCommand):
+    help = (
+        'Upload the issue-146 test-tile HEICs for inspection, crop the centered tile + '
+        'lower label, upload the corrected crops to Cloudinary, and upsert public '
+        'GlazeType / GlazeCombination rows.'
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--batch-folder',
+            default='',
+            help=(
+                'Cloudinary folder prefix for this import batch. Defaults to '
+                '<CLOUDINARY_UPLOAD_FOLDER>/issue-146-public-test-tiles.'
+            ),
+        )
+        parser.add_argument(
+            '--inspection-dir',
+            default=str(_DEFAULT_INSPECTION_DIR),
+            help='Local directory for downloaded inspection JPGs from Cloudinary.',
+        )
+        parser.add_argument(
+            '--crop-dir',
+            default=str(_DEFAULT_CROP_DIR),
+            help='Local directory for the corrected crop JPGs.',
+        )
+        parser.add_argument(
+            '--manifest',
+            default=str(_DEFAULT_MANIFEST),
+            help='JSON file where the import mapping and Cloudinary URLs are written.',
+        )
+
+    def handle(self, *args, **options):
+        _configure_cloudinary()
+
+        base_folder = options['batch_folder'].strip().strip('/')
+        if not base_folder:
+            env_folder = os.environ.get('CLOUDINARY_UPLOAD_FOLDER', '').strip().strip('/')
+            base_folder = '/'.join(part for part in [env_folder, 'issue-146-public-test-tiles'] if part)
+        inspection_dir = Path(options['inspection_dir'])
+        crop_dir = Path(options['crop_dir'])
+        manifest_path = Path(options['manifest'])
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+
+        manifest: list[dict] = []
+        created_types = 0
+        updated_types = 0
+        created_combos = 0
+        updated_combos = 0
+
+        with transaction.atomic():
+            for spec in _GLAZE_TYPE_SPECS:
+                record, created = self._import_glaze_type(spec, base_folder, inspection_dir, crop_dir)
+                manifest.append(record)
+                if created:
+                    created_types += 1
+                else:
+                    updated_types += 1
+
+            for spec in _GLAZE_COMBINATION_SPECS:
+                record, created = self._import_glaze_combination(spec, base_folder, inspection_dir, crop_dir)
+                manifest.append(record)
+                if created:
+                    created_combos += 1
+                else:
+                    updated_combos += 1
+
+            verification = self._verify()
+
+        manifest_path.write_text(json.dumps({'records': manifest, 'verification': verification}, indent=2))
+        self.stdout.write(
+            self.style.SUCCESS(
+                f'Imported issue-146 test tiles: '
+                f'{created_types} glaze types created, {updated_types} glaze types updated, '
+                f'{created_combos} glaze combinations created, {updated_combos} glaze combinations updated.'
+            )
+        )
+        self.stdout.write(self.style.SUCCESS(f'Manifest written to {manifest_path}'))
+
+    def _import_glaze_type(
+        self,
+        spec: TileImportSpec,
+        base_folder: str,
+        inspection_dir: Path,
+        crop_dir: Path,
+    ) -> tuple[dict, bool]:
+        src = _TYPES_DIR / spec.filename
+        if not src.exists():
+            raise CommandError(f'Missing source HEIC: {src}')
+
+        inspection_public_id = f'glaze-type-source-{Path(spec.filename).stem}'
+        inspection_upload = _upload_file(
+            src,
+            public_id=inspection_public_id,
+            folder=f'{base_folder}/inspection/glaze-types',
+        )
+        jpg_url, _ = cloudinary_url(
+            inspection_upload['public_id'],
+            secure=True,
+            format='jpg',
+            resource_type='image',
+            type='upload',
+        )
+        inspection_path = inspection_dir / 'glaze_types' / f'{Path(spec.filename).stem}.jpg'
+        _download_file(jpg_url, inspection_path)
+
+        cropped_path = crop_dir / 'glaze_types' / f'{Path(spec.filename).stem}.jpg'
+        _save_crop(src, cropped_path, spec.crop_box)
+        final_upload = _upload_file(
+            cropped_path,
+            public_id=f'glaze-type-{Path(spec.filename).stem}',
+            folder=f'{base_folder}/final/glaze-types',
+        )
+        glaze_type, created = GlazeType.objects.get_or_create(user=None, name=spec.name)
+        glaze_type.test_tile_image = final_upload['secure_url']
+        glaze_type.save(update_fields=['test_tile_image'])
+        _ensure_single_layer_combination(glaze_type)
+        return {
+            'kind': 'glaze_type',
+            'filename': spec.filename,
+            'name': spec.name,
+            'source_path': str(src),
+            'inspection_jpg_url': jpg_url,
+            'inspection_public_id': inspection_upload['public_id'],
+            'cropped_path': str(cropped_path),
+            'final_cloudinary_url': final_upload['secure_url'],
+            'final_public_id': final_upload['public_id'],
+        }, created
+
+    def _import_glaze_combination(
+        self,
+        spec: TileImportSpec,
+        base_folder: str,
+        inspection_dir: Path,
+        crop_dir: Path,
+    ) -> tuple[dict, bool]:
+        src = _COMBOS_DIR / spec.filename
+        if not src.exists():
+            raise CommandError(f'Missing source HEIC: {src}')
+        if not spec.first_glaze or not spec.second_glaze:
+            raise CommandError(f'Combination spec is missing glaze references: {spec.filename}')
+
+        inspection_public_id = f'glaze-combination-source-{Path(spec.filename).stem}'
+        inspection_upload = _upload_file(
+            src,
+            public_id=inspection_public_id,
+            folder=f'{base_folder}/inspection/glaze-combinations',
+        )
+        jpg_url, _ = cloudinary_url(
+            inspection_upload['public_id'],
+            secure=True,
+            format='jpg',
+            resource_type='image',
+            type='upload',
+        )
+        inspection_path = inspection_dir / 'glaze_combinations' / f'{Path(spec.filename).stem}.jpg'
+        _download_file(jpg_url, inspection_path)
+
+        cropped_path = crop_dir / 'glaze_combinations' / f'{Path(spec.filename).stem}.jpg'
+        _save_crop(src, cropped_path, spec.crop_box)
+        final_upload = _upload_file(
+            cropped_path,
+            public_id=f'glaze-combination-{Path(spec.filename).stem}',
+            folder=f'{base_folder}/final/glaze-combinations',
+        )
+
+        first = GlazeType.objects.get(user=None, name=spec.first_glaze)
+        second = GlazeType.objects.get(user=None, name=spec.second_glaze)
+        combo, created = GlazeCombination.objects.get_or_create(user=None, name=spec.name)
+        combo.test_tile_image = final_upload['secure_url']
+        combo.save(update_fields=['test_tile_image'])
+        _ensure_combination_layers(combo, [first, second])
+        return {
+            'kind': 'glaze_combination',
+            'filename': spec.filename,
+            'name': spec.name,
+            'first_glaze': spec.first_glaze,
+            'second_glaze': spec.second_glaze,
+            'source_path': str(src),
+            'inspection_jpg_url': jpg_url,
+            'inspection_public_id': inspection_upload['public_id'],
+            'cropped_path': str(cropped_path),
+            'final_cloudinary_url': final_upload['secure_url'],
+            'final_public_id': final_upload['public_id'],
+        }, created
+
+    def _verify(self) -> dict:
+        type_results = []
+        for spec in _GLAZE_TYPE_SPECS:
+            glaze_type = GlazeType.objects.get(user=None, name=spec.name)
+            single = GlazeCombination.objects.get(user=None, name=spec.name)
+            layers = list(single.layers.order_by('order').values_list('glaze_type__name', flat=True))
+            type_results.append(
+                {
+                    'name': glaze_type.name,
+                    'test_tile_image': glaze_type.test_tile_image,
+                    'single_layer_combination_layers': layers,
+                }
+            )
+
+        combo_results = []
+        for spec in _GLAZE_COMBINATION_SPECS:
+            combo = GlazeCombination.objects.get(user=None, name=spec.name)
+            layers = list(combo.layers.order_by('order').values_list('glaze_type__name', flat=True))
+            combo_results.append(
+                {
+                    'name': combo.name,
+                    'test_tile_image': combo.test_tile_image,
+                    'layers': layers,
+                }
+            )
+
+        return {
+            'glaze_types': type_results,
+            'glaze_combinations': combo_results,
+        }

--- a/api/manual_tile_imports.py
+++ b/api/manual_tile_imports.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import os
+import uuid
+from collections import Counter
+
+import cloudinary
+import cloudinary.uploader
+from django.db import transaction
+from django.utils.text import slugify
+
+from .models import GlazeCombination, GlazeCombinationLayer, GlazeType
+
+_SHARED_GLAZE_FIELDS = (
+    'test_tile_image',
+    'is_food_safe',
+    'runs',
+    'highlights_grooves',
+    'is_different_on_white_and_brown_clay',
+    'apply_thin',
+)
+
+
+def _configure_cloudinary() -> None:
+    cloud_name = os.environ.get('CLOUDINARY_CLOUD_NAME', '').strip()
+    api_key = os.environ.get('CLOUDINARY_API_KEY', '').strip()
+    api_secret = os.environ.get('CLOUDINARY_API_SECRET', '').strip()
+    if not cloud_name or not api_key or not api_secret:
+        raise ValueError('CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY, and CLOUDINARY_API_SECRET are required.')
+    cloudinary.config(cloud_name=cloud_name, api_key=api_key, api_secret=api_secret, secure=True)
+
+
+def _default_batch_folder() -> str:
+    env_folder = os.environ.get('CLOUDINARY_UPLOAD_FOLDER', '').strip().strip('/')
+    return '/'.join(part for part in [env_folder, 'manual-square-crop-imports'] if part)
+
+
+def _upload_file(uploaded_file, *, kind: str, filename: str, folder: str) -> dict:
+    stem = slugify(filename.rsplit('.', 1)[0]) or 'tile'
+    public_id = f'{kind}-{stem}-{uuid.uuid4().hex[:8]}'
+    return cloudinary.uploader.upload(
+        uploaded_file,
+        public_id=public_id,
+        overwrite=False,
+        resource_type='image',
+        folder=folder,
+    )
+
+
+def _ensure_single_layer_combination(glaze_type: GlazeType) -> GlazeCombination:
+    combo_props = {field: getattr(glaze_type, field) for field in _SHARED_GLAZE_FIELDS}
+    combo, _ = GlazeCombination.objects.get_or_create(
+        user=None,
+        name=glaze_type.name,
+        defaults=combo_props,
+    )
+    for field, value in combo_props.items():
+        setattr(combo, field, value)
+    combo.save(update_fields=list(_SHARED_GLAZE_FIELDS))
+    layers = list(combo.layers.select_related('glaze_type').order_by('order'))
+    if len(layers) != 1 or layers[0].glaze_type_id != glaze_type.id:
+        combo.layers.all().delete()
+        GlazeCombinationLayer.objects.create(combination=combo, glaze_type=glaze_type, order=0)
+    return combo
+
+
+def _ensure_combination_layers(combo: GlazeCombination, glaze_types: list[GlazeType]) -> None:
+    existing = list(combo.layers.select_related('glaze_type').order_by('order'))
+    expected_ids = [glaze_type.id for glaze_type in glaze_types]
+    existing_ids = [layer.glaze_type_id for layer in existing]
+    if existing_ids == expected_ids and [layer.order for layer in existing] == list(range(len(glaze_types))):
+        return
+    combo.layers.all().delete()
+    for order, glaze_type in enumerate(glaze_types):
+        GlazeCombinationLayer.objects.create(combination=combo, glaze_type=glaze_type, order=order)
+
+
+def _result_payload(record: dict, *, status: str, reason: str | None = None, object_id: str | None = None, image_url: str | None = None) -> dict:
+    parsed = record.get('parsed_fields', {}) or {}
+    return {
+        'client_id': record.get('client_id', ''),
+        'filename': record.get('filename', ''),
+        'kind': parsed.get('kind', record.get('kind', '')),
+        'name': parsed.get('name', ''),
+        'status': status,
+        'reason': reason,
+        'object_id': object_id,
+        'image_url': image_url,
+    }
+
+
+def import_manual_tile_records(records: list[dict], uploaded_files: dict[str, object], *, batch_folder: str | None = None) -> dict:
+    _configure_cloudinary()
+    folder = (batch_folder or _default_batch_folder()).strip().strip('/')
+    results: list[dict] = []
+
+    def import_glaze_type(record: dict) -> dict:
+        parsed = record.get('parsed_fields', {}) or {}
+        name = (parsed.get('name') or '').strip()
+        client_id = record.get('client_id', '')
+        uploaded = uploaded_files.get(client_id)
+        if not name:
+            return _result_payload(record, status='error', reason='Missing parsed glaze type name.')
+        if uploaded is None:
+            return _result_payload(record, status='error', reason='Missing cropped image upload.')
+        existing = GlazeType.objects.filter(user=None, name=name).first()
+        if existing:
+            return _result_payload(record, status='skipped_duplicate', reason='Public glaze type already exists.', object_id=str(existing.pk), image_url=existing.test_tile_image)
+
+        upload = _upload_file(
+            uploaded,
+            kind='glaze-type',
+            filename=record.get('filename', name),
+            folder=f'{folder}/final/glaze-types',
+        )
+        glaze_type = GlazeType.objects.create(
+            user=None,
+            name=name,
+            test_tile_image=upload['secure_url'],
+            runs=parsed.get('runs'),
+            is_food_safe=parsed.get('is_food_safe'),
+        )
+        _ensure_single_layer_combination(glaze_type)
+        return _result_payload(record, status='created', object_id=str(glaze_type.pk), image_url=glaze_type.test_tile_image)
+
+    def import_glaze_combination(record: dict) -> dict:
+        parsed = record.get('parsed_fields', {}) or {}
+        name = (parsed.get('name') or '').strip()
+        first_name = (parsed.get('first_glaze') or '').strip()
+        second_name = (parsed.get('second_glaze') or '').strip()
+        client_id = record.get('client_id', '')
+        uploaded = uploaded_files.get(client_id)
+        if not name:
+            if first_name and second_name:
+                name = f'{first_name}!{second_name}'
+            else:
+                return _result_payload(record, status='error', reason='Missing parsed glaze combination name.')
+        if not first_name or not second_name:
+            return _result_payload(record, status='error', reason='Glaze combinations require first and second glaze names.')
+        if uploaded is None:
+            return _result_payload(record, status='error', reason='Missing cropped image upload.')
+        existing = GlazeCombination.objects.filter(user=None, name=name).first()
+        if existing:
+            return _result_payload(record, status='skipped_duplicate', reason='Public glaze combination already exists.', object_id=str(existing.pk), image_url=existing.test_tile_image)
+
+        first = GlazeType.objects.filter(user=None, name=first_name).first()
+        second = GlazeType.objects.filter(user=None, name=second_name).first()
+        if first is None or second is None:
+            missing = first_name if first is None else second_name
+            return _result_payload(record, status='error', reason=f'Missing referenced public glaze type: {missing}.')
+
+        upload = _upload_file(
+            uploaded,
+            kind='glaze-combination',
+            filename=record.get('filename', name),
+            folder=f'{folder}/final/glaze-combinations',
+        )
+        combo = GlazeCombination.objects.create(
+            user=None,
+            name=name,
+            test_tile_image=upload['secure_url'],
+            runs=parsed.get('runs'),
+            is_food_safe=parsed.get('is_food_safe'),
+        )
+        _ensure_combination_layers(combo, [first, second])
+        return _result_payload(record, status='created', object_id=str(combo.pk), image_url=combo.test_tile_image)
+
+    with transaction.atomic():
+        for record in [r for r in records if (r.get('parsed_fields', {}) or {}).get('kind') == 'glaze_type']:
+            results.append(import_glaze_type(record))
+        for record in [r for r in records if (r.get('parsed_fields', {}) or {}).get('kind') == 'glaze_combination']:
+            results.append(import_glaze_combination(record))
+
+    counts = Counter(result['status'] for result in results)
+    created_type_count = sum(1 for result in results if result['status'] == 'created' and result['kind'] == 'glaze_type')
+    created_combo_count = sum(1 for result in results if result['status'] == 'created' and result['kind'] == 'glaze_combination')
+    return {
+        'results': results,
+        'summary': {
+            'created_glaze_types': created_type_count,
+            'created_glaze_combinations': created_combo_count,
+            'skipped_duplicates': counts.get('skipped_duplicate', 0),
+            'errors': counts.get('error', 0),
+        },
+    }

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -522,6 +522,7 @@ class AuthUserSerializer(serializers.Serializer):
     email = serializers.EmailField(read_only=True)
     first_name = serializers.CharField(read_only=True, allow_blank=True)
     last_name = serializers.CharField(read_only=True, allow_blank=True)
+    is_staff = serializers.BooleanField(read_only=True)
     openid_subject = serializers.SerializerMethodField()
     profile_image_url = serializers.SerializerMethodField()
 

--- a/api/tests/test_auth.py
+++ b/api/tests/test_auth.py
@@ -20,6 +20,7 @@ class TestAuthEndpoints:
         assert response.status_code == 201
         data = response.json()
         assert data['email'] == 'newuser@example.com'
+        assert data['is_staff'] is False
         assert User.objects.filter(email='newuser@example.com').exists()
         me_response = client.get('/api/auth/me/')
         assert me_response.status_code == 200
@@ -39,6 +40,7 @@ class TestAuthEndpoints:
         )
         assert response.status_code == 200
         assert response.json()['email'] == 'person@example.com'
+        assert response.json()['is_staff'] is False
 
     def test_logout_clears_session(self):
         user = User.objects.create(
@@ -54,6 +56,18 @@ class TestAuthEndpoints:
         client = APIClient()
         response = client.get('/api/auth/me/')
         assert response.status_code == 403
+
+    def test_me_includes_staff_flag(self):
+        user = User.objects.create(
+            username='admin@example.com',
+            email='admin@example.com',
+            is_staff=True,
+        )
+        client = APIClient()
+        client.force_authenticate(user=user)
+        response = client.get('/api/auth/me/')
+        assert response.status_code == 200
+        assert response.json()['is_staff'] is True
 
     def test_data_endpoints_require_auth(self):
         client = APIClient()

--- a/api/tests/test_manual_square_crop_import.py
+++ b/api/tests/test_manual_square_crop_import.py
@@ -1,0 +1,180 @@
+import io
+import json
+
+import pytest
+from django.contrib.auth.models import User
+from django.core.files.uploadedfile import SimpleUploadedFile
+from PIL import Image
+from rest_framework.test import APIClient
+
+from api.models import GlazeCombination, GlazeType
+
+URL = '/api/admin/manual-square-crop-import/'
+
+
+def _png_upload(name: str = 'crop.png') -> SimpleUploadedFile:
+    buf = io.BytesIO()
+    Image.new('RGBA', (16, 16), (255, 0, 0, 0)).save(buf, format='PNG')
+    return SimpleUploadedFile(name, buf.getvalue(), content_type='image/png')
+
+
+@pytest.mark.django_db
+class TestManualSquareCropImport:
+    def test_requires_admin_user(self):
+        user = User.objects.create(username='potter@example.com', email='potter@example.com')
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        response = client.post(URL, {'payload': json.dumps({'records': []})})
+
+        assert response.status_code == 403
+
+    def test_creates_public_glaze_type_and_single_layer_combination(self, monkeypatch):
+        admin = User.objects.create(username='admin@example.com', email='admin@example.com', is_staff=True)
+        client = APIClient()
+        client.force_authenticate(user=admin)
+
+        upload_calls = []
+
+        def fake_upload(file_obj, **kwargs):
+            upload_calls.append(kwargs)
+            return {
+                'secure_url': 'https://example.com/manual-square-crop/type.png',
+                'public_id': 'manual-square-crop/type',
+            }
+
+        monkeypatch.setenv('CLOUDINARY_CLOUD_NAME', 'demo-cloud')
+        monkeypatch.setenv('CLOUDINARY_API_KEY', 'demo-key')
+        monkeypatch.setenv('CLOUDINARY_API_SECRET', 'demo-secret')
+        monkeypatch.setattr('api.manual_tile_imports.cloudinary.uploader.upload', fake_upload)
+
+        payload = {
+            'records': [
+                {
+                    'client_id': 'rec-1',
+                    'filename': 'dragon-green.png',
+                    'reviewed': True,
+                    'parsed_fields': {
+                        'name': 'Dragon Green',
+                        'kind': 'glaze_type',
+                        'first_glaze': '',
+                        'second_glaze': '',
+                        'runs': None,
+                        'is_food_safe': None,
+                    },
+                },
+            ],
+        }
+
+        response = client.post(
+            URL,
+            {
+                'payload': json.dumps(payload),
+                'crop_image__rec-1': _png_upload(),
+            },
+            format='multipart',
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body['summary'] == {
+            'created_glaze_types': 1,
+            'created_glaze_combinations': 0,
+            'skipped_duplicates': 0,
+            'errors': 0,
+        }
+        assert body['results'][0]['status'] == 'created'
+        glaze_type = GlazeType.objects.get(user=None, name='Dragon Green')
+        assert glaze_type.test_tile_image == 'https://example.com/manual-square-crop/type.png'
+        assert glaze_type.runs is None
+        assert glaze_type.is_food_safe is None
+        combo = GlazeCombination.objects.get(user=None, name='Dragon Green')
+        assert list(combo.layers.order_by('order').values_list('glaze_type__name', flat=True)) == ['Dragon Green']
+        assert len(upload_calls) == 1
+
+    def test_runs_and_food_safe_written_to_created_glaze_type(self, monkeypatch):
+        admin = User.objects.create(username='admin3@example.com', email='admin3@example.com', is_staff=True)
+        client = APIClient()
+        client.force_authenticate(user=admin)
+
+        monkeypatch.setenv('CLOUDINARY_CLOUD_NAME', 'demo-cloud')
+        monkeypatch.setenv('CLOUDINARY_API_KEY', 'demo-key')
+        monkeypatch.setenv('CLOUDINARY_API_SECRET', 'demo-secret')
+        monkeypatch.setattr(
+            'api.manual_tile_imports.cloudinary.uploader.upload',
+            lambda *a, **kw: {'secure_url': 'https://example.com/caution.png', 'public_id': 'caution'},
+        )
+
+        payload = {
+            'records': [
+                {
+                    'client_id': 'rec-runs',
+                    'filename': 'caution.png',
+                    'reviewed': True,
+                    'parsed_fields': {
+                        'name': 'Caution Drip',
+                        'kind': 'glaze_type',
+                        'first_glaze': '',
+                        'second_glaze': '',
+                        'runs': True,
+                        'is_food_safe': False,
+                    },
+                },
+            ],
+        }
+
+        response = client.post(
+            URL,
+            {'payload': json.dumps(payload), 'crop_image__rec-runs': _png_upload('caution.png')},
+            format='multipart',
+        )
+
+        assert response.status_code == 200
+        glaze_type = GlazeType.objects.get(user=None, name='Caution Drip')
+        assert glaze_type.runs is True
+        assert glaze_type.is_food_safe is False
+
+    def test_skips_duplicate_public_glaze_type_without_uploading(self, monkeypatch):
+        admin = User.objects.create(username='admin2@example.com', email='admin2@example.com', is_staff=True)
+        existing = GlazeType.objects.create(user=None, name='Celadon', test_tile_image='https://example.com/existing.png')
+        client = APIClient()
+        client.force_authenticate(user=admin)
+
+        def fail_upload(*args, **kwargs):
+            raise AssertionError('upload should not be called for duplicates')
+
+        monkeypatch.setenv('CLOUDINARY_CLOUD_NAME', 'demo-cloud')
+        monkeypatch.setenv('CLOUDINARY_API_KEY', 'demo-key')
+        monkeypatch.setenv('CLOUDINARY_API_SECRET', 'demo-secret')
+        monkeypatch.setattr('api.manual_tile_imports.cloudinary.uploader.upload', fail_upload)
+
+        payload = {
+            'records': [
+                {
+                    'client_id': 'rec-dup',
+                    'filename': 'celadon.png',
+                    'reviewed': True,
+                    'parsed_fields': {
+                        'name': 'Celadon',
+                        'kind': 'glaze_type',
+                        'first_glaze': '',
+                        'second_glaze': '',
+                    },
+                },
+            ],
+        }
+
+        response = client.post(
+            URL,
+            {
+                'payload': json.dumps(payload),
+                'crop_image__rec-dup': _png_upload('celadon.png'),
+            },
+            format='multipart',
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body['summary']['skipped_duplicates'] == 1
+        assert body['results'][0]['status'] == 'skipped_duplicate'
+        assert body['results'][0]['object_id'] == str(existing.pk)

--- a/api/urls.py
+++ b/api/urls.py
@@ -5,6 +5,7 @@ from .workflow import get_global_model_and_field, get_global_names
 
 urlpatterns = [
     path('analysis/glaze-combination-images/', views.glaze_combination_images, name='analysis-glaze-combination-images'),
+    path('admin/manual-square-crop-import/', views.admin_manual_square_crop_import, name='admin-manual-square-crop-import'),
     path('auth/csrf/', views.csrf, name='auth-csrf'),
     path('auth/login/', views.auth_login, name='auth-login'),
     path('auth/logout/', views.auth_logout, name='auth-logout'),

--- a/api/views.py
+++ b/api/views.py
@@ -1,5 +1,6 @@
 import hashlib
 import os
+import json
 
 from drf_spectacular.utils import extend_schema
 from django.conf import settings
@@ -10,8 +11,10 @@ from google.auth.transport import requests as google_requests
 from google.oauth2 import id_token as google_id_token
 from rest_framework import status
 from rest_framework.decorators import api_view
+from rest_framework.decorators import parser_classes
 from rest_framework.decorators import permission_classes
-from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.parsers import FormParser, MultiPartParser
+from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -20,6 +23,7 @@ from collections import defaultdict
 from django.apps import apps
 from django.db.models import Q
 
+from .manual_tile_imports import import_manual_tile_records
 from .models import FavoriteGlazeCombination, GlazeCombination, Piece, PieceState, UserProfile
 from .registry import _GLOBAL_ENTRY_SERIALIZERS  # populated by @global_entry_serializer decorators in serializers.py
 from .serializers import (
@@ -707,3 +711,48 @@ def auth_register(request: Request) -> Response:
     user = serializer.save()
     login(request, user)
     return Response(AuthUserSerializer(user).data, status=status.HTTP_201_CREATED)
+
+
+@extend_schema(
+    request={'multipart/form-data': {
+        'type': 'object',
+        'properties': {
+            'payload': {'type': 'string'},
+        },
+        'required': ['payload'],
+    }},
+    responses={200: {'type': 'object'}},
+)
+@api_view(['POST'])
+@permission_classes([IsAdminUser])
+@parser_classes([MultiPartParser, FormParser])
+def admin_manual_square_crop_import(request: Request) -> Response:
+    payload_raw = request.data.get('payload', '')
+    if not payload_raw:
+        return Response({'detail': 'payload is required.'}, status=status.HTTP_400_BAD_REQUEST)
+    try:
+        payload = json.loads(payload_raw)
+    except json.JSONDecodeError:
+        return Response({'detail': 'payload must be valid JSON.'}, status=status.HTTP_400_BAD_REQUEST)
+
+    records = payload.get('records')
+    if not isinstance(records, list) or not records:
+        return Response({'detail': 'payload.records must be a non-empty list.'}, status=status.HTTP_400_BAD_REQUEST)
+
+    if any(not record.get('reviewed') for record in records):
+        return Response({'detail': 'All records must be reviewed before import.'}, status=status.HTTP_400_BAD_REQUEST)
+
+    uploaded_files = {}
+    for record in records:
+        client_id = record.get('client_id', '')
+        if not client_id:
+            return Response({'detail': 'Each record must include client_id.'}, status=status.HTTP_400_BAD_REQUEST)
+        file_obj = request.FILES.get(f'crop_image__{client_id}')
+        if file_obj is not None:
+            uploaded_files[client_id] = file_obj
+
+    try:
+        result = import_manual_tile_records(records, uploaded_files)
+    except ValueError as exc:
+        return Response({'detail': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+    return Response(result)

--- a/docs/agents/glaze-domain.md
+++ b/docs/agents/glaze-domain.md
@@ -361,6 +361,39 @@ All data-fetching components must render a loading spinner (`<CircularProgress /
 
 ---
 
+## Glaze Import Tool (Admin)
+
+Staff users have access to a browser-based bulk import workflow at `/tools/glaze-import`. It is the canonical way to seed the public `GlazeType` and `GlazeCombination` libraries from physical test-tile photographs. The tool is a five-to-six step tabbed flow:
+
+| Tab | Purpose |
+|-----|---------|
+| **1. Upload** | Bulk-upload source images from disk (JPEG/PNG) or via the Cloudinary widget (HEIC/HEIF conversion). Each image becomes an independent record. |
+| **2. Crop** | Draw a rotatable square crop box over each image. The box may extend beyond the image bounds; overflow becomes transparent in the output. Crop geometry is debounced so the live preview updates only after 200 ms of inactivity. |
+| **3. OCR** | Optionally draw a rotatable OCR region bounding box on the crop preview. Running OCR on all records at once feeds Tesseract.js with a domain word list (runs, caution, food safe, 1st, 2nd, glaze) and then parses the result with two heuristics applied in order: (1) structured-line detection (`/[I1]st Glaze[:;]/` → `first_glaze`, `/[2=Z]nd Glaze[:;]/` → `second_glaze`) and (2) a token-split fallback that looks for common combo separators (`!`, `/`, `&`, `+`, `over`). CAUTION RUNS detection sets `runs: true`; NOT FOOD SAFE detection sets `is_food_safe: false`. |
+| **4. Review** | Per-record editable form: name, kind (`glaze_type` / `glaze_combination`), first/second glaze fields (hidden for types), `runs?`, and `food safe?` selects. For combinations, the name field is auto-computed as `<first>!<second>` and is read-only. Records must be checked as reviewed before import. |
+| **5. Import** | Sends all reviewed records and their compressed crop images (WebP ≤ 2000 px, 0.85 quality) to `POST /api/admin/manual-square-crop-import/`. A per-record progress list shows Build → Upload → Done for each file. Import results include admin links to every created or matched object. |
+| **6. Reconcile** *(conditional)* | Appears only when the import skipped duplicates. Shows the scraped fields for each skipped record alongside an "Open in Admin" link to the existing record, and a resolved checkbox checklist. |
+
+### Backend import endpoint
+
+`POST /api/admin/manual-square-crop-import/` — staff only (`is_staff`). Accepts a `multipart/form-data` body:
+- `payload` — JSON string `{ records: ManualSquareCropImportRecordPayload[] }` (see `frontend_common/src/api.ts` for the shape).
+- `crop_image__<client_id>` — one WebP file per record.
+
+The endpoint is implemented in `api/manual_tile_imports.py`. For each `glaze_type` record it creates a public `GlazeType` (and a matching single-layer `GlazeCombination`) and uploads the crop to Cloudinary. For each `glaze_combination` record it resolves the two referenced public `GlazeType` rows by name, creates a public `GlazeCombination`, and sets the ordered layers. **`runs` and `is_food_safe` from `parsed_fields` are written to both `GlazeType` and `GlazeCombination` on creation.** Existing public records with the same name are reported as `skipped_duplicate` (not updated).
+
+### OCR parsing conventions
+
+- Structured lines take priority: a line matching `/^[I1l]st\s+[Gg]laze\s*[:;]\s*(.+)/` is the first glaze; `/^[2=Z]nd\s+[Gg]laze\s*[:;]/` is the second. The character classes handle common OCR confusions (`I`/`1`/`l` for `1`, `=`/`Z` for `2`, `;` for `:`).
+- If no structured lines are found, the longest non-annotation line is used. Tokens split on `!`, `/`, `&`, `+`, `over` determine whether the result is a combination (≥ 2 tokens) or a single type.
+- Annotation lines matching `CAUTION.*RUNS` or `NOT FOOD SAFE` are stripped from the name and used to set `runs`/`is_food_safe` in `parsed_fields`.
+
+### Protected files for this feature
+
+`api/manual_tile_imports.py` and `web/src/pages/AdminManualSquareCropToolPage.tsx` are the two primary implementation files. `api/tests/test_manual_square_crop_import.py` must be kept in sync with any import-logic changes.
+
+---
+
 ## GitHub: Scope Limits & Definition of Done (Glaze-specific)
 
 These extend the generic GitHub interactions guide with Glaze-specific protected files and DoD checks.

--- a/fixtures/public_library.json
+++ b/fixtures/public_library.json
@@ -1,161 +1,5 @@
 [
   {
-    "model": "api.glazetype",
-    "fields": {
-      "name": "Celadon",
-      "short_description": "",
-      "test_tile_image": "",
-      "is_food_safe": true,
-      "runs": true,
-      "highlights_grooves": null,
-      "is_different_on_white_and_brown_clay": null,
-      "apply_thin": false
-    }
-  },
-  {
-    "model": "api.glazetype",
-    "fields": {
-      "name": "Wild Hare Fur",
-      "short_description": "",
-      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776304189/glaze_public/jvrmpfxkjjhniqpqzqrs.heic",
-      "is_food_safe": true,
-      "runs": false,
-      "highlights_grooves": null,
-      "is_different_on_white_and_brown_clay": true,
-      "apply_thin": false
-    }
-  },
-  {
-    "model": "api.glazetype",
-    "fields": {
-      "name": "Amber",
-      "short_description": "",
-      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776803024/glaze_public/naxk2tch9yg5lbfde5ff.heic",
-      "is_food_safe": true,
-      "runs": false,
-      "highlights_grooves": true,
-      "is_different_on_white_and_brown_clay": true,
-      "apply_thin": false
-    }
-  },
-  {
-    "model": "api.glazetype",
-    "fields": {
-      "name": "Volcanic Ash",
-      "short_description": "",
-      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776304349/glaze_public/eyy9whpmb5wajybtfk3p.heic",
-      "is_food_safe": true,
-      "runs": false,
-      "highlights_grooves": true,
-      "is_different_on_white_and_brown_clay": true,
-      "apply_thin": false
-    }
-  },
-  {
-    "model": "api.glazetype",
-    "fields": {
-      "name": "Creamy Red",
-      "short_description": "",
-      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776823398/glaze_public/zotiqbcrfmdfxtty2wmv.heic",
-      "is_food_safe": true,
-      "runs": false,
-      "highlights_grooves": true,
-      "is_different_on_white_and_brown_clay": true,
-      "apply_thin": true
-    }
-  },
-  {
-    "model": "api.glazecombination",
-    "fields": {
-      "name": "Celadon!Volcanic Ash",
-      "firing_temperature": null,
-      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776304417/glaze_public/j3gz35q5fecp48ncy2qp.heic",
-      "is_food_safe": true,
-      "runs": false,
-      "highlights_grooves": false,
-      "is_different_on_white_and_brown_clay": false,
-      "apply_thin": null
-    }
-  },
-  {
-    "model": "api.glazecombination",
-    "fields": {
-      "name": "Wild Hare Fur!Celadon",
-      "firing_temperature": null,
-      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776304417/glaze_public/j3gz35q5fecp48ncy2qp.heic",
-      "is_food_safe": true,
-      "runs": false,
-      "highlights_grooves": false,
-      "is_different_on_white_and_brown_clay": false,
-      "apply_thin": null
-    }
-  },
-  {
-    "model": "api.glazecombination",
-    "fields": {
-      "name": "Celadon",
-      "firing_temperature": null,
-      "test_tile_image": "",
-      "is_food_safe": true,
-      "runs": true,
-      "highlights_grooves": null,
-      "is_different_on_white_and_brown_clay": null,
-      "apply_thin": false
-    }
-  },
-  {
-    "model": "api.glazecombination",
-    "fields": {
-      "name": "Wild Hare Fur",
-      "firing_temperature": null,
-      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776304189/glaze_public/jvrmpfxkjjhniqpqzqrs.heic",
-      "is_food_safe": true,
-      "runs": false,
-      "highlights_grooves": null,
-      "is_different_on_white_and_brown_clay": true,
-      "apply_thin": false
-    }
-  },
-  {
-    "model": "api.glazecombination",
-    "fields": {
-      "name": "Amber",
-      "firing_temperature": null,
-      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776803024/glaze_public/naxk2tch9yg5lbfde5ff.heic",
-      "is_food_safe": true,
-      "runs": false,
-      "highlights_grooves": true,
-      "is_different_on_white_and_brown_clay": true,
-      "apply_thin": false
-    }
-  },
-  {
-    "model": "api.glazecombination",
-    "fields": {
-      "name": "Volcanic Ash",
-      "firing_temperature": null,
-      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776304349/glaze_public/eyy9whpmb5wajybtfk3p.heic",
-      "is_food_safe": true,
-      "runs": false,
-      "highlights_grooves": true,
-      "is_different_on_white_and_brown_clay": true,
-      "apply_thin": false
-    }
-  },
-  {
-    "model": "api.glazecombination",
-    "fields": {
-      "name": "Creamy Red",
-      "firing_temperature": null,
-      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776823398/glaze_public/zotiqbcrfmdfxtty2wmv.heic",
-      "is_food_safe": true,
-      "runs": false,
-      "highlights_grooves": true,
-      "is_different_on_white_and_brown_clay": true,
-      "apply_thin": true
-    }
-  },
-  {
     "model": "api.claybody",
     "fields": {
       "name": "Brown",
@@ -167,6 +11,409 @@
     "fields": {
       "name": "White",
       "short_description": "white"
+    }
+  },
+  {
+    "model": "api.glazetype",
+    "fields": {
+      "name": "Albany Blue Slip",
+      "short_description": "",
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988117/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143807-1c56cf6a.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazetype",
+    "fields": {
+      "name": "Albany Green Slip",
+      "short_description": "",
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988116/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143811-53ad4dc0.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazetype",
+    "fields": {
+      "name": "Albany Manganese Slip",
+      "short_description": "",
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988115/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143814-8097c73f.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazetype",
+    "fields": {
+      "name": "Breakthrough Blue",
+      "short_description": "",
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988118/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143802-f4a84d28.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazetype",
+    "fields": {
+      "name": "Breakthrough White",
+      "short_description": "",
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988119/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143759-9bd7135f.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazetype",
+    "fields": {
+      "name": "Celadon",
+      "short_description": "",
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988120/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143750-c66c36bf.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazetype",
+    "fields": {
+      "name": "Choy",
+      "short_description": "",
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988115/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143732-902c440f.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazetype",
+    "fields": {
+      "name": "Clear Crackle",
+      "short_description": "",
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988118/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143736-da700ea4.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazetype",
+    "fields": {
+      "name": "Cobalt Blue Green",
+      "short_description": "",
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988120/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143753-6013693b.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazetype",
+    "fields": {
+      "name": "Cornwall",
+      "short_description": "",
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988114/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143738-0ebbbb48.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazetype",
+    "fields": {
+      "name": "Dragon Green",
+      "short_description": "",
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988121/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143709-bfc538c3.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazetype",
+    "fields": {
+      "name": "French Blue",
+      "short_description": "",
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988123/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143712-c05af528.webp",
+      "is_food_safe": true,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazetype",
+    "fields": {
+      "name": "French Green",
+      "short_description": "",
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988122/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143714-b3d13f9c.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazetype",
+    "fields": {
+      "name": "Gloss White",
+      "short_description": "",
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988121/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143716-57d25039.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazetype",
+    "fields": {
+      "name": "Turquoise",
+      "short_description": "",
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988123/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143647-9a0a750a.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazecombination",
+    "fields": {
+      "name": "Albany Blue Slip",
+      "firing_temperature": null,
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988117/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143807-1c56cf6a.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazecombination",
+    "fields": {
+      "name": "Albany Green Slip",
+      "firing_temperature": null,
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988116/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143811-53ad4dc0.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazecombination",
+    "fields": {
+      "name": "Albany Manganese Slip",
+      "firing_temperature": null,
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988115/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143814-8097c73f.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazecombination",
+    "fields": {
+      "name": "Breakthrough Blue",
+      "firing_temperature": null,
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988118/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143802-f4a84d28.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazecombination",
+    "fields": {
+      "name": "Breakthrough White",
+      "firing_temperature": null,
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988119/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143759-9bd7135f.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazecombination",
+    "fields": {
+      "name": "Celadon",
+      "firing_temperature": null,
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988120/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143750-c66c36bf.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazecombination",
+    "fields": {
+      "name": "Choy",
+      "firing_temperature": null,
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988115/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143732-902c440f.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazecombination",
+    "fields": {
+      "name": "Clear Crackle",
+      "firing_temperature": null,
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988118/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143736-da700ea4.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazecombination",
+    "fields": {
+      "name": "Cobalt Blue Green",
+      "firing_temperature": null,
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988120/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143753-6013693b.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazecombination",
+    "fields": {
+      "name": "Cornwall",
+      "firing_temperature": null,
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988114/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143738-0ebbbb48.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazecombination",
+    "fields": {
+      "name": "Dragon Green",
+      "firing_temperature": null,
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988121/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143709-bfc538c3.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazecombination",
+    "fields": {
+      "name": "French Blue",
+      "firing_temperature": null,
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988123/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143712-c05af528.webp",
+      "is_food_safe": true,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazecombination",
+    "fields": {
+      "name": "French Blue!Gloss White",
+      "firing_temperature": null,
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776990965/glaze_dev/manual-square-crop-imports/final/glaze-combinations/glaze-combination-2026-04-22-145232-68468e22.webp",
+      "is_food_safe": null,
+      "runs": true,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazecombination",
+    "fields": {
+      "name": "French Green",
+      "firing_temperature": null,
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988122/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143714-b3d13f9c.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazecombination",
+    "fields": {
+      "name": "Gloss White",
+      "firing_temperature": null,
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988121/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143716-57d25039.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
+    }
+  },
+  {
+    "model": "api.glazecombination",
+    "fields": {
+      "name": "Turquoise",
+      "firing_temperature": null,
+      "test_tile_image": "https://res.cloudinary.com/dxpnyhe1f/image/upload/v1776988123/glaze_dev/manual-square-crop-imports/final/glaze-types/glaze-type-2026-04-22-143647-9a0a750a.webp",
+      "is_food_safe": null,
+      "runs": null,
+      "highlights_grooves": null,
+      "is_different_on_white_and_brown_clay": null,
+      "apply_thin": null
     }
   }
 ]

--- a/frontend_common/src/api.ts
+++ b/frontend_common/src/api.ts
@@ -21,6 +21,7 @@ export type AuthUser = {
     email: string
     first_name: string
     last_name: string
+    is_staff: boolean
     openid_subject: string
     profile_image_url: string
 }
@@ -337,4 +338,53 @@ export async function signCloudinaryWidgetParams(paramsToSign: Record<string, un
         params_to_sign: paramsToSign,
     })
     return data.signature
+}
+
+export type ManualSquareCropImportRecordPayload = {
+    client_id: string
+    filename: string
+    reviewed: boolean
+    parsed_fields: {
+        name: string
+        kind: 'glaze_type' | 'glaze_combination'
+        first_glaze: string
+        second_glaze: string
+        runs: boolean | null
+        is_food_safe: boolean | null
+    }
+}
+
+export type ManualSquareCropImportResponse = {
+    results: Array<{
+        client_id: string
+        filename: string
+        kind: string
+        name: string
+        status: 'created' | 'skipped_duplicate' | 'error'
+        reason: string | null
+        object_id: string | null
+        image_url: string | null
+    }>
+    summary: {
+        created_glaze_types: number
+        created_glaze_combinations: number
+        skipped_duplicates: number
+        errors: number
+    }
+}
+
+export async function importManualSquareCropRecords(
+    records: ManualSquareCropImportRecordPayload[],
+    cropFiles: Record<string, File>
+): Promise<ManualSquareCropImportResponse> {
+    const form = new FormData()
+    form.append('payload', JSON.stringify({ records }))
+    for (const record of records) {
+        const file = cropFiles[record.client_id]
+        if (file) {
+            form.append(`crop_image__${record.client_id}`, file, file.name)
+        }
+    }
+    const { data } = await client.post<ManualSquareCropImportResponse>('admin/manual-square-crop-import/', form)
+    return data
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,8 @@ mypy==1.20.0
 mypy_extensions==1.1.0
 packaging==26.0
 pathspec==1.0.4
+pillow-heif==1.3.0
+Pillow==12.2.0
 pluggy==1.6.0
 psycopg2-binary==2.9.10
 pyasn1==0.6.3

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,13 +14,15 @@
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^7.3.10",
         "@mui/material": "^7.3.9",
+        "@opencvjs/web": "^4.13.0-release.1",
         "@react-oauth/google": "^0.13.4",
         "axios": "^1.14.0",
         "mui": "^0.0.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.14.0",
-        "react-sketch-canvas": "^6.2.0"
+        "react-sketch-canvas": "^6.2.0",
+        "tesseract.js": "^7.0.0"
       },
       "devDependencies": {
         "@babel/core": "^7.29.0",
@@ -31,6 +33,7 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
         "@types/babel__core": "^7.20.5",
+        "@types/jimp": "^0.2.1",
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -1282,6 +1285,21 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@opencvjs/types": {
+      "version": "4.13.0-release.1",
+      "resolved": "https://registry.npmjs.org/@opencvjs/types/-/types-4.13.0-release.1.tgz",
+      "integrity": "sha512-HipuX/QrafzIjTPoTwnrgYkk3VUEpwLxmuekdwdnud0vvqyxUhMPmEX+a3dHglNkHhgkpKY22WFLHm0LItG6Mg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@opencvjs/web": {
+      "version": "4.13.0-release.1",
+      "resolved": "https://registry.npmjs.org/@opencvjs/web/-/web-4.13.0-release.1.tgz",
+      "integrity": "sha512-IGmJc54pMWk5cQmhcHSAfcCSEnS8oVEdL1gHRhZr4acztZr2tjpZSJHZ8XD2DRM0tOFnpZQ+WGRA4gkizm9khg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opencvjs/types": "4.13.0-release.1"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.123.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.123.0.tgz",
@@ -1928,6 +1946,16 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/jimp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@types/jimp/-/jimp-0.2.1.tgz",
+      "integrity": "sha512-UiMzF9Foi3MtfyKrUlx6xjRzBy23S13INyGLhYLg2BHZM+lf17k0W8qni123mKgRqn3jEx13ryqc/JHQo1l2Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -2726,6 +2754,12 @@
       "dependencies": {
         "require-from-string": "^2.0.2"
       }
+    },
+    "node_modules/bmp-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
@@ -3760,6 +3794,12 @@
         "node": ">= 14"
       }
     },
+    "node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3868,6 +3908,12 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -4566,6 +4612,48 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
@@ -4643,6 +4731,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "license": "MIT",
+      "bin": {
+        "opencollective-postinstall": "index.js"
       }
     },
     "node_modules/optionator": {
@@ -5089,6 +5186,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT"
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -5345,6 +5448,30 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tesseract.js": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-7.0.0.tgz",
+      "integrity": "sha512-exPBkd+z+wM1BuMkx/Bjv43OeLBxhL5kKWsz/9JY+DXcXdiBjiAch0V49QR3oAJqCaL5qURE0vx9Eo+G5YE7mA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bmp-js": "^0.1.0",
+        "idb-keyval": "^6.2.0",
+        "is-url": "^1.2.4",
+        "node-fetch": "^2.6.9",
+        "opencollective-postinstall": "^2.0.3",
+        "regenerator-runtime": "^0.13.3",
+        "tesseract.js-core": "^7.0.0",
+        "wasm-feature-detect": "^1.8.0",
+        "zlibjs": "^0.3.1"
+      }
+    },
+    "node_modules/tesseract.js-core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-7.0.0.tgz",
+      "integrity": "sha512-WnNH518NzmbSq9zgTPeoF8c+xmilS8rFIl1YKbk/ptuuc7p6cLNELNuPAzcmsYw450ca6bLa8j3t0VAtq435Vw==",
+      "license": "Apache-2.0"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -5786,6 +5913,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/wasm-feature-detect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+      "integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -5938,6 +6071,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zlibjs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
+      "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/zod": {

--- a/web/package.json
+++ b/web/package.json
@@ -19,13 +19,15 @@
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^7.3.10",
     "@mui/material": "^7.3.9",
+    "@opencvjs/web": "^4.13.0-release.1",
     "@react-oauth/google": "^0.13.4",
     "axios": "^1.14.0",
     "mui": "^0.0.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.14.0",
-    "react-sketch-canvas": "^6.2.0"
+    "react-sketch-canvas": "^6.2.0",
+    "tesseract.js": "^7.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",
@@ -36,6 +38,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/babel__core": "^7.20.5",
+    "@types/jimp": "^0.2.1",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -39,6 +39,10 @@ vi.mock('./components/GlazeCombinationGallery', () => ({
     default: () => <div>Glaze Gallery Content</div>,
 }))
 
+vi.mock('./pages/AdminManualSquareCropToolPage', () => ({
+    default: () => <div>Glaze Import Tool Page</div>,
+}))
+
 // Now import App and the mocked api
 import { fetchCurrentUser, loginWithEmail, loginWithGoogle, logoutUser } from '@common/api'
 import App from './App'
@@ -48,8 +52,14 @@ const MOCK_USER = {
     email: 'potter@example.com',
     first_name: 'Pat',
     last_name: 'Potter',
+    is_staff: false,
     openid_subject: '',
     profile_image_url: '',
+}
+
+const MOCK_ADMIN_USER = {
+    ...MOCK_USER,
+    is_staff: true,
 }
 
 describe('App auth flow', () => {
@@ -198,6 +208,38 @@ describe('App auth flow', () => {
         await waitFor(() => {
             expect(screen.getByText('Track every pottery piece through your workflow.')).toBeInTheDocument()
         })
+    })
+
+    it('shows the manual crop tool menu item only for admin users and routes to it', async () => {
+        vi.mocked(fetchCurrentUser).mockResolvedValue(MOCK_ADMIN_USER)
+
+        render(<App />)
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: /new piece/i })).toBeInTheDocument()
+        })
+
+        await userEvent.click(screen.getByText('Pat Potter'))
+        await userEvent.click(screen.getByText('Glaze Import Tool'))
+
+        await waitFor(() => {
+            expect(screen.getByText('Glaze Import Tool Page')).toBeInTheDocument()
+            expect(window.location.pathname).toBe('/tools/glaze-import')
+        })
+    })
+
+    it('does not show the manual crop tool menu item for non-admin users', async () => {
+        vi.mocked(fetchCurrentUser).mockResolvedValue(MOCK_USER)
+
+        render(<App />)
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: /new piece/i })).toBeInTheDocument()
+        })
+
+        await userEvent.click(screen.getByText('Pat Potter'))
+
+        expect(screen.queryByText('Glaze Import Tool')).not.toBeInTheDocument()
     })
 
     it('activates the analyze tab on direct navigation to /analyze', async () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -28,6 +28,7 @@ import {
 } from '@mui/material'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import LogoutIcon from '@mui/icons-material/Logout'
+import CropFreeIcon from '@mui/icons-material/CropFree'
 import { alpha, ThemeProvider, createTheme } from '@mui/material/styles'
 
 import { GoogleOAuthProvider, GoogleLogin } from '@react-oauth/google'
@@ -40,6 +41,7 @@ const LandingPage = lazy(() => import('./pages/LandingPage'))
 const PieceListPage = lazy(() => import('./pages/PieceListPage'))
 const PieceDetailPage = lazy(() => import('./pages/PieceDetailPage'))
 const AnalyzePage = lazy(() => import('./pages/AnalyzePage'))
+const AdminManualSquareCropToolPage = lazy(() => import('./pages/AdminManualSquareCropToolPage'))
 const AboutPage = lazy(() => import('./pages/AboutPage'))
 const PrivacyPolicyPage = lazy(() => import('./pages/PrivacyPolicyPage'))
 
@@ -385,6 +387,16 @@ function AppShell({
           anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
           transformOrigin={{ vertical: 'top', horizontal: 'right' }}
         >
+          {currentUser.is_staff ? (
+            <MenuItem
+              component={Link}
+              to="/tools/glaze-import"
+              onClick={() => setMenuAnchor(null)}
+            >
+              <ListItemIcon><CropFreeIcon fontSize="small" /></ListItemIcon>
+              Glaze Import Tool
+            </MenuItem>
+          ) : null}
           <MenuItem onClick={() => { setMenuAnchor(null); onLogout() }}>
             <ListItemIcon><LogoutIcon fontSize="small" /></ListItemIcon>
             Log out
@@ -417,6 +429,14 @@ function AuthenticatedApp({
               <Route path="analyze" element={<AnalyzePage />} />
             </Route>
             <Route path="/pieces/:id" element={<PieceDetailPage />} />
+            <Route
+              path="/tools/glaze-import"
+              element={
+                currentUser.is_staff
+                  ? <AdminManualSquareCropToolPage />
+                  : <Navigate to="/" replace />
+              }
+            />
             <Route path="*" element={<Navigate to="/" replace />} />
           </Route>,
         ),

--- a/web/src/components/__tests__/AdminManualSquareCropToolPage.test.tsx
+++ b/web/src/components/__tests__/AdminManualSquareCropToolPage.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@common/api', () => ({
+    fetchCloudinaryWidgetConfig: vi.fn(),
+    importManualSquareCropRecords: vi.fn(),
+    signCloudinaryWidgetParams: vi.fn(),
+}))
+
+import AdminManualSquareCropToolPage from '../../pages/AdminManualSquareCropToolPage'
+
+describe('AdminManualSquareCropToolPage', () => {
+    it('renders the tabbed workflow headings', () => {
+        render(<AdminManualSquareCropToolPage />)
+
+        expect(screen.getByRole('heading', { name: 'Glaze Import Tool' })).toBeInTheDocument()
+        expect(screen.getByRole('tab', { name: '1. Upload' })).toBeInTheDocument()
+        expect(screen.getByRole('tab', { name: '2. Crop' })).toBeDisabled()
+        expect(screen.getByRole('button', { name: 'Bulk Upload Images' })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Upload Via Cloudinary' })).toBeInTheDocument()
+    })
+})

--- a/web/src/pages/AdminManualSquareCropToolPage.tsx
+++ b/web/src/pages/AdminManualSquareCropToolPage.tsx
@@ -1,0 +1,1916 @@
+import { useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from 'react'
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Divider,
+  FormControlLabel,
+  LinearProgress,
+  List,
+  ListItemButton,
+  ListItemText,
+  Stack,
+  Tab,
+  Tabs,
+  TextField,
+  Typography,
+} from '@mui/material'
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
+import UploadFileIcon from '@mui/icons-material/UploadFile'
+import CropFreeIcon from '@mui/icons-material/CropFree'
+import TextSnippetIcon from '@mui/icons-material/TextSnippet'
+import FactCheckIcon from '@mui/icons-material/FactCheck'
+import CloudUploadIcon from '@mui/icons-material/CloudUpload'
+import MergeIcon from '@mui/icons-material/MergeType'
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+import { createWorker } from 'tesseract.js'
+import {
+  fetchCloudinaryWidgetConfig,
+  importManualSquareCropRecords,
+  signCloudinaryWidgetParams,
+  type CloudinaryWidgetConfig,
+  type ManualSquareCropImportResponse,
+} from '@common/api'
+
+type CropSquare = {
+  x: number        // axis-aligned top-left in source pixels (rotation is around the center)
+  y: number
+  size: number
+  rotation: number // degrees clockwise
+}
+
+type OcrRegion = {
+  x: number        // axis-aligned top-left within the crop image (rotation around center)
+  y: number
+  width: number
+  height: number
+  rotation: number // degrees clockwise
+}
+
+type ParsedFields = {
+  name: string
+  kind: 'glaze_type' | 'glaze_combination'
+  first_glaze: string
+  second_glaze: string
+  runs: boolean | null
+  is_food_safe: boolean | null
+}
+
+type OcrSuggestion = {
+  rawText: string
+  suggestedName: string
+  suggestedKind: 'glaze_type' | 'glaze_combination'
+  suggestedFirstGlaze: string
+  suggestedSecondGlaze: string
+  confidence: number | null
+}
+
+type UploadedRecord = {
+  id: string
+  file: File | null
+  sourceUrl: string
+  filename: string
+  dimensions: { width: number; height: number }
+  crop: CropSquare | null
+  ocrRegion: OcrRegion | null
+  parsedFields: ParsedFields
+  ocrSuggestion: OcrSuggestion | null
+  reviewed: boolean
+  ocrStatus: 'idle' | 'running' | 'done' | 'error'
+  ocrError: string | null
+  sourceKind: 'local' | 'cloudinary'
+  cloudinaryPublicId: string | null
+}
+
+type CropDragState = {
+  handle: 'move' | 'nw' | 'ne' | 'sw' | 'se' | 'rotate'
+  startCrop: CropSquare
+  // move: pointer offset from box top-left in source coords
+  // rotate: box center in source coords (fixed during rotation)
+  // resize: unused (recomputed each frame from startCrop)
+  anchorX: number
+  anchorY: number
+  startAngle: number // rotate only: atan2 angle from center to pointer at drag start
+}
+
+type OcrDragState = {
+  handle: 'move' | 'nw' | 'ne' | 'sw' | 'se' | 'rotate'
+  startRegion: OcrRegion
+  anchorX: number
+  anchorY: number
+  startAngle: number
+}
+
+type UploadProgressEntry = {
+  id: string
+  filename: string
+  status: 'queued' | 'processing' | 'uploading' | 'ready' | 'error'
+  progress: number
+  error: string | null
+}
+
+const MIN_CROP_SIZE = 96
+const MIN_OCR_REGION_SIZE = 16
+const COMBO_NAME_SEPARATOR = '!'
+const TAB_UPLOAD = 0
+const TAB_CROP = 1
+const TAB_OCR = 2
+const TAB_REVIEW = 3
+const TAB_IMPORT = 4
+const TAB_RECONCILE = 5
+
+function createRecordId() {
+  return globalThis.crypto?.randomUUID?.() ?? `rec-${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+
+function loadImageElement(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image()
+    image.crossOrigin = 'anonymous'
+    image.onload = () => resolve(image)
+    image.onerror = () => reject(new Error('Failed to load image.'))
+    image.src = src
+  })
+}
+
+function buildCloudinaryJpgUrl(config: CloudinaryWidgetConfig, publicId: string) {
+  return `https://res.cloudinary.com/${config.cloud_name}/image/upload/f_jpg/${publicId}.jpg`
+}
+
+function defaultCrop(dimensions: { width: number; height: number }): CropSquare {
+  const size = Math.max(dimensions.width, dimensions.height)
+  return {
+    x: Math.round((dimensions.width - size) / 2),
+    y: Math.round((dimensions.height - size) / 2),
+    size,
+    rotation: 0,
+  }
+}
+
+function defaultOcrRegion(cropSize: number): OcrRegion {
+  const width = Math.round(cropSize * 0.7)
+  const height = Math.round(cropSize * 0.25)
+  return {
+    x: Math.round((cropSize - width) / 2),
+    y: Math.round((cropSize - height) / 2),
+    width,
+    height,
+    rotation: 0,
+  }
+}
+
+function getOverflowPadding(dimensions: { width: number; height: number }) {
+  return Math.max(dimensions.width, dimensions.height)
+}
+
+function getViewportPadding(dimensions: { width: number; height: number }) {
+  return Math.min(180, Math.max(56, Math.round(Math.max(dimensions.width, dimensions.height) * 0.06)))
+}
+
+function clampCrop(dimensions: { width: number; height: number }, crop: CropSquare): CropSquare {
+  const padding = getOverflowPadding(dimensions)
+  const stageWidth = dimensions.width + padding * 2
+  const stageHeight = dimensions.height + padding * 2
+  const maxSize = Math.min(stageWidth, stageHeight)
+  const size = Math.max(MIN_CROP_SIZE, Math.min(Math.round(crop.size), maxSize))
+  const minX = -padding
+  const minY = -padding
+  const maxX = dimensions.width + padding - size
+  const maxY = dimensions.height + padding - size
+  return {
+    ...crop,
+    x: Math.max(minX, Math.min(Math.round(crop.x), maxX)),
+    y: Math.max(minY, Math.min(Math.round(crop.y), maxY)),
+    size,
+  }
+}
+
+function clampOcrRegion(cropSize: number, region: OcrRegion): OcrRegion {
+  const width = Math.max(MIN_OCR_REGION_SIZE, Math.min(Math.round(region.width), cropSize))
+  const height = Math.max(MIN_OCR_REGION_SIZE, Math.min(Math.round(region.height), cropSize))
+  return {
+    ...region,
+    x: Math.max(0, Math.min(Math.round(region.x), cropSize - width)),
+    y: Math.max(0, Math.min(Math.round(region.y), cropSize - height)),
+    width,
+    height,
+  }
+}
+
+function rotatePt(x: number, y: number, angleDeg: number): [number, number] {
+  const rad = (angleDeg * Math.PI) / 180
+  return [x * Math.cos(rad) - y * Math.sin(rad), x * Math.sin(rad) + y * Math.cos(rad)]
+}
+
+function titleCaseWords(value: string) {
+  return value
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
+function sanitizeOcrText(text: string) {
+  return text
+    .replace(/\r/g, '\n')
+    .replace(/[|]/g, 'I')
+    .replace(/[^\S\n]+/g, ' ')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+}
+
+// Words fed to Tesseract's user_words file so the language model prefers
+// these over visually similar alternatives (e.g. "1st" over "Ist").
+const TESSERACT_USER_WORDS = [
+  'RUNS', 'Runs', 'runs',
+  'CAUTION', 'Caution',
+  'FOOD', 'Food',
+  'SAFE', 'Safe',
+  'NOT', 'Not',
+  '1st', '2nd', '3rd',
+  'GLAZE', 'Glaze',
+  ';', ':',
+].join('\n')
+
+const RUNS_RE = /caution\W{0,10}runs/i
+const NOT_FOOD_SAFE_RE = /not\s+food[\s-]?safe/i
+
+function detectRunsFromOcrText(text: string): true | null {
+  return RUNS_RE.test(text) ? true : null
+}
+
+function detectFoodSafeFromOcrText(text: string): false | null {
+  return NOT_FOOD_SAFE_RE.test(text) ? false : null
+}
+
+// Matches "1st Glaze: ..." lines, tolerating OCR confusions: I/1 and :/;
+const STRUCTURED_FIRST_RE = /^[I1l]st\s+[Gg]laze\s*[:;]\s*(.+)/
+// Matches "2nd Glaze: ..." lines, tolerating OCR confusions: 2/= and :/;
+const STRUCTURED_SECOND_RE = /^[2=Z]nd\s+[Gg]laze\s*[:;]\s*(.+)/
+
+function parseOcrSuggestion(text: string, fallbackKind: ParsedFields['kind']): OcrSuggestion {
+  const cleaned = sanitizeOcrText(text)
+  const lines = cleaned
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => /[A-Za-z]/.test(line))
+
+  // Structured label detection takes priority: if the OCR output contains
+  // labeled lines like "1st Glaze: Celadon" / "2nd Glaze: Shino", extract
+  // them directly rather than relying on the token-split heuristic below.
+  let structuredFirst: string | null = null
+  let structuredSecond: string | null = null
+  for (const line of lines) {
+    const firstMatch = STRUCTURED_FIRST_RE.exec(line)
+    if (firstMatch) structuredFirst = titleCaseWords(firstMatch[1].trim())
+    const secondMatch = STRUCTURED_SECOND_RE.exec(line)
+    if (secondMatch) structuredSecond = titleCaseWords(secondMatch[1].trim())
+  }
+  if (structuredFirst !== null || structuredSecond !== null) {
+    const first = structuredFirst ?? ''
+    const second = structuredSecond ?? ''
+    const isCombo = structuredFirst !== null && structuredSecond !== null
+    return {
+      rawText: cleaned,
+      suggestedName: isCombo ? `${first}${COMBO_NAME_SEPARATOR}${second}` : first || second,
+      suggestedKind: isCombo ? 'glaze_combination' : fallbackKind,
+      suggestedFirstGlaze: first,
+      suggestedSecondGlaze: second,
+      confidence: null,
+    }
+  }
+
+  // Fallback: token-split heuristic for unlabeled combo lines.
+
+  // Strip lines that carry property annotations (runs, food-safe warnings) so
+  // they don't bleed into the glaze name.
+  const nameLines = lines.filter((line) => !RUNS_RE.test(line) && !NOT_FOOD_SAFE_RE.test(line))
+
+  // Use the longest line to detect combo separators (most likely to be the label).
+  const bestLine = [...nameLines]
+    .sort((a, b) => b.replace(/[^A-Za-z]/g, '').length - a.replace(/[^A-Za-z]/g, '').length)[0] || ''
+  const normalized = bestLine
+    .replace(/[_]+/g, ' ')
+    .replace(/\s{2,}/g, ' ')
+    .replace(/\s*!\s*/g, '!')
+    .replace(/\s*\/\s*/g, ' / ')
+    .trim()
+  const comboTokens = normalized
+    .split(/!|\/|&|\+|\bover\b/gi)
+    .map((token) => titleCaseWords(token.replace(/[^A-Za-z\s-]/g, ' ').replace(/\s{2,}/g, ' ').trim()))
+    .filter(Boolean)
+  const isCombo = comboTokens.length >= 2
+
+  // For combinations: join title-cased tokens so each component is capitalized.
+  // For glaze types: concatenate all non-annotation lines so multi-line labels
+  // (e.g. brand on one line, name on the next) aren't truncated.
+  const suggestedName = isCombo
+    ? comboTokens.join('!')
+    : titleCaseWords(
+        nameLines.join(' ').replace(/[^A-Za-z0-9!\s/-]/g, ' ').replace(/\s{2,}/g, ' ').trim()
+      )
+
+  return {
+    rawText: cleaned,
+    suggestedName,
+    suggestedKind: isCombo ? 'glaze_combination' : fallbackKind,
+    suggestedFirstGlaze: comboTokens[0] || '',
+    suggestedSecondGlaze: comboTokens[1] || '',
+    confidence: null,
+  }
+}
+
+function renderCropToCanvas(image: HTMLImageElement, crop: CropSquare, outputSize: number): HTMLCanvasElement {
+  const canvas = document.createElement('canvas')
+  canvas.width = outputSize
+  canvas.height = outputSize
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('Canvas 2D context is unavailable.')
+  const cx = crop.x + crop.size / 2
+  const cy = crop.y + crop.size / 2
+  const scale = outputSize / crop.size
+  ctx.save()
+  ctx.translate(outputSize / 2, outputSize / 2)
+  ctx.rotate((-crop.rotation * Math.PI) / 180)
+  ctx.scale(scale, scale)
+  ctx.drawImage(image, -cx, -cy)
+  ctx.restore()
+  return canvas
+}
+
+async function buildCropFile(record: UploadedRecord): Promise<File> {
+  if (!record.crop) throw new Error('Record is not cropped yet.')
+  const image = await loadImageElement(record.sourceUrl)
+  const crop = clampCrop(record.dimensions, record.crop)
+  // Cap at 2000px to stay within Cloudinary's upload size limit.
+  const outputSize = Math.min(crop.size, 2000)
+  const canvas = renderCropToCanvas(image, crop, outputSize)
+  const blob = await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (result) => { if (result) resolve(result); else reject(new Error('Failed to render crop image.')) },
+      'image/webp',
+      0.85,
+    )
+  })
+  const safeStem = record.filename.replace(/\.[^.]+$/, '') || 'crop'
+  return new File([blob], `${safeStem}.webp`, { type: 'image/webp' })
+}
+
+async function runOcrOnRecord(record: UploadedRecord): Promise<{ text: string; confidence: number }> {
+  if (!record.crop) throw new Error('Record is not cropped yet.')
+  const image = await loadImageElement(record.sourceUrl)
+  const crop = clampCrop(record.dimensions, record.crop)
+  // Full-resolution crop canvas (uncompressed) for accurate OCR.
+  const cropCanvas = renderCropToCanvas(image, crop, crop.size)
+
+  let ocrCanvas: HTMLCanvasElement
+  if (record.ocrRegion) {
+    const region = record.ocrRegion
+    ocrCanvas = document.createElement('canvas')
+    ocrCanvas.width = Math.max(1, region.width)
+    ocrCanvas.height = Math.max(1, region.height)
+    const ctx = ocrCanvas.getContext('2d')
+    if (!ctx) throw new Error('Canvas 2D context is unavailable.')
+    const rcx = region.x + region.width / 2
+    const rcy = region.y + region.height / 2
+    ctx.save()
+    ctx.translate(region.width / 2, region.height / 2)
+    ctx.rotate((-region.rotation * Math.PI) / 180)
+    ctx.drawImage(cropCanvas, -rcx, -rcy)
+    ctx.restore()
+  } else {
+    ocrCanvas = cropCanvas
+  }
+
+  const worker = await createWorker('eng')
+  await worker.writeText('user-words.txt', TESSERACT_USER_WORDS)
+  await worker.setParameters({ user_words: 'user-words.txt' })
+  const result = await worker.recognize(ocrCanvas)
+  await worker.terminate()
+  return { text: result.data.text, confidence: result.data.confidence }
+}
+
+function RecordList({
+  records,
+  selectedId,
+  onSelect,
+  onDelete,
+  showReviewed,
+  hideCropChip,
+  showOcrRegionChip,
+}: {
+  records: UploadedRecord[]
+  selectedId: string | null
+  onSelect: (id: string) => void
+  onDelete: (id: string) => void
+  showReviewed?: boolean
+  hideCropChip?: boolean
+  showOcrRegionChip?: boolean
+}) {
+  return (
+    <List sx={{ border: (theme) => `1px solid ${theme.palette.divider}`, borderRadius: 3, overflow: 'auto' }}>
+      {records.map((record) => (
+        <ListItemButton
+          key={record.id}
+          selected={record.id === selectedId}
+          onClick={() => onSelect(record.id)}
+          sx={{ alignItems: 'center', gap: 1 }}
+        >
+          <ListItemText
+            primary={record.parsedFields.name || record.filename}
+            slotProps={{ primary: { noWrap: true } }}
+          />
+          <Stack direction="row" spacing={0.5} flexShrink={0}>
+            {!hideCropChip ? (
+              <Chip
+                label={record.crop ? 'cropped' : 'uncropped'}
+                color={record.crop ? 'success' : 'error'}
+                size="small"
+              />
+            ) : null}
+            {showOcrRegionChip ? (
+              <Chip
+                label={record.ocrRegion ? 'region set' : 'no region'}
+                color={record.ocrRegion ? 'success' : 'error'}
+                size="small"
+              />
+            ) : null}
+            {record.ocrStatus !== 'idle' ? (
+              <Chip
+                label={record.ocrStatus === 'done' ? 'ocr ready' : record.ocrStatus}
+                color={record.ocrStatus === 'done' ? 'success' : record.ocrStatus === 'error' ? 'error' : 'default'}
+                size="small"
+              />
+            ) : null}
+            {showReviewed ? (
+              <Chip
+                label={record.reviewed ? 'reviewed' : 'unreviewed'}
+                color={record.reviewed ? 'success' : 'default'}
+                size="small"
+              />
+            ) : null}
+          </Stack>
+          <Button
+            color="error"
+            size="small"
+            onClick={(event) => {
+              event.stopPropagation()
+              onDelete(record.id)
+            }}
+          >
+            <DeleteOutlineIcon fontSize="small" />
+          </Button>
+        </ListItemButton>
+      ))}
+    </List>
+  )
+}
+
+export default function AdminManualSquareCropToolPage() {
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const cropStageRef = useRef<HTMLDivElement | null>(null)
+  const ocrStageRef = useRef<HTMLDivElement | null>(null)
+  const recordsRef = useRef<UploadedRecord[]>([])
+
+  const [activeTab, setActiveTab] = useState(TAB_UPLOAD)
+  const [records, setRecords] = useState<UploadedRecord[]>([])
+  const [selectedRecordId, setSelectedRecordId] = useState<string | null>(null)
+  const [cropDragState, setCropDragState] = useState<CropDragState | null>(null)
+  const [ocrDragState, setOcrDragState] = useState<OcrDragState | null>(null)
+  const [cropPreviewUrl, setCropPreviewUrl] = useState<string | null>(null)
+  const [cropPreviewLoading, setCropPreviewLoading] = useState(false)
+  // Debounced snapshot of the record used to generate the crop preview.
+  // Only updated after 200ms of no crop changes so dragging stays snappy.
+  const [previewRecord, setPreviewRecord] = useState<UploadedRecord | null>(null)
+  const [ocrRunning, setOcrRunning] = useState(false)
+  const [importRunning, setImportRunning] = useState(false)
+  const [importResult, setImportResult] = useState<ManualSquareCropImportResponse | null>(null)
+  const [importError, setImportError] = useState<string | null>(null)
+  const [uploadProgress, setUploadProgress] = useState<UploadProgressEntry[]>([])
+  const [uploading, setUploading] = useState(false)
+  const [widgetUploading, setWidgetUploading] = useState(false)
+  const [widgetError, setWidgetError] = useState<string | null>(null)
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null)
+  const [importBuildProgress, setImportBuildProgress] = useState<UploadProgressEntry[]>([])
+  const [reconciledIds, setReconciledIds] = useState<Set<string>>(new Set())
+
+  const selectedRecord = records.find((record) => record.id === selectedRecordId) ?? null
+  const allCropped = records.length > 0 && records.every((record) => record.crop)
+  const allOcrDone = records.length > 0 && records.every((record) => record.ocrStatus === 'done')
+  const allReviewed = records.length > 0 && records.every((record) => record.reviewed)
+  const duplicateResults = importResult?.results.filter((r) => r.status === 'skipped_duplicate') ?? []
+  const hasDuplicates = duplicateResults.length > 0
+
+  const selectedCrop = selectedRecord?.crop
+    ? clampCrop(selectedRecord.dimensions, selectedRecord.crop)
+    : null
+  const selectedOcrRegion = selectedRecord?.ocrRegion && selectedCrop
+    ? clampOcrRegion(selectedCrop.size, selectedRecord.ocrRegion)
+    : null
+
+  const selectedPadding = selectedRecord ? getViewportPadding(selectedRecord.dimensions) : 0
+  const selectedStageWidth = selectedRecord ? selectedRecord.dimensions.width + selectedPadding * 2 : 1
+  const selectedStageHeight = selectedRecord ? selectedRecord.dimensions.height + selectedPadding * 2 : 1
+  const selectedStageScale = selectedRecord
+    ? Math.min(1, 760 / Math.max(selectedStageWidth, selectedStageHeight))
+    : 1
+
+  // OCR stage display: the crop preview is a square of selectedCrop.size pixels
+  const ocrStageDisplaySize = 360
+  const ocrStageScale = selectedCrop ? Math.min(1, ocrStageDisplaySize / selectedCrop.size) : 1
+
+  useEffect(() => {
+    recordsRef.current = records
+  }, [records])
+
+  useEffect(() => {
+    if (!window.cloudinary?.createUploadWidget) return
+    const existing = document.querySelector<HTMLScriptElement>('script[data-cloudinary-widget="true"]')
+    if (existing) return
+    const script = document.createElement('script')
+    script.src = 'https://upload-widget.cloudinary.com/global/all.js'
+    script.async = true
+    script.dataset.cloudinaryWidget = 'true'
+    document.body.appendChild(script)
+  }, [])
+
+  // Stable string key that only changes when the crop geometry changes.
+  // Adjusting the OCR region leaves this key unchanged, so the preview is
+  // not re-rendered (or even re-debounced) when only ocrRegion moves.
+  const cropKey = selectedRecord
+    ? `${selectedRecord.id}:${selectedRecord.crop ? `${selectedRecord.crop.x},${selectedRecord.crop.y},${selectedRecord.crop.size},${selectedRecord.crop.rotation}` : ''}`
+    : ''
+  const selectedRecordRef = useRef(selectedRecord)
+  selectedRecordRef.current = selectedRecord
+
+  // Show the spinner immediately when the crop changes, then debounce the
+  // actual preview render so rapid drag moves don't queue up buildCropFile calls.
+  useEffect(() => {
+    if (!selectedRecordRef.current?.crop) {
+      setCropPreviewLoading(false)
+      setPreviewRecord(selectedRecordRef.current)
+      return
+    }
+    setCropPreviewLoading(true)
+    const timer = setTimeout(() => setPreviewRecord(selectedRecordRef.current), 200)
+    return () => clearTimeout(timer)
+  // cropKey is intentionally used as the sole dependency: only the crop
+  // geometry (not ocrRegion or other fields) should trigger a preview rebuild.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cropKey])
+
+  useEffect(() => {
+    let revokedUrl: string | null = null
+    async function refreshPreview() {
+      if (!previewRecord || !previewRecord.crop) {
+        setCropPreviewUrl(null)
+        setCropPreviewLoading(false)
+        return
+      }
+      try {
+        const file = await buildCropFile(previewRecord)
+        const objectUrl = URL.createObjectURL(file)
+        revokedUrl = objectUrl
+        setCropPreviewUrl(objectUrl)
+      } catch {
+        setCropPreviewUrl(null)
+      } finally {
+        setCropPreviewLoading(false)
+      }
+    }
+    void refreshPreview()
+    return () => {
+      if (revokedUrl) URL.revokeObjectURL(revokedUrl)
+    }
+  }, [previewRecord])
+
+  // Crop drag handling
+  useEffect(() => {
+    if (!cropDragState || !selectedRecord || !selectedRecord.crop) return
+    const currentDrag = cropDragState
+
+    function handlePointerMove(event: PointerEvent) {
+      if (!cropStageRef.current || !selectedRecord) return
+      const rect = cropStageRef.current.getBoundingClientRect()
+      const padding = getViewportPadding(selectedRecord.dimensions)
+      const stageScale = rect.width / (selectedRecord.dimensions.width + padding * 2)
+      const sourceX = (event.clientX - rect.left) / stageScale - padding
+      const sourceY = (event.clientY - rect.top) / stageScale - padding
+
+      const start = currentDrag.startCrop
+      let nextCrop: CropSquare = { ...start }
+      if (currentDrag.handle === 'rotate') {
+        const currentAngle = Math.atan2(sourceY - currentDrag.anchorY, sourceX - currentDrag.anchorX)
+        const delta = ((currentAngle - currentDrag.startAngle) * 180) / Math.PI
+        nextCrop = { ...start, rotation: start.rotation + delta }
+      } else if (currentDrag.handle === 'move') {
+        nextCrop = { ...start, x: sourceX - currentDrag.anchorX, y: sourceY - currentDrag.anchorY }
+      } else {
+        // Rotation-aware resize: fix the opposite corner and scale the box.
+        // fixedSign is +1 when the fixed corner is on the positive side of that axis.
+        const fixedSignX = (currentDrag.handle === 'nw' || currentDrag.handle === 'sw') ? 1 : -1
+        const fixedSignY = (currentDrag.handle === 'nw' || currentDrag.handle === 'ne') ? 1 : -1
+        const cx = start.x + start.size / 2
+        const cy = start.y + start.size / 2
+        const [fRotX, fRotY] = rotatePt(fixedSignX * start.size / 2, fixedSignY * start.size / 2, start.rotation)
+        const fixedX = cx + fRotX
+        const fixedY = cy + fRotY
+        const [localDx, localDy] = rotatePt(sourceX - fixedX, sourceY - fixedY, -start.rotation)
+        const size = Math.max(Math.abs(localDx), Math.abs(localDy), MIN_CROP_SIZE)
+        const [newRotFx, newRotFy] = rotatePt(fixedSignX * size / 2, fixedSignY * size / 2, start.rotation)
+        const newCx = fixedX - newRotFx
+        const newCy = fixedY - newRotFy
+        nextCrop = { ...start, x: newCx - size / 2, y: newCy - size / 2, size }
+      }
+
+      setRecords((current) => current.map((record) => (
+        record.id === selectedRecord.id
+          ? { ...record, crop: clampCrop(record.dimensions, nextCrop), reviewed: false }
+          : record
+      )))
+    }
+
+    function handlePointerUp() {
+      setCropDragState(null)
+    }
+
+    window.addEventListener('pointermove', handlePointerMove)
+    window.addEventListener('pointerup', handlePointerUp)
+    window.addEventListener('pointercancel', handlePointerUp)
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove)
+      window.removeEventListener('pointerup', handlePointerUp)
+      window.removeEventListener('pointercancel', handlePointerUp)
+    }
+  }, [cropDragState, selectedRecord])
+
+  // OCR region drag handling
+  useEffect(() => {
+    if (!ocrDragState || !selectedRecord || !selectedCrop) return
+    const currentDrag = ocrDragState
+    const cropSize = selectedCrop.size
+
+    function handlePointerMove(event: PointerEvent) {
+      if (!ocrStageRef.current || !selectedRecord) return
+      const rect = ocrStageRef.current.getBoundingClientRect()
+      const scale = rect.width / cropSize
+      const sourceX = (event.clientX - rect.left) / scale
+      const sourceY = (event.clientY - rect.top) / scale
+
+      const start = currentDrag.startRegion
+      let next: OcrRegion = { ...start }
+
+      if (currentDrag.handle === 'rotate') {
+        const currentAngle = Math.atan2(sourceY - currentDrag.anchorY, sourceX - currentDrag.anchorX)
+        const delta = ((currentAngle - currentDrag.startAngle) * 180) / Math.PI
+        next = { ...start, rotation: start.rotation + delta }
+      } else if (currentDrag.handle === 'move') {
+        next = { ...start, x: sourceX - currentDrag.anchorX, y: sourceY - currentDrag.anchorY }
+      } else {
+        // Rotation-aware resize: fix the opposite corner.
+        const fixedSignX = (currentDrag.handle === 'nw' || currentDrag.handle === 'sw') ? 1 : -1
+        const fixedSignY = (currentDrag.handle === 'nw' || currentDrag.handle === 'ne') ? 1 : -1
+        const cx = start.x + start.width / 2
+        const cy = start.y + start.height / 2
+        const [fRotX, fRotY] = rotatePt(fixedSignX * start.width / 2, fixedSignY * start.height / 2, start.rotation)
+        const fixedX = cx + fRotX
+        const fixedY = cy + fRotY
+        const [localDx, localDy] = rotatePt(sourceX - fixedX, sourceY - fixedY, -start.rotation)
+        const width = Math.max(Math.abs(localDx), MIN_OCR_REGION_SIZE)
+        const height = Math.max(Math.abs(localDy), MIN_OCR_REGION_SIZE)
+        const [newRotFx, newRotFy] = rotatePt(fixedSignX * width / 2, fixedSignY * height / 2, start.rotation)
+        const newCx = fixedX - newRotFx
+        const newCy = fixedY - newRotFy
+        next = { ...start, x: newCx - width / 2, y: newCy - height / 2, width, height }
+      }
+
+      setRecords((current) => current.map((record) => (
+        record.id === selectedRecord.id
+          ? { ...record, ocrRegion: clampOcrRegion(cropSize, next), reviewed: false }
+          : record
+      )))
+    }
+
+    function handlePointerUp() {
+      setOcrDragState(null)
+    }
+
+    window.addEventListener('pointermove', handlePointerMove)
+    window.addEventListener('pointerup', handlePointerUp)
+    window.addEventListener('pointercancel', handlePointerUp)
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove)
+      window.removeEventListener('pointerup', handlePointerUp)
+      window.removeEventListener('pointercancel', handlePointerUp)
+    }
+  }, [ocrDragState, selectedRecord, selectedCrop])
+
+  useEffect(() => (
+    () => {
+      for (const record of recordsRef.current) {
+        if (record.sourceKind === 'local') {
+          URL.revokeObjectURL(record.sourceUrl)
+        }
+      }
+    }
+  ), [])
+
+  async function handleFileSelection(fileList: FileList | null) {
+    if (!fileList?.length) return
+    const files = Array.from(fileList)
+    setUploading(true)
+    setUploadProgress(files.map((file) => ({
+      id: createRecordId(),
+      filename: file.name,
+      status: 'queued',
+      progress: 5,
+      error: null,
+    })))
+    const nextRecords: UploadedRecord[] = []
+    for (const [index, file] of files.entries()) {
+      setUploadProgress((current) => current.map((entry, entryIndex) => (
+        entryIndex === index
+          ? { ...entry, status: 'processing', progress: 35, error: null }
+          : entry
+      )))
+      const objectUrl = URL.createObjectURL(file)
+      try {
+        const image = await loadImageElement(objectUrl)
+        nextRecords.push({
+          id: createRecordId(),
+          file,
+          sourceUrl: objectUrl,
+          filename: file.name,
+          dimensions: { width: image.naturalWidth, height: image.naturalHeight },
+          crop: null,
+          ocrRegion: null,
+          parsedFields: { name: '', kind: 'glaze_type', first_glaze: '', second_glaze: '', runs: null, is_food_safe: null },
+          ocrSuggestion: null,
+          reviewed: false,
+          ocrStatus: 'idle',
+          ocrError: null,
+          sourceKind: 'local',
+          cloudinaryPublicId: null,
+        })
+        setUploadProgress((current) => current.map((entry, entryIndex) => (
+          entryIndex === index
+            ? { ...entry, status: 'ready', progress: 100, error: null }
+            : entry
+        )))
+      } catch {
+        URL.revokeObjectURL(objectUrl)
+        setUploadProgress((current) => current.map((entry, entryIndex) => (
+          entryIndex === index
+            ? { ...entry, status: 'error', progress: 100, error: 'This file could not be decoded in the browser.' }
+            : entry
+        )))
+      }
+    }
+    setUploading(false)
+    if (!nextRecords.length) return
+    setRecords((current) => [...current, ...nextRecords])
+    setSelectedRecordId(null)
+    setImportResult(null)
+    setActiveTab(TAB_CROP)
+  }
+
+  async function startCloudinaryUpload() {
+    setWidgetError(null)
+    setWidgetUploading(true)
+    let config: CloudinaryWidgetConfig
+    try {
+      config = await fetchCloudinaryWidgetConfig()
+    } catch {
+      setWidgetUploading(false)
+      setWidgetError('Failed to load Cloudinary upload configuration.')
+      return
+    }
+
+    if (!window.cloudinary?.createUploadWidget) {
+      setWidgetUploading(false)
+      setWidgetError('Cloudinary upload widget is not available in this browser.')
+      return
+    }
+
+    const widget = window.cloudinary.createUploadWidget(
+      {
+        cloudName: config.cloud_name,
+        apiKey: config.api_key,
+        uploadSignature: (callback, paramsToSign) => {
+          signCloudinaryWidgetParams(paramsToSign as Record<string, unknown>)
+            .then(callback)
+            .catch(() => setWidgetError('Failed to sign Cloudinary upload.'))
+        },
+        ...(config.folder ? { folder: config.folder } : {}),
+        sources: ['local'],
+        multiple: true,
+        resourceType: 'image',
+      },
+      async (error, result) => {
+        if (error) {
+          setWidgetUploading(false)
+          setWidgetError('Cloudinary upload failed.')
+          return
+        }
+        if (result?.event === 'display-changed') {
+          const displayState = typeof result.info === 'string'
+            ? result.info
+            : (result.info as Record<string, unknown>)?.state
+          if (displayState === 'shown') {
+            setWidgetUploading(false)
+          }
+        }
+        if (result?.event === 'success') {
+          const publicId = String(result.info.public_id || '')
+          const originalFilename = String(result.info.original_filename || publicId || 'upload')
+          const format = String(result.info.format || '')
+          const filename = format ? `${originalFilename}.${format}` : originalFilename
+          const progressId = createRecordId()
+          setUploadProgress((current) => [
+            { id: progressId, filename, status: 'uploading', progress: 70, error: null },
+            ...current,
+          ])
+          try {
+            const jpgUrl = buildCloudinaryJpgUrl(config, publicId)
+            const image = await loadImageElement(jpgUrl)
+            const record: UploadedRecord = {
+              id: createRecordId(),
+              file: null,
+              sourceUrl: jpgUrl,
+              filename,
+              dimensions: { width: image.naturalWidth, height: image.naturalHeight },
+              crop: null,
+              ocrRegion: null,
+              parsedFields: { name: '', kind: 'glaze_type', first_glaze: '', second_glaze: '', runs: null, is_food_safe: null },
+              ocrSuggestion: null,
+              reviewed: false,
+              ocrStatus: 'idle',
+              ocrError: null,
+              sourceKind: 'cloudinary',
+              cloudinaryPublicId: publicId,
+            }
+            setRecords((current) => [record, ...current])
+            setSelectedRecordId(null)
+            setUploadProgress((current) => current.map((entry) => (
+              entry.id === progressId
+                ? { ...entry, status: 'ready', progress: 100, error: null }
+                : entry
+            )))
+            setImportResult(null)
+            setActiveTab(TAB_CROP)
+          } catch {
+            setUploadProgress((current) => current.map((entry) => (
+              entry.id === progressId
+                ? {
+                    ...entry,
+                    status: 'error',
+                    progress: 100,
+                    error: 'Cloudinary upload succeeded, but the converted JPG could not be loaded.',
+                  }
+                : entry
+            )))
+          }
+        }
+      },
+    )
+
+    widget.open()
+  }
+
+  function confirmDeleteRecord(id: string) {
+    setDeleteConfirmId(id)
+  }
+
+  function executeDeleteRecord() {
+    const id = deleteConfirmId
+    setDeleteConfirmId(null)
+    if (!id) return
+    const record = records.find((item) => item.id === id)
+    if (!record) return
+    if (record.sourceKind === 'local') {
+      URL.revokeObjectURL(record.sourceUrl)
+    }
+    const remaining = records.filter((item) => item.id !== id)
+    setRecords(remaining)
+    setSelectedRecordId((current) => {
+      if (current !== id) return current
+      return remaining[0]?.id ?? null
+    })
+  }
+
+  function updateSelectedRecord(updater: (record: UploadedRecord) => UploadedRecord) {
+    if (!selectedRecord) return
+    setRecords((current) => current.map((record) => (
+      record.id === selectedRecord.id ? updater(record) : record
+    )))
+  }
+
+  function createCropForSelected() {
+    if (!selectedRecord) return
+    updateSelectedRecord((record) => ({
+      ...record,
+      crop: clampCrop(record.dimensions, defaultCrop(record.dimensions)),
+      reviewed: false,
+    }))
+  }
+
+  function resetCropForSelected() {
+    if (!selectedRecord) return
+    updateSelectedRecord((record) => ({
+      ...record,
+      crop: null,
+      ocrRegion: null,
+      reviewed: false,
+      ocrSuggestion: null,
+      ocrStatus: 'idle',
+      ocrError: null,
+    }))
+  }
+
+  function createOcrRegionForSelected() {
+    if (!selectedRecord || !selectedCrop) return
+    updateSelectedRecord((record) => ({
+      ...record,
+      ocrRegion: defaultOcrRegion(selectedCrop.size),
+    }))
+  }
+
+  function resetOcrRegionForSelected() {
+    if (!selectedRecord) return
+    updateSelectedRecord((record) => ({ ...record, ocrRegion: null }))
+  }
+
+  function startCropDrag(handle: CropDragState['handle'], event: ReactPointerEvent<HTMLDivElement>) {
+    if (!selectedRecord?.crop || !cropStageRef.current) return
+    const rect = cropStageRef.current.getBoundingClientRect()
+    const padding = getViewportPadding(selectedRecord.dimensions)
+    const stageScale = rect.width / (selectedRecord.dimensions.width + padding * 2)
+    const sourceX = (event.clientX - rect.left) / stageScale - padding
+    const sourceY = (event.clientY - rect.top) / stageScale - padding
+    const crop = selectedRecord.crop
+    const cx = crop.x + crop.size / 2
+    const cy = crop.y + crop.size / 2
+    setCropDragState({
+      handle,
+      startCrop: crop,
+      anchorX: handle === 'move' ? sourceX - crop.x : cx,
+      anchorY: handle === 'move' ? sourceY - crop.y : cy,
+      startAngle: handle === 'rotate' ? Math.atan2(sourceY - cy, sourceX - cx) : 0,
+    })
+  }
+
+  function startOcrDrag(handle: OcrDragState['handle'], event: ReactPointerEvent<HTMLDivElement>) {
+    if (!selectedRecord?.ocrRegion || !selectedCrop || !ocrStageRef.current) return
+    const rect = ocrStageRef.current.getBoundingClientRect()
+    const scale = rect.width / selectedCrop.size
+    const sourceX = (event.clientX - rect.left) / scale
+    const sourceY = (event.clientY - rect.top) / scale
+    const region = selectedRecord.ocrRegion
+    const cx = region.x + region.width / 2
+    const cy = region.y + region.height / 2
+    setOcrDragState({
+      handle,
+      startRegion: region,
+      anchorX: handle === 'move' ? sourceX - region.x : cx,
+      anchorY: handle === 'move' ? sourceY - region.y : cy,
+      startAngle: handle === 'rotate' ? Math.atan2(sourceY - cy, sourceX - cx) : 0,
+    })
+  }
+
+  async function runOcrForAllRecords() {
+    if (!allCropped) return
+    setOcrRunning(true)
+    setImportResult(null)
+    for (const record of records) {
+      setRecords((current) => current.map((item) => (
+        item.id === record.id ? { ...item, ocrStatus: 'running', ocrError: null } : item
+      )))
+      try {
+        const result = await runOcrOnRecord(record)
+        const suggestion = parseOcrSuggestion(result.text || '', record.parsedFields.kind)
+        suggestion.confidence = Number.isFinite(result.confidence) ? result.confidence : null
+        setRecords((current) => current.map((item) => (
+          item.id === record.id
+            ? {
+                ...item,
+                ocrSuggestion: suggestion,
+                ocrStatus: 'done',
+                reviewed: false,
+                parsedFields: {
+                  name: suggestion.suggestedName,
+                  kind: suggestion.suggestedKind,
+                  first_glaze: suggestion.suggestedFirstGlaze,
+                  second_glaze: suggestion.suggestedSecondGlaze,
+                  runs: detectRunsFromOcrText(suggestion.rawText) ?? item.parsedFields.runs,
+                  is_food_safe: detectFoodSafeFromOcrText(suggestion.rawText) ?? item.parsedFields.is_food_safe,
+                },
+              }
+            : item
+        )))
+      } catch (error) {
+        setRecords((current) => current.map((item) => (
+          item.id === record.id
+            ? {
+                ...item,
+                ocrStatus: 'error',
+                ocrError: error instanceof Error ? error.message : String(error),
+                reviewed: false,
+              }
+            : item
+        )))
+      }
+    }
+    setOcrRunning(false)
+    setSelectedRecordId(null)
+    setActiveTab(TAB_REVIEW)
+  }
+
+  async function runImport() {
+    if (!allReviewed) return
+    setImportRunning(true)
+    setImportError(null)
+    setImportResult(null)
+    setReconciledIds(new Set())
+    setImportBuildProgress(records.map((record) => ({
+      id: record.id,
+      filename: record.parsedFields.name || record.filename,
+      status: 'queued',
+      progress: 0,
+      error: null,
+    })))
+    try {
+      const cropFiles: Record<string, File> = {}
+      for (const record of records) {
+        setImportBuildProgress((current) => current.map((entry) => (
+          entry.id === record.id ? { ...entry, status: 'processing', progress: 40 } : entry
+        )))
+        cropFiles[record.id] = await buildCropFile(record)
+        setImportBuildProgress((current) => current.map((entry) => (
+          entry.id === record.id ? { ...entry, status: 'uploading', progress: 80 } : entry
+        )))
+      }
+      const result = await importManualSquareCropRecords(
+        records.map((record) => ({
+          client_id: record.id,
+          filename: record.filename,
+          reviewed: record.reviewed,
+          parsed_fields: record.parsedFields,
+        })),
+        cropFiles,
+      )
+      setImportBuildProgress((current) => current.map((entry) => ({ ...entry, status: 'ready', progress: 100 })))
+      setImportResult(result)
+      setActiveTab(TAB_IMPORT)
+    } catch (error) {
+      setImportError(error instanceof Error ? error.message : 'Import failed.')
+      setImportBuildProgress((current) => current.map((entry) => (
+        entry.status !== 'ready' ? { ...entry, status: 'error', progress: 100 } : entry
+      )))
+    } finally {
+      setImportRunning(false)
+    }
+  }
+
+  const deleteConfirmRecord = records.find((r) => r.id === deleteConfirmId) ?? null
+
+  return (
+    <Stack spacing={3}>
+      <Stack spacing={1}>
+        <Typography variant="h4" component="h1">
+          Glaze Import Tool
+        </Typography>
+        <Typography color="text.secondary">
+          Bulk upload source images, crop each record into a transparency-safe square, run OCR on the cropped result, review the parsed fields, then import new public glaze records while skipping duplicates.
+        </Typography>
+      </Stack>
+
+      <Tabs
+        value={activeTab}
+        onChange={(_event, nextValue) => {
+          if (nextValue === TAB_CROP || nextValue === TAB_OCR || nextValue === TAB_REVIEW) {
+            setSelectedRecordId(null)
+          }
+          setActiveTab(nextValue)
+        }}
+        variant="scrollable"
+        scrollButtons="auto"
+      >
+        <Tab icon={<UploadFileIcon />} iconPosition="start" label="1. Upload" value={TAB_UPLOAD} />
+        <Tab icon={<CropFreeIcon />} iconPosition="start" label="2. Crop" value={TAB_CROP} disabled={records.length === 0} />
+        <Tab icon={<TextSnippetIcon />} iconPosition="start" label="3. OCR" value={TAB_OCR} disabled={!allCropped} />
+        <Tab icon={<FactCheckIcon />} iconPosition="start" label="4. Review" value={TAB_REVIEW} disabled={!allOcrDone} />
+        <Tab icon={<CloudUploadIcon />} iconPosition="start" label="5. Import" value={TAB_IMPORT} disabled={!allReviewed && !importResult} />
+        {hasDuplicates ? (
+          <Tab icon={<MergeIcon />} iconPosition="start" label="6. Reconcile" value={TAB_RECONCILE} />
+        ) : null}
+      </Tabs>
+
+      {activeTab === TAB_UPLOAD ? (
+        <Stack spacing={2}>
+          <Alert severity="info">
+            Start by bulk uploading the source images. Each uploaded image becomes its own record and starts uncropped.
+          </Alert>
+          <Alert severity="warning">
+            Browser-side upload works best for JPG and PNG. For `.heic` and `.heif`, use `Upload Via Cloudinary` so Cloudinary can convert the source before the crop tool loads it.
+          </Alert>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*,.heic,.heif"
+            multiple
+            hidden
+            onChange={(event) => {
+              void handleFileSelection(event.target.files)
+              event.target.value = ''
+            }}
+          />
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+            <Button variant="contained" onClick={() => fileInputRef.current?.click()} disabled={uploading}>
+              {uploading ? 'Processing Images…' : 'Bulk Upload Images'}
+            </Button>
+            <Button variant="outlined" onClick={() => void startCloudinaryUpload()} disabled={widgetUploading}>
+              {widgetUploading ? 'Opening Cloudinary…' : 'Upload Via Cloudinary'}
+            </Button>
+            {records.length > 0 ? (
+              <Button variant="outlined" onClick={() => setActiveTab(TAB_CROP)}>
+                Continue To Crop
+              </Button>
+            ) : null}
+          </Stack>
+          {widgetError ? <Alert severity="error">{widgetError}</Alert> : null}
+          {uploadProgress.length > 0 ? (
+            <Stack spacing={1.5}>
+              <Typography variant="subtitle1">Upload Progress</Typography>
+              <List sx={{ border: (theme) => `1px solid ${theme.palette.divider}`, borderRadius: 3 }}>
+                {uploadProgress.map((entry) => (
+                  <Box key={entry.id} sx={{ px: 2, py: 1.5 }}>
+                    <Stack spacing={0.75}>
+                      <Stack direction="row" justifyContent="space-between" spacing={2}>
+                        <Typography variant="body2">{entry.filename}</Typography>
+                        <Typography variant="body2" color={entry.status === 'error' ? 'error' : 'text.secondary'}>
+                          {entry.status === 'queued' ? 'Queued' : null}
+                          {entry.status === 'processing' ? 'Reading metadata…' : null}
+                          {entry.status === 'uploading' ? 'Converting via Cloudinary…' : null}
+                          {entry.status === 'ready' ? 'Ready' : null}
+                          {entry.status === 'error' ? 'Error' : null}
+                        </Typography>
+                      </Stack>
+                      <LinearProgress
+                        variant="determinate"
+                        value={entry.progress}
+                        color={entry.status === 'error' ? 'error' : entry.status === 'ready' ? 'success' : 'primary'}
+                      />
+                      {entry.error ? (
+                        <Typography variant="body2" color="error">
+                          {entry.error}
+                        </Typography>
+                      ) : null}
+                    </Stack>
+                  </Box>
+                ))}
+              </List>
+            </Stack>
+          ) : null}
+          {records.length > 0 ? (
+            <>
+              <Typography variant="subtitle1">Uploaded Records</Typography>
+              <RecordList
+                records={records}
+                selectedId={selectedRecordId}
+                onSelect={setSelectedRecordId}
+                onDelete={confirmDeleteRecord}
+                showReviewed
+              />
+            </>
+          ) : (
+            <Typography color="text.secondary">No records uploaded yet.</Typography>
+          )}
+        </Stack>
+      ) : null}
+
+      {activeTab === TAB_CROP ? (
+        <Stack spacing={2}>
+          <Alert severity="info">
+            Use the record browser to choose an image. The crop square can extend beyond the image bounds; any overflow becomes transparent in the final crop.
+          </Alert>
+          <Box sx={{ display: 'grid', gap: 2, gridTemplateColumns: { xs: '1fr', lg: 'minmax(0, 1fr) 320px' } }}>
+            {selectedRecordId == null ? (
+              <RecordList
+                records={records}
+                selectedId={selectedRecordId}
+                onSelect={setSelectedRecordId}
+                onDelete={confirmDeleteRecord}
+              />
+            ) : (
+              <Stack spacing={2}>
+                {selectedRecord ? (
+                  <>
+                    <Stack direction="row" spacing={1} flexWrap="wrap">
+                      <Button onClick={(evt) => { setSelectedRecordId(null); evt.stopPropagation() }}>
+                        ← Back to Records
+                      </Button>
+                      <Chip label={selectedRecord.filename} />
+                      <Chip
+                        label={selectedRecord.crop ? 'cropped' : 'uncropped'}
+                        color={selectedRecord.crop ? 'success' : 'default'}
+                      />
+                    </Stack>
+                    <Stack direction="row" spacing={1} flexWrap="wrap">
+                      <Button variant="contained" onClick={createCropForSelected}>
+                        {selectedRecord.crop ? 'Recenter Crop' : 'Create Crop'}
+                      </Button>
+                      <Button variant="outlined" onClick={resetCropForSelected} disabled={!selectedRecord.crop}>
+                        Clear Crop
+                      </Button>
+                      {allCropped ? (
+                        <Button variant="outlined" onClick={() => setActiveTab(TAB_OCR)}>
+                          Continue To OCR
+                        </Button>
+                      ) : null}
+                    </Stack>
+                    <Box sx={{ border: (theme) => `1px solid ${theme.palette.divider}`, borderRadius: 3, overflow: 'auto', p: 2, bgcolor: '#181511' }}>
+                      <Box
+                        ref={cropStageRef}
+                        sx={{
+                          position: 'relative',
+                          width: selectedStageWidth * selectedStageScale,
+                          height: selectedStageHeight * selectedStageScale,
+                          mx: 'auto',
+                          touchAction: 'none',
+                          backgroundImage: 'linear-gradient(45deg, rgba(255,255,255,0.04) 25%, transparent 25%), linear-gradient(-45deg, rgba(255,255,255,0.04) 25%, transparent 25%), linear-gradient(45deg, transparent 75%, rgba(255,255,255,0.04) 75%), linear-gradient(-45deg, transparent 75%, rgba(255,255,255,0.04) 75%)',
+                          backgroundSize: '24px 24px',
+                          backgroundPosition: '0 0, 0 12px, 12px -12px, -12px 0px',
+                        }}
+                      >
+                        <Box
+                          component="img"
+                          src={selectedRecord.sourceUrl}
+                          alt={selectedRecord.filename}
+                          sx={{
+                            position: 'absolute',
+                            left: selectedPadding * selectedStageScale,
+                            top: selectedPadding * selectedStageScale,
+                            width: selectedRecord.dimensions.width * selectedStageScale,
+                            height: selectedRecord.dimensions.height * selectedStageScale,
+                            userSelect: 'none',
+                            WebkitUserDrag: 'none',
+                          }}
+                        />
+                        {selectedCrop ? (
+                          <Box
+                            onPointerDown={(event: ReactPointerEvent<HTMLDivElement>) => startCropDrag('move', event)}
+                            sx={{
+                              position: 'absolute',
+                              left: (selectedCrop.x + selectedPadding) * selectedStageScale,
+                              top: (selectedCrop.y + selectedPadding) * selectedStageScale,
+                              width: selectedCrop.size * selectedStageScale,
+                              height: selectedCrop.size * selectedStageScale,
+                              transform: `rotate(${selectedCrop.rotation}deg)`,
+                              transformOrigin: 'center',
+                              border: '2px solid white',
+                              boxShadow: '0 0 0 9999px rgba(0, 0, 0, 0.42)',
+                              cursor: 'move',
+                              bgcolor: 'rgba(255,255,255,0.08)',
+                              '&::before, &::after': {
+                                content: '""',
+                                position: 'absolute',
+                                bgcolor: 'rgba(255,255,255,0.72)',
+                              },
+                              '&::before': {
+                                left: '50%',
+                                top: 0,
+                                width: '1px',
+                                height: '100%',
+                                transform: 'translateX(-50%)',
+                              },
+                              '&::after': {
+                                top: '50%',
+                                left: 0,
+                                width: '100%',
+                                height: '1px',
+                                transform: 'translateY(-50%)',
+                              },
+                            }}
+                          >
+                            {/* Rotation handle — above the top-center edge, rotates with the box */}
+                            <Box
+                              onPointerDown={(event: ReactPointerEvent<HTMLDivElement>) => {
+                                event.stopPropagation()
+                                startCropDrag('rotate', event)
+                              }}
+                              sx={{
+                                position: 'absolute',
+                                left: '50%',
+                                top: -30,
+                                transform: 'translateX(-50%)',
+                                width: 16,
+                                height: 16,
+                                borderRadius: '50%',
+                                bgcolor: '#2196f3',
+                                border: '2px solid white',
+                                cursor: 'grab',
+                                '&:active': { cursor: 'grabbing' },
+                              }}
+                            />
+                            {(['nw', 'ne', 'sw', 'se'] as const).map((handle) => (
+                              <Box
+                                key={handle}
+                                onPointerDown={(event: ReactPointerEvent<HTMLDivElement>) => {
+                                  event.stopPropagation()
+                                  startCropDrag(handle, event)
+                                }}
+                                sx={{
+                                  position: 'absolute',
+                                  width: 16,
+                                  height: 16,
+                                  borderRadius: '50%',
+                                  bgcolor: 'white',
+                                  border: '2px solid #8f4e21',
+                                  ...(handle === 'nw' ? { left: -8, top: -8, cursor: 'nwse-resize' } : {}),
+                                  ...(handle === 'ne' ? { right: -8, top: -8, cursor: 'nesw-resize' } : {}),
+                                  ...(handle === 'sw' ? { left: -8, bottom: -8, cursor: 'nesw-resize' } : {}),
+                                  ...(handle === 'se' ? { right: -8, bottom: -8, cursor: 'nwse-resize' } : {}),
+                                }}
+                              />
+                            ))}
+                          </Box>
+                        ) : null}
+                      </Box>
+                    </Box>
+                  </>
+                ) : (
+                  <Typography color="text.secondary">Select a record to crop it.</Typography>
+                )}
+              </Stack>
+            )}
+            <Stack spacing={2}>
+              <Typography variant="subtitle1">Crop Preview</Typography>
+              <Box sx={{ border: (theme) => `1px solid ${theme.palette.divider}`, borderRadius: 3, aspectRatio: '1 / 1', overflow: 'hidden', display: 'grid', placeItems: 'center', bgcolor: 'rgba(255,255,255,0.06)' }}>
+                {cropPreviewLoading ? (
+                  <CircularProgress size={32} />
+                ) : cropPreviewUrl ? (
+                  <Box component="img" src={cropPreviewUrl} alt="Crop preview" sx={{ width: '100%', height: '100%', objectFit: 'contain' }} />
+                ) : (
+                  <Typography color="text.secondary" sx={{ p: 2, textAlign: 'center' }}>
+                    Create a crop to preview the transparency-safe square result.
+                  </Typography>
+                )}
+              </Box>
+              {selectedRecord ? (
+                <>
+                  <Typography variant="body2" color="text.secondary">
+                    Source: {selectedRecord.dimensions.width} × {selectedRecord.dimensions.height}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    Crop: {selectedCrop ? `${selectedCrop.x}, ${selectedCrop.y}, ${selectedCrop.size}` : 'not set'}
+                  </Typography>
+                </>
+              ) : null}
+            </Stack>
+          </Box>
+        </Stack>
+      ) : null}
+
+      {activeTab === TAB_OCR ? (
+        <Stack spacing={2}>
+          <Alert severity="info">
+            For each record, drag the yellow box to select the region containing the text label. OCR will only run on the selected region. Leave no region set to run on the full crop.
+          </Alert>
+          <Box sx={{ display: 'grid', gap: 2, gridTemplateColumns: { xs: '1fr', lg: '320px minmax(0, 1fr)' } }}>
+            <RecordList
+              records={records}
+              selectedId={selectedRecordId}
+              onSelect={setSelectedRecordId}
+              onDelete={confirmDeleteRecord}
+              hideCropChip
+              showOcrRegionChip
+            />
+            <Stack spacing={2}>
+              {selectedRecord ? (
+                <>
+                  <Stack direction="row" spacing={1} flexWrap="wrap" alignItems="center">
+                    <Chip label={selectedRecord.filename} />
+                    <Chip
+                      label={selectedRecord.ocrRegion ? 'region set' : 'no region (full crop)'}
+                      color={selectedRecord.ocrRegion ? 'primary' : 'default'}
+                    />
+                    {selectedRecord.ocrStatus === 'running' ? <CircularProgress size={18} /> : null}
+                  </Stack>
+                  <Stack direction="row" spacing={1} flexWrap="wrap">
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      onClick={createOcrRegionForSelected}
+                      disabled={!selectedCrop}
+                    >
+                      {selectedRecord.ocrRegion ? 'Reset Region' : 'Add OCR Region'}
+                    </Button>
+                    {selectedRecord.ocrRegion ? (
+                      <Button variant="outlined" size="small" onClick={resetOcrRegionForSelected}>
+                        Remove Region
+                      </Button>
+                    ) : null}
+                  </Stack>
+                  {cropPreviewLoading ? (
+                    <CircularProgress size={32} sx={{ alignSelf: 'flex-start', m: 1 }} />
+                  ) : cropPreviewUrl && selectedCrop ? (
+                    <Box
+                      sx={{
+                        border: (theme) => `1px solid ${theme.palette.divider}`,
+                        borderRadius: 3,
+                        overflow: 'hidden',
+                        display: 'inline-block',
+                        bgcolor: 'rgba(255,255,255,0.06)',
+                        touchAction: 'none',
+                        alignSelf: 'flex-start',
+                      }}
+                    >
+                      <Box
+                        ref={ocrStageRef}
+                        sx={{
+                          position: 'relative',
+                          width: selectedCrop.size * ocrStageScale,
+                          height: selectedCrop.size * ocrStageScale,
+                        }}
+                      >
+                        <Box
+                          component="img"
+                          src={cropPreviewUrl}
+                          alt="OCR region selector"
+                          sx={{
+                            display: 'block',
+                            width: '100%',
+                            height: '100%',
+                            userSelect: 'none',
+                            WebkitUserDrag: 'none',
+                          }}
+                        />
+                        {selectedOcrRegion ? (
+                          <Box
+                            onPointerDown={(event: ReactPointerEvent<HTMLDivElement>) => startOcrDrag('move', event)}
+                            sx={{
+                              position: 'absolute',
+                              left: selectedOcrRegion.x * ocrStageScale,
+                              top: selectedOcrRegion.y * ocrStageScale,
+                              width: selectedOcrRegion.width * ocrStageScale,
+                              height: selectedOcrRegion.height * ocrStageScale,
+                              transform: `rotate(${selectedOcrRegion.rotation}deg)`,
+                              transformOrigin: 'center',
+                              border: '2px solid #f0c040',
+                              boxShadow: '0 0 0 9999px rgba(0, 0, 0, 0.38)',
+                              cursor: 'move',
+                              bgcolor: 'rgba(240, 192, 64, 0.08)',
+                            }}
+                          >
+                            {/* Rotation handle — above the top-center edge, rotates with the box */}
+                            <Box
+                              onPointerDown={(event: ReactPointerEvent<HTMLDivElement>) => {
+                                event.stopPropagation()
+                                startOcrDrag('rotate', event)
+                              }}
+                              sx={{
+                                position: 'absolute',
+                                left: '50%',
+                                top: -26,
+                                transform: 'translateX(-50%)',
+                                width: 14,
+                                height: 14,
+                                borderRadius: '50%',
+                                bgcolor: '#2196f3',
+                                border: '2px solid #7a6010',
+                                cursor: 'grab',
+                                '&:active': { cursor: 'grabbing' },
+                              }}
+                            />
+                            {(['nw', 'ne', 'sw', 'se'] as const).map((handle) => (
+                              <Box
+                                key={handle}
+                                onPointerDown={(event: ReactPointerEvent<HTMLDivElement>) => {
+                                  event.stopPropagation()
+                                  startOcrDrag(handle, event)
+                                }}
+                                sx={{
+                                  position: 'absolute',
+                                  width: 14,
+                                  height: 14,
+                                  borderRadius: '50%',
+                                  bgcolor: '#f0c040',
+                                  border: '2px solid #7a6010',
+                                  ...(handle === 'nw' ? { left: -7, top: -7, cursor: 'nwse-resize' } : {}),
+                                  ...(handle === 'ne' ? { right: -7, top: -7, cursor: 'nesw-resize' } : {}),
+                                  ...(handle === 'sw' ? { left: -7, bottom: -7, cursor: 'nesw-resize' } : {}),
+                                  ...(handle === 'se' ? { right: -7, bottom: -7, cursor: 'nwse-resize' } : {}),
+                                }}
+                              />
+                            ))}
+                          </Box>
+                        ) : null}
+                      </Box>
+                    </Box>
+                  ) : (
+                    <Typography color="text.secondary">
+                      Crop this record first to set an OCR region.
+                    </Typography>
+                  )}
+                  {selectedRecord.ocrSuggestion ? (
+                    <Stack spacing={1}>
+                      <Typography variant="subtitle2">Last OCR result</Typography>
+                      <Typography variant="body2" color="text.secondary">
+                        Confidence: {selectedRecord.ocrSuggestion.confidence != null
+                          ? `${Math.round(selectedRecord.ocrSuggestion.confidence)}%`
+                          : 'n/a'}
+                      </Typography>
+                      <Box sx={{ p: 2, borderRadius: 2, bgcolor: 'rgba(255,255,255,0.05)', whiteSpace: 'pre-wrap', fontFamily: 'monospace', fontSize: '0.8rem' }}>
+                        {selectedRecord.ocrSuggestion.rawText || 'No text found.'}
+                      </Box>
+                    </Stack>
+                  ) : null}
+                  {selectedRecord.ocrError ? (
+                    <Alert severity="error">{selectedRecord.ocrError}</Alert>
+                  ) : null}
+                </>
+              ) : (
+                <Typography color="text.secondary">Select a record to set its OCR region.</Typography>
+              )}
+            </Stack>
+          </Box>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems={{ sm: 'center' }}>
+            <Button
+              variant="contained"
+              onClick={() => void runOcrForAllRecords()}
+              disabled={!allCropped || ocrRunning}
+            >
+              {ocrRunning ? 'Running OCR…' : 'Run OCR For All Records'}
+            </Button>
+            {ocrRunning ? <CircularProgress size={22} /> : null}
+            {allOcrDone ? (
+              <Button variant="outlined" onClick={() => setActiveTab(TAB_REVIEW)}>
+                Continue To Review
+              </Button>
+            ) : null}
+          </Stack>
+        </Stack>
+      ) : null}
+
+      {activeTab === TAB_REVIEW ? (
+        <Stack spacing={2}>
+          <Alert severity="info">
+            Every record starts unreviewed after OCR. Fix any parsing issues, then check the review box for each record.
+          </Alert>
+          <Box sx={{ display: 'grid', gap: 2, gridTemplateColumns: { xs: '1fr', lg: '320px minmax(0, 1fr)' } }}>
+            <RecordList
+              records={records}
+              selectedId={selectedRecordId}
+              onSelect={setSelectedRecordId}
+              onDelete={confirmDeleteRecord}
+              showReviewed
+            />
+            {selectedRecord ? (
+              <Stack spacing={2}>
+                <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
+                  <Box sx={{ flex: 1 }}>
+                    <Typography variant="subtitle1" gutterBottom>
+                      Cropped Preview
+                    </Typography>
+                    <Box sx={{ border: (theme) => `1px solid ${theme.palette.divider}`, borderRadius: 3, aspectRatio: '1 / 1', overflow: 'hidden', display: 'grid', placeItems: 'center', bgcolor: 'rgba(255,255,255,0.06)' }}>
+                      {cropPreviewLoading ? (
+                        <CircularProgress size={32} />
+                      ) : cropPreviewUrl ? (
+                        <Box component="img" src={cropPreviewUrl} alt="Reviewed crop preview" sx={{ width: '100%', height: '100%', objectFit: 'contain' }} />
+                      ) : null}
+                    </Box>
+                  </Box>
+                  <Box sx={{ flex: 1 }}>
+                    <Stack direction="row" alignItems="baseline" spacing={1} sx={{ mb: 1 }}>
+                      <Typography variant="subtitle1">OCR Raw Text</Typography>
+                      {selectedRecord.ocrSuggestion?.confidence != null ? (
+                        <Typography variant="body2" color="text.secondary">
+                          confidence: {Math.round(selectedRecord.ocrSuggestion.confidence)}%
+                        </Typography>
+                      ) : null}
+                    </Stack>
+                    <Box sx={{ p: 2, borderRadius: 2, minHeight: 220, bgcolor: 'rgba(255,255,255,0.05)', whiteSpace: 'pre-wrap', fontFamily: 'monospace', fontSize: '0.8rem' }}>
+                      {selectedRecord.ocrSuggestion?.rawText || selectedRecord.ocrError || 'No OCR output.'}
+                    </Box>
+                  </Box>
+                </Stack>
+                <Divider />
+                <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
+                  <TextField
+                    label="Parsed name"
+                    fullWidth
+                    value={selectedRecord.parsedFields.name}
+                    disabled={selectedRecord.parsedFields.kind === 'glaze_combination'}
+                    helperText={selectedRecord.parsedFields.kind === 'glaze_combination' ? 'Auto-computed from glaze fields' : undefined}
+                    onChange={(event) => updateSelectedRecord((record) => ({
+                      ...record,
+                      parsedFields: { ...record.parsedFields, name: event.target.value },
+                      reviewed: false,
+                    }))}
+                  />
+                  <TextField
+                    label="Parsed kind"
+                    select
+                    fullWidth
+                    slotProps={{ select: { native: true } }}
+                    value={selectedRecord.parsedFields.kind}
+                    onChange={(event) => updateSelectedRecord((record) => {
+                      const kind = event.target.value as ParsedFields['kind']
+                      const name = kind === 'glaze_combination'
+                        ? `${record.parsedFields.first_glaze}${COMBO_NAME_SEPARATOR}${record.parsedFields.second_glaze}`
+                        : record.parsedFields.name
+                      return { ...record, parsedFields: { ...record.parsedFields, kind, name }, reviewed: false }
+                    })}
+                  >
+                    <option value="glaze_type">glaze_type</option>
+                    <option value="glaze_combination">glaze_combination</option>
+                  </TextField>
+                </Stack>
+                {selectedRecord.parsedFields.kind === 'glaze_combination' ? (
+                  <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
+                    <TextField
+                      label="Parsed 1st glaze"
+                      fullWidth
+                      value={selectedRecord.parsedFields.first_glaze}
+                      onChange={(event) => updateSelectedRecord((record) => {
+                        const first_glaze = event.target.value
+                        const name = `${first_glaze}${COMBO_NAME_SEPARATOR}${record.parsedFields.second_glaze}`
+                        return { ...record, parsedFields: { ...record.parsedFields, first_glaze, name }, reviewed: false }
+                      })}
+                    />
+                    <TextField
+                      label="Parsed 2nd glaze"
+                      fullWidth
+                      value={selectedRecord.parsedFields.second_glaze}
+                      onChange={(event) => updateSelectedRecord((record) => {
+                        const second_glaze = event.target.value
+                        const name = `${record.parsedFields.first_glaze}${COMBO_NAME_SEPARATOR}${second_glaze}`
+                        return { ...record, parsedFields: { ...record.parsedFields, second_glaze, name }, reviewed: false }
+                      })}
+                    />
+                  </Stack>
+                ) : null}
+                <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
+                  <TextField
+                    label="Runs?"
+                    select
+                    fullWidth
+                    slotProps={{ select: { native: true }, inputLabel: { shrink: true } }}
+                    value={selectedRecord.parsedFields.runs === null ? '' : String(selectedRecord.parsedFields.runs)}
+                    helperText={selectedRecord.parsedFields.runs === null ? 'Not specified' : undefined}
+                    onChange={(event) => updateSelectedRecord((record) => ({
+                      ...record,
+                      parsedFields: {
+                        ...record.parsedFields,
+                        runs: event.target.value === '' ? null : event.target.value === 'true',
+                      },
+                      reviewed: false,
+                    }))}
+                  >
+                    <option value="" />
+                    <option value="true">Yes</option>
+                    <option value="false">No</option>
+                  </TextField>
+                  <TextField
+                    label="Food safe?"
+                    select
+                    fullWidth
+                    slotProps={{ select: { native: true }, inputLabel: { shrink: true } }}
+                    value={selectedRecord.parsedFields.is_food_safe === null ? '' : String(selectedRecord.parsedFields.is_food_safe)}
+                    helperText={selectedRecord.parsedFields.is_food_safe === null ? 'Not specified' : undefined}
+                    onChange={(event) => updateSelectedRecord((record) => ({
+                      ...record,
+                      parsedFields: {
+                        ...record.parsedFields,
+                        is_food_safe: event.target.value === '' ? null : event.target.value === 'true',
+                      },
+                      reviewed: false,
+                    }))}
+                  >
+                    <option value="" />
+                    <option value="true">Yes</option>
+                    <option value="false">No</option>
+                  </TextField>
+                </Stack>
+                <FormControlLabel
+                  control={(
+                    <Checkbox
+                      checked={selectedRecord.reviewed}
+                      onChange={(event) => updateSelectedRecord((record) => ({
+                        ...record,
+                        reviewed: event.target.checked,
+                      }))}
+                    />
+                  )}
+                  label="This record has been reviewed and is ready for import."
+                />
+                {allReviewed ? (
+                  <Button variant="contained" onClick={() => setActiveTab(TAB_IMPORT)}>
+                    Continue To Import
+                  </Button>
+                ) : null}
+              </Stack>
+            ) : (
+              <Typography color="text.secondary">Select a record to review it.</Typography>
+            )}
+          </Box>
+        </Stack>
+      ) : null}
+
+      {activeTab === TAB_IMPORT ? (
+        <Stack spacing={2}>
+          <Alert severity="info">
+            Import creates new public glaze types and glaze combinations and skips duplicates that already exist in the public library.
+          </Alert>
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems={{ sm: 'center' }}>
+            <Button variant="contained" onClick={() => void runImport()} disabled={!allReviewed || importRunning}>
+              {importRunning ? 'Importing…' : 'Run Bulk Import'}
+            </Button>
+            {!allReviewed ? (
+              <Typography color="text.secondary">Review every record before importing.</Typography>
+            ) : null}
+            {importRunning ? <CircularProgress size={22} /> : null}
+          </Stack>
+          {importError ? <Alert severity="error">{importError}</Alert> : null}
+          {importBuildProgress.length > 0 ? (
+            <Stack spacing={1.5}>
+              <Typography variant="subtitle1">Build Progress</Typography>
+              <List sx={{ border: (theme) => `1px solid ${theme.palette.divider}`, borderRadius: 3 }}>
+                {importBuildProgress.map((entry) => (
+                  <Box key={entry.id} sx={{ px: 2, py: 1.5 }}>
+                    <Stack spacing={0.75}>
+                      <Stack direction="row" justifyContent="space-between" spacing={2}>
+                        <Typography variant="body2">{entry.filename}</Typography>
+                        <Typography variant="body2" color={entry.status === 'error' ? 'error' : 'text.secondary'}>
+                          {entry.status === 'queued' ? 'Queued' : null}
+                          {entry.status === 'processing' ? 'Building crop…' : null}
+                          {entry.status === 'uploading' ? 'Uploading…' : null}
+                          {entry.status === 'ready' ? 'Done' : null}
+                          {entry.status === 'error' ? 'Error' : null}
+                        </Typography>
+                      </Stack>
+                      <LinearProgress
+                        variant="determinate"
+                        value={entry.progress}
+                        color={entry.status === 'error' ? 'error' : entry.status === 'ready' ? 'success' : 'primary'}
+                      />
+                      {entry.error ? (
+                        <Typography variant="body2" color="error">{entry.error}</Typography>
+                      ) : null}
+                    </Stack>
+                  </Box>
+                ))}
+              </List>
+            </Stack>
+          ) : null}
+          {importResult ? (
+            <Stack spacing={2}>
+              <Stack direction="row" spacing={1} flexWrap="wrap" alignItems="center">
+                <Chip color="success" label={`${importResult.summary.created_glaze_types} glaze types created`} />
+                <Chip color="success" label={`${importResult.summary.created_glaze_combinations} combinations created`} />
+                <Chip
+                  label={`${importResult.summary.skipped_duplicates} duplicates skipped`}
+                  color={hasDuplicates ? 'warning' : 'default'}
+                />
+                <Chip color={importResult.summary.errors ? 'error' : 'default'} label={`${importResult.summary.errors} errors`} />
+                {hasDuplicates ? (
+                  <Button variant="outlined" size="small" onClick={() => setActiveTab(TAB_RECONCILE)}>
+                    Reconcile Duplicates →
+                  </Button>
+                ) : null}
+              </Stack>
+              <List sx={{ border: (theme) => `1px solid ${theme.palette.divider}`, borderRadius: 3 }}>
+                {importResult.results.map((result) => {
+                  const adminPath = result.object_id
+                    ? `/admin/api/${result.kind.replace('_', '')}/${result.object_id}/change/`
+                    : null
+                  return (
+                    <ListItemButton
+                      key={result.client_id}
+                      {...(adminPath ? { component: 'a', href: adminPath, target: '_blank', rel: 'noopener noreferrer' } : { disabled: true })}
+                    >
+                      <ListItemText
+                        primary={`${result.name || result.filename} — ${result.status}`}
+                        secondary={result.reason || result.kind}
+                      />
+                    </ListItemButton>
+                  )
+                })}
+              </List>
+            </Stack>
+          ) : null}
+        </Stack>
+      ) : null}
+
+      {activeTab === TAB_RECONCILE ? (
+        <Stack spacing={2}>
+          <Alert severity="info">
+            These records were skipped because an entry with the same name already exists in the public library. Review the scraped data below, open the existing record in the admin, and update it manually if needed. Check each record as resolved when done.
+          </Alert>
+          <Typography variant="body2" color="text.secondary">
+            {reconciledIds.size} / {duplicateResults.length} resolved
+          </Typography>
+          <Stack spacing={2}>
+            {duplicateResults.map((result) => {
+              const sourceRecord = records.find((r) => r.id === result.client_id)
+              const adminPath = result.object_id
+                ? `/admin/api/${result.kind.replace('_', '')}/${result.object_id}/change/`
+                : null
+              const isResolved = reconciledIds.has(result.client_id)
+              return (
+                <Box
+                  key={result.client_id}
+                  sx={{
+                    border: (theme) => `1px solid ${isResolved ? theme.palette.success.main : theme.palette.divider}`,
+                    borderRadius: 2,
+                    p: 2,
+                    opacity: isResolved ? 0.6 : 1,
+                    transition: 'opacity 0.15s, border-color 0.15s',
+                  }}
+                >
+                  <Stack spacing={1.5}>
+                    <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                      <Typography variant="subtitle1" sx={{ flex: 1 }}>
+                        {result.name || result.filename}
+                      </Typography>
+                      <Chip label={result.kind} size="small" />
+                      {adminPath ? (
+                        <Button
+                          size="small"
+                          variant="outlined"
+                          href={adminPath}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          component="a"
+                          endIcon={<OpenInNewIcon fontSize="small" />}
+                        >
+                          Open in Admin
+                        </Button>
+                      ) : null}
+                    </Stack>
+                    {sourceRecord ? (
+                      <Box
+                        sx={{
+                          display: 'grid',
+                          gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))',
+                          gap: 1,
+                        }}
+                      >
+                        {Object.entries(sourceRecord.parsedFields).map(([key, value]) => (
+                          <Box key={key}>
+                            <Typography variant="caption" color="text.secondary" display="block">
+                              {key.replace(/_/g, ' ')}
+                            </Typography>
+                            <Typography variant="body2">
+                              {value === null ? '—' : String(value)}
+                            </Typography>
+                          </Box>
+                        ))}
+                      </Box>
+                    ) : null}
+                    <FormControlLabel
+                      control={(
+                        <Checkbox
+                          checked={isResolved}
+                          onChange={(event) => setReconciledIds((current) => {
+                            const next = new Set(current)
+                            if (event.target.checked) next.add(result.client_id)
+                            else next.delete(result.client_id)
+                            return next
+                          })}
+                        />
+                      )}
+                      label="Resolved"
+                    />
+                  </Stack>
+                </Box>
+              )
+            })}
+          </Stack>
+        </Stack>
+      ) : null}
+
+      <Dialog open={deleteConfirmId != null} onClose={() => setDeleteConfirmId(null)}>
+        <DialogTitle>Delete record?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {deleteConfirmRecord?.filename} will be removed from this session. This cannot be undone.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteConfirmId(null)}>Cancel</Button>
+          <Button color="error" variant="contained" onClick={executeDeleteRecord}>Delete</Button>
+        </DialogActions>
+      </Dialog>
+    </Stack>
+  )
+}


### PR DESCRIPTION
## Summary

Implements the end-to-end admin workflow specified in issue #146: a browser-based bulk import tool for seeding the public `GlazeType` and `GlazeCombination` libraries from test-tile photographs.

Closes #146. Related to #90 and #91.

## What's included

### New page: Glaze Import Tool (`/tools/glaze-import`)

A tabbed 5-step flow (+ optional Reconcile tab) accessible to staff users only:

| Tab | What it does |
|-----|-------------|
| **1. Upload** | Local file picker or Cloudinary widget (HEIC/HEIF → JPEG via CDN) |
| **2. Crop** | Rotatable square crop box; overflow → transparent; 200 ms debounced preview |
| **3. OCR** | Rotatable OCR region box; Tesseract.js with domain word list; structured-line parser (`1st Glaze:` / `2nd Glaze:`); annotation detection (`CAUTION: RUNS`, `NOT FOOD SAFE`) |
| **4. Review** | Editable parsed fields; combo name auto-computed as `first!second` |
| **5. Import** | Per-record build progress; WebP ≤ 2000 px compression; admin links to results |
| **6. Reconcile** *(if duplicates)* | Checklist with scraped fields and Open-in-Admin links |

### Bug fix: `runs` and `is_food_safe` not written on import

`import_glaze_type` and `import_glaze_combination` in `api/manual_tile_imports.py` were discarding `runs` and `is_food_safe` from `parsed_fields` — both fields were being set to their model defaults on every created record. They are now forwarded to `.create()`.

### Route rename

`/tools/manual-square-crop` → `/tools/glaze-import`; menu item and page heading updated to "Glaze Import Tool".

### Docs

- `docs/agents/glaze-domain.md` — new "Glaze Import Tool" section covering the tab flow, backend endpoint contract, and OCR parsing conventions
- `README.md` — new "Glaze Import Tool" section with step-by-step guide and post-import fixture export workflow

## Test plan

- [ ] `pytest api/tests/test_manual_square_crop_import.py` — 4 tests including `runs`/`is_food_safe` round-trip
- [ ] `npm test` in `web/` — 270 tests pass
- [ ] Staff user: navigate to `/tools/glaze-import`, upload a JPEG, crop, run OCR, review, import
- [ ] Non-staff user: verify the menu item is not shown and the route returns a permission error
- [ ] Import with a duplicate name: verify the Reconcile tab appears with correct scraped fields and admin link
- [ ] Import a combination: verify `runs` and `is_food_safe` appear on the created `GlazeCombination` in the admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)
