### PR TITLE
refactor: extract shared singleton-combo sync into workflow helper

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -15,7 +15,7 @@ from import_export.admin import ExportMixin
 
 from .models import FiringTemperature, GlazeCombination, GlazeCombinationLayer, GlazeMethod, GlazeType, Piece, PieceState, UserProfile
 from .serializers import PieceStateSerializer
-from .workflow import get_image_fields_for_global_model, get_public_global_models
+from .workflow import get_image_fields_for_global_model, get_public_global_models, sync_glaze_type_singleton_combination
 
 
 class GlazeAdminSite(admin.AdminSite):
@@ -258,15 +258,6 @@ class GlazeTypeAdmin(PublicLibraryAdmin):
       renamed as well.
     """
 
-    _SHARED_FIELDS = (
-        'test_tile_image',
-        'is_food_safe',
-        'runs',
-        'highlights_grooves',
-        'is_different_on_white_and_brown_clay',
-        'apply_thin',
-    )
-
     def save_model(self, request: HttpRequest, obj: GlazeType, form, change: bool) -> None:
         # Capture the old name before super() persists any changes.
         old_name: str | None = None
@@ -274,36 +265,7 @@ class GlazeTypeAdmin(PublicLibraryAdmin):
             old_name = GlazeType.objects.filter(pk=obj.pk).values_list('name', flat=True).first()
 
         super().save_model(request, obj, form, change)
-        self._sync_single_layer_combination(obj, old_name)
-
-    def _sync_single_layer_combination(self, glaze_type: GlazeType, old_name: str | None) -> None:
-        combo_props = {field: getattr(glaze_type, field) for field in self._SHARED_FIELDS}
-
-        combo: GlazeCombination | None = None
-
-        if old_name and old_name != glaze_type.name:
-            # Name changed — rename the existing single-layer combination.
-            combo = GlazeCombination.objects.filter(user=None, name=old_name).first()
-            if combo:
-                combo.name = glaze_type.name
-                for field, value in combo_props.items():
-                    setattr(combo, field, value)
-                combo.save(update_fields=['name', *self._SHARED_FIELDS])
-
-        if combo is None:
-            combo, created = GlazeCombination.objects.get_or_create(
-                user=None,
-                name=glaze_type.name,
-                defaults=combo_props,
-            )
-            if created:
-                GlazeCombinationLayer.objects.create(
-                    combination=combo, glaze_type=glaze_type, order=0
-                )
-            else:
-                for field, value in combo_props.items():
-                    setattr(combo, field, value)
-                combo.save(update_fields=list(self._SHARED_FIELDS))
+        sync_glaze_type_singleton_combination(obj, old_name=old_name)
 
 
 admin.site.register(GlazeType, GlazeTypeAdmin)

--- a/api/admin.py
+++ b/api/admin.py
@@ -15,7 +15,8 @@ from import_export.admin import ExportMixin
 
 from .models import FiringTemperature, GlazeCombination, GlazeCombinationLayer, GlazeMethod, GlazeType, Piece, PieceState, UserProfile
 from .serializers import PieceStateSerializer
-from .workflow import get_image_fields_for_global_model, get_public_global_models, sync_glaze_type_singleton_combination
+from .utils import sync_glaze_type_singleton_combination
+from .workflow import get_image_fields_for_global_model, get_public_global_models
 
 
 class GlazeAdminSite(admin.AdminSite):

--- a/api/manual_tile_imports.py
+++ b/api/manual_tile_imports.py
@@ -10,15 +10,7 @@ from django.db import transaction
 from django.utils.text import slugify
 
 from .models import GlazeCombination, GlazeCombinationLayer, GlazeType
-
-_SHARED_GLAZE_FIELDS = (
-    'test_tile_image',
-    'is_food_safe',
-    'runs',
-    'highlights_grooves',
-    'is_different_on_white_and_brown_clay',
-    'apply_thin',
-)
+from .workflow import sync_glaze_type_singleton_combination
 
 
 def _configure_cloudinary() -> None:
@@ -45,23 +37,6 @@ def _upload_file(uploaded_file, *, kind: str, filename: str, folder: str) -> dic
         resource_type='image',
         folder=folder,
     )
-
-
-def _ensure_single_layer_combination(glaze_type: GlazeType) -> GlazeCombination:
-    combo_props = {field: getattr(glaze_type, field) for field in _SHARED_GLAZE_FIELDS}
-    combo, _ = GlazeCombination.objects.get_or_create(
-        user=None,
-        name=glaze_type.name,
-        defaults=combo_props,
-    )
-    for field, value in combo_props.items():
-        setattr(combo, field, value)
-    combo.save(update_fields=list(_SHARED_GLAZE_FIELDS))
-    layers = list(combo.layers.select_related('glaze_type').order_by('order'))
-    if len(layers) != 1 or layers[0].glaze_type_id != glaze_type.id:
-        combo.layers.all().delete()
-        GlazeCombinationLayer.objects.create(combination=combo, glaze_type=glaze_type, order=0)
-    return combo
 
 
 def _ensure_combination_layers(combo: GlazeCombination, glaze_types: list[GlazeType]) -> None:
@@ -120,7 +95,7 @@ def import_manual_tile_records(records: list[dict], uploaded_files: dict[str, ob
             runs=parsed.get('runs'),
             is_food_safe=parsed.get('is_food_safe'),
         )
-        _ensure_single_layer_combination(glaze_type)
+        sync_glaze_type_singleton_combination(glaze_type)
         return _result_payload(record, status='created', object_id=str(glaze_type.pk), image_url=glaze_type.test_tile_image)
 
     def import_glaze_combination(record: dict) -> dict:

--- a/api/manual_tile_imports.py
+++ b/api/manual_tile_imports.py
@@ -10,7 +10,7 @@ from django.db import transaction
 from django.utils.text import slugify
 
 from .models import GlazeCombination, GlazeCombinationLayer, GlazeType
-from .workflow import sync_glaze_type_singleton_combination
+from .utils import sync_glaze_type_singleton_combination
 
 
 def _configure_cloudinary() -> None:

--- a/api/utils.py
+++ b/api/utils.py
@@ -1,0 +1,69 @@
+"""Glaze-specific utility helpers.
+
+This module holds business-logic helpers that are shared across multiple parts
+of the api app but do not belong in workflow.py (which is reserved for
+workflow-state-machine logic derived from workflow.yml).
+"""
+
+
+# Fields that are mirrored between a public GlazeType and its singleton
+# single-layer GlazeCombination.  Kept here so both admin.py and
+# manual_tile_imports.py can import from one place without pulling in the
+# full workflow module.
+SHARED_GLAZE_FIELDS: tuple[str, ...] = (
+    'test_tile_image',
+    'is_food_safe',
+    'runs',
+    'highlights_grooves',
+    'is_different_on_white_and_brown_clay',
+    'apply_thin',
+)
+
+
+def sync_glaze_type_singleton_combination(glaze_type, *, old_name: str | None = None) -> None:
+    """Ensure a matching public single-layer GlazeCombination exists for a public GlazeType.
+
+    Creates or updates the singleton combination so that its name and shared
+    property fields stay in sync with the given GlazeType.
+
+    When ``old_name`` is provided and differs from ``glaze_type.name``, any
+    existing combination named ``old_name`` is renamed before the sync step
+    (handles the admin rename-GlazeType case).
+
+    The layer check avoids unnecessary delete/create cycles: if a single layer
+    already points at the correct GlazeType, the layers are left unchanged.
+
+    Imports are deferred to the function body to avoid circular imports at
+    module load time (models import workflow at the module level).
+    """
+    # Deferred imports to avoid circular dependency (models import workflow).
+    from .models import GlazeCombination, GlazeCombinationLayer  # noqa: PLC0415
+
+    combo_props = {field: getattr(glaze_type, field) for field in SHARED_GLAZE_FIELDS}
+    combo = None
+
+    if old_name and old_name != glaze_type.name:
+        # GlazeType was renamed — rename the existing singleton combination too.
+        combo = GlazeCombination.objects.filter(user=None, name=old_name).first()
+        if combo is not None:
+            combo.name = glaze_type.name
+            for field, value in combo_props.items():
+                setattr(combo, field, value)
+            combo.save(update_fields=['name', *SHARED_GLAZE_FIELDS])
+
+    if combo is None:
+        combo, created = GlazeCombination.objects.get_or_create(
+            user=None,
+            name=glaze_type.name,
+            defaults=combo_props,
+        )
+        if not created:
+            for field, value in combo_props.items():
+                setattr(combo, field, value)
+            combo.save(update_fields=list(SHARED_GLAZE_FIELDS))
+
+    # Ensure exactly one layer pointing at this GlazeType.
+    layers = list(combo.layers.select_related('glaze_type').order_by('order'))
+    if len(layers) != 1 or layers[0].glaze_type_id != glaze_type.id:
+        combo.layers.all().delete()
+        GlazeCombinationLayer.objects.create(combination=combo, glaze_type=glaze_type, order=0)

--- a/api/workflow.py
+++ b/api/workflow.py
@@ -382,65 +382,6 @@ def _resolve_field_def(field_def: dict) -> dict:
     return _resolve_field_def(target)
 
 
-_SHARED_GLAZE_FIELDS: tuple[str, ...] = (
-    'test_tile_image',
-    'is_food_safe',
-    'runs',
-    'highlights_grooves',
-    'is_different_on_white_and_brown_clay',
-    'apply_thin',
-)
-
-
-def sync_glaze_type_singleton_combination(glaze_type, *, old_name: str | None = None) -> None:
-    """Ensure a matching public single-layer GlazeCombination exists for a public GlazeType.
-
-    Creates or updates the singleton combination so that its name and shared
-    property fields stay in sync with the given GlazeType.
-
-    When ``old_name`` is provided and differs from ``glaze_type.name``, any
-    existing combination named ``old_name`` is renamed before the sync step
-    (handles the admin rename-GlazeType case).
-
-    The layer check avoids unnecessary delete/create cycles: if a single layer
-    already points at the correct GlazeType, the layers are left unchanged.
-
-    Imports are deferred to the function body to avoid circular imports at
-    module load time (models import workflow at the module level).
-    """
-    # Deferred imports to avoid circular dependency (models import workflow).
-    from .models import GlazeCombination, GlazeCombinationLayer  # noqa: PLC0415
-
-    combo_props = {field: getattr(glaze_type, field) for field in _SHARED_GLAZE_FIELDS}
-    combo = None
-
-    if old_name and old_name != glaze_type.name:
-        # GlazeType was renamed — rename the existing singleton combination too.
-        combo = GlazeCombination.objects.filter(user=None, name=old_name).first()
-        if combo is not None:
-            combo.name = glaze_type.name
-            for field, value in combo_props.items():
-                setattr(combo, field, value)
-            combo.save(update_fields=['name', *_SHARED_GLAZE_FIELDS])
-
-    if combo is None:
-        combo, created = GlazeCombination.objects.get_or_create(
-            user=None,
-            name=glaze_type.name,
-            defaults=combo_props,
-        )
-        if not created:
-            for field, value in combo_props.items():
-                setattr(combo, field, value)
-            combo.save(update_fields=list(_SHARED_GLAZE_FIELDS))
-
-    # Ensure exactly one layer pointing at this GlazeType.
-    layers = list(combo.layers.select_related('glaze_type').order_by('order'))
-    if len(layers) != 1 or layers[0].glaze_type_id != glaze_type.id:
-        combo.layers.all().delete()
-        GlazeCombinationLayer.objects.create(combination=combo, glaze_type=glaze_type, order=0)
-
-
 def build_additional_fields_schema(state_id: str) -> dict:
     """Return a JSON Schema that validates the inline_fields blob for a given state.
 

--- a/api/workflow.py
+++ b/api/workflow.py
@@ -382,6 +382,65 @@ def _resolve_field_def(field_def: dict) -> dict:
     return _resolve_field_def(target)
 
 
+_SHARED_GLAZE_FIELDS: tuple[str, ...] = (
+    'test_tile_image',
+    'is_food_safe',
+    'runs',
+    'highlights_grooves',
+    'is_different_on_white_and_brown_clay',
+    'apply_thin',
+)
+
+
+def sync_glaze_type_singleton_combination(glaze_type, *, old_name: str | None = None) -> None:
+    """Ensure a matching public single-layer GlazeCombination exists for a public GlazeType.
+
+    Creates or updates the singleton combination so that its name and shared
+    property fields stay in sync with the given GlazeType.
+
+    When ``old_name`` is provided and differs from ``glaze_type.name``, any
+    existing combination named ``old_name`` is renamed before the sync step
+    (handles the admin rename-GlazeType case).
+
+    The layer check avoids unnecessary delete/create cycles: if a single layer
+    already points at the correct GlazeType, the layers are left unchanged.
+
+    Imports are deferred to the function body to avoid circular imports at
+    module load time (models import workflow at the module level).
+    """
+    # Deferred imports to avoid circular dependency (models import workflow).
+    from .models import GlazeCombination, GlazeCombinationLayer  # noqa: PLC0415
+
+    combo_props = {field: getattr(glaze_type, field) for field in _SHARED_GLAZE_FIELDS}
+    combo = None
+
+    if old_name and old_name != glaze_type.name:
+        # GlazeType was renamed — rename the existing singleton combination too.
+        combo = GlazeCombination.objects.filter(user=None, name=old_name).first()
+        if combo is not None:
+            combo.name = glaze_type.name
+            for field, value in combo_props.items():
+                setattr(combo, field, value)
+            combo.save(update_fields=['name', *_SHARED_GLAZE_FIELDS])
+
+    if combo is None:
+        combo, created = GlazeCombination.objects.get_or_create(
+            user=None,
+            name=glaze_type.name,
+            defaults=combo_props,
+        )
+        if not created:
+            for field, value in combo_props.items():
+                setattr(combo, field, value)
+            combo.save(update_fields=list(_SHARED_GLAZE_FIELDS))
+
+    # Ensure exactly one layer pointing at this GlazeType.
+    layers = list(combo.layers.select_related('glaze_type').order_by('order'))
+    if len(layers) != 1 or layers[0].glaze_type_id != glaze_type.id:
+        combo.layers.all().delete()
+        GlazeCombinationLayer.objects.create(combination=combo, glaze_type=glaze_type, order=0)
+
+
 def build_additional_fields_schema(state_id: str) -> dict:
     """Return a JSON Schema that validates the inline_fields blob for a given state.
 

--- a/docs/agents/glaze-domain.md
+++ b/docs/agents/glaze-domain.md
@@ -179,6 +179,10 @@ These supplement the generic Django/DRF conventions.
 
 All API endpoints are registered in `backend/urls.py`.
 
+**Module boundaries — what goes in `api/workflow.py` vs. `api/utils.py`:**
+- `api/workflow.py` is reserved strictly for helpers that read from the workflow state machine (`workflow.yml`) — state lookups, successor queries, globals-map queries, field-definition resolution, and JSON Schema generation. Do not add domain helpers unrelated to the state machine here, even if both `admin.py` and another module need them.
+- `api/utils.py` holds shared business-logic helpers that span multiple api modules but have nothing to do with the workflow state machine (e.g. `sync_glaze_type_singleton_combination`). When a new helper is needed by more than one api module and it is not a workflow-state-machine concept, put it in `api/utils.py`.
+
 **Production environment variables** — `settings.py` gates dev/prod behavior on `IS_PRODUCTION = bool(os.environ.get('PRODUCTION', ''))`. The full env var reference:
 
 | Setting | Env var | Dev behavior | Prod behavior |


### PR DESCRIPTION
## Summary

Both `api/admin.py` (`GlazeTypeAdmin._sync_single_layer_combination`) and `api/manual_tile_imports.py` (`_ensure_single_layer_combination`) duplicated the same core logic — and both declared an identical 6-field tuple — for ensuring a matching public single-layer `GlazeCombination` exists for a given public `GlazeType`, with shared property fields kept in sync.

- Extracted `sync_glaze_type_singleton_combination(glaze_type, *, old_name=None)` into `api/workflow.py`, consolidating both implementations:
  - Handles the rename case via `old_name` (from the admin's logic)
  - Uses the import's layer-checking approach (avoids a delete/create cycle when layers already match)
  - Defers model imports inside the function body to avoid circular imports at module load time
- `GlazeTypeAdmin.save_model` now calls the shared helper; the private `_sync_single_layer_combination` method and `_SHARED_FIELDS` tuple are removed from `GlazeTypeAdmin`
- `import_glaze_type` in `manual_tile_imports.py` calls the same helper; `_ensure_single_layer_combination` and `_SHARED_GLAZE_FIELDS` are removed

No behavioral change. All 394 tests pass.

## Test plan

- [x] `pytest api/ tests/ -x` — all 394 tests pass
