### PR TITLE
feat: combine all piece images per glaze combination in gallery lightbox

### DIFF
--- a/web/src/components/GlazeCombinationGallery.tsx
+++ b/web/src/components/GlazeCombinationGallery.tsx
@@ -9,8 +9,9 @@
  * Each card header shows the combination name, a test-tile thumbnail if
  * available, and a chip for each constituent glaze type.
  * The card body is a horizontally scrollable row of CloudinaryImage
- * thumbnails. Clicking any thumbnail opens an ImageLightbox; piece thumbnails
- * include a "Go to the Piece" button in the lightbox footer.
+ * thumbnails. Clicking any thumbnail opens an ImageLightbox that shows all
+ * images for the combination across every piece; the footer "Go to the Piece"
+ * button reflects whichever piece owns the currently-displayed image.
  */
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
@@ -38,9 +39,16 @@ const EMPTY_STATE_MESSAGE =
 
 type PieceEntry = GlazeCombinationImageEntry['pieces'][number]
 
+// A CaptionedImage tagged with the piece it came from.
+interface GalleryImage extends CaptionedImage {
+    pieceId: string
+    pieceName: string
+    pieceState: string
+}
+
 type LightboxState =
     | { kind: 'tile'; images: CaptionedImage[]; initialIndex: 0 }
-    | { kind: 'piece'; images: CaptionedImage[]; initialIndex: number; pieceId: string }
+    | { kind: 'piece'; images: GalleryImage[]; initialIndex: number }
 
 // ---------------------------------------------------------------------------
 // Sub-components
@@ -66,25 +74,24 @@ function TileAvatarButton({ url, name, onClick }: TileAvatarButtonProps) {
 }
 
 interface PieceImageButtonProps {
-    piece: PieceEntry
     img: CaptionedImage
-    imgIdx: number
-    onClick: (piece: PieceEntry, imgIdx: number) => void
+    label: string
+    onClick: () => void
 }
 
-function PieceImageButton({ piece, img, imgIdx, onClick }: PieceImageButtonProps) {
+function PieceImageButton({ img, label, onClick }: PieceImageButtonProps) {
     return (
-        <Tooltip title={`${piece.name} — ${formatState(piece.state)}`} placement="top">
+        <Tooltip title={label} placement="top">
             <Box
                 component="button"
-                onClick={() => onClick(piece, imgIdx)}
+                onClick={onClick}
                 sx={{ flexShrink: 0, display: 'inline-flex', background: 'none', border: 'none', padding: 0, cursor: 'pointer' }}
-                aria-label={`${piece.name} — ${formatState(piece.state)}`}
+                aria-label={label}
             >
                 <CloudinaryImage
                     url={img.url}
                     cloudinary_public_id={img.cloudinary_public_id}
-                    alt={`${piece.name} — ${formatState(piece.state)}`}
+                    alt={label}
                     context="preview"
                 />
             </Box>
@@ -96,10 +103,19 @@ interface ComboCardProps {
     combo: GlazeCombinationEntry
     pieces: PieceEntry[]
     onTileClick: (url: string, name: string) => void
-    onPieceImageClick: (piece: PieceEntry, imgIdx: number) => void
+    onPieceImageClick: (images: GalleryImage[], idx: number) => void
 }
 
 function ComboCard({ combo, pieces, onTileClick, onPieceImageClick }: ComboCardProps) {
+    const galleryImages: GalleryImage[] = pieces.flatMap((piece) =>
+        piece.images.map((img) => ({
+            ...img,
+            pieceId: piece.id,
+            pieceName: piece.name,
+            pieceState: piece.state,
+        }))
+    )
+
     return (
         <Card variant="outlined">
             <CardHeader
@@ -117,17 +133,14 @@ function ComboCard({ combo, pieces, onTileClick, onPieceImageClick }: ComboCardP
             />
             <CardContent sx={{ pt: 0 }}>
                 <Box sx={{ display: 'flex', flexDirection: 'row', overflowX: 'auto', gap: 1, pb: 1 }}>
-                    {pieces.map((piece) =>
-                        piece.images.map((img, imgIdx) => (
-                            <PieceImageButton
-                                key={`${piece.id}-${imgIdx}`}
-                                piece={piece}
-                                img={img}
-                                imgIdx={imgIdx}
-                                onClick={onPieceImageClick}
-                            />
-                        ))
-                    )}
+                    {galleryImages.map((gi, idx) => (
+                        <PieceImageButton
+                            key={`${gi.pieceId}-${idx}`}
+                            img={gi}
+                            label={`${gi.pieceName} — ${formatState(gi.pieceState)}`}
+                            onClick={() => onPieceImageClick(galleryImages, idx)}
+                        />
+                    ))}
                 </Box>
             </CardContent>
         </Card>
@@ -173,8 +186,8 @@ export default function GlazeCombinationGallery() {
         })
     }
 
-    function handlePieceImageClick(piece: PieceEntry, imgIdx: number) {
-        setLightbox({ kind: 'piece', images: piece.images, initialIndex: imgIdx, pieceId: piece.id })
+    function handlePieceImageClick(images: GalleryImage[], idx: number) {
+        setLightbox({ kind: 'piece', images, initialIndex: idx })
     }
 
     return (
@@ -195,18 +208,18 @@ export default function GlazeCombinationGallery() {
                     images={lightbox.images}
                     initialIndex={lightbox.initialIndex}
                     onClose={() => setLightbox(null)}
-                    footerActions={
-                        lightbox.kind === 'piece' ? (
+                    footerActions={lightbox.kind === 'piece'
+                        ? (i) => (
                             <Button
                                 size="small"
                                 variant="outlined"
-                                onClick={() => navigate(`/pieces/${lightbox.pieceId}`, { state: { fromGallery: true } })}
+                                onClick={() => navigate(`/pieces/${lightbox.images[i].pieceId}`, { state: { fromGallery: true } })}
                                 sx={{ color: 'white', borderColor: 'rgba(255,255,255,0.5)' }}
                             >
                                 Go to the Piece
                             </Button>
-                        ) : undefined
-                    }
+                        )
+                        : undefined}
                 />
             )}
         </>

--- a/web/src/components/ImageLightbox.tsx
+++ b/web/src/components/ImageLightbox.tsx
@@ -9,7 +9,7 @@ type ImageLightboxProps = {
     onClose: () => void
     currentThumbnailUrl?: string
     onSetAsThumbnail?: (image: CaptionedImage) => Promise<void>
-    footerActions?: React.ReactNode
+    footerActions?: (index: number) => React.ReactNode
 }
 
 export default function ImageLightbox({ images, initialIndex, onClose, currentThumbnailUrl, onSetAsThumbnail, footerActions }: ImageLightboxProps) {
@@ -95,7 +95,7 @@ export default function ImageLightbox({ images, initialIndex, onClose, currentTh
                 )}
                 {footerActions && (
                     <Box onClick={(e) => e.stopPropagation()}>
-                        {footerActions}
+                        {footerActions(index)}
                     </Box>
                 )}
                 {!isTouchDevice && images.length > 1 && (

--- a/web/src/components/__tests__/GlazeCombinationGallery.test.tsx
+++ b/web/src/components/__tests__/GlazeCombinationGallery.test.tsx
@@ -14,15 +14,17 @@ vi.mock('../CloudinaryImage', () => ({
 }))
 
 // Stub out ImageLightbox to keep lightbox tests simple.
+// footerActions is a function of the current index; the stub calls it with 0.
 vi.mock('../ImageLightbox', () => ({
-    default: ({ images, footerActions, onClose }: {
+    default: ({ images, initialIndex, footerActions, onClose }: {
         images: { url: string }[]
-        footerActions?: React.ReactNode
+        initialIndex: number
+        footerActions?: (index: number) => React.ReactNode
         onClose: () => void
     }) => (
         <div data-testid="lightbox">
-            <img src={images[0].url} alt="lightbox-image" />
-            {footerActions}
+            <img src={images[initialIndex ?? 0].url} alt="lightbox-image" />
+            {footerActions?.(initialIndex ?? 0)}
             <button onClick={onClose}>Close</button>
         </div>
     ),
@@ -213,27 +215,28 @@ describe('GlazeCombinationGallery', () => {
     })
 
     describe('with multiple pieces and images', () => {
+        const multiEntry: GlazeCombinationImageEntry = {
+            ...MOCK_COMBO_ENTRY,
+            pieces: [
+                {
+                    id: 'piece-1',
+                    name: 'Mug',
+                    state: 'glaze_fired',
+                    images: [
+                        { ...MOCK_IMAGE, url: 'https://example.com/mug.jpg' },
+                        { ...MOCK_IMAGE, url: 'https://example.com/mug2.jpg' },
+                    ],
+                },
+                {
+                    id: 'piece-2',
+                    name: 'Bowl',
+                    state: 'completed',
+                    images: [{ ...MOCK_IMAGE, url: 'https://example.com/bowl.jpg' }],
+                },
+            ],
+        }
+
         it('renders thumbnails for each image across all pieces', async () => {
-            const multiEntry: GlazeCombinationImageEntry = {
-                ...MOCK_COMBO_ENTRY,
-                pieces: [
-                    {
-                        id: 'piece-1',
-                        name: 'Mug',
-                        state: 'glaze_fired',
-                        images: [
-                            { ...MOCK_IMAGE, url: 'https://example.com/mug.jpg' },
-                            { ...MOCK_IMAGE, url: 'https://example.com/mug2.jpg' },
-                        ],
-                    },
-                    {
-                        id: 'piece-2',
-                        name: 'Bowl',
-                        state: 'completed',
-                        images: [{ ...MOCK_IMAGE, url: 'https://example.com/bowl.jpg' }],
-                    },
-                ],
-            }
             vi.mocked(api.fetchGlazeCombinationImages).mockResolvedValue([multiEntry])
             renderGallery()
             await waitFor(() => {
@@ -241,6 +244,30 @@ describe('GlazeCombinationGallery', () => {
                     img.getAttribute('src')?.includes('example.com')
                 )).toHaveLength(3) // tile img absent, 2 mug + 1 bowl
             })
+        })
+
+        it('opens the combination-wide gallery starting at the clicked image', async () => {
+            vi.mocked(api.fetchGlazeCombinationImages).mockResolvedValue([multiEntry])
+            renderGallery()
+            // Click the bowl image (index 2 in the flat gallery)
+            await waitFor(() => screen.getByRole('button', { name: /Bowl/i }))
+            await userEvent.click(screen.getByRole('button', { name: /Bowl/i }))
+            await waitFor(() => {
+                const lightboxImg = screen.getByAltText('lightbox-image')
+                expect(lightboxImg).toHaveAttribute('src', 'https://example.com/bowl.jpg')
+            })
+        })
+
+        it('Go to the Piece navigates to the piece that owns the current image', async () => {
+            vi.mocked(api.fetchGlazeCombinationImages).mockResolvedValue([multiEntry])
+            renderGallery()
+            await waitFor(() => screen.getByRole('button', { name: /Bowl/i }))
+            await userEvent.click(screen.getByRole('button', { name: /Bowl/i }))
+            await waitFor(() => screen.getByTestId('lightbox'))
+            await userEvent.click(screen.getByRole('button', { name: /Go to the Piece/i }))
+            await waitFor(() =>
+                expect(screen.getByTestId('piece-detail')).toBeInTheDocument()
+            )
         })
     })
 


### PR DESCRIPTION
## Summary

Follow-up to #150. Previously clicking a piece thumbnail in the `GlazeCombinationGallery` opened a lightbox scoped only to that piece's images. This PR changes the lightbox to show all images for the glaze combination across every piece in one unified gallery.

- Clicking any piece thumbnail now opens a lightbox over the full combination image set, starting at the clicked image.
- The **"Go to the Piece"** footer button is index-aware: it links to the piece that owns whichever image is currently displayed, updating as the user pages left/right.
- `ImageLightbox.footerActions` changed from `ReactNode` to `(index: number) => ReactNode` to support this.

## Test plan

- [ ] `gz_test_web` passes (277 tests).
- [ ] Gallery with a combination used on multiple pieces: clicking any thumbnail opens the full combined gallery at the right starting image.
- [ ] Navigate left/right in the lightbox; confirm "Go to the Piece" updates to match the current image's piece.
- [ ] Test tile click still opens a single-image lightbox with no "Go to the Piece" button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
