### PR TITLE
[codex] Start PieceDetail redesign: Autosaving components

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -368,6 +368,8 @@ class PieceStateCreateSerializer(serializers.ModelSerializer):
         global_ref_pks: dict[str, str] = {}
         for field_name, value in incoming.items():
             if field_name in global_ref_fields:
+                if value in (None, ''):
+                    continue
                 global_ref_pks[field_name] = str(value)
             else:
                 inline_fields[field_name] = value
@@ -412,12 +414,24 @@ class PieceStateCreateSerializer(serializers.ModelSerializer):
         return piece_state
 
 
-def _write_global_ref_rows(piece_state: PieceState, global_ref_fields: dict[str, str], global_ref_pks: dict[str, str]) -> None:
+def _write_global_ref_rows(
+    piece_state: PieceState,
+    global_ref_fields: dict[str, str],
+    global_ref_pks: dict[str, str],
+    clear_fields: set[str] | None = None,
+) -> None:
     """Create or update junction table rows for global ref fields.
 
     ``global_ref_pks`` maps field_name → PK string supplied by the client.
     Raises ``serializers.ValidationError`` if a supplied PK does not exist.
     """
+    clear_fields = clear_fields or set()
+    for field_name in clear_fields:
+        global_name = global_ref_fields[field_name]
+        config = get_global_config(global_name)
+        ref_model_cls = apps.get_model('api', f'PieceState{config["model"]}Ref')
+        ref_model_cls.objects.filter(piece_state=piece_state, field_name=field_name).delete()
+
     for field_name, pk_str in global_ref_pks.items():
         global_name = global_ref_fields[field_name]
         config = get_global_config(global_name)
@@ -467,8 +481,12 @@ class PieceStateUpdateSerializer(serializers.Serializer):
             # Separate incoming dict into inline fields and global-ref PKs.
             inline_fields: dict = {}
             global_ref_pks: dict[str, str] = {}
+            clear_global_ref_fields: set[str] = set()
             for field_name, value in incoming.items():
                 if field_name in global_ref_fields:
+                    if value in (None, ''):
+                        clear_global_ref_fields.add(field_name)
+                        continue
                     global_ref_pks[field_name] = str(value)
                 else:
                     inline_fields[field_name] = value
@@ -478,7 +496,7 @@ class PieceStateUpdateSerializer(serializers.Serializer):
                 instance.save()
             except ValueError as exc:
                 raise serializers.ValidationError({'additional_fields': str(exc)}) from exc
-            _write_global_ref_rows(instance, global_ref_fields, global_ref_pks)
+            _write_global_ref_rows(instance, global_ref_fields, global_ref_pks, clear_global_ref_fields)
         else:
             try:
                 instance.save()

--- a/api/tests/test_patch_current_state.py
+++ b/api/tests/test_patch_current_state.py
@@ -1,8 +1,9 @@
 import uuid
 
 import pytest
+from django.apps import apps
 
-from api.models import ENTRY_STATE, SUCCESSORS
+from api.models import ENTRY_STATE, SUCCESSORS, GlazeCombination, GlazeType
 
 # ---------------------------------------------------------------------------
 # PATCH /api/pieces/{id}/state/
@@ -113,6 +114,32 @@ class TestPatchCurrentState:
             format='json',
         )
         assert response.status_code == 400
+
+    def test_null_global_ref_additional_field_clears_junction_row(self, client, piece):
+        glaze = GlazeType.objects.create(user=None, name='Iron Red')
+        combo, _ = GlazeCombination.get_or_create_with_components(user=None, glaze_types=[glaze])
+        state = piece.current_state
+        state.state = 'glazed'
+        state.save()
+        ref_model = apps.get_model('api', 'PieceStateGlazeCombinationRef')
+        ref_model.objects.create(
+            piece_state=state,
+            field_name='glaze_combination',
+            glaze_combination=combo,
+        )
+
+        response = client.patch(
+            f'/api/pieces/{piece.id}/state/',
+            {'additional_fields': {'glaze_combination': None}},
+            format='json',
+        )
+
+        assert response.status_code == 200
+        assert 'glaze_combination' not in response.json()['current_state']['additional_fields']
+        assert not ref_model.objects.filter(
+            piece_state=state,
+            field_name='glaze_combination',
+        ).exists()
 
     def test_cannot_patch_past_state_via_endpoint(self, client, piece):
         """Transitioning seals the old state; PATCH endpoint targets the new current state."""

--- a/docs/agents/dev.md
+++ b/docs/agents/dev.md
@@ -135,6 +135,15 @@ Run from the repo root with the venv active. There is no Bazel-integrated auto-f
 
 Prefer Bazel targets — they match CI exactly and benefit from incremental caching:
 
+Before running a granular Bazel test after adding or importing new source files,
+check that the target's source slice includes the new dependencies. Use
+`rtk bazel query 'labels(srcs, <library-target>)'` (for example,
+`rtk bazel query 'labels(srcs, //web:workflow_state_src)'`) to inspect the
+files currently included, then add any missing component files or helper modules
+to the appropriate `BUILD.bazel` `js_library` before rerunning the test. Use
+`rtk bazel query 'deps(<test-target>)'` only when the relevant source library is
+not obvious.
+
 ```bash
 # Workflow schema validation
 rtk bazel test //tests:...

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -304,7 +304,11 @@ js_library(
 
 js_library(
     name = "workflow_state_src",
-    srcs = ["src/components/WorkflowState.tsx"],
+    srcs = [
+        "src/components/AutosaveStatus.tsx",
+        "src/components/WorkflowState.tsx",
+        "src/components/useAutosave.ts",
+    ],
     deps = [
         ":cloudinary_image_src",
         ":generated_types",
@@ -552,6 +556,7 @@ test_suite(
         ":web_piece_list_test",
         ":web_primitive_test",
         ":web_tag_test",
+        ":web_workflow_state_test",
         ":workflow_test",
     ],
 )

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -223,6 +223,17 @@ js_library(
     ],
 )
 
+js_library(
+    name = "autosave_src",
+    srcs = [
+        "src/components/AutosaveStatus.tsx",
+        "src/components/useAutosave.ts",
+    ],
+    deps = [
+        ":node_modules",
+    ],
+)
+
 # Tag components: TagAutocomplete and TagChipList depend on TagChip; CreateTagDialog depends on tagPalette.
 js_library(
     name = "tag_src",
@@ -247,6 +258,7 @@ js_library(
         "src/components/GlobalFieldPicker.tsx",
     ],
     deps = [
+        ":autosave_src",
         ":cloudinary_image_src",
         ":generated_types",
         ":node_modules",
@@ -305,11 +317,10 @@ js_library(
 js_library(
     name = "workflow_state_src",
     srcs = [
-        "src/components/AutosaveStatus.tsx",
         "src/components/WorkflowState.tsx",
-        "src/components/useAutosave.ts",
     ],
     deps = [
+        ":autosave_src",
         ":cloudinary_image_src",
         ":generated_types",
         ":global_picker_src",

--- a/web/src/components/AutosaveStatus.tsx
+++ b/web/src/components/AutosaveStatus.tsx
@@ -1,0 +1,77 @@
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
+import PendingIcon from "@mui/icons-material/Pending";
+import SyncIcon from "@mui/icons-material/Sync";
+import { Box, CircularProgress, Typography } from "@mui/material";
+import type React from "react";
+import type { AutosaveStatus as AutosaveStatusValue } from "./useAutosave";
+
+type AutosaveStatusProps = {
+  status: AutosaveStatusValue;
+  error?: string | null;
+  lastSavedAt?: Date | null;
+};
+
+function formatSavedTime(date: Date | null | undefined): string {
+  if (!date) return "Saved";
+  return `Saved ${date.toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+  })}`;
+}
+
+export default function AutosaveStatus({
+  status,
+  error,
+  lastSavedAt,
+}: AutosaveStatusProps) {
+  const statusConfig = {
+    idle: {
+      label: "All changes saved",
+      color: "text.secondary",
+      icon: <CheckCircleIcon fontSize="small" />,
+    },
+    pending: {
+      label: "Saving soon",
+      color: "warning.main",
+      icon: <PendingIcon fontSize="small" />,
+    },
+    saving: {
+      label: "Saving",
+      color: "primary.main",
+      icon: <CircularProgress size={16} color="inherit" />,
+    },
+    saved: {
+      label: formatSavedTime(lastSavedAt),
+      color: "success.main",
+      icon: <CheckCircleIcon fontSize="small" />,
+    },
+    error: {
+      label: error ?? "Autosave failed",
+      color: "error.main",
+      icon: <ErrorOutlineIcon fontSize="small" />,
+    },
+  } satisfies Record<
+    AutosaveStatusValue,
+    { label: string; color: string; icon: React.ReactNode }
+  >;
+  const config = statusConfig[status];
+
+  return (
+    <Box
+      data-testid="autosave-status"
+      role="status"
+      aria-live="polite"
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 0.75,
+        minHeight: 32,
+        color: config.color,
+      }}
+    >
+      {status === "pending" ? <SyncIcon fontSize="small" /> : config.icon}
+      <Typography variant="body2">{config.label}</Typography>
+    </Box>
+  );
+}

--- a/web/src/components/GlobalEntryPicker.tsx
+++ b/web/src/components/GlobalEntryPicker.tsx
@@ -33,6 +33,8 @@ import {
   type GlobalPickerFilter,
 } from "../util/workflow";
 import CloudinaryImage from "./CloudinaryImage";
+import AutosaveStatus from "./AutosaveStatus";
+import type { AutosaveStatus as AutosaveStatusValue } from "./useAutosave";
 
 export interface GlobalEntryPickerProps {
   globalName: string;
@@ -122,6 +124,9 @@ export default function GlobalEntryPicker({
     Record<string, NamedRef[]>
   >({});
   const [togglingId, setTogglingId] = useState<string | null>(null);
+  const [saveStatus, setSaveStatus] = useState<AutosaveStatusValue>("idle");
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
 
   // Fetch autocomplete options for each related-filter global when the dialog opens.
   useEffect(() => {
@@ -189,6 +194,8 @@ export default function GlobalEntryPicker({
 
   async function handleToggleFavorite(entry: GenericGlobalEntry) {
     setTogglingId(entry.id);
+    setSaveStatus("saving");
+    setSaveError(null);
     try {
       await toggleGlobalEntryFavorite(globalName, entry.id, !entry.is_favorite);
       setEntries((prev) =>
@@ -196,6 +203,11 @@ export default function GlobalEntryPicker({
           e.id === entry.id ? { ...e, is_favorite: !e.is_favorite } : e,
         ),
       );
+      setLastSavedAt(new Date());
+      setSaveStatus("saved");
+    } catch {
+      setSaveError("Failed to update favorite. Please try again.");
+      setSaveStatus("error");
     } finally {
       setTogglingId(null);
     }
@@ -488,6 +500,13 @@ export default function GlobalEntryPicker({
         )}
       </DialogContent>
       <DialogActions>
+        {saveStatus !== "idle" && (
+          <AutosaveStatus
+            status={saveStatus}
+            error={saveError}
+            lastSavedAt={lastSavedAt}
+          />
+        )}
         <Button onClick={handleClose}>Cancel</Button>
       </DialogActions>
     </Dialog>

--- a/web/src/components/GlobalFieldPicker.tsx
+++ b/web/src/components/GlobalFieldPicker.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import Autocomplete, { createFilterOptions } from "@mui/material/Autocomplete";
-import { CircularProgress, IconButton, TextField } from "@mui/material";
+import { Box, CircularProgress, IconButton, TextField } from "@mui/material";
 import type { SxProps, Theme } from "@mui/material";
 import StarIcon from "@mui/icons-material/Star";
 import StarBorderIcon from "@mui/icons-material/StarBorder";
@@ -17,6 +17,8 @@ import {
   parseCreateOption,
   stripPublicSuffix,
 } from "./globalFieldPickerUtils";
+import AutosaveStatus from "./AutosaveStatus";
+import type { AutosaveStatus as AutosaveStatusValue } from "./useAutosave";
 
 // Pre-built filter; module-level to avoid reconstruction on every render.
 const FILTER = createFilterOptions<string>();
@@ -106,6 +108,8 @@ export default function GlobalFieldPicker({
   const isFavoritable = isFavoritableGlobal(globalName);
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [saveStatus, setSaveStatus] = useState<AutosaveStatusValue>("idle");
+  const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
   // Tracks what is shown in the text field while the user is typing.
   // Separate from `value` so that partially-typed text is never committed.
   const [inputValue, setInputValue] = useState(value);
@@ -184,9 +188,16 @@ export default function GlobalFieldPicker({
     if (!selectedEntry || togglingFavorite) return;
     const newFav = !getEffectiveFavorite(selectedEntry);
     setTogglingFavorite(true);
+    setSaveStatus("saving");
+    setError(null);
     try {
       await toggleGlobalEntryFavorite(globalName, selectedEntry.id, newFav);
       setLocalFavorites((prev) => ({ ...prev, [selectedEntry.id]: newFav }));
+      setLastSavedAt(new Date());
+      setSaveStatus("saved");
+    } catch {
+      setError("Failed to update favorite. Please try again.");
+      setSaveStatus("error");
     } finally {
       setTogglingFavorite(false);
     }
@@ -194,6 +205,8 @@ export default function GlobalFieldPicker({
 
   async function handleChange(displayOption: string | null) {
     if (!displayOption) {
+      setSaveStatus("idle");
+      setError(null);
       onChange("");
       onSelectEntry?.(null);
       return;
@@ -201,6 +214,7 @@ export default function GlobalFieldPicker({
     const createValue = parseCreateOption(displayOption);
     if (createValue) {
       setCreating(true);
+      setSaveStatus("saving");
       setError(null);
       try {
         const created = await createGlobalEntry(
@@ -219,10 +233,13 @@ export default function GlobalFieldPicker({
         }
         onChange(created.name);
         onSelectEntry?.(created);
+        setLastSavedAt(new Date());
+        setSaveStatus("saved");
         // Newly created entries are never auto-favorited; the user
         // hasn't expressed a preference yet.
       } catch {
         setError(`Failed to create ${label.toLowerCase()}. Please try again.`);
+        setSaveStatus("error");
       } finally {
         setCreating(false);
       }
@@ -230,6 +247,8 @@ export default function GlobalFieldPicker({
     }
     // Strip display suffix before emitting the raw name.
     const rawName = stripPublicSuffix(displayOption);
+    setSaveStatus("idle");
+    setError(null);
     onChange(rawName);
     if (onSelectEntry) {
       const entry = entries.find((e) => e.name === rawName) ?? null;
@@ -243,7 +262,8 @@ export default function GlobalFieldPicker({
     : false;
 
   return (
-    <Autocomplete
+    <Box sx={sx}>
+      <Autocomplete
       freeSolo={canCreate}
       options={displayOptions}
       inputValue={inputValue}
@@ -277,8 +297,7 @@ export default function GlobalFieldPicker({
           {...params}
           label={label}
           fullWidth
-          sx={sx}
-          helperText={error ?? fetchError ?? helperText ?? ""}
+          helperText={fetchError ?? (error ? undefined : helperText) ?? ""}
           error={Boolean(error) || Boolean(fetchError)}
           required={required}
           slotProps={{
@@ -315,6 +334,14 @@ export default function GlobalFieldPicker({
           }}
         />
       )}
-    />
+      />
+      {saveStatus !== "idle" && (
+        <AutosaveStatus
+          status={saveStatus}
+          error={error}
+          lastSavedAt={lastSavedAt}
+        />
+      )}
+    </Box>
   );
 }

--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -114,12 +114,12 @@ function normalizeAdditionalFieldPayload(
   defs: ResolvedAdditionalField[],
   inputs: AdditionalFieldInputMap,
   globalRefPks: GlobalRefPkMap,
-): Record<string, string | number | boolean> {
-  const payload: Record<string, string | number | boolean> = {};
+): Record<string, string | number | boolean | null> {
+  const payload: Record<string, string | number | boolean | null> = {};
   defs.forEach((def) => {
     if (def.isGlobalRef) {
       const pk = globalRefPks[def.name];
-      if (pk) payload[def.name] = pk;
+      payload[def.name] = pk || null;
       return;
     }
     const raw = inputs[def.name];

--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTheme } from "@mui/material";
 import {
   Box,
@@ -31,6 +31,8 @@ import {
 } from "../util/workflow";
 import GlobalFieldPicker from "./GlobalFieldPicker";
 import GlobalEntryPicker from "./GlobalEntryPicker";
+import AutosaveStatus from "./AutosaveStatus";
+import { useAutosave } from "./useAutosave";
 
 type WorkflowStateProps = {
   pieceState: PieceState;
@@ -39,6 +41,7 @@ type WorkflowStateProps = {
   onDirtyChange?: (dirty: boolean) => void;
   currentLocation?: string;
   currentThumbnail?: import("../util/types").Thumbnail | null;
+  autosaveDelayMs?: number;
 };
 
 type ImageEntry = {
@@ -170,6 +173,7 @@ export default function WorkflowState({
   onDirtyChange,
   currentLocation: currentLocationProp = "",
   currentThumbnail,
+  autosaveDelayMs,
 }: WorkflowStateProps) {
   const [notes, setNotes] = useState(pieceState.notes);
   const [images, setImages] = useState<ImageEntry[]>(stateImages(pieceState));
@@ -179,8 +183,6 @@ export default function WorkflowState({
     null,
   );
   const [editingCaptionValue, setEditingCaptionValue] = useState("");
-  const [saving, setSaving] = useState(false);
-  const [saveError, setSaveError] = useState<string | null>(null);
   const [currentLocation, setCurrentLocation] = useState(currentLocationProp);
   const additionalFieldDefs = useMemo(
     () => getAdditionalFieldDefinitions(pieceState.state),
@@ -270,30 +272,46 @@ export default function WorkflowState({
     onDirtyChange?.(isDirty);
   }, [isDirty, onDirtyChange]);
 
-  async function handleSave() {
-    setSaving(true);
-    setSaveError(null);
-    try {
-      const payload = {
-        notes,
-        images, // always in sync with server after each image operation
-        additional_fields: normalizedAdditionalFields,
-      };
-      const result = await updateCurrentState(pieceId, payload);
-      let finalResult = result;
-      if (locationDirty) {
-        const updated = await updatePiece(pieceId, {
-          current_location: currentLocation.trim() || undefined,
-        });
-        finalResult = updated;
-      }
-      onSaved(finalResult);
-    } catch {
-      setSaveError("Failed to save. Please try again.");
-    } finally {
-      setSaving(false);
+  const saveWorkflowState = useCallback(async () => {
+    const payload = {
+      notes,
+      images, // always in sync with server after each image operation
+      additional_fields: normalizedAdditionalFields,
+    };
+    const result = await updateCurrentState(pieceId, payload);
+    let finalResult = result;
+    if (locationDirty) {
+      finalResult = await updatePiece(pieceId, {
+        current_location: currentLocation.trim() || undefined,
+      });
     }
-  }
+    onSaved(finalResult);
+  }, [
+    currentLocation,
+    images,
+    locationDirty,
+    normalizedAdditionalFields,
+    notes,
+    onSaved,
+    pieceId,
+  ]);
+  const autosaveKey = useMemo(
+    () =>
+      JSON.stringify({
+        notes,
+        images,
+        additional_fields: normalizedAdditionalFields,
+        current_location: currentLocation.trim(),
+      }),
+    [currentLocation, images, normalizedAdditionalFields, notes],
+  );
+
+  const autosave = useAutosave({
+    dirty: isDirty,
+    saveKey: autosaveKey,
+    save: saveWorkflowState,
+    delayMs: autosaveDelayMs,
+  });
 
   async function removeImage(index: number) {
     if (!window.confirm("Remove this image?")) return;
@@ -695,35 +713,11 @@ export default function WorkflowState({
         </Box>
       )}
 
-      {/* Save controls */}
-      {saveError && (
-        <Typography color="error" variant="body2">
-          {saveError}
-        </Typography>
-      )}
-      <Box sx={{ display: "flex", alignItems: "center" }}>
-        <Button
-          variant="contained"
-          color="primary"
-          onClick={handleSave}
-          disabled={saving || !isDirty}
-          data-testid="save-button"
-          startIcon={
-            saving ? <CircularProgress size={16} color="inherit" /> : undefined
-          }
-        >
-          Save
-        </Button>
-        {isDirty && (
-          <Typography
-            variant="body2"
-            sx={{ color: "warning.main" }}
-            data-testid="unsaved-indicator"
-          >
-            Unsaved changes
-          </Typography>
-        )}
-      </Box>
+      <AutosaveStatus
+        status={autosave.status}
+        error={autosave.error}
+        lastSavedAt={autosave.lastSavedAt}
+      />
       {/* Images */}
       <Box>
         {images.length > 0 && (

--- a/web/src/components/__tests__/GlobalEntryPicker.test.tsx
+++ b/web/src/components/__tests__/GlobalEntryPicker.test.tsx
@@ -192,6 +192,35 @@ describe("GlobalEntryPicker (glaze_combination)", () => {
       );
     });
 
+    it("shows saved status after favoriting", async () => {
+      render(<GlobalEntryPicker {...defaultProps} />);
+      await waitFor(() =>
+        expect(screen.getByLabelText("Add to favorites")).toBeInTheDocument(),
+      );
+      await userEvent.click(screen.getByLabelText("Add to favorites"));
+      await waitFor(() =>
+        expect(screen.getByTestId("autosave-status")).toHaveTextContent(
+          "Saved",
+        ),
+      );
+    });
+
+    it("shows autosave status when favorite update fails", async () => {
+      vi.mocked(api.toggleGlobalEntryFavorite).mockRejectedValue(
+        new Error("Network error"),
+      );
+      render(<GlobalEntryPicker {...defaultProps} />);
+      await waitFor(() =>
+        expect(screen.getByLabelText("Add to favorites")).toBeInTheDocument(),
+      );
+      await userEvent.click(screen.getByLabelText("Add to favorites"));
+      await waitFor(() =>
+        expect(screen.getByTestId("autosave-status")).toHaveTextContent(
+          "Failed to update favorite. Please try again.",
+        ),
+      );
+    });
+
     it("calls toggleGlobalEntryFavorite with false when unfavoriting", async () => {
       vi.mocked(api.fetchGlobalEntriesWithFilters).mockResolvedValue([
         makeCombo({ is_favorite: true }),

--- a/web/src/components/__tests__/GlobalFieldPicker.test.tsx
+++ b/web/src/components/__tests__/GlobalFieldPicker.test.tsx
@@ -62,6 +62,7 @@ function Controlled(props: Partial<GlobalFieldPickerProps>) {
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(api.fetchGlobalEntries).mockResolvedValue([]);
+  vi.mocked(api.toggleGlobalEntryFavorite).mockResolvedValue(undefined);
 });
 
 describe("GlobalFieldPicker", () => {
@@ -268,6 +269,29 @@ describe("GlobalFieldPicker", () => {
       );
       await waitFor(() =>
         expect(screen.getByLabelText("Location")).toHaveValue("New Studio"),
+      );
+    });
+
+    it("shows saved status after creating an entry", async () => {
+      vi.mocked(api.createGlobalEntry).mockResolvedValue({
+        id: "new-id",
+        name: "New Studio",
+        isPublic: false,
+      });
+      render(<Controlled canCreate />);
+      await userEvent.type(screen.getByLabelText("Location"), "New Studio");
+      await waitFor(() =>
+        expect(
+          screen.getByRole("option", { name: 'Create "New Studio"' }),
+        ).toBeInTheDocument(),
+      );
+      fireEvent.click(
+        screen.getByRole("option", { name: 'Create "New Studio"' }),
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId("autosave-status")).toHaveTextContent(
+          "Saved",
+        ),
       );
     });
 
@@ -538,6 +562,45 @@ describe("GlobalFieldPicker", () => {
           "glaze_combination",
           "id-Iron Red",
           true,
+        ),
+      );
+    });
+
+    it("shows saved status after toggling favorite", async () => {
+      await act(async () => {
+        render(
+          <GlobalFieldPicker
+            {...favoritableProps}
+            value="Iron Red"
+            options={[entry("Iron Red", false, false)]}
+          />,
+        );
+      });
+      await userEvent.click(screen.getByLabelText("Add to favorites"));
+      await waitFor(() =>
+        expect(screen.getByTestId("autosave-status")).toHaveTextContent(
+          "Saved",
+        ),
+      );
+    });
+
+    it("shows autosave status when favorite update fails", async () => {
+      vi.mocked(api.toggleGlobalEntryFavorite).mockRejectedValue(
+        new Error("Network error"),
+      );
+      await act(async () => {
+        render(
+          <GlobalFieldPicker
+            {...favoritableProps}
+            value="Iron Red"
+            options={[entry("Iron Red", false, false)]}
+          />,
+        );
+      });
+      await userEvent.click(screen.getByLabelText("Add to favorites"));
+      await waitFor(() =>
+        expect(screen.getByTestId("autosave-status")).toHaveTextContent(
+          "Failed to update favorite. Please try again.",
         ),
       );
     });

--- a/web/src/components/__tests__/PieceDetail.test.tsx
+++ b/web/src/components/__tests__/PieceDetail.test.tsx
@@ -155,7 +155,6 @@ describe("PieceDetail", () => {
       ),
     );
     await waitFor(() => expect(input).toHaveValue("Studio K"));
-    fireEvent.click(screen.getByTestId("save-button"));
     await waitFor(() =>
       expect(api.updatePiece).toHaveBeenCalledWith("piece-id-1", {
         current_location: "Studio K",
@@ -182,7 +181,6 @@ describe("PieceDetail", () => {
     );
     fireEvent.click(screen.getByRole("option", { name: "Studio 7" }));
     await waitFor(() => expect(input).toHaveValue("Studio 7"));
-    fireEvent.click(screen.getByTestId("save-button"));
     await waitFor(() =>
       expect(api.updatePiece).toHaveBeenCalledWith("piece-id-1", {
         current_location: "Studio 7",

--- a/web/src/components/__tests__/WorkflowState.test.tsx
+++ b/web/src/components/__tests__/WorkflowState.test.tsx
@@ -820,6 +820,14 @@ describe("WorkflowState", () => {
     });
 
     it("clears the selected value when the chip cancel icon is clicked", async () => {
+      vi.mocked(api.updateCurrentState).mockResolvedValue(
+        makePieceDetail({
+          current_state: makeState({
+            state: "glazed",
+            additional_fields: {},
+          }),
+        }),
+      );
       const glazedState = makeState({
         state: "glazed",
         additional_fields: {
@@ -841,6 +849,16 @@ describe("WorkflowState", () => {
       expect(
         screen.getByRole("button", { name: "Browse…" }),
       ).toBeInTheDocument();
+      await waitFor(() =>
+        expect(api.updateCurrentState).toHaveBeenCalledWith(
+          "test-piece-id",
+          expect.objectContaining({
+            additional_fields: expect.objectContaining({
+              glaze_combination: null,
+            }),
+          }),
+        ),
+      );
     });
 
     it("opens GlobalEntryPicker when Browse button is clicked", async () => {

--- a/web/src/components/__tests__/WorkflowState.test.tsx
+++ b/web/src/components/__tests__/WorkflowState.test.tsx
@@ -75,6 +75,7 @@ const defaultProps = {
   pieceId: "test-piece-id",
   onSaved: vi.fn(),
   onDirtyChange: vi.fn(),
+  autosaveDelayMs: 0,
 };
 
 const noop = () => {};
@@ -304,8 +305,6 @@ describe("WorkflowState", () => {
       resolveCreate({ id: "new-id", name: "New Shelf", isPublic: false }),
     );
     await waitFor(() => expect(input).toHaveValue("New Shelf"));
-    expect(api.updatePiece).not.toHaveBeenCalled();
-    fireEvent.click(screen.getByTestId("save-button"));
     await waitFor(() =>
       expect(api.updatePiece).toHaveBeenCalledWith("test-piece-id", {
         current_location: "New Shelf",
@@ -313,18 +312,20 @@ describe("WorkflowState", () => {
     );
   });
 
-  it("renders a Save button", async () => {
+  it("renders an autosave status", async () => {
     await act(async () => {
       render(<WorkflowState {...defaultProps} />);
     });
-    expect(screen.getByTestId("save-button")).toBeInTheDocument();
+    expect(screen.getByTestId("autosave-status")).toHaveTextContent(
+      "All changes saved",
+    );
   });
 
-  it("Save button is disabled when no changes", async () => {
+  it("does not save when there are no changes", async () => {
     await act(async () => {
       render(<WorkflowState {...defaultProps} />);
     });
-    expect(screen.getByTestId("save-button")).toBeDisabled();
+    expect(api.updateCurrentState).not.toHaveBeenCalled();
   });
 
   it("shows notes from pieceState", async () => {
@@ -339,31 +340,37 @@ describe("WorkflowState", () => {
     expect(screen.getByLabelText("Notes")).toHaveValue("Some notes");
   });
 
-  it("Save button enabled after editing notes", async () => {
+  it("shows pending autosave after editing notes", async () => {
     await act(async () => {
       render(<WorkflowState {...defaultProps} />);
     });
     fireEvent.change(screen.getByLabelText("Notes"), {
       target: { value: "New notes" },
     });
-    expect(screen.getByTestId("save-button")).not.toBeDisabled();
+    expect(screen.getByTestId("autosave-status")).toHaveTextContent(
+      "Saving soon",
+    );
   });
 
-  it("shows unsaved indicator after editing", async () => {
+  it("shows autosave activity after editing", async () => {
     await act(async () => {
       render(<WorkflowState {...defaultProps} />);
     });
     fireEvent.change(screen.getByLabelText("Notes"), {
       target: { value: "Changed" },
     });
-    expect(screen.getByTestId("unsaved-indicator")).toBeInTheDocument();
+    expect(screen.getByTestId("autosave-status")).toHaveTextContent(
+      "Saving soon",
+    );
   });
 
-  it("no unsaved indicator when not dirty", async () => {
+  it("shows saved status when not dirty", async () => {
     await act(async () => {
       render(<WorkflowState {...defaultProps} />);
     });
-    expect(screen.queryByTestId("unsaved-indicator")).not.toBeInTheDocument();
+    expect(screen.getByTestId("autosave-status")).toHaveTextContent(
+      "All changes saved",
+    );
   });
 
   it("calls onSaved after successful save", async () => {
@@ -374,7 +381,6 @@ describe("WorkflowState", () => {
     fireEvent.change(screen.getByLabelText("Notes"), {
       target: { value: "New notes" },
     });
-    fireEvent.click(screen.getByTestId("save-button"));
     await waitFor(() => expect(onSaved).toHaveBeenCalledWith(updated));
   });
 
@@ -386,10 +392,9 @@ describe("WorkflowState", () => {
     fireEvent.change(screen.getByLabelText("Notes"), {
       target: { value: "New notes" },
     });
-    fireEvent.click(screen.getByTestId("save-button"));
     await waitFor(() =>
       expect(
-        screen.getByText("Failed to save. Please try again."),
+        screen.getByText("Autosave failed. Your changes are still here."),
       ).toBeInTheDocument(),
     );
   });
@@ -402,14 +407,14 @@ describe("WorkflowState", () => {
     fireEvent.change(screen.getByLabelText("Notes"), {
       target: { value: "Dirty notes" },
     });
-    fireEvent.click(screen.getByTestId("save-button"));
     await waitFor(() =>
       expect(
-        screen.getByText("Failed to save. Please try again."),
+        screen.getByText("Autosave failed. Your changes are still here."),
       ).toBeInTheDocument(),
     );
-    expect(screen.getByTestId("unsaved-indicator")).toBeInTheDocument();
-    expect(screen.getByTestId("save-button")).not.toBeDisabled();
+    expect(screen.getByTestId("autosave-status")).toHaveTextContent(
+      "Autosave failed",
+    );
   });
 
   it("remains dirty when piece API fails during save", async () => {
@@ -429,14 +434,14 @@ describe("WorkflowState", () => {
     );
     fireEvent.click(screen.getByRole("option", { name: "Shelf Z" }));
     await waitFor(() => expect(input).toHaveValue("Shelf Z"));
-    await userEvent.click(screen.getByTestId("save-button"));
     await waitFor(() =>
       expect(
-        screen.getByText("Failed to save. Please try again."),
+        screen.getByText("Autosave failed. Your changes are still here."),
       ).toBeInTheDocument(),
     );
-    expect(screen.getByTestId("unsaved-indicator")).toBeInTheDocument();
-    expect(screen.getByTestId("save-button")).not.toBeDisabled();
+    expect(screen.getByTestId("autosave-status")).toHaveTextContent(
+      "Autosave failed",
+    );
     expect(api.updatePiece).toHaveBeenCalledWith("test-piece-id", {
       current_location: "Shelf Z",
     });

--- a/web/src/components/useAutosave.ts
+++ b/web/src/components/useAutosave.ts
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type AutosaveStatus = "idle" | "pending" | "saving" | "saved" | "error";
+
+type UseAutosaveOptions = {
+  dirty: boolean;
+  saveKey: string;
+  save: () => Promise<void>;
+  delayMs?: number;
+};
+
+type UseAutosaveResult = {
+  status: AutosaveStatus;
+  error: string | null;
+  lastSavedAt: Date | null;
+  saveNow: () => Promise<void>;
+};
+
+const DEFAULT_AUTOSAVE_DELAY_MS = 700;
+
+export function useAutosave({
+  dirty,
+  saveKey,
+  save,
+  delayMs = DEFAULT_AUTOSAVE_DELAY_MS,
+}: UseAutosaveOptions): UseAutosaveResult {
+  const [status, setStatus] = useState<AutosaveStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
+  const [lastSavedKey, setLastSavedKey] = useState<string | null>(null);
+  const [failedKey, setFailedKey] = useState<string | null>(null);
+  const saveRef = useRef(save);
+  const runIdRef = useRef(0);
+
+  useEffect(() => {
+    saveRef.current = save;
+  }, [save]);
+
+  const saveNow = useCallback(async () => {
+    if (!dirty) {
+      setError(null);
+      return;
+    }
+    const runId = runIdRef.current + 1;
+    runIdRef.current = runId;
+    setStatus("saving");
+    setError(null);
+    try {
+      await saveRef.current();
+      if (runIdRef.current !== runId) return;
+      setLastSavedKey(saveKey);
+      setFailedKey(null);
+      setLastSavedAt(new Date());
+      setStatus("saved");
+    } catch {
+      if (runIdRef.current !== runId) return;
+      setFailedKey(saveKey);
+      setStatus("error");
+      setError("Autosave failed. Your changes are still here.");
+    }
+  }, [dirty, saveKey]);
+
+  useEffect(() => {
+    if (!dirty) return;
+
+    const timeoutId = window.setTimeout(() => {
+      void saveNow();
+    }, delayMs);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [delayMs, dirty, saveNow]);
+
+  let displayStatus: AutosaveStatus = lastSavedAt ? "saved" : "idle";
+  if (dirty) {
+    if (status === "saving") {
+      displayStatus = "saving";
+    } else if (failedKey === saveKey) {
+      displayStatus = "error";
+    } else if (lastSavedKey === saveKey) {
+      displayStatus = "saved";
+    } else {
+      displayStatus = "pending";
+    }
+  }
+
+  return { status: displayStatus, error, lastSavedAt, saveNow };
+}

--- a/web/src/util/api.ts
+++ b/web/src/util/api.ts
@@ -221,7 +221,7 @@ export type AddStatePayload = {
   state: State;
   notes?: string;
   images?: Wire<CaptionedImage>[];
-  additional_fields?: Record<string, string | number | boolean>;
+  additional_fields?: Record<string, string | number | boolean | null>;
 };
 
 export async function addPieceState(
@@ -242,7 +242,7 @@ export type UpdateStatePayload = {
     caption: string;
     cloudinary_public_id?: string | null;
   }>;
-  additional_fields?: Record<string, string | number | boolean>;
+  additional_fields?: Record<string, string | number | boolean | null>;
 };
 
 export async function updateCurrentState(


### PR DESCRIPTION
## Summary
Add debounced autosave for the current PieceDetail workflow-state editor as the first implementation slice of the broader PieceDetail redesign tracked in #172.

## Scope
- replace the WorkflowState manual Save button with debounced autosave for notes, current location, and state-specific fields
- add reusable autosave status UI for pending, saving, saved, and error states
- keep dirty-state transition blocking in place until the current draft is saved
- update focused WorkflowState and PieceDetail tests for automatic persistence
- document the granular Bazel source-slice check using labels(srcs, ...)

## Related issues
- Closes #169
- Related: #172
- Related: #170
- Related: #163

## Design context
- This keeps the PR aligned with the PieceDetail redesign direction from `PieceDetailA.html`: https://shaoster.github.io/glaze/claude_designs/PieceDetailA.html

## Validation
- `rtk bazel test //web:web_workflow_state_test //web:web_piece_detail_test`
- `rtk bazel build --config=lint //web/...`
