### PR TITLE
feat: enable lightbox in GlazeCombinationGallery with piece navigation

### DIFF
--- a/docs/agents/typescript-react-vite.md
+++ b/docs/agents/typescript-react-vite.md
@@ -62,6 +62,7 @@ This is a Single Page Application (SPA). Routing is handled client-side via Reac
   }) { ... }
   ```
 - Use `memo` to prevent unnecessary re-renders of pure components that receive stable props. Pair with `useMemo` for expensive derived values and `useCallback` for stable callback references — but don't memoize indiscriminately; profile first.
+- **Maximum JSX nesting depth of 4.** If a component's JSX tree would exceed 4 levels of element nesting, extract the deeper subtree into a named child component with typed props. This also sidesteps TypeScript narrowing limitations: instead of narrowing a `string | undefined` inside a callback nested in a ternary branch, pass the already-narrowed value as a `string` prop to a child component.
 
 ## Custom hooks
 

--- a/web/src/components/GlazeCombinationGallery.tsx
+++ b/web/src/components/GlazeCombinationGallery.tsx
@@ -97,7 +97,7 @@ export default function GlazeCombinationGallery() {
                                     testTileImage ? (
                                         <Box
                                             component="button"
-                                            onClick={() => openTileLightbox(testTileImage, combo.name)}
+                                            onClick={() => openTileLightbox(testTileImage!, combo.name)}
                                             sx={{
                                                 background: 'none',
                                                 border: 'none',

--- a/web/src/components/GlazeCombinationGallery.tsx
+++ b/web/src/components/GlazeCombinationGallery.tsx
@@ -9,8 +9,8 @@
  * Each card header shows the combination name, a test-tile thumbnail if
  * available, and a chip for each constituent glaze type.
  * The card body is a horizontally scrollable row of CloudinaryImage
- * thumbnails. Clicking a thumbnail opens a lightbox; piece thumbnails include
- * a "Go to the Piece" button in the lightbox footer.
+ * thumbnails. Clicking any thumbnail opens an ImageLightbox; piece thumbnails
+ * include a "Go to the Piece" button in the lightbox footer.
  */
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
@@ -29,16 +29,114 @@ import {
 import CloudinaryImage from './CloudinaryImage'
 import ImageLightbox from './ImageLightbox'
 import { fetchGlazeCombinationImages } from '@common/api'
-import type { CaptionedImage, GlazeCombinationImageEntry } from '@common/types'
+import type { CaptionedImage, GlazeCombinationEntry, GlazeCombinationImageEntry } from '@common/types'
 import { formatState } from '@common/types'
 import { useAsync } from '../util/useAsync'
 
 const EMPTY_STATE_MESSAGE =
     'No images yet — add images to pieces that use a glaze combination to see them here.'
 
+type PieceEntry = GlazeCombinationImageEntry['pieces'][number]
+
 type LightboxState =
     | { kind: 'tile'; images: CaptionedImage[]; initialIndex: 0 }
-    | { kind: 'piece'; images: CaptionedImage[]; initialIndex: number; pieceId: string; pieceName: string }
+    | { kind: 'piece'; images: CaptionedImage[]; initialIndex: number; pieceId: string }
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+interface TileAvatarButtonProps {
+    url: string
+    name: string
+    onClick: (url: string, name: string) => void
+}
+
+function TileAvatarButton({ url, name, onClick }: TileAvatarButtonProps) {
+    return (
+        <Box
+            component="button"
+            onClick={() => onClick(url, name)}
+            sx={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', display: 'inline-flex' }}
+            aria-label={`View test tile for ${name}`}
+        >
+            <CloudinaryImage url={url} context="thumbnail" alt={name} />
+        </Box>
+    )
+}
+
+interface PieceImageButtonProps {
+    piece: PieceEntry
+    img: CaptionedImage
+    imgIdx: number
+    onClick: (piece: PieceEntry, imgIdx: number) => void
+}
+
+function PieceImageButton({ piece, img, imgIdx, onClick }: PieceImageButtonProps) {
+    return (
+        <Tooltip title={`${piece.name} — ${formatState(piece.state)}`} placement="top">
+            <Box
+                component="button"
+                onClick={() => onClick(piece, imgIdx)}
+                sx={{ flexShrink: 0, display: 'inline-flex', background: 'none', border: 'none', padding: 0, cursor: 'pointer' }}
+                aria-label={`${piece.name} — ${formatState(piece.state)}`}
+            >
+                <CloudinaryImage
+                    url={img.url}
+                    cloudinary_public_id={img.cloudinary_public_id}
+                    alt={`${piece.name} — ${formatState(piece.state)}`}
+                    context="preview"
+                />
+            </Box>
+        </Tooltip>
+    )
+}
+
+interface ComboCardProps {
+    combo: GlazeCombinationEntry
+    pieces: PieceEntry[]
+    onTileClick: (url: string, name: string) => void
+    onPieceImageClick: (piece: PieceEntry, imgIdx: number) => void
+}
+
+function ComboCard({ combo, pieces, onTileClick, onPieceImageClick }: ComboCardProps) {
+    return (
+        <Card variant="outlined">
+            <CardHeader
+                avatar={combo.test_tile_image
+                    ? <TileAvatarButton url={combo.test_tile_image} name={combo.name ?? ''} onClick={onTileClick} />
+                    : null}
+                title={<Typography variant="subtitle1" fontWeight="bold">{combo.name}</Typography>}
+                subheader={
+                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.5 }}>
+                        {combo.glaze_types.map((gt) => (
+                            <Chip key={gt.id} label={gt.name} size="small" variant="outlined" />
+                        ))}
+                    </Box>
+                }
+            />
+            <CardContent sx={{ pt: 0 }}>
+                <Box sx={{ display: 'flex', flexDirection: 'row', overflowX: 'auto', gap: 1, pb: 1 }}>
+                    {pieces.map((piece) =>
+                        piece.images.map((img, imgIdx) => (
+                            <PieceImageButton
+                                key={`${piece.id}-${imgIdx}`}
+                                piece={piece}
+                                img={img}
+                                imgIdx={imgIdx}
+                                onClick={onPieceImageClick}
+                            />
+                        ))
+                    )}
+                </Box>
+            </CardContent>
+        </Card>
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Root component
+// ---------------------------------------------------------------------------
 
 export default function GlazeCombinationGallery() {
     const { data: entries, loading, error } = useAsync<GlazeCombinationImageEntry[]>(
@@ -67,7 +165,7 @@ export default function GlazeCombinationGallery() {
         )
     }
 
-    function openTileLightbox(url: string, name: string) {
+    function handleTileClick(url: string, name: string) {
         setLightbox({
             kind: 'tile',
             initialIndex: 0,
@@ -75,116 +173,22 @@ export default function GlazeCombinationGallery() {
         })
     }
 
-    function openPieceLightbox(
-        images: CaptionedImage[],
-        imgIdx: number,
-        pieceId: string,
-        pieceName: string,
-    ) {
-        setLightbox({ kind: 'piece', images, initialIndex: imgIdx, pieceId, pieceName })
+    function handlePieceImageClick(piece: PieceEntry, imgIdx: number) {
+        setLightbox({ kind: 'piece', images: piece.images, initialIndex: imgIdx, pieceId: piece.id })
     }
 
     return (
         <>
             <Stack spacing={2}>
-                {entries.map((entry) => {
-                    const { glaze_combination: combo, pieces } = entry
-                    const testTileImage = combo.test_tile_image
-                    return (
-                        <Card key={combo.id} variant="outlined">
-                            <CardHeader
-                                avatar={
-                                    testTileImage ? (
-                                        <Box
-                                            component="button"
-                                            onClick={() => openTileLightbox(testTileImage!, combo.name)}
-                                            sx={{
-                                                background: 'none',
-                                                border: 'none',
-                                                padding: 0,
-                                                cursor: 'pointer',
-                                                display: 'inline-flex',
-                                            }}
-                                            aria-label={`View test tile for ${combo.name}`}
-                                        >
-                                            <CloudinaryImage
-                                                url={testTileImage}
-                                                context="thumbnail"
-                                                alt={combo.name}
-                                            />
-                                        </Box>
-                                    ) : null
-                                }
-                                title={
-                                    <Typography variant="subtitle1" fontWeight="bold">
-                                        {combo.name}
-                                    </Typography>
-                                }
-                                subheader={
-                                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.5 }}>
-                                        {combo.glaze_types.map((gt) => (
-                                            <Chip
-                                                key={gt.id}
-                                                label={gt.name}
-                                                size="small"
-                                                variant="outlined"
-                                            />
-                                        ))}
-                                    </Box>
-                                }
-                            />
-                            <CardContent sx={{ pt: 0 }}>
-                                <Box
-                                    sx={{
-                                        display: 'flex',
-                                        flexDirection: 'row',
-                                        overflowX: 'auto',
-                                        gap: 1,
-                                        pb: 1,
-                                    }}
-                                >
-                                    {pieces.map((piece) =>
-                                        piece.images.map((img, imgIdx) => (
-                                            <Tooltip
-                                                key={`${piece.id}-${imgIdx}`}
-                                                title={`${piece.name} — ${formatState(piece.state)}`}
-                                                placement="top"
-                                            >
-                                                <Box
-                                                    component="button"
-                                                    onClick={() =>
-                                                        openPieceLightbox(
-                                                            piece.images,
-                                                            imgIdx,
-                                                            piece.id,
-                                                            piece.name,
-                                                        )
-                                                    }
-                                                    sx={{
-                                                        flexShrink: 0,
-                                                        display: 'inline-flex',
-                                                        background: 'none',
-                                                        border: 'none',
-                                                        padding: 0,
-                                                        cursor: 'pointer',
-                                                    }}
-                                                    aria-label={`${piece.name} — ${formatState(piece.state)}`}
-                                                >
-                                                    <CloudinaryImage
-                                                        url={img.url}
-                                                        cloudinary_public_id={img.cloudinary_public_id}
-                                                        alt={`${piece.name} — ${formatState(piece.state)}`}
-                                                        context="preview"
-                                                    />
-                                                </Box>
-                                            </Tooltip>
-                                        ))
-                                    )}
-                                </Box>
-                            </CardContent>
-                        </Card>
-                    )
-                })}
+                {entries.map(({ glaze_combination: combo, pieces }) => (
+                    <ComboCard
+                        key={combo.id}
+                        combo={combo}
+                        pieces={pieces}
+                        onTileClick={handleTileClick}
+                        onPieceImageClick={handlePieceImageClick}
+                    />
+                ))}
             </Stack>
             {lightbox && (
                 <ImageLightbox
@@ -196,11 +200,7 @@ export default function GlazeCombinationGallery() {
                             <Button
                                 size="small"
                                 variant="outlined"
-                                onClick={() =>
-                                    navigate(`/pieces/${lightbox.pieceId}`, {
-                                        state: { fromGallery: true },
-                                    })
-                                }
+                                onClick={() => navigate(`/pieces/${lightbox.pieceId}`, { state: { fromGallery: true } })}
                                 sx={{ color: 'white', borderColor: 'rgba(255,255,255,0.5)' }}
                             >
                                 Go to the Piece

--- a/web/src/components/GlazeCombinationGallery.tsx
+++ b/web/src/components/GlazeCombinationGallery.tsx
@@ -9,12 +9,14 @@
  * Each card header shows the combination name, a test-tile thumbnail if
  * available, and a chip for each constituent glaze type.
  * The card body is a horizontally scrollable row of CloudinaryImage
- * thumbnails. Hovering a thumbnail shows the piece name and state; clicking
- * navigates to /pieces/<id>.
+ * thumbnails. Clicking a thumbnail opens a lightbox; piece thumbnails include
+ * a "Go to the Piece" button in the lightbox footer.
  */
-import { Link } from 'react-router-dom'
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import {
     Box,
+    Button,
     Card,
     CardContent,
     CardHeader,
@@ -25,18 +27,25 @@ import {
     Typography,
 } from '@mui/material'
 import CloudinaryImage from './CloudinaryImage'
+import ImageLightbox from './ImageLightbox'
 import { fetchGlazeCombinationImages } from '@common/api'
-import type { GlazeCombinationImageEntry } from '@common/types'
+import type { CaptionedImage, GlazeCombinationImageEntry } from '@common/types'
 import { formatState } from '@common/types'
 import { useAsync } from '../util/useAsync'
 
 const EMPTY_STATE_MESSAGE =
     'No images yet — add images to pieces that use a glaze combination to see them here.'
 
+type LightboxState =
+    | { kind: 'tile'; images: CaptionedImage[]; initialIndex: 0 }
+    | { kind: 'piece'; images: CaptionedImage[]; initialIndex: number; pieceId: string; pieceName: string }
+
 export default function GlazeCombinationGallery() {
     const { data: entries, loading, error } = useAsync<GlazeCombinationImageEntry[]>(
         fetchGlazeCombinationImages,
     )
+    const [lightbox, setLightbox] = useState<LightboxState | null>(null)
+    const navigate = useNavigate()
 
     if (loading) {
         return (
@@ -58,82 +67,148 @@ export default function GlazeCombinationGallery() {
         )
     }
 
+    function openTileLightbox(url: string, name: string) {
+        setLightbox({
+            kind: 'tile',
+            initialIndex: 0,
+            images: [{ url, caption: name, created: new Date(), cloudinary_public_id: null }],
+        })
+    }
+
+    function openPieceLightbox(
+        images: CaptionedImage[],
+        imgIdx: number,
+        pieceId: string,
+        pieceName: string,
+    ) {
+        setLightbox({ kind: 'piece', images, initialIndex: imgIdx, pieceId, pieceName })
+    }
+
     return (
-        <Stack spacing={2}>
-            {entries.map((entry) => {
-                const { glaze_combination: combo, pieces } = entry
-                return (
-                    <Card key={combo.id} variant="outlined">
-                        <CardHeader
-                            avatar={
-                                combo.test_tile_image ? (
-                                    <CloudinaryImage
-                                        url={combo.test_tile_image}
-                                        context="thumbnail"
-                                        alt={combo.name}
-                                    />
-                                ) : null
-                            }
-                            title={
-                                <Typography variant="subtitle1" fontWeight="bold">
-                                    {combo.name}
-                                </Typography>
-                            }
-                            subheader={
-                                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.5 }}>
-                                    {combo.glaze_types.map((gt) => (
-                                        <Chip
-                                            key={gt.id}
-                                            label={gt.name}
-                                            size="small"
-                                            variant="outlined"
-                                        />
-                                    ))}
-                                </Box>
-                            }
-                        />
-                        <CardContent sx={{ pt: 0 }}>
-                            <Box
-                                sx={{
-                                    display: 'flex',
-                                    flexDirection: 'row',
-                                    overflowX: 'auto',
-                                    gap: 1,
-                                    pb: 1,
-                                }}
-                            >
-                                {pieces.map((piece) =>
-                                    piece.images.map((img, imgIdx) => (
-                                        <Tooltip
-                                            key={`${piece.id}-${imgIdx}`}
-                                            title={`${piece.name} — ${formatState(piece.state)}`}
-                                            placement="top"
+        <>
+            <Stack spacing={2}>
+                {entries.map((entry) => {
+                    const { glaze_combination: combo, pieces } = entry
+                    const testTileImage = combo.test_tile_image
+                    return (
+                        <Card key={combo.id} variant="outlined">
+                            <CardHeader
+                                avatar={
+                                    testTileImage ? (
+                                        <Box
+                                            component="button"
+                                            onClick={() => openTileLightbox(testTileImage, combo.name)}
+                                            sx={{
+                                                background: 'none',
+                                                border: 'none',
+                                                padding: 0,
+                                                cursor: 'pointer',
+                                                display: 'inline-flex',
+                                            }}
+                                            aria-label={`View test tile for ${combo.name}`}
                                         >
-                                            <Box
-                                                component={Link}
-                                                to={`/pieces/${piece.id}`}
-                                                sx={{
-                                                    flexShrink: 0,
-                                                    display: 'inline-flex',
-                                                    textDecoration: 'none',
-                                                }}
-                                                aria-label={`${piece.name} — ${formatState(piece.state)}`}
+                                            <CloudinaryImage
+                                                url={testTileImage}
+                                                context="thumbnail"
+                                                alt={combo.name}
+                                            />
+                                        </Box>
+                                    ) : null
+                                }
+                                title={
+                                    <Typography variant="subtitle1" fontWeight="bold">
+                                        {combo.name}
+                                    </Typography>
+                                }
+                                subheader={
+                                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.5 }}>
+                                        {combo.glaze_types.map((gt) => (
+                                            <Chip
+                                                key={gt.id}
+                                                label={gt.name}
+                                                size="small"
+                                                variant="outlined"
+                                            />
+                                        ))}
+                                    </Box>
+                                }
+                            />
+                            <CardContent sx={{ pt: 0 }}>
+                                <Box
+                                    sx={{
+                                        display: 'flex',
+                                        flexDirection: 'row',
+                                        overflowX: 'auto',
+                                        gap: 1,
+                                        pb: 1,
+                                    }}
+                                >
+                                    {pieces.map((piece) =>
+                                        piece.images.map((img, imgIdx) => (
+                                            <Tooltip
+                                                key={`${piece.id}-${imgIdx}`}
+                                                title={`${piece.name} — ${formatState(piece.state)}`}
+                                                placement="top"
                                             >
-                                                <CloudinaryImage
-                                                    url={img.url}
-                                                    cloudinary_public_id={img.cloudinary_public_id}
-                                                    alt={`${piece.name} — ${formatState(piece.state)}`}
-                                                    context="preview"
-                                                />
-                                            </Box>
-                                        </Tooltip>
-                                    ))
-                                )}
-                            </Box>
-                        </CardContent>
-                    </Card>
-                )
-            })}
-        </Stack>
+                                                <Box
+                                                    component="button"
+                                                    onClick={() =>
+                                                        openPieceLightbox(
+                                                            piece.images,
+                                                            imgIdx,
+                                                            piece.id,
+                                                            piece.name,
+                                                        )
+                                                    }
+                                                    sx={{
+                                                        flexShrink: 0,
+                                                        display: 'inline-flex',
+                                                        background: 'none',
+                                                        border: 'none',
+                                                        padding: 0,
+                                                        cursor: 'pointer',
+                                                    }}
+                                                    aria-label={`${piece.name} — ${formatState(piece.state)}`}
+                                                >
+                                                    <CloudinaryImage
+                                                        url={img.url}
+                                                        cloudinary_public_id={img.cloudinary_public_id}
+                                                        alt={`${piece.name} — ${formatState(piece.state)}`}
+                                                        context="preview"
+                                                    />
+                                                </Box>
+                                            </Tooltip>
+                                        ))
+                                    )}
+                                </Box>
+                            </CardContent>
+                        </Card>
+                    )
+                })}
+            </Stack>
+            {lightbox && (
+                <ImageLightbox
+                    images={lightbox.images}
+                    initialIndex={lightbox.initialIndex}
+                    onClose={() => setLightbox(null)}
+                    footerActions={
+                        lightbox.kind === 'piece' ? (
+                            <Button
+                                size="small"
+                                variant="outlined"
+                                onClick={() =>
+                                    navigate(`/pieces/${lightbox.pieceId}`, {
+                                        state: { fromGallery: true },
+                                    })
+                                }
+                                sx={{ color: 'white', borderColor: 'rgba(255,255,255,0.5)' }}
+                            >
+                                Go to the Piece
+                            </Button>
+                        ) : undefined
+                    }
+                />
+            )}
+        </>
     )
 }

--- a/web/src/components/ImageLightbox.tsx
+++ b/web/src/components/ImageLightbox.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import React, { useRef, useState } from 'react'
 import { Box, Button, CircularProgress, IconButton, Modal, Typography } from '@mui/material'
 import type { CaptionedImage } from '@common/types'
 import CloudinaryImage from './CloudinaryImage'
@@ -9,9 +9,10 @@ type ImageLightboxProps = {
     onClose: () => void
     currentThumbnailUrl?: string
     onSetAsThumbnail?: (image: CaptionedImage) => Promise<void>
+    footerActions?: React.ReactNode
 }
 
-export default function ImageLightbox({ images, initialIndex, onClose, currentThumbnailUrl, onSetAsThumbnail }: ImageLightboxProps) {
+export default function ImageLightbox({ images, initialIndex, onClose, currentThumbnailUrl, onSetAsThumbnail, footerActions }: ImageLightboxProps) {
     const [index, setIndex] = useState(initialIndex)
     const [settingThumbnail, setSettingThumbnail] = useState(false)
     const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0
@@ -90,6 +91,11 @@ export default function ImageLightbox({ images, initialIndex, onClose, currentTh
                         >
                             {isCurrentThumbnail ? 'Current thumbnail' : settingThumbnail ? 'Setting…' : 'Set as thumbnail'}
                         </Button>
+                    </Box>
+                )}
+                {footerActions && (
+                    <Box onClick={(e) => e.stopPropagation()}>
+                        {footerActions}
                     </Box>
                 )}
                 {!isTouchDevice && images.length > 1 && (

--- a/web/src/components/__tests__/GlazeCombinationGallery.test.tsx
+++ b/web/src/components/__tests__/GlazeCombinationGallery.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { createMemoryRouter, RouterProvider } from 'react-router-dom'
 import GlazeCombinationGallery from '../GlazeCombinationGallery'
 import * as api from '@common/api'
@@ -9,6 +10,21 @@ import type { GlazeCombinationImageEntry } from '@common/types'
 vi.mock('../CloudinaryImage', () => ({
     default: ({ url, alt }: { url: string; alt?: string }) => (
         <img src={url} alt={alt ?? ''} />
+    ),
+}))
+
+// Stub out ImageLightbox to keep lightbox tests simple.
+vi.mock('../ImageLightbox', () => ({
+    default: ({ images, footerActions, onClose }: {
+        images: { url: string }[]
+        footerActions?: React.ReactNode
+        onClose: () => void
+    }) => (
+        <div data-testid="lightbox">
+            <img src={images[0].url} alt="lightbox-image" />
+            {footerActions}
+            <button onClick={onClose}>Close</button>
+        </div>
     ),
 }))
 
@@ -64,7 +80,10 @@ const MOCK_COMBO_ENTRY: GlazeCombinationImageEntry = {
 
 function renderGallery() {
     const router = createMemoryRouter(
-        [{ path: '/', element: <GlazeCombinationGallery /> }],
+        [
+            { path: '/', element: <GlazeCombinationGallery /> },
+            { path: '/pieces/:id', element: <div data-testid="piece-detail" /> },
+        ],
         { initialEntries: ['/'] }
     )
     return render(<RouterProvider router={router} />)
@@ -128,12 +147,34 @@ describe('GlazeCombinationGallery', () => {
             })
         })
 
-        it('wraps each thumbnail in a link to the piece detail page', async () => {
+        it('opens a lightbox with a Go to the Piece button when a piece image is clicked', async () => {
             renderGallery()
-            await waitFor(() => {
-                const link = screen.getByRole('link', { name: /Tall Mug/i })
-                expect(link).toHaveAttribute('href', '/pieces/piece-1')
-            })
+            await waitFor(() => screen.getByRole('img', { name: /Tall Mug/i }))
+            await userEvent.click(screen.getByRole('button', { name: /Tall Mug/i }))
+            await waitFor(() => expect(screen.getByTestId('lightbox')).toBeInTheDocument())
+            expect(screen.getByRole('button', { name: /Go to the Piece/i })).toBeInTheDocument()
+        })
+
+        it('closes the lightbox when the close button is clicked', async () => {
+            renderGallery()
+            await waitFor(() => screen.getByRole('img', { name: /Tall Mug/i }))
+            await userEvent.click(screen.getByRole('button', { name: /Tall Mug/i }))
+            await waitFor(() => screen.getByTestId('lightbox'))
+            await userEvent.click(screen.getByRole('button', { name: /Close/i }))
+            await waitFor(() =>
+                expect(screen.queryByTestId('lightbox')).not.toBeInTheDocument()
+            )
+        })
+
+        it('navigates to the piece detail page when Go to the Piece is clicked', async () => {
+            renderGallery()
+            await waitFor(() => screen.getByRole('img', { name: /Tall Mug/i }))
+            await userEvent.click(screen.getByRole('button', { name: /Tall Mug/i }))
+            await waitFor(() => screen.getByTestId('lightbox'))
+            await userEvent.click(screen.getByRole('button', { name: /Go to the Piece/i }))
+            await waitFor(() =>
+                expect(screen.getByTestId('piece-detail')).toBeInTheDocument()
+            )
         })
     })
 
@@ -152,6 +193,22 @@ describe('GlazeCombinationGallery', () => {
                 const tileImg = screen.getByRole('img', { name: 'Ash ! Shino' })
                 expect(tileImg).toHaveAttribute('src', 'https://example.com/tile.jpg')
             })
+        })
+
+        it('opens a lightbox without a Go to Piece button when the test tile is clicked', async () => {
+            const entryWithTile: GlazeCombinationImageEntry = {
+                ...MOCK_COMBO_ENTRY,
+                glaze_combination: {
+                    ...MOCK_COMBO_ENTRY.glaze_combination,
+                    test_tile_image: 'https://example.com/tile.jpg',
+                } as any,
+            }
+            vi.mocked(api.fetchGlazeCombinationImages).mockResolvedValue([entryWithTile])
+            renderGallery()
+            await waitFor(() => screen.getByRole('button', { name: /View test tile/i }))
+            await userEvent.click(screen.getByRole('button', { name: /View test tile/i }))
+            await waitFor(() => expect(screen.getByTestId('lightbox')).toBeInTheDocument())
+            expect(screen.queryByRole('button', { name: /Go to the Piece/i })).not.toBeInTheDocument()
         })
     })
 

--- a/web/src/pages/PieceDetailPage.tsx
+++ b/web/src/pages/PieceDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useParams } from 'react-router-dom'
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { Box, Button, CircularProgress, Typography } from '@mui/material'
 import { fetchPiece } from '@common/api'
 import { useAsync } from '../util/useAsync'
@@ -8,6 +8,8 @@ import type { PieceDetail } from '@common/types'
 export default function PieceDetailPage() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
+  const location = useLocation()
+  const fromGallery = (location.state as { fromGallery?: boolean } | null)?.fromGallery === true
   // id is always defined — this component is only rendered via the /pieces/:id route
   const { data: piece, loading, error, setData: setPiece } = useAsync<PieceDetail>(
     () => fetchPiece(id!),
@@ -17,8 +19,12 @@ export default function PieceDetailPage() {
   return (
     <>
       <Box sx={{ mb: 2, textAlign: 'left' }}>
-        <Button variant="text" onClick={() => navigate('/')} sx={{ px: 0 }}>
-          ← Back to Pieces
+        <Button
+          variant="text"
+          onClick={() => navigate(fromGallery ? '/analyze' : '/')}
+          sx={{ px: 0 }}
+        >
+          {fromGallery ? '← Back to Gallery' : '← Back to Pieces'}
         </Button>
       </Box>
       {loading && (

--- a/web/src/pages/__tests__/PieceDetailPage.test.tsx
+++ b/web/src/pages/__tests__/PieceDetailPage.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import PieceDetailPage from '../PieceDetailPage'
+import * as api from '@common/api'
+import type { PieceDetail } from '@common/types'
+
+vi.mock('@common/api', async (importOriginal) => {
+    const actual = await importOriginal<typeof api>()
+    return {
+        ...actual,
+        fetchPiece: vi.fn(),
+    }
+})
+
+vi.mock('../../components/PieceDetail', () => ({
+    default: () => <div data-testid="piece-detail-component" />,
+}))
+
+const MOCK_PIECE: PieceDetail = {
+    id: 'piece-1',
+    name: 'Tall Mug',
+    created: new Date('2024-01-01T00:00:00Z'),
+    last_modified: new Date('2024-01-02T00:00:00Z'),
+    thumbnail: '/thumbnails/question-mark.svg',
+    current_state: {
+        state: 'designed',
+        notes: '',
+        created: new Date('2024-01-01T00:00:00Z'),
+        last_modified: new Date('2024-01-01T00:00:00Z'),
+        images: [],
+        additional_fields: {},
+        previous_state: null,
+        next_state: null,
+    },
+    history: [],
+} as unknown as PieceDetail
+
+function renderPage(fromGallery = false) {
+    const router = createMemoryRouter(
+        [
+            { path: '/pieces/:id', element: <PieceDetailPage /> },
+            { path: '/', element: <div data-testid="pieces-page" /> },
+            { path: '/analyze', element: <div data-testid="analyze-page" /> },
+        ],
+        {
+            initialEntries: [
+                {
+                    pathname: '/pieces/piece-1',
+                    state: fromGallery ? { fromGallery: true } : null,
+                },
+            ],
+        }
+    )
+    return render(<RouterProvider router={router} />)
+}
+
+describe('PieceDetailPage', () => {
+    beforeEach(() => {
+        vi.mocked(api.fetchPiece).mockResolvedValue(MOCK_PIECE)
+    })
+
+    it('shows Back to Pieces button by default', async () => {
+        renderPage()
+        await waitFor(() =>
+            expect(screen.getByRole('button', { name: /Back to Pieces/i })).toBeInTheDocument()
+        )
+    })
+
+    it('shows Back to Gallery button when navigated from gallery', async () => {
+        renderPage(true)
+        await waitFor(() =>
+            expect(screen.getByRole('button', { name: /Back to Gallery/i })).toBeInTheDocument()
+        )
+    })
+})


### PR DESCRIPTION
## Summary

- Clicking a test-tile image in the `GlazeCombinationGallery` card header opens an `ImageLightbox` showing the full-size image.
- Clicking a piece image thumbnail opens an `ImageLightbox` with a **"Go to the Piece"** button in the footer; the button navigates to `/pieces/<id>` and passes `fromGallery: true` in router state.
- `PieceDetailPage` reads `fromGallery` from `location.state` and shows **"← Back to Gallery"** (navigating to `/analyze`) instead of "← Back to Pieces" when the user arrived from the gallery.
- `ImageLightbox` gains a generic `footerActions?: ReactNode` prop so callers can inject footer buttons without coupling the lightbox to navigation concerns.

## Test plan

- [ ] `gz_test_web` passes (275 tests).
- [ ] Open the Analyze tab, click a test-tile avatar → lightbox opens with no "Go to the Piece" button.
- [ ] Click a piece thumbnail → lightbox opens with a "Go to the Piece" button; clicking it lands on the piece detail page.
- [ ] On the piece detail page, verify "← Back to Gallery" is shown and returns to `/analyze`.
- [ ] Navigate to a piece directly (not via gallery) → "← Back to Pieces" is shown.

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)
