### PR TITLE
[codex] Cleaner dev bootstrap for repo-local worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,8 @@ web/.vite
 .dev-pids/
 .codex
 .codex/
+.agent-worktrees/
+.agent-config/
 
 # Flask stuff:
 instance/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@
 ## Git Worktree Policy
 
 When asked to work on a PR or implement a feature branch, always create a git worktree first using the `EnterWorktree` tool rather than modifying the current branch directly. Ask before proceeding if worktree creation would be inappropriate (e.g. the user explicitly wants to work on the current branch).
+Prefer repo-local worktree roots over system temp directories: use `.agent-worktrees/` under the repo so the worktree stays near the shared repo bootstrap, secrets fallback, and editable files without colliding with tool-reserved paths like `.codex`.
 
 ## Instruction Priority
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ source env.sh
 
 **VS Code / Cursor:** the repo ships a terminal profile in [`.vscode/settings.json`](.vscode/settings.json) that automatically sources `env.sh` in every new integrated terminal — no manual step needed. The venv is activated and `gz_*` helpers are available from the moment the terminal opens.
 
-**AI coding agents (Claude Code, Codex, Cursor agent):** a companion script [`env-agent.sh`](env-agent.sh) provides a silent, lightweight bootstrap (venv activation + `.env.local` loading) for non-interactive shells. Claude Code picks it up via `.claude/settings.json`; Codex and other agents inherit it through `BASH_ENV` when launched from an `env.sh`-sourced terminal. See [`docs/agents/dev.md`](docs/agents/dev.md) for details.
+**AI coding agents (Claude Code, Codex, Cursor agent):** a companion script [`env-agent.sh`](env-agent.sh) provides a silent, lightweight bootstrap (venv activation + `.env.local` loading) for non-interactive shells. Claude Code picks it up via `.claude/settings.json`; Codex and other agents inherit it through `BASH_ENV` when launched from an `env.sh`-sourced terminal. Prefer repo-local worktrees under `.agent-worktrees/...` instead of `/tmp`; the bootstrap detects the active git worktree root automatically and falls back to the main checkout's `.env.local` and `.venv` when the worktree does not have its own yet. `gz_setup` reuses the shared `.venv` and `web/node_modules` by default, and `gz_setup --isolated` creates worktree-local dependency installs when a branch is changing Python or Node packages. Keep repo-local Codex-specific config in `.agent-config/codex/` rather than `.codex`, which may be reserved by the local Codex installation. See [`docs/agents/dev.md`](docs/agents/dev.md) for details.
 
 ### Local secrets and config (git-safe)
 
@@ -136,7 +136,7 @@ The app runs without any credentials — both optional services degrade graceful
 
 | Command    | Description                                                                                                             |
 | ---------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `gz_setup` | First-time setup: creates `.venv`, installs Python + Node deps, runs DB migrations. Installs Node via nvm if not found. |
+| `gz_setup` | Setup helper: reuses shared deps by default in repo-local worktrees, or use `gz_setup --isolated` for fresh worktree-local `.venv` and `web/node_modules`. Also runs DB migrations and installs Node via nvm if needed. |
 
 ### Servers
 

--- a/api/admin.py
+++ b/api/admin.py
@@ -14,7 +14,7 @@ from django.utils.html import format_html
 from import_export import fields, resources
 from import_export.admin import ExportMixin
 
-from .models import (  # type: ignore[attr-defined]
+from .models import (
     FiringTemperature,
     GlazeCombination,
     GlazeCombinationLayer,

--- a/api/models.py
+++ b/api/models.py
@@ -216,10 +216,12 @@ class UserProfile(models.Model):
 # These names are injected into the module namespace by _register_globals().
 # Typed as Any so mypy allows arbitrary attribute access and type annotation use.
 if TYPE_CHECKING:
+    ClayBody: Any
     FiringTemperature: Any
     GlazeCombination: Any
     GlazeCombinationLayer: Any
     FavoriteGlazeCombination: Any
     GlazeType: Any
+    GlazeMethod: Any
     Location: Any
     Tag: Any

--- a/api/tests/test_auth.py
+++ b/api/tests/test_auth.py
@@ -2,123 +2,175 @@ import pytest
 from django.contrib.auth.models import User
 from rest_framework.test import APIClient
 
+from api.models import Piece
+
 
 @pytest.mark.django_db
 class TestAuthEndpoints:
     def test_register_creates_user_and_logs_in(self):
         client = APIClient()
         response = client.post(
-            '/api/auth/register/',
+            "/api/auth/register/",
             {
-                'email': 'newuser@example.com',
-                'password': 'password123',
-                'first_name': 'New',
-                'last_name': 'User',
+                "email": "newuser@example.com",
+                "password": "password123",
+                "first_name": "New",
+                "last_name": "User",
             },
-            format='json',
+            format="json",
         )
         assert response.status_code == 201
         data = response.json()
-        assert data['email'] == 'newuser@example.com'
-        assert data['is_staff'] is False
-        assert User.objects.filter(email='newuser@example.com').exists()
-        me_response = client.get('/api/auth/me/')
+        assert data["email"] == "newuser@example.com"
+        assert data["is_staff"] is False
+        assert User.objects.filter(email="newuser@example.com").exists()
+        me_response = client.get("/api/auth/me/")
         assert me_response.status_code == 200
-        assert me_response.json()['email'] == 'newuser@example.com'
+        assert me_response.json()["email"] == "newuser@example.com"
 
     def test_login_with_email(self):
         User.objects.create_user(
-            username='person@example.com',
-            email='person@example.com',
-            password='password123',
+            username="person@example.com",
+            email="person@example.com",
+            password="password123",
         )
         client = APIClient()
         response = client.post(
-            '/api/auth/login/',
-            {'email': 'person@example.com', 'password': 'password123'},
-            format='json',
+            "/api/auth/login/",
+            {"email": "person@example.com", "password": "password123"},
+            format="json",
         )
         assert response.status_code == 200
-        assert response.json()['email'] == 'person@example.com'
-        assert response.json()['is_staff'] is False
+        assert response.json()["email"] == "person@example.com"
+        assert response.json()["is_staff"] is False
 
     def test_login_rejects_invalid_password(self):
         User.objects.create_user(
-            username='person@example.com',
-            email='person@example.com',
-            password='password123',
+            username="person@example.com",
+            email="person@example.com",
+            password="password123",
         )
         client = APIClient()
         response = client.post(
-            '/api/auth/login/',
-            {'email': 'person@example.com', 'password': 'wrong-password'},
-            format='json',
+            "/api/auth/login/",
+            {"email": "person@example.com", "password": "wrong-password"},
+            format="json",
         )
         assert response.status_code == 400
-        assert response.json() == {'detail': 'Invalid email or password.'}
+        assert response.json() == {"detail": "Invalid email or password."}
 
     def test_logout_clears_session(self):
         user = User.objects.create(
-            username='logout@example.com',
-            email='logout@example.com',
+            username="logout@example.com",
+            email="logout@example.com",
         )
         client = APIClient()
         client.force_authenticate(user=user)
-        response = client.post('/api/auth/logout/', {}, format='json')
+        response = client.post("/api/auth/logout/", {}, format="json")
         assert response.status_code == 204
 
     def test_me_requires_auth(self):
         client = APIClient()
-        response = client.get('/api/auth/me/')
+        response = client.get("/api/auth/me/")
         assert response.status_code == 403
 
     def test_csrf_endpoint_returns_204(self):
         client = APIClient()
-        response = client.get('/api/auth/csrf/')
+        response = client.get("/api/auth/csrf/")
         assert response.status_code == 204
 
     def test_register_rejects_duplicate_email(self):
         User.objects.create_user(
-            username='existing@example.com',
-            email='existing@example.com',
-            password='password123',
+            username="existing@example.com",
+            email="existing@example.com",
+            password="password123",
         )
         client = APIClient()
         response = client.post(
-            '/api/auth/register/',
+            "/api/auth/register/",
             {
-                'email': 'existing@example.com',
-                'password': 'password123',
+                "email": "existing@example.com",
+                "password": "password123",
             },
-            format='json',
+            format="json",
         )
         assert response.status_code == 400
-        assert response.json() == {'email': ['A user with this email already exists.']}
+        assert response.json() == {"email": ["A user with this email already exists."]}
 
     def test_google_auth_returns_503_when_not_configured(self, settings):
-        settings.GOOGLE_OAUTH_CLIENT_ID = ''
+        settings.GOOGLE_OAUTH_CLIENT_ID = ""
         client = APIClient()
         response = client.post(
-            '/api/auth/google/',
-            {'credential': 'fake-token'},
-            format='json',
+            "/api/auth/google/",
+            {"credential": "fake-token"},
+            format="json",
         )
         assert response.status_code == 503
-        assert response.json() == {'detail': 'Google sign-in is not configured on this server.'}
+        assert response.json() == {
+            "detail": "Google sign-in is not configured on this server."
+        }
 
     def test_me_includes_staff_flag(self):
         user = User.objects.create(
-            username='admin@example.com',
-            email='admin@example.com',
+            username="admin@example.com",
+            email="admin@example.com",
             is_staff=True,
         )
         client = APIClient()
         client.force_authenticate(user=user)
-        response = client.get('/api/auth/me/')
+        response = client.get("/api/auth/me/")
         assert response.status_code == 200
-        assert response.json()['is_staff'] is True
+        assert response.json()["is_staff"] is True
 
     def test_data_endpoints_require_auth(self):
         client = APIClient()
-        response = client.get('/api/pieces/')
+        response = client.get("/api/pieces/")
         assert response.status_code == 403
+
+    def test_register_bootstraps_first_dev_user_when_enabled(self, settings):
+        settings.DEV_BOOTSTRAP_ENABLED = True
+
+        client = APIClient()
+        response = client.post(
+            "/api/auth/register/",
+            {
+                "email": "devadmin@example.com",
+                "password": "password123",
+                "first_name": "Dev",
+                "last_name": "Admin",
+            },
+            format="json",
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["is_staff"] is True
+
+        user = User.objects.get(email="devadmin@example.com")
+        assert user.is_staff is True
+        assert user.is_superuser is True
+        assert Piece.objects.filter(user=user).count() == 3
+
+    def test_login_bootstraps_existing_first_dev_user_when_enabled(self, settings):
+        settings.DEV_BOOTSTRAP_ENABLED = True
+
+        user = User.objects.create_user(
+            username="person@example.com",
+            email="person@example.com",
+            password="password123",
+        )
+
+        client = APIClient()
+        response = client.post(
+            "/api/auth/login/",
+            {"email": "person@example.com", "password": "password123"},
+            format="json",
+        )
+
+        assert response.status_code == 200
+        assert response.json()["is_staff"] is True
+
+        user.refresh_from_db()
+        assert user.is_staff is True
+        assert user.is_superuser is True
+        assert Piece.objects.filter(user=user).exists()

--- a/api/tests/test_public_library_commands.py
+++ b/api/tests/test_public_library_commands.py
@@ -1,4 +1,5 @@
 """Tests for the dump_public_library and load_public_library management commands."""
+
 import json
 from io import StringIO
 
@@ -7,94 +8,116 @@ from django.core.management import call_command
 from django.core.management.base import CommandError
 
 from api.models import COMPOSITE_NAME_SEPARATOR, ClayBody, GlazeCombination, GlazeType
+from api.utils import bootstrap_dev_user
 
 
 @pytest.mark.django_db
 class TestDumpPublicLibrary:
     def test_exports_public_clay_bodies(self, tmp_path):
-        ClayBody.objects.create(user=None, name='Stoneware', short_description='A stoneware body')
-        ClayBody.objects.create(user=None, name='Porcelain')
-        output = tmp_path / 'out.json'
+        ClayBody.objects.create(
+            user=None, name="Stoneware", short_description="A stoneware body"
+        )
+        ClayBody.objects.create(user=None, name="Porcelain")
+        output = tmp_path / "out.json"
 
-        call_command('dump_public_library', output=str(output))
+        call_command("dump_public_library", output=str(output))
 
         records = json.loads(output.read_text())
-        clay_records = [r for r in records if r['model'] == 'api.claybody']
-        names = [r['fields']['name'] for r in clay_records]
-        assert 'Stoneware' in names
-        assert 'Porcelain' in names
+        clay_records = [r for r in records if r["model"] == "api.claybody"]
+        names = [r["fields"]["name"] for r in clay_records]
+        assert "Stoneware" in names
+        assert "Porcelain" in names
 
     def test_exports_public_glaze_types(self, tmp_path):
-        GlazeType.objects.create(user=None, name='Celadon', is_food_safe=True)
-        output = tmp_path / 'out.json'
+        GlazeType.objects.create(user=None, name="Celadon", is_food_safe=True)
+        output = tmp_path / "out.json"
 
-        call_command('dump_public_library', output=str(output))
+        call_command("dump_public_library", output=str(output))
 
         records = json.loads(output.read_text())
-        glaze_records = [r for r in records if r['model'] == 'api.glazetype']
+        glaze_records = [r for r in records if r["model"] == "api.glazetype"]
         assert len(glaze_records) == 1
-        assert glaze_records[0]['fields']['name'] == 'Celadon'
-        assert glaze_records[0]['fields']['is_food_safe'] is True
+        assert glaze_records[0]["fields"]["name"] == "Celadon"
+        assert glaze_records[0]["fields"]["is_food_safe"] is True
 
     def test_excludes_private_objects(self, tmp_path, django_user_model):
-        user = django_user_model.objects.create(username='user@example.com')
-        ClayBody.objects.create(user=user, name='My Private Clay')
-        ClayBody.objects.create(user=None, name='Public Clay')
-        output = tmp_path / 'out.json'
+        user = django_user_model.objects.create(username="user@example.com")
+        ClayBody.objects.create(user=user, name="My Private Clay")
+        ClayBody.objects.create(user=None, name="Public Clay")
+        output = tmp_path / "out.json"
 
-        call_command('dump_public_library', output=str(output))
+        call_command("dump_public_library", output=str(output))
 
         records = json.loads(output.read_text())
-        names = [r['fields']['name'] for r in records]
-        assert 'Public Clay' in names
-        assert 'My Private Clay' not in names
+        names = [r["fields"]["name"] for r in records]
+        assert "Public Clay" in names
+        assert "My Private Clay" not in names
 
     def test_no_pk_or_user_in_output(self, tmp_path):
-        ClayBody.objects.create(user=None, name='Stoneware')
-        output = tmp_path / 'out.json'
+        ClayBody.objects.create(user=None, name="Stoneware")
+        output = tmp_path / "out.json"
 
-        call_command('dump_public_library', output=str(output))
+        call_command("dump_public_library", output=str(output))
 
         records = json.loads(output.read_text())
         assert len(records) == 1
-        fields = records[0]['fields']
-        assert 'pk' not in records[0]
-        assert 'id' not in fields
-        assert 'user' not in fields
+        fields = records[0]["fields"]
+        assert "pk" not in records[0]
+        assert "id" not in fields
+        assert "user" not in fields
 
     def test_records_sorted_by_name(self, tmp_path):
-        ClayBody.objects.create(user=None, name='Stoneware')
-        ClayBody.objects.create(user=None, name='Earthenware')
-        ClayBody.objects.create(user=None, name='Porcelain')
-        output = tmp_path / 'out.json'
+        ClayBody.objects.create(user=None, name="Stoneware")
+        ClayBody.objects.create(user=None, name="Earthenware")
+        ClayBody.objects.create(user=None, name="Porcelain")
+        output = tmp_path / "out.json"
 
-        call_command('dump_public_library', output=str(output))
+        call_command("dump_public_library", output=str(output))
 
         records = json.loads(output.read_text())
-        names = [r['fields']['name'] for r in records]
+        names = [r["fields"]["name"] for r in records]
         assert names == sorted(names)
 
     def test_stdout_output(self):
-        ClayBody.objects.create(user=None, name='Stoneware')
+        ClayBody.objects.create(user=None, name="Stoneware")
         out = StringIO()
 
-        call_command('dump_public_library', output='-', stdout=out)
+        call_command("dump_public_library", output="-", stdout=out)
 
         records = json.loads(out.getvalue())
-        assert any(r['fields']['name'] == 'Stoneware' for r in records)
+        assert any(r["fields"]["name"] == "Stoneware" for r in records)
 
     def test_empty_library_produces_empty_array(self, tmp_path):
-        output = tmp_path / 'out.json'
+        output = tmp_path / "out.json"
 
-        call_command('dump_public_library', output=str(output))
+        call_command("dump_public_library", output=str(output))
 
         records = json.loads(output.read_text())
         assert records == []
 
-    def test_creates_parent_directories(self, tmp_path):
-        nested = tmp_path / 'a' / 'b' / 'c' / 'library.json'
+    def test_excludes_dev_bootstrap_fixture_data(
+        self, tmp_path, django_user_model, settings
+    ):
+        settings.DEV_BOOTSTRAP_ENABLED = True
+        user = django_user_model.objects.create_user(
+            username="devadmin@example.com",
+            email="devadmin@example.com",
+            password="password123",
+        )
+        bootstrap_dev_user(user)
+        output = tmp_path / "out.json"
 
-        call_command('dump_public_library', output=str(nested))
+        call_command("dump_public_library", output=str(output))
+
+        records = json.loads(output.read_text())
+        exported_names = {record["fields"]["name"] for record in records}
+        assert "Brown Stoneware" not in exported_names
+        assert "Floating Blue" not in exported_names
+
+    def test_creates_parent_directories(self, tmp_path):
+        nested = tmp_path / "a" / "b" / "c" / "library.json"
+
+        call_command("dump_public_library", output=str(nested))
 
         assert nested.exists()
 
@@ -102,157 +125,212 @@ class TestDumpPublicLibrary:
 @pytest.mark.django_db
 class TestLoadPublicLibrary:
     def _write_fixture(self, tmp_path, records):
-        fixture = tmp_path / 'library.json'
+        fixture = tmp_path / "library.json"
         fixture.write_text(json.dumps(records))
         return fixture
 
     def test_creates_new_records(self, tmp_path):
-        fixture = self._write_fixture(tmp_path, [
-            {'model': 'api.claybody', 'fields': {'name': 'Stoneware', 'short_description': 'A body'}},
-            {'model': 'api.glazetype', 'fields': {'name': 'Celadon', 'short_description': '', 'test_tile_image': '', 'is_food_safe': True, 'runs': None, 'highlights_grooves': None, 'is_different_on_white_and_brown_clay': None, 'apply_thin': None}},
-        ])
+        fixture = self._write_fixture(
+            tmp_path,
+            [
+                {
+                    "model": "api.claybody",
+                    "fields": {"name": "Stoneware", "short_description": "A body"},
+                },
+                {
+                    "model": "api.glazetype",
+                    "fields": {
+                        "name": "Celadon",
+                        "short_description": "",
+                        "test_tile_image": "",
+                        "is_food_safe": True,
+                        "runs": None,
+                        "highlights_grooves": None,
+                        "is_different_on_white_and_brown_clay": None,
+                        "apply_thin": None,
+                    },
+                },
+            ],
+        )
 
-        call_command('load_public_library', fixture=str(fixture))
+        call_command("load_public_library", fixture=str(fixture))
 
-        assert ClayBody.objects.filter(user=None, name='Stoneware').exists()
-        assert GlazeType.objects.filter(user=None, name='Celadon').exists()
+        assert ClayBody.objects.filter(user=None, name="Stoneware").exists()
+        assert GlazeType.objects.filter(user=None, name="Celadon").exists()
 
     def test_updates_existing_records(self, tmp_path):
-        ClayBody.objects.create(user=None, name='Stoneware', short_description='Old')
-        fixture = self._write_fixture(tmp_path, [
-            {'model': 'api.claybody', 'fields': {'name': 'Stoneware', 'short_description': 'Updated'}},
-        ])
+        ClayBody.objects.create(user=None, name="Stoneware", short_description="Old")
+        fixture = self._write_fixture(
+            tmp_path,
+            [
+                {
+                    "model": "api.claybody",
+                    "fields": {"name": "Stoneware", "short_description": "Updated"},
+                },
+            ],
+        )
 
-        call_command('load_public_library', fixture=str(fixture))
+        call_command("load_public_library", fixture=str(fixture))
 
-        obj = ClayBody.objects.get(user=None, name='Stoneware')
-        assert obj.short_description == 'Updated'
-        assert ClayBody.objects.filter(user=None, name='Stoneware').count() == 1
+        obj = ClayBody.objects.get(user=None, name="Stoneware")
+        assert obj.short_description == "Updated"
+        assert ClayBody.objects.filter(user=None, name="Stoneware").count() == 1
 
     def test_idempotent_on_repeated_runs(self, tmp_path):
-        fixture = self._write_fixture(tmp_path, [
-            {'model': 'api.claybody', 'fields': {'name': 'Porcelain', 'short_description': 'Fine'}},
-        ])
+        fixture = self._write_fixture(
+            tmp_path,
+            [
+                {
+                    "model": "api.claybody",
+                    "fields": {"name": "Porcelain", "short_description": "Fine"},
+                },
+            ],
+        )
 
-        call_command('load_public_library', fixture=str(fixture))
-        call_command('load_public_library', fixture=str(fixture))
+        call_command("load_public_library", fixture=str(fixture))
+        call_command("load_public_library", fixture=str(fixture))
 
-        assert ClayBody.objects.filter(user=None, name='Porcelain').count() == 1
+        assert ClayBody.objects.filter(user=None, name="Porcelain").count() == 1
 
     def test_does_not_touch_private_objects(self, tmp_path, django_user_model):
-        user = django_user_model.objects.create(username='owner@example.com')
-        private = ClayBody.objects.create(user=user, name='My Clay', short_description='Private')
-        fixture = self._write_fixture(tmp_path, [
-            {'model': 'api.claybody', 'fields': {'name': 'My Clay', 'short_description': 'Public version'}},
-        ])
+        user = django_user_model.objects.create(username="owner@example.com")
+        private = ClayBody.objects.create(
+            user=user, name="My Clay", short_description="Private"
+        )
+        fixture = self._write_fixture(
+            tmp_path,
+            [
+                {
+                    "model": "api.claybody",
+                    "fields": {
+                        "name": "My Clay",
+                        "short_description": "Public version",
+                    },
+                },
+            ],
+        )
 
-        call_command('load_public_library', fixture=str(fixture))
+        call_command("load_public_library", fixture=str(fixture))
 
         private.refresh_from_db()
-        assert private.short_description == 'Private'
+        assert private.short_description == "Private"
         # A separate public record should have been created.
-        assert ClayBody.objects.filter(user=None, name='My Clay').exists()
+        assert ClayBody.objects.filter(user=None, name="My Clay").exists()
 
     def test_raises_for_missing_fixture(self, tmp_path):
-        with pytest.raises(CommandError, match='not found'):
-            call_command('load_public_library', fixture=str(tmp_path / 'missing.json'))
+        with pytest.raises(CommandError, match="not found"):
+            call_command("load_public_library", fixture=str(tmp_path / "missing.json"))
 
     def test_skip_if_missing_exits_cleanly(self, tmp_path):
         out = StringIO()
         # Should not raise; should print a warning instead.
         call_command(
-            'load_public_library',
-            fixture=str(tmp_path / 'missing.json'),
+            "load_public_library",
+            fixture=str(tmp_path / "missing.json"),
             skip_if_missing=True,
             stdout=out,
         )
-        assert 'skipping' in out.getvalue().lower()
+        assert "skipping" in out.getvalue().lower()
 
     def test_raises_for_invalid_json(self, tmp_path):
-        bad = tmp_path / 'bad.json'
-        bad.write_text('not valid json {{{')
+        bad = tmp_path / "bad.json"
+        bad.write_text("not valid json {{{")
 
-        with pytest.raises(CommandError, match='Invalid JSON'):
-            call_command('load_public_library', fixture=str(bad))
+        with pytest.raises(CommandError, match="Invalid JSON"):
+            call_command("load_public_library", fixture=str(bad))
 
     def test_raises_for_unknown_model(self, tmp_path):
-        fixture = self._write_fixture(tmp_path, [
-            {'model': 'api.doesnotexist', 'fields': {'name': 'X'}},
-        ])
+        fixture = self._write_fixture(
+            tmp_path,
+            [
+                {"model": "api.doesnotexist", "fields": {"name": "X"}},
+            ],
+        )
 
-        with pytest.raises(CommandError, match='Unknown model'):
-            call_command('load_public_library', fixture=str(fixture))
+        with pytest.raises(CommandError, match="Unknown model"):
+            call_command("load_public_library", fixture=str(fixture))
 
     def test_roundtrip_dump_then_load(self, tmp_path, django_user_model):
         """dump_public_library output can be fed directly to load_public_library."""
-        ClayBody.objects.create(user=None, name='Stoneware', short_description='A body')
+        ClayBody.objects.create(user=None, name="Stoneware", short_description="A body")
         GlazeType.objects.create(
-            user=None, name='Celadon', is_food_safe=True, runs=False,
+            user=None,
+            name="Celadon",
+            is_food_safe=True,
+            runs=False,
         )
-        output = tmp_path / 'library.json'
+        output = tmp_path / "library.json"
 
-        call_command('dump_public_library', output=str(output))
+        call_command("dump_public_library", output=str(output))
 
         # Clear the database and reload from the fixture.
         ClayBody.objects.all().delete()
         GlazeType.objects.all().delete()
 
-        call_command('load_public_library', fixture=str(output))
+        call_command("load_public_library", fixture=str(output))
 
-        clay = ClayBody.objects.get(user=None, name='Stoneware')
-        assert clay.short_description == 'A body'
+        clay = ClayBody.objects.get(user=None, name="Stoneware")
+        assert clay.short_description == "A body"
 
-        glaze = GlazeType.objects.get(user=None, name='Celadon')
+        glaze = GlazeType.objects.get(user=None, name="Celadon")
         assert glaze.is_food_safe is True
         assert glaze.runs is False
 
     def test_loads_glaze_combination_from_computed_name(self, tmp_path):
         """GlazeCombination fixtures use the computed name; layers are reconstructed on load."""
-        GlazeType.objects.create(user=None, name='Celadon', is_food_safe=True)
-        GlazeType.objects.create(user=None, name='Tenmoku', is_food_safe=False)
-        fixture = self._write_fixture(tmp_path, [
-            {
-                'model': 'api.glazecombination',
-                'fields': {
-                    'name': 'Celadon!Tenmoku',
-                    'test_tile_image': '',
-                    'is_food_safe': False,
-                    'runs': False,
-                    'highlights_grooves': None,
-                    'is_different_on_white_and_brown_clay': None,
+        GlazeType.objects.create(user=None, name="Celadon", is_food_safe=True)
+        GlazeType.objects.create(user=None, name="Tenmoku", is_food_safe=False)
+        fixture = self._write_fixture(
+            tmp_path,
+            [
+                {
+                    "model": "api.glazecombination",
+                    "fields": {
+                        "name": "Celadon!Tenmoku",
+                        "test_tile_image": "",
+                        "is_food_safe": False,
+                        "runs": False,
+                        "highlights_grooves": None,
+                        "is_different_on_white_and_brown_clay": None,
+                    },
                 },
-            },
-        ])
+            ],
+        )
 
-        call_command('load_public_library', fixture=str(fixture))
+        call_command("load_public_library", fixture=str(fixture))
 
         combo = GlazeCombination.objects.get(user=None)
         sep = COMPOSITE_NAME_SEPARATOR
-        assert combo.name == f'Celadon{sep}Tenmoku'
-        layer_names = list(combo.layers.order_by('order').values_list('glaze_type__name', flat=True))
-        assert layer_names == ['Celadon', 'Tenmoku']
+        assert combo.name == f"Celadon{sep}Tenmoku"
+        layer_names = list(
+            combo.layers.order_by("order").values_list("glaze_type__name", flat=True)
+        )
+        assert layer_names == ["Celadon", "Tenmoku"]
         assert combo.is_food_safe is False
 
     def test_glaze_combination_load_is_idempotent(self, tmp_path):
         """Loading a GlazeCombination fixture twice does not duplicate layers."""
-        GlazeType.objects.create(user=None, name='Celadon')
-        GlazeType.objects.create(user=None, name='Tenmoku')
-        fixture = self._write_fixture(tmp_path, [
-            {
-                'model': 'api.glazecombination',
-                'fields': {
-                    'name': 'Celadon!Tenmoku',
-                    'test_tile_image': '',
-                    'is_food_safe': None,
-                    'runs': None,
-                    'highlights_grooves': None,
-                    'is_different_on_white_and_brown_clay': None,
+        GlazeType.objects.create(user=None, name="Celadon")
+        GlazeType.objects.create(user=None, name="Tenmoku")
+        fixture = self._write_fixture(
+            tmp_path,
+            [
+                {
+                    "model": "api.glazecombination",
+                    "fields": {
+                        "name": "Celadon!Tenmoku",
+                        "test_tile_image": "",
+                        "is_food_safe": None,
+                        "runs": None,
+                        "highlights_grooves": None,
+                        "is_different_on_white_and_brown_clay": None,
+                    },
                 },
-            },
-        ])
+            ],
+        )
 
-        call_command('load_public_library', fixture=str(fixture))
-        call_command('load_public_library', fixture=str(fixture))
+        call_command("load_public_library", fixture=str(fixture))
+        call_command("load_public_library", fixture=str(fixture))
 
         assert GlazeCombination.objects.filter(user=None).count() == 1
         combo = GlazeCombination.objects.get(user=None)

--- a/api/utils.py
+++ b/api/utils.py
@@ -5,22 +5,34 @@ of the api app but do not belong in workflow.py (which is reserved for
 workflow-state-machine logic derived from workflow.yml).
 """
 
+from django.apps import apps
+from django.conf import settings
+
+DEV_THUMBNAIL_URLS = {
+    "bowl": "/thumbnails/bowl.svg",
+    "mug": "/thumbnails/mug.svg",
+    "plate": "/thumbnails/plate.svg",
+    "vase": "/thumbnails/vase.svg",
+}
+
 
 # Fields that are mirrored between a public GlazeType and its singleton
 # single-layer GlazeCombination.  Kept here so both admin.py and
 # manual_tile_imports.py can import from one place without pulling in the
 # full workflow module.
 SHARED_GLAZE_FIELDS: tuple[str, ...] = (
-    'test_tile_image',
-    'is_food_safe',
-    'runs',
-    'highlights_grooves',
-    'is_different_on_white_and_brown_clay',
-    'apply_thin',
+    "test_tile_image",
+    "is_food_safe",
+    "runs",
+    "highlights_grooves",
+    "is_different_on_white_and_brown_clay",
+    "apply_thin",
 )
 
 
-def sync_glaze_type_singleton_combination(glaze_type, *, old_name: str | None = None) -> None:
+def sync_glaze_type_singleton_combination(
+    glaze_type, *, old_name: str | None = None
+) -> None:
     """Ensure a matching public single-layer GlazeCombination exists for a public GlazeType.
 
     Creates or updates the singleton combination so that its name and shared
@@ -49,7 +61,7 @@ def sync_glaze_type_singleton_combination(glaze_type, *, old_name: str | None = 
             combo.name = glaze_type.name
             for field, value in combo_props.items():
                 setattr(combo, field, value)
-            combo.save(update_fields=['name', *SHARED_GLAZE_FIELDS])
+            combo.save(update_fields=["name", *SHARED_GLAZE_FIELDS])
 
     if combo is None:
         combo, created = GlazeCombination.objects.get_or_create(
@@ -63,7 +75,206 @@ def sync_glaze_type_singleton_combination(glaze_type, *, old_name: str | None = 
             combo.save(update_fields=list(SHARED_GLAZE_FIELDS))
 
     # Ensure exactly one layer pointing at this GlazeType.
-    layers = list(combo.layers.select_related('glaze_type').order_by('order'))
+    layers = list(combo.layers.select_related("glaze_type").order_by("order"))
     if len(layers) != 1 or layers[0].glaze_type_id != glaze_type.id:
         combo.layers.all().delete()
-        GlazeCombinationLayer.objects.create(combination=combo, glaze_type=glaze_type, order=0)
+        GlazeCombinationLayer.objects.create(
+            combination=combo, glaze_type=glaze_type, order=0
+        )
+
+
+def bootstrap_dev_user(user) -> None:
+    """Make a fresh DEBUG-only account immediately usable in local development.
+
+    The first dev account in a database without any existing superuser is
+    promoted to staff/superuser and receives a few sample pieces in
+    representative workflow states. The helper is idempotent and a no-op
+    outside local development.
+    """
+    if not getattr(settings, "DEV_BOOTSTRAP_ENABLED", False):
+        return
+
+    user_model = type(user)
+    if user_model.objects.exclude(pk=user.pk).filter(is_superuser=True).exists():
+        return
+
+    if not user.is_staff or not user.is_superuser:
+        user.is_staff = True
+        user.is_superuser = True
+        user.save(update_fields=["is_staff", "is_superuser"])
+
+    from .models import Piece  # noqa: PLC0415
+
+    if not Piece.objects.exists() and not Piece.objects.filter(user=user).exists():
+        _seed_dev_pieces(user)
+
+
+def _seed_dev_pieces(user) -> None:
+    """Create a few representative pieces for a newly bootstrapped dev user."""
+    from .models import (  # noqa: PLC0415
+        ClayBody,
+        FiringTemperature,
+        GlazeType,
+        Piece,
+    )
+
+    clay_body, _ = ClayBody.objects.get_or_create(
+        user=None,
+        name="Brown Stoneware",
+        defaults={
+            "short_description": "Reliable mid-fire stoneware for local dev demos."
+        },
+    )
+    firing_temperature, _ = FiringTemperature.objects.get_or_create(
+        user=None,
+        name="Cone 6 Oxidation",
+        defaults={
+            "cone": "6",
+            "temperature_c": 1222,
+            "atmosphere": "Oxidation",
+        },
+    )
+    glaze_type, _ = GlazeType.objects.get_or_create(
+        user=None,
+        name="Floating Blue",
+        defaults={
+            "short_description": "Sample glaze for bootstrapped dev data.",
+            "test_tile_image": "",
+            "is_food_safe": True,
+            "runs": False,
+            "highlights_grooves": True,
+            "is_different_on_white_and_brown_clay": True,
+            "apply_thin": False,
+        },
+    )
+    sync_glaze_type_singleton_combination(glaze_type)
+
+    from .models import GlazeCombination, Location  # noqa: PLC0415
+
+    glaze_combination = GlazeCombination.objects.get(user=None, name=glaze_type.name)
+    bisque_kiln, _ = Location.objects.get_or_create(user=user, name="Bisque Kiln")
+    glaze_kiln, _ = Location.objects.get_or_create(user=user, name="Glaze Kiln")
+
+    trimmed_piece = Piece.objects.create(
+        user=user,
+        name="Trimmed Practice Bowl",
+        thumbnail={"url": DEV_THUMBNAIL_URLS["bowl"], "cloudinary_public_id": None},
+    )
+    _create_piece_state(trimmed_piece, "designed", notes="Starting a quick demo bowl.")
+    _create_piece_state(
+        trimmed_piece,
+        "wheel_thrown",
+        notes="Opened and pulled on the wheel.",
+        additional_fields={"clay_weight_grams": 1250, "wall_thickness_mm": 7.5},
+        global_refs={"clay_body": ("clay_body", clay_body)},
+    )
+    _create_piece_state(
+        trimmed_piece,
+        "trimmed",
+        notes="Foot ring cleaned up and ready to dry.",
+        additional_fields={"trimmed_weight_grams": 980, "pre_trim_weight_grams": 1250},
+    )
+
+    bisque_piece = Piece.objects.create(
+        user=user,
+        name="Bisque Queue Mug",
+        thumbnail={"url": DEV_THUMBNAIL_URLS["mug"], "cloudinary_public_id": None},
+    )
+    _create_piece_state(bisque_piece, "designed", notes="Planning a handbuilt mug.")
+    _create_piece_state(
+        bisque_piece,
+        "handbuilt",
+        notes="Walls are up and the handle is attached.",
+        global_refs={"clay_body": ("clay_body", clay_body)},
+    )
+    _create_piece_state(
+        bisque_piece,
+        "submitted_to_bisque_fire",
+        notes="Queued for the next bisque load.",
+        global_refs={"kiln_location": ("location", bisque_kiln)},
+    )
+
+    finished_piece = Piece.objects.create(
+        user=user,
+        name="Finished Test Plate",
+        thumbnail={"url": DEV_THUMBNAIL_URLS["plate"], "cloudinary_public_id": None},
+    )
+    _create_piece_state(
+        finished_piece, "designed", notes="Small plate for glaze testing."
+    )
+    _create_piece_state(
+        finished_piece,
+        "handbuilt",
+        notes="Slab-built and compressed.",
+        global_refs={"clay_body": ("clay_body", clay_body)},
+    )
+    _create_piece_state(
+        finished_piece,
+        "submitted_to_bisque_fire",
+        notes="Waiting for bisque firing.",
+        global_refs={"kiln_location": ("location", bisque_kiln)},
+    )
+    _create_piece_state(
+        finished_piece,
+        "bisque_fired",
+        notes="Bisque firing complete.",
+        additional_fields={"kiln_temperature_c": 1060, "cone": "04"},
+    )
+    _create_piece_state(
+        finished_piece,
+        "glazed",
+        notes="Floating Blue test coat applied.",
+        global_refs={"glaze_combination": ("glaze_combination", glaze_combination)},
+    )
+    _create_piece_state(
+        finished_piece,
+        "submitted_to_glaze_fire",
+        notes="Queued for glaze firing.",
+        global_refs={"kiln_location": ("location", glaze_kiln)},
+    )
+    _create_piece_state(
+        finished_piece,
+        "glaze_fired",
+        notes="Out of the kiln and looking promising.",
+        additional_fields={"kiln_temperature_c": 1060, "cone": "04"},
+        global_refs={"glaze_combination": ("glaze_combination", glaze_combination)},
+    )
+    _create_piece_state(
+        finished_piece,
+        "completed",
+        notes="Ready for quick UI smoke testing.",
+    )
+
+
+def _create_piece_state(
+    piece,
+    state: str,
+    *,
+    notes: str = "",
+    additional_fields: dict | None = None,
+    global_refs: dict | None = None,
+):
+    """Create a PieceState plus any workflow global-ref junction rows it needs."""
+    from .models import PieceState  # noqa: PLC0415
+    from .workflow import get_global_config  # noqa: PLC0415
+
+    piece_state = PieceState.objects.create(
+        user=piece.user,
+        piece=piece,
+        state=state,
+        notes=notes,
+        additional_fields=additional_fields or {},
+    )
+
+    for field_name, (global_name, global_obj) in (global_refs or {}).items():
+        config = get_global_config(global_name)
+        ref_model = apps.get_model(
+            "api", f"{piece_state.__class__.__name__}{config['model']}Ref"
+        )
+        ref_model.objects.create(
+            piece_state=piece_state,
+            field_name=field_name,
+            **{global_name: global_obj},
+        )
+
+    return piece_state

--- a/api/utils.py
+++ b/api/utils.py
@@ -111,31 +111,17 @@ def bootstrap_dev_user(user) -> None:
 
 def _seed_dev_pieces(user) -> None:
     """Create a few representative pieces for a newly bootstrapped dev user."""
-    from .models import (  # noqa: PLC0415
-        ClayBody,
-        FiringTemperature,
-        GlazeType,
-        Piece,
-    )
+    from .models import ClayBody, GlazeCombination, GlazeType, Piece  # noqa: PLC0415
 
     clay_body, _ = ClayBody.objects.get_or_create(
-        user=None,
+        user=user,
         name="Brown Stoneware",
         defaults={
             "short_description": "Reliable mid-fire stoneware for local dev demos."
         },
     )
-    firing_temperature, _ = FiringTemperature.objects.get_or_create(
-        user=None,
-        name="Cone 6 Oxidation",
-        defaults={
-            "cone": "6",
-            "temperature_c": 1222,
-            "atmosphere": "Oxidation",
-        },
-    )
     glaze_type, _ = GlazeType.objects.get_or_create(
-        user=None,
+        user=user,
         name="Floating Blue",
         defaults={
             "short_description": "Sample glaze for bootstrapped dev data.",
@@ -147,11 +133,13 @@ def _seed_dev_pieces(user) -> None:
             "apply_thin": False,
         },
     )
-    sync_glaze_type_singleton_combination(glaze_type)
+    glaze_combination, _ = GlazeCombination.get_or_create_with_components(
+        user=user,
+        glaze_types=[glaze_type],
+    )
 
-    from .models import GlazeCombination, Location  # noqa: PLC0415
+    from .models import Location  # noqa: PLC0415
 
-    glaze_combination = GlazeCombination.objects.get(user=None, name=glaze_type.name)
     bisque_kiln, _ = Location.objects.get_or_create(user=user, name="Bisque Kiln")
     glaze_kiln, _ = Location.objects.get_or_create(user=user, name="Glaze Kiln")
 

--- a/api/views.py
+++ b/api/views.py
@@ -43,6 +43,7 @@ from .serializers import (
     PieceUpdateSerializer,
     RegisterSerializer,
 )
+from .utils import bootstrap_dev_user
 from .workflow import (
     get_glaze_image_qualifying_states,
     get_global_model_and_field,
@@ -64,22 +65,22 @@ def _apply_global_filters(qs, model_cls, request):
     - ``m2m_id``: ?param=id1,id2,... → successive filters so ALL ids must match
     - ``fk_id``: ?param=<pk> → exact FK match (filter(**{lookup: pk}))
     """
-    filterable = getattr(model_cls, 'filterable_fields', {})
+    filterable = getattr(model_cls, "filterable_fields", {})
     for lookup, meta in filterable.items():
-        param = meta.get('param', lookup)
-        filter_type = meta.get('type', 'boolean')
-        raw = request.query_params.get(param, '').strip()
+        param = meta.get("param", lookup)
+        filter_type = meta.get("type", "boolean")
+        raw = request.query_params.get(param, "").strip()
         if not raw:
             continue
-        if filter_type == 'boolean':
-            if raw.lower() == 'true':
+        if filter_type == "boolean":
+            if raw.lower() == "true":
                 qs = qs.filter(**{lookup: True})
-            elif raw.lower() == 'false':
+            elif raw.lower() == "false":
                 qs = qs.filter(**{lookup: False})
-        elif filter_type == 'm2m_id':
-            for pk in (s.strip() for s in raw.split(',') if s.strip()):
+        elif filter_type == "m2m_id":
+            for pk in (s.strip() for s in raw.split(",") if s.strip()):
                 qs = qs.filter(**{lookup: pk})
-        elif filter_type == 'fk_id':
+        elif filter_type == "fk_id":
             qs = qs.filter(**{lookup: raw})
     return qs
 
@@ -92,31 +93,35 @@ _FAVORITES_REGISTRY = {
 
 
 def _piece_queryset(request: Request):
-    return Piece.objects.prefetch_related('states', 'tag_links__tag').filter(user=request.user)  # type: ignore[misc]
+    return Piece.objects.prefetch_related("states", "tag_links__tag").filter(
+        user=request.user
+    )  # type: ignore[misc]
 
 
 @extend_schema(
-    methods=['GET'],
+    methods=["GET"],
     responses={200: PieceSummarySerializer(many=True)},
 )
 @extend_schema(
-    methods=['POST'],
+    methods=["POST"],
     request=PieceCreateSerializer,
     responses={201: PieceDetailSerializer},
 )
-@api_view(['GET', 'POST'])
+@api_view(["GET", "POST"])
 @permission_classes([IsAuthenticated])
 def pieces(request: Request) -> Response:
-    if request.method == 'GET':
+    if request.method == "GET":
         qs = _piece_queryset(request)
-        raw_tag_ids = request.query_params.get('tag_ids', '').strip()
+        raw_tag_ids = request.query_params.get("tag_ids", "").strip()
         if raw_tag_ids:
-            for tag_id in (item.strip() for item in raw_tag_ids.split(',') if item.strip()):
+            for tag_id in (
+                item.strip() for item in raw_tag_ids.split(",") if item.strip()
+            ):
                 qs = qs.filter(tag_links__tag_id=tag_id)
             qs = qs.distinct()
         return Response(PieceSummarySerializer(qs, many=True).data)
 
-    serializer = PieceCreateSerializer(data=request.data, context={'request': request})
+    serializer = PieceCreateSerializer(data=request.data, context={"request": request})
     serializer.is_valid(raise_exception=True)
     piece = serializer.save()
     return Response(PieceDetailSerializer(piece).data, status=status.HTTP_201_CREATED)
@@ -124,16 +129,18 @@ def pieces(request: Request) -> Response:
 
 @extend_schema(responses={200: PieceDetailSerializer})
 @extend_schema(
-    methods=['PATCH'],
+    methods=["PATCH"],
     request=PieceUpdateSerializer,
     responses={200: PieceDetailSerializer},
 )
-@api_view(['GET', 'PATCH'])
+@api_view(["GET", "PATCH"])
 @permission_classes([IsAuthenticated])
 def piece_detail(request: Request, piece_id: str) -> Response:
     piece = get_object_or_404(_piece_queryset(request), pk=piece_id)
-    if request.method == 'PATCH':
-        serializer = PieceUpdateSerializer(data=request.data, context={'request': request})
+    if request.method == "PATCH":
+        serializer = PieceUpdateSerializer(
+            data=request.data, context={"request": request}
+        )
         serializer.is_valid(raise_exception=True)
         serializer.update(piece, serializer.validated_data)
         piece.refresh_from_db()
@@ -144,11 +151,11 @@ def piece_detail(request: Request, piece_id: str) -> Response:
     request=PieceStateCreateSerializer,
     responses={201: PieceDetailSerializer},
 )
-@api_view(['POST'])
+@api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def piece_states(request: Request, piece_id: str) -> Response:
     piece = get_object_or_404(_piece_queryset(request), pk=piece_id)
-    serializer = PieceStateCreateSerializer(data=request.data, context={'piece': piece})
+    serializer = PieceStateCreateSerializer(data=request.data, context={"piece": piece})
     serializer.is_valid(raise_exception=True)
     serializer.save()
     # Reload to pick up updated last_modified on current_state
@@ -157,17 +164,19 @@ def piece_states(request: Request, piece_id: str) -> Response:
 
 
 @extend_schema(
-    methods=['PATCH'],
+    methods=["PATCH"],
     request=PieceStateUpdateSerializer,
     responses={200: PieceDetailSerializer},
 )
-@api_view(['PATCH'])
+@api_view(["PATCH"])
 @permission_classes([IsAuthenticated])
 def piece_current_state(request: Request, piece_id: str) -> Response:
     piece = get_object_or_404(_piece_queryset(request), pk=piece_id)
     current = piece.current_state
     if current is None:
-        return Response({'detail': 'Piece has no states.'}, status=status.HTTP_404_NOT_FOUND)
+        return Response(
+            {"detail": "Piece has no states."}, status=status.HTTP_404_NOT_FOUND
+        )
     serializer = PieceStateUpdateSerializer(data=request.data)
     serializer.is_valid(raise_exception=True)
     serializer.update(current, serializer.validated_data)
@@ -175,25 +184,24 @@ def piece_current_state(request: Request, piece_id: str) -> Response:
     return Response(PieceDetailSerializer(piece).data)
 
 
-
 _GLOBAL_ENTRY_SCHEMA = {
-    'type': 'object',
-    'properties': {
-        'id': {'type': 'string'},
-        'name': {'type': 'string'},
-        'is_public': {'type': 'boolean'},
+    "type": "object",
+    "properties": {
+        "id": {"type": "string"},
+        "name": {"type": "string"},
+        "is_public": {"type": "boolean"},
     },
-    'required': ['id', 'name', 'is_public'],
+    "required": ["id", "name", "is_public"],
 }
 
 _GLOBAL_CREATE_REQUEST_SCHEMA = {
-    'application/json': {
-        'type': 'object',
-        'properties': {
-            'field': {'type': 'string'},
-            'value': {'type': 'string'},
+    "application/json": {
+        "type": "object",
+        "properties": {
+            "field": {"type": "string"},
+            "value": {"type": "string"},
         },
-        'required': ['field', 'value'],
+        "required": ["field", "value"],
     }
 }
 
@@ -208,10 +216,12 @@ def _global_entries_impl(request: Request, global_name: str) -> Response:
     model_cls, fields, display_field = get_global_model_and_field(global_name)
     has_public_library = is_public_global(global_name)
 
-    if request.method == 'GET':
+    if request.method == "GET":
         if has_public_library:
             # Return both the user's private objects and all public objects (user IS NULL).
-            base_qs = model_cls.objects.filter(Q(user=request.user) | Q(user__isnull=True))
+            base_qs = model_cls.objects.filter(
+                Q(user=request.user) | Q(user__isnull=True)
+            )
         else:
             base_qs = model_cls.objects.filter(user=request.user)
 
@@ -222,13 +232,17 @@ def _global_entries_impl(request: Request, global_name: str) -> Response:
         entry_serializer_cls = _GLOBAL_ENTRY_SERIALIZERS.get(model_cls)
         if entry_serializer_cls is not None:
             fav_model = _FAVORITES_REGISTRY.get(model_cls)
-            favorite_ids = fav_model.get_favorite_ids_for(request.user) if fav_model else set()
-            objects = list(base_qs.prefetch_related('layers__glaze_type').order_by('name'))
+            favorite_ids = (
+                fav_model.get_favorite_ids_for(request.user) if fav_model else set()
+            )
+            objects = list(
+                base_qs.prefetch_related("layers__glaze_type").order_by("name")
+            )
             return Response(
                 entry_serializer_cls(
                     objects,
                     many=True,
-                    context={'request': request, 'favorite_ids': favorite_ids},
+                    context={"request": request, "favorite_ids": favorite_ids},
                 ).data
             )
 
@@ -237,21 +251,21 @@ def _global_entries_impl(request: Request, global_name: str) -> Response:
         # loading and stringify the value; otherwise use only() for efficiency.
         try:
             display_field_meta = model_cls._meta.get_field(display_field)
-            display_is_relation = getattr(display_field_meta, 'is_relation', False)
+            display_is_relation = getattr(display_field_meta, "is_relation", False)
         except Exception:
             display_is_relation = False
 
         if display_is_relation:
             objects = base_qs.select_related(display_field).order_by(display_field)
         else:
-            objects = base_qs.only('pk', display_field).order_by(display_field)
+            objects = base_qs.only("pk", display_field).order_by(display_field)
 
         return Response(
             [
                 {
-                    'id': str(obj.pk),
-                    'name': str(getattr(obj, display_field)),
-                    'is_public': obj.user_id is None,
+                    "id": str(obj.pk),
+                    "name": str(getattr(obj, display_field)),
+                    "is_public": obj.user_id is None,
                 }
                 for obj in objects
             ]
@@ -259,61 +273,77 @@ def _global_entries_impl(request: Request, global_name: str) -> Response:
 
     if not is_private_global(global_name):
         return Response(
-            {'detail': 'Private instances of this type are not supported.'},
+            {"detail": "Private instances of this type are not supported."},
             status=status.HTTP_405_METHOD_NOT_ALLOWED,
         )
 
     # Models with ordered M2M relations declare get_or_create_from_ordered_pks.
-    if hasattr(model_cls, 'get_or_create_from_ordered_pks'):
-        pks = request.data.get('layers')
+    if hasattr(model_cls, "get_or_create_from_ordered_pks"):
+        pks = request.data.get("layers")
         if not pks or not isinstance(pks, list):
             return Response(
-                {'detail': 'layers must be a non-empty list of PKs.'},
+                {"detail": "layers must be a non-empty list of PKs."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         try:
-            obj, created = model_cls.get_or_create_from_ordered_pks(user=request.user, pks=pks)
+            obj, created = model_cls.get_or_create_from_ordered_pks(
+                user=request.user, pks=pks
+            )
         except ValueError as exc:
-            return Response({'detail': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
         status_code = status.HTTP_201_CREATED if created else status.HTTP_200_OK
         return Response(
-            {'id': str(obj.pk), 'name': obj.name, 'is_public': obj.user_id is None},
+            {"id": str(obj.pk), "name": obj.name, "is_public": obj.user_id is None},
             status=status_code,
         )
 
-    field = request.data.get('field')
-    value = request.data.get('value')
-    values = request.data.get('values')
+    field = request.data.get("field")
+    value = request.data.get("value")
+    values = request.data.get("values")
     if values is not None and not isinstance(values, dict):
-        return Response({'detail': 'values must be an object.'}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(
+            {"detail": "values must be an object."}, status=status.HTTP_400_BAD_REQUEST
+        )
 
     payload = dict(values or {})
     if field:
         if field not in fields:
-            return Response({'detail': 'Invalid field'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": "Invalid field"}, status=status.HTTP_400_BAD_REQUEST
+            )
         payload[field] = value
 
     allowed_fields = {
-        field_name for field_name, field_def in fields.items()
-        if '$ref' not in field_def
+        field_name
+        for field_name, field_def in fields.items()
+        if "$ref" not in field_def
     }
     unknown_fields = sorted(set(payload) - allowed_fields)
     if unknown_fields:
-        return Response({'detail': f'Invalid field: {unknown_fields[0]}'}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(
+            {"detail": f"Invalid field: {unknown_fields[0]}"},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
     if not payload.get(display_field):
-        return Response({'detail': 'Value is required'}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(
+            {"detail": "Value is required"}, status=status.HTTP_400_BAD_REQUEST
+        )
 
-    lookup = {'user': request.user, display_field: payload[display_field]}
+    lookup = {"user": request.user, display_field: payload[display_field]}
     defaults = {key: val for key, val in payload.items() if key != display_field}
     obj, created = model_cls.objects.get_or_create(**lookup, defaults=defaults)
     status_code = status.HTTP_201_CREATED if created else status.HTTP_200_OK
     entry_serializer_cls = _GLOBAL_ENTRY_SERIALIZERS.get(model_cls)
     if entry_serializer_cls is not None:
         return Response(
-            entry_serializer_cls(obj, context={'request': request, 'favorite_ids': set()}).data,
+            entry_serializer_cls(
+                obj, context={"request": request, "favorite_ids": set()}
+            ).data,
             status=status_code,
         )
-    return Response({'id': str(obj.pk), 'name': getattr(obj, display_field)}, status=status_code)
+    return Response(
+        {"id": str(obj.pk), "name": getattr(obj, display_field)}, status=status_code
+    )
 
 
 def make_global_entry_view(global_name: str):
@@ -331,26 +361,28 @@ def make_global_entry_view(global_name: str):
     get_responses: dict = (
         {200: entry_serializer_cls(many=True)}
         if entry_serializer_cls is not None
-        else {200: {'type': 'array', 'items': _GLOBAL_ENTRY_SCHEMA}}
+        else {200: {"type": "array", "items": _GLOBAL_ENTRY_SCHEMA}}
     )
 
-    @extend_schema(responses=get_responses, methods=['GET'])
+    @extend_schema(responses=get_responses, methods=["GET"])
     @extend_schema(
         request=_GLOBAL_CREATE_REQUEST_SCHEMA,
         responses={200: _GLOBAL_ENTRY_SCHEMA, 201: _GLOBAL_ENTRY_SCHEMA},
-        methods=['POST'],
+        methods=["POST"],
     )
-    @api_view(['GET', 'POST'])
+    @api_view(["GET", "POST"])
     @permission_classes([IsAuthenticated])
     def view(request: Request) -> Response:
         return _global_entries_impl(request, global_name)
 
-    view.__name__ = f'global_entries_{global_name}'  # type: ignore[attr-defined]
-    view.__qualname__ = f'global_entries_{global_name}'  # type: ignore[attr-defined]
+    view.__name__ = f"global_entries_{global_name}"  # type: ignore[attr-defined]
+    view.__qualname__ = f"global_entries_{global_name}"  # type: ignore[attr-defined]
     return view
 
 
-def _global_entry_favorite_impl(request: Request, model_cls, fav_model_cls, pk: str) -> Response:
+def _global_entry_favorite_impl(
+    request: Request, model_cls, fav_model_cls, pk: str
+) -> Response:
     """Core implementation for POST/DELETE /api/globals/<global_name>/<pk>/favorite/.
 
     model_cls is the global's Django model; fav_model_cls is its Favorite* model.
@@ -362,7 +394,7 @@ def _global_entry_favorite_impl(request: Request, model_cls, fav_model_cls, pk: 
         return Response(status=status.HTTP_404_NOT_FOUND)
 
     fk_field = fav_model_cls.global_fk_field
-    if request.method == 'POST':
+    if request.method == "POST":
         fav_model_cls.objects.get_or_create(user=request.user, **{fk_field: obj})
     else:
         fav_model_cls.objects.filter(user=request.user, **{fk_field: obj}).delete()
@@ -380,15 +412,15 @@ def make_global_entry_favorite_view(global_name: str):
     model_cls, _, _ = get_global_model_and_field(global_name)
     fav_model_cls = _FAVORITES_REGISTRY[model_cls]
 
-    @extend_schema(methods=['POST'], request=None, responses={204: None, 404: None})
-    @extend_schema(methods=['DELETE'], request=None, responses={204: None, 404: None})
-    @api_view(['POST', 'DELETE'])
+    @extend_schema(methods=["POST"], request=None, responses={204: None, 404: None})
+    @extend_schema(methods=["DELETE"], request=None, responses={204: None, 404: None})
+    @api_view(["POST", "DELETE"])
     @permission_classes([IsAuthenticated])
     def view(request: Request, pk: str) -> Response:
         return _global_entry_favorite_impl(request, model_cls, fav_model_cls, pk)
 
-    view.__name__ = f'global_entry_favorite_{global_name}'  # type: ignore[attr-defined]
-    view.__qualname__ = f'global_entry_favorite_{global_name}'  # type: ignore[attr-defined]
+    view.__name__ = f"global_entry_favorite_{global_name}"  # type: ignore[attr-defined]
+    view.__qualname__ = f"global_entry_favorite_{global_name}"  # type: ignore[attr-defined]
     return view
 
 
@@ -396,107 +428,115 @@ def make_global_entry_favorite_view(global_name: str):
     request=None,
     responses={
         200: {
-            'type': 'object',
-            'properties': {
-                'cloud_name': {'type': 'string'},
-                'api_key': {'type': 'string'},
-                'folder': {'type': 'string'},
+            "type": "object",
+            "properties": {
+                "cloud_name": {"type": "string"},
+                "api_key": {"type": "string"},
+                "folder": {"type": "string"},
             },
-            'required': ['cloud_name', 'api_key'],
+            "required": ["cloud_name", "api_key"],
         }
     },
 )
-@api_view(['GET'])
+@api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def cloudinary_widget_config(request: Request) -> Response:
     """Return Cloudinary config needed to initialize the Upload Widget."""
-    cloud_name = os.environ.get('CLOUDINARY_CLOUD_NAME')
-    api_key = os.environ.get('CLOUDINARY_API_KEY')
-    folder = os.environ.get('CLOUDINARY_UPLOAD_FOLDER', '').strip()
+    cloud_name = os.environ.get("CLOUDINARY_CLOUD_NAME")
+    api_key = os.environ.get("CLOUDINARY_API_KEY")
+    folder = os.environ.get("CLOUDINARY_UPLOAD_FOLDER", "").strip()
 
     if not cloud_name or not api_key:
         return Response(
-            {'detail': 'Cloudinary is not configured on the server.'},
+            {"detail": "Cloudinary is not configured on the server."},
             status=status.HTTP_503_SERVICE_UNAVAILABLE,
         )
 
-    payload: dict[str, str] = {'cloud_name': cloud_name, 'api_key': api_key}
+    payload: dict[str, str] = {"cloud_name": cloud_name, "api_key": api_key}
     if folder:
-        payload['folder'] = folder
-    preset = os.environ.get('CLOUDINARY_UPLOAD_PRESET', '').strip()
+        payload["folder"] = folder
+    preset = os.environ.get("CLOUDINARY_UPLOAD_PRESET", "").strip()
     if preset:
-        payload['upload_preset'] = preset
+        payload["upload_preset"] = preset
     return Response(payload)
 
 
 @extend_schema(
     request={
-        'application/json': {
-            'type': 'object',
-            'properties': {'params_to_sign': {'type': 'object'}},
-            'required': ['params_to_sign'],
+        "application/json": {
+            "type": "object",
+            "properties": {"params_to_sign": {"type": "object"}},
+            "required": ["params_to_sign"],
         }
     },
     responses={
         200: {
-            'type': 'object',
-            'properties': {'signature': {'type': 'string'}},
-            'required': ['signature'],
+            "type": "object",
+            "properties": {"signature": {"type": "string"}},
+            "required": ["signature"],
         }
     },
 )
-@api_view(['POST'])
+@api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def cloudinary_widget_sign(request: Request) -> Response:
     """Sign the params_to_sign dict provided by the Cloudinary Upload Widget."""
-    api_secret = os.environ.get('CLOUDINARY_API_SECRET')
+    api_secret = os.environ.get("CLOUDINARY_API_SECRET")
     if not api_secret:
         return Response(
-            {'detail': 'Cloudinary is not configured on the server.'},
+            {"detail": "Cloudinary is not configured on the server."},
             status=status.HTTP_503_SERVICE_UNAVAILABLE,
         )
 
-    params_to_sign = request.data.get('params_to_sign', {})
+    params_to_sign = request.data.get("params_to_sign", {})
     if not isinstance(params_to_sign, dict):
-        return Response({'detail': 'params_to_sign must be an object.'}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(
+            {"detail": "params_to_sign must be an object."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
 
     # Cloudinary signature format: sorted key=value pairs joined by '&',
     # then append the API secret and SHA1-hash the result.
-    signing_string = '&'.join(
-        f'{key}={params_to_sign[key]}' for key in sorted(params_to_sign.keys())
+    signing_string = "&".join(
+        f"{key}={params_to_sign[key]}" for key in sorted(params_to_sign.keys())
     )
-    signature = hashlib.sha1(f'{signing_string}{api_secret}'.encode('utf-8')).hexdigest()
-    return Response({'signature': signature})
+    signature = hashlib.sha1(
+        f"{signing_string}{api_secret}".encode("utf-8")
+    ).hexdigest()
+    return Response({"signature": signature})
 
 
 @extend_schema(request=None, responses={204: None})
 @ensure_csrf_cookie
-@api_view(['GET'])
+@api_view(["GET"])
 @permission_classes([AllowAny])
 def csrf(request: Request) -> Response:
     return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 @extend_schema(request=LoginSerializer, responses={200: AuthUserSerializer})
-@api_view(['POST'])
+@api_view(["POST"])
 @permission_classes([AllowAny])
 def auth_login(request: Request) -> Response:
     serializer = LoginSerializer(data=request.data)
     serializer.is_valid(raise_exception=True)
-    email = serializer.validated_data['email']
-    password = serializer.validated_data['password']
+    email = serializer.validated_data["email"]
+    password = serializer.validated_data["password"]
     user_model = get_user_model()
     matched = user_model.objects.filter(email__iexact=email).first()
     auth_username = matched.username if matched else email
     user = authenticate(request=request, username=auth_username, password=password)
     if user is None:
-        return Response({'detail': 'Invalid email or password.'}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(
+            {"detail": "Invalid email or password."}, status=status.HTTP_400_BAD_REQUEST
+        )
+    bootstrap_dev_user(user)
     login(request, user)
     return Response(AuthUserSerializer(user).data)
 
 
 @extend_schema(request=None, responses={204: None})
-@api_view(['POST'])
+@api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def auth_logout(request: Request) -> Response:
     logout(request)
@@ -504,26 +544,26 @@ def auth_logout(request: Request) -> Response:
 
 
 @extend_schema(request=None, responses={200: AuthUserSerializer, 401: None})
-@api_view(['GET'])
+@api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def auth_me(request: Request) -> Response:
     return Response(AuthUserSerializer(request.user).data)
 
 
 @extend_schema(request=GoogleAuthSerializer, responses={200: AuthUserSerializer})
-@api_view(['POST'])
+@api_view(["POST"])
 @permission_classes([AllowAny])
 def auth_google(request: Request) -> Response:
     client_id = settings.GOOGLE_OAUTH_CLIENT_ID
     if not client_id:
         return Response(
-            {'detail': 'Google sign-in is not configured on this server.'},
+            {"detail": "Google sign-in is not configured on this server."},
             status=status.HTTP_503_SERVICE_UNAVAILABLE,
         )
 
     serializer = GoogleAuthSerializer(data=request.data)
     serializer.is_valid(raise_exception=True)
-    credential = serializer.validated_data['credential']
+    credential = serializer.validated_data["credential"]
 
     try:
         idinfo = google_id_token.verify_oauth2_token(
@@ -531,19 +571,26 @@ def auth_google(request: Request) -> Response:
         )
     except ValueError as e:
         import logging
-        logging.getLogger(__name__).error('Google token verification failed: %s', e)
-        return Response({'detail': 'Invalid Google credential.'}, status=status.HTTP_400_BAD_REQUEST)
 
-    google_sub = idinfo['sub']
-    email = idinfo.get('email', '')
-    first_name = idinfo.get('given_name', '')
-    last_name = idinfo.get('family_name', '')
-    picture = idinfo.get('picture', '')
+        logging.getLogger(__name__).error("Google token verification failed: %s", e)
+        return Response(
+            {"detail": "Invalid Google credential."}, status=status.HTTP_400_BAD_REQUEST
+        )
+
+    google_sub = idinfo["sub"]
+    email = idinfo.get("email", "")
+    first_name = idinfo.get("given_name", "")
+    last_name = idinfo.get("family_name", "")
+    picture = idinfo.get("picture", "")
 
     User = get_user_model()
 
     # Look up by Google subject first (handles email changes gracefully).
-    profile = UserProfile.objects.filter(openid_subject=google_sub).select_related('user').first()
+    profile = (
+        UserProfile.objects.filter(openid_subject=google_sub)
+        .select_related("user")
+        .first()
+    )
     if profile:
         user = profile.user
         # Refresh display name and picture in case they changed.
@@ -556,7 +603,11 @@ def auth_google(request: Request) -> Response:
     else:
         # Fall back to matching by email so existing email/password accounts
         # can sign in via Google without creating a duplicate.
-        existing_profile = UserProfile.objects.filter(user__email__iexact=email).select_related('user').first()
+        existing_profile = (
+            UserProfile.objects.filter(user__email__iexact=email)
+            .select_related("user")
+            .first()
+        )
         found_user = existing_profile.user if existing_profile else None
         if found_user is None:
             user = User.objects.create_user(
@@ -576,15 +627,16 @@ def auth_google(request: Request) -> Response:
         profile.profile_image_url = picture
         profile.save()
 
+    bootstrap_dev_user(user)
     login(request, user)
     return Response(AuthUserSerializer(user).data)
 
 
 @extend_schema(
-    methods=['GET'],
+    methods=["GET"],
     responses={200: GlazeCombinationImageEntrySerializer(many=True)},
 )
-@api_view(['GET'])
+@api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def glaze_combination_images(request: Request) -> Response:
     """Return images from pieces grouped by the glaze combination applied.
@@ -600,21 +652,20 @@ def glaze_combination_images(request: Request) -> Response:
     qualifying = get_glaze_image_qualifying_states()
 
     # Resolve the GlazeCombination junction model generated at import time.
-    GlazeCombinationRef = apps.get_model('api', 'PieceStateGlazeCombinationRef')
+    GlazeCombinationRef = apps.get_model("api", "PieceStateGlazeCombinationRef")
 
     # Collect all (piece_id → combo_id) mappings for this user's pieces.
     # A piece may appear in multiple refs (glazed + glaze_fired both carry the
     # combo forward), so deduplicate by piece — same combo in each case.
     refs = (
-        GlazeCombinationRef.objects
-        .filter(piece_state__piece__user=request.user)
-        .values('piece_state__piece_id', 'glaze_combination_id')
+        GlazeCombinationRef.objects.filter(piece_state__piece__user=request.user)
+        .values("piece_state__piece_id", "glaze_combination_id")
         .distinct()
     )
     piece_to_combo: dict = {}
     for ref in refs:
-        piece_id = ref['piece_state__piece_id']
-        combo_id = ref['glaze_combination_id']
+        piece_id = ref["piece_state__piece_id"]
+        combo_id = ref["glaze_combination_id"]
         piece_to_combo[piece_id] = combo_id
 
     if not piece_to_combo:
@@ -622,14 +673,13 @@ def glaze_combination_images(request: Request) -> Response:
 
     # Fetch qualifying PieceState records that have at least one image.
     qualifying_ps = (
-        PieceState.objects
-        .filter(
+        PieceState.objects.filter(
             piece_id__in=piece_to_combo.keys(),
             piece__user=request.user,  # type: ignore[misc]
             state__in=qualifying,
         )
-        .select_related('piece')
-        .order_by('-last_modified')
+        .select_related("piece")
+        .order_by("-last_modified")
     )
 
     # Group images and state by piece — collect all images across qualifying states.
@@ -640,19 +690,19 @@ def glaze_combination_images(request: Request) -> Response:
         pid = ps.piece_id
         if pid not in piece_data:
             piece_data[pid] = {
-                'id': str(pid),
-                'name': ps.piece.name,
-                'state': ps.state,
-                'images': list(ps.images),
-                'last_modified': ps.last_modified,
+                "id": str(pid),
+                "name": ps.piece.name,
+                "state": ps.state,
+                "images": list(ps.images),
+                "last_modified": ps.last_modified,
             }
         else:
             # Additional qualifying state for the same piece: extend images;
             # keep state pointing at the most recently modified qualifying state.
-            if ps.last_modified > piece_data[pid]['last_modified']:
-                piece_data[pid]['state'] = ps.state
-                piece_data[pid]['last_modified'] = ps.last_modified
-            piece_data[pid]['images'].extend(ps.images)
+            if ps.last_modified > piece_data[pid]["last_modified"]:
+                piece_data[pid]["state"] = ps.state
+                piece_data[pid]["last_modified"] = ps.last_modified
+            piece_data[pid]["images"].extend(ps.images)
 
     # Group pieces by combo.
     combo_pieces: dict = defaultdict(list)
@@ -663,27 +713,25 @@ def glaze_combination_images(request: Request) -> Response:
 
     # Sort pieces within each combo by last_modified descending.
     for combo_id in combo_pieces:
-        combo_pieces[combo_id].sort(key=lambda d: d['last_modified'], reverse=True)
+        combo_pieces[combo_id].sort(key=lambda d: d["last_modified"], reverse=True)
 
     # Sort combos by the most-recently-modified qualifying piece.
     def _combo_latest(combo_id):
         pieces = combo_pieces.get(combo_id, [])
         if not pieces:
             return None
-        return max(d['last_modified'] for d in pieces)
+        return max(d["last_modified"] for d in pieces)
 
     sorted_combo_ids = sorted(combo_pieces.keys(), key=_combo_latest, reverse=True)
 
     # Bulk-fetch GlazeCombination objects for serialization.
-    combos_qs = (
-        GlazeCombination.objects
-        .filter(pk__in=sorted_combo_ids)
-        .prefetch_related('layers__glaze_type', 'firing_temperature')
-    )
+    combos_qs = GlazeCombination.objects.filter(
+        pk__in=sorted_combo_ids
+    ).prefetch_related("layers__glaze_type", "firing_temperature")
     combo_by_id = {c.pk: c for c in combos_qs}
 
     favorite_ids = FavoriteGlazeCombination.get_favorite_ids_for(request.user)
-    ctx = {'request': request, 'favorite_ids': favorite_ids}
+    ctx = {"request": request, "favorite_ids": favorite_ids}
 
     result = []
     for combo_id in sorted_combo_ids:
@@ -692,20 +740,22 @@ def glaze_combination_images(request: Request) -> Response:
             continue
         pieces_payload = [
             {
-                'id': d['id'],
-                'name': d['name'],
-                'state': d['state'],
-                'images': d['images'],
+                "id": d["id"],
+                "name": d["name"],
+                "state": d["state"],
+                "images": d["images"],
             }
             for d in combo_pieces[combo_id]
         ]
-        result.append({
-            # Pass the model instance so the nested GlazeCombinationEntrySerializer
-            # can serialize it properly (it expects obj.pk, obj.layers, etc.).
-            # Context (favorite_ids) propagates from the top-level serializer.
-            'glaze_combination': combo,
-            'pieces': pieces_payload,
-        })
+        result.append(
+            {
+                # Pass the model instance so the nested GlazeCombinationEntrySerializer
+                # can serialize it properly (it expects obj.pk, obj.layers, etc.).
+                # Context (favorite_ids) propagates from the top-level serializer.
+                "glaze_combination": combo,
+                "pieces": pieces_payload,
+            }
+        )
 
     return Response(
         GlazeCombinationImageEntrySerializer(result, many=True, context=ctx).data
@@ -713,59 +763,81 @@ def glaze_combination_images(request: Request) -> Response:
 
 
 @extend_schema(request=RegisterSerializer, responses={201: AuthUserSerializer})
-@api_view(['POST'])
+@api_view(["POST"])
 @permission_classes([AllowAny])
 def auth_register(request: Request) -> Response:
     serializer = RegisterSerializer(data=request.data)
     serializer.is_valid(raise_exception=True)
     user_model = get_user_model()
-    if user_model.objects.filter(email__iexact=serializer.validated_data['email']).exists():
-        return Response({'email': ['A user with this email already exists.']}, status=status.HTTP_400_BAD_REQUEST)
+    if user_model.objects.filter(
+        email__iexact=serializer.validated_data["email"]
+    ).exists():
+        return Response(
+            {"email": ["A user with this email already exists."]},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
     user = serializer.save()
+    bootstrap_dev_user(user)
     login(request, user)
     return Response(AuthUserSerializer(user).data, status=status.HTTP_201_CREATED)
 
 
 @extend_schema(
-    request={'multipart/form-data': {
-        'type': 'object',
-        'properties': {
-            'payload': {'type': 'string'},
-        },
-        'required': ['payload'],
-    }},
-    responses={200: {'type': 'object'}},
+    request={
+        "multipart/form-data": {
+            "type": "object",
+            "properties": {
+                "payload": {"type": "string"},
+            },
+            "required": ["payload"],
+        }
+    },
+    responses={200: {"type": "object"}},
 )
-@api_view(['POST'])
+@api_view(["POST"])
 @permission_classes([IsAdminUser])
 @parser_classes([MultiPartParser, FormParser])
 def admin_manual_square_crop_import(request: Request) -> Response:
-    payload_raw = request.data.get('payload', '')
+    payload_raw = request.data.get("payload", "")
     if not payload_raw:
-        return Response({'detail': 'payload is required.'}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(
+            {"detail": "payload is required."}, status=status.HTTP_400_BAD_REQUEST
+        )
     try:
         payload = json.loads(payload_raw)
     except json.JSONDecodeError:
-        return Response({'detail': 'payload must be valid JSON.'}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(
+            {"detail": "payload must be valid JSON."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
 
-    records = payload.get('records')
+    records = payload.get("records")
     if not isinstance(records, list) or not records:
-        return Response({'detail': 'payload.records must be a non-empty list.'}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(
+            {"detail": "payload.records must be a non-empty list."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
 
-    if any(not record.get('reviewed') for record in records):
-        return Response({'detail': 'All records must be reviewed before import.'}, status=status.HTTP_400_BAD_REQUEST)
+    if any(not record.get("reviewed") for record in records):
+        return Response(
+            {"detail": "All records must be reviewed before import."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
 
     uploaded_files = {}
     for record in records:
-        client_id = record.get('client_id', '')
+        client_id = record.get("client_id", "")
         if not client_id:
-            return Response({'detail': 'Each record must include client_id.'}, status=status.HTTP_400_BAD_REQUEST)
-        file_obj = request.FILES.get(f'crop_image__{client_id}')
+            return Response(
+                {"detail": "Each record must include client_id."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        file_obj = request.FILES.get(f"crop_image__{client_id}")
         if file_obj is not None:
             uploaded_files[client_id] = file_obj
 
     try:
         result = import_manual_tile_records(records, uploaded_files)
     except ValueError as exc:
-        return Response({'detail': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
     return Response(result)

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -212,6 +212,11 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 # Google OAuth — set GOOGLE_OAUTH_CLIENT_ID in the environment to enable Google sign-in.
 GOOGLE_OAUTH_CLIENT_ID = os.environ.get("GOOGLE_OAUTH_CLIENT_ID", "")
 
+# Development bootstrap helpers. Enabled by default in DEBUG to make freshly
+# created local worktrees usable immediately after first login, but fully
+# disabled in production.
+DEV_BOOTSTRAP_ENABLED = DEBUG and os.environ.get("GLAZE_DEV_BOOTSTRAP", "1") == "1"
+
 # Security settings
 SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
 SECURE_CROSS_ORIGIN_OPENER_POLICY = "same-origin-allow-popups"

--- a/backend/test_settings.py
+++ b/backend/test_settings.py
@@ -2,5 +2,8 @@ from .settings import *  # noqa: F401,F403
 
 # Speed up tests that create/authenticate users by using a lightweight hasher.
 PASSWORD_HASHERS = [
-    'django.contrib.auth.hashers.MD5PasswordHasher',
+    "django.contrib.auth.hashers.MD5PasswordHasher",
 ]
+
+# Tests opt into dev bootstrap behavior explicitly when needed.
+DEV_BOOTSTRAP_ENABLED = False

--- a/docs/agents/dev.md
+++ b/docs/agents/dev.md
@@ -18,6 +18,7 @@ npm run dev
 
 See [`env.sh`](../../env.sh) for shell helpers (`gz_setup`, `gz_start`, etc.) that wrap these commands.
 In a new environment, always run `source env.sh` and `gz_setup` before trying to do anything else.
+`gz_setup` reuses the main checkout's `.venv` and `web/node_modules` by default when invoked from a repo-local worktree. Use `gz_setup --isolated` (or `GLAZE_SETUP_ISOLATED=1 gz_setup`) when a branch needs its own dependency environment, such as when changing Python requirements or Node packages.
 
 ---
 
@@ -45,6 +46,22 @@ Two scripts handle environment bootstrap:
 ### Codex and other agents
 
 `env-agent.sh` exports `BASH_ENV` pointing at itself, so any agent process spawned from a shell that has already sourced `env.sh` (e.g. a VS Code terminal) automatically propagates the bootstrap to its own subshells. No per-tool config is needed for Codex or similar CLI agents launched from the integrated terminal.
+
+### Agent worktree location
+
+Keep agent-created worktrees inside the repository instead of under `/tmp` or another system temp directory:
+
+- Shared worktree root: `.agent-worktrees/<agent>/<branch-or-task>`
+- Claude example: `.agent-worktrees/claude/<branch-or-task>`
+- Codex example: `.agent-worktrees/codex/<branch-or-task>`
+
+Keep repo-local agent configuration out of `.codex`, which may be reserved by the local Codex installation. Prefer:
+
+- Codex-specific local config: `.agent-config/codex/`
+- Shared agent assets and instructions: `.agents/`
+
+This keeps worktrees close to the repo-local bootstrap, makes cleanup easier, and avoids temp-directory permission/path surprises. `env-agent.sh` resolves the active git worktree root from the current working directory, then falls back to the main checkout's `.env.local` files and `.venv` when the worktree does not have its own copies yet, so repo-local worktrees inherit the normal dev setup without manually copying secrets first.
+When you do want a truly separate dependency environment inside the worktree, run `gz_setup --isolated` to replace any shared `.venv` or `web/node_modules` symlinks with local worktree-specific installs.
 
 ### Working directory discipline
 

--- a/env-agent.sh
+++ b/env-agent.sh
@@ -6,10 +6,42 @@
 [[ -n "$_GLAZE_AGENT_ENV_LOADED" ]] && return
 export _GLAZE_AGENT_ENV_LOADED=1
 
-GLAZE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_GLAZE_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+_gz_detect_git_root() {
+    local cwd="${PWD:-$_GLAZE_SCRIPT_DIR}"
+    git -C "$cwd" rev-parse --show-toplevel 2>/dev/null
+}
+
+_gz_detect_shared_root() {
+    local git_root="$1"
+    local common_dir
+    common_dir="$(git -C "$git_root" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || return 1
+    cd "$common_dir/.." 2>/dev/null && pwd
+}
+
+GLAZE_ROOT="$(_gz_detect_git_root)"
+GLAZE_ROOT="${GLAZE_ROOT:-$_GLAZE_SCRIPT_DIR}"
+GLAZE_SHARED_ROOT="$(_gz_detect_shared_root "$GLAZE_ROOT")"
+GLAZE_SHARED_ROOT="${GLAZE_SHARED_ROOT:-$GLAZE_ROOT}"
+export GLAZE_ROOT GLAZE_SHARED_ROOT
+
+_gz_preferred_root_for() {
+    local rel="$1"
+    if [[ -e "$GLAZE_ROOT/$rel" ]]; then
+        printf '%s\n' "$GLAZE_ROOT"
+        return 0
+    fi
+    if [[ "$GLAZE_SHARED_ROOT" != "$GLAZE_ROOT" && -e "$GLAZE_SHARED_ROOT/$rel" ]]; then
+        printf '%s\n' "$GLAZE_SHARED_ROOT"
+        return 0
+    fi
+    printf '%s\n' "$GLAZE_ROOT"
+}
 
 # Activate venv if present
-[[ -f "$GLAZE_ROOT/.venv/bin/activate" ]] && source "$GLAZE_ROOT/.venv/bin/activate"
+_GLAZE_VENV_ROOT="$(_gz_preferred_root_for ".venv/bin/activate")"
+[[ -f "$_GLAZE_VENV_ROOT/.venv/bin/activate" ]] && source "$_GLAZE_VENV_ROOT/.venv/bin/activate"
 
 # Load local env vars
 _gz_load_env_file() {
@@ -20,10 +52,18 @@ _gz_load_env_file() {
     source "$path"
     set +a
 }
-_gz_load_env_file "$GLAZE_ROOT/.env.local"
-_gz_load_env_file "$GLAZE_ROOT/web/.env.local"
-_gz_load_env_file "$GLAZE_ROOT/mobile/.env.local"
+
+_gz_load_preferred_env_file() {
+    local rel="$1"
+    local preferred_root
+    preferred_root="$(_gz_preferred_root_for "$rel")"
+    _gz_load_env_file "$preferred_root/$rel"
+}
+
+_gz_load_preferred_env_file ".env.local"
+_gz_load_preferred_env_file "web/.env.local"
+_gz_load_preferred_env_file "mobile/.env.local"
 
 # Propagate to child processes so agents spawned from an interactive shell
 # (Codex, etc.) also get this bootstrap without per-tool config.
-export BASH_ENV="$GLAZE_ROOT/env-agent.sh"
+export BASH_ENV="$_GLAZE_SCRIPT_DIR/env-agent.sh"

--- a/env.sh
+++ b/env.sh
@@ -5,11 +5,13 @@
 # When used as --rcfile, ~/.bashrc is not loaded automatically — do it first.
 [[ -f ~/.bashrc ]] && source ~/.bashrc
 
-GLAZE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_GLAZE_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Bootstrap: venv activation, .env.local loading, BASH_ENV export.
 # env-agent.sh is also the entry point for non-interactive agent subshells.
-source "$GLAZE_ROOT/env-agent.sh"
+source "$_GLAZE_SCRIPT_DIR/env-agent.sh"
+GLAZE_ROOT="${GLAZE_ROOT:-$_GLAZE_SCRIPT_DIR}"
+GLAZE_SHARED_ROOT="${GLAZE_SHARED_ROOT:-$GLAZE_ROOT}"
 
 _GLAZE_PIDS="$GLAZE_ROOT/.dev-pids"
 _GLAZE_LOGS="$GLAZE_ROOT/.dev-logs"
@@ -55,6 +57,40 @@ _gz_rotate_log() {  # _gz_rotate_log <name>
     [[ -f "$logfile" ]] && mv "$logfile" "${logfile%.log}.$(date +%Y%m%dT%H%M%S).log"
 }
 
+_gz_preferred_root_for() {  # _gz_preferred_root_for <relative_path>
+    local rel="$1"
+    if [[ -e "$GLAZE_ROOT/$rel" ]]; then
+        printf '%s\n' "$GLAZE_ROOT"
+        return 0
+    fi
+    if [[ "$GLAZE_SHARED_ROOT" != "$GLAZE_ROOT" && -e "$GLAZE_SHARED_ROOT/$rel" ]]; then
+        printf '%s\n' "$GLAZE_SHARED_ROOT"
+        return 0
+    fi
+    printf '%s\n' "$GLAZE_ROOT"
+}
+
+_gz_venv_root() {
+    _gz_preferred_root_for ".venv/bin/activate"
+}
+
+_gz_remove_symlink_if_present() {  # _gz_remove_symlink_if_present <path>
+    local path="$1"
+    [[ -L "$path" ]] || return 1
+    rm "$path"
+    return 0
+}
+
+_gz_link_shared_dir_if_missing() {  # _gz_link_shared_dir_if_missing <relative_path>
+    local rel="$1"
+    local shared_path="$GLAZE_SHARED_ROOT/$rel"
+    local local_path="$GLAZE_ROOT/$rel"
+    [[ "$GLAZE_SHARED_ROOT" == "$GLAZE_ROOT" ]] && return 1
+    [[ -e "$local_path" || ! -e "$shared_path" ]] && return 1
+    mkdir -p "$(dirname "$local_path")"
+    ln -s "$shared_path" "$local_path"
+}
+
 _gz_ensure_node() {
     if command -v node &>/dev/null; then
         return 0
@@ -84,9 +120,15 @@ _gz_load_env_file() {  # _gz_load_env_file <path>
 }
 
 _gz_load_local_env() {
-    _gz_load_env_file "$GLAZE_ROOT/.env.local"
-    _gz_load_env_file "$GLAZE_ROOT/web/.env.local"
-    _gz_load_env_file "$GLAZE_ROOT/mobile/.env.local"
+    local root
+    root="$(_gz_preferred_root_for ".env.local")"
+    _gz_load_env_file "$root/.env.local"
+
+    root="$(_gz_preferred_root_for "web/.env.local")"
+    _gz_load_env_file "$root/web/.env.local"
+
+    root="$(_gz_preferred_root_for "mobile/.env.local")"
+    _gz_load_env_file "$root/mobile/.env.local"
 }
 
 # ---------------------------------------------------------------------------
@@ -119,7 +161,29 @@ gz_install_mcp_tools() {
 }
 
 gz_setup() {
+    local setup_mode="shared"
+    if [[ "${GLAZE_SETUP_ISOLATED:-0}" == "1" ]]; then
+        setup_mode="isolated"
+    fi
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --isolated)
+                setup_mode="isolated"
+                ;;
+            --shared)
+                setup_mode="shared"
+                ;;
+            *)
+                echo "Usage: gz_setup [--shared|--isolated]"
+                return 2
+                ;;
+        esac
+        shift
+    done
+
     echo "=== Glaze: setting up development environment ==="
+    echo "--- Setup mode: $setup_mode"
     # RTK
     if ! command -v rtk &>/dev/null; then
         echo "--- Installing RTK (for test optimizations and type generation)..."
@@ -128,12 +192,34 @@ gz_setup() {
     fi
 
     # Python venv
-    if [[ ! -d "$GLAZE_ROOT/.venv" ]]; then
-        echo "--- Creating virtual environment..."
-        rtk python3 -m venv "$GLAZE_ROOT/.venv"
+    if [[ "$setup_mode" == "isolated" ]]; then
+        if _gz_remove_symlink_if_present "$GLAZE_ROOT/.venv"; then
+            echo "--- Replacing shared .venv symlink with an isolated worktree virtual environment"
+        fi
+        if [[ ! -f "$GLAZE_ROOT/.venv/bin/activate" ]]; then
+            echo "--- Creating virtual environment..."
+            rtk python3 -m venv "$GLAZE_ROOT/.venv"
+        fi
+        source "$GLAZE_ROOT/.venv/bin/activate"
+        echo "--- Installing Python dependencies into the isolated worktree virtual environment..."
+    else
+        if [[ ! -f "$GLAZE_ROOT/.venv/bin/activate" ]]; then
+            if _gz_link_shared_dir_if_missing ".venv"; then
+                echo "--- Reusing shared virtual environment from $GLAZE_SHARED_ROOT/.venv"
+            elif [[ -f "$GLAZE_SHARED_ROOT/.venv/bin/activate" && "$GLAZE_SHARED_ROOT" != "$GLAZE_ROOT" ]]; then
+                echo "--- Reusing shared virtual environment from $GLAZE_SHARED_ROOT/.venv"
+            else
+                echo "--- Creating virtual environment..."
+                rtk python3 -m venv "$GLAZE_ROOT/.venv"
+            fi
+        fi
+        source "$(_gz_venv_root)/.venv/bin/activate"
+        if [[ "$(_gz_venv_root)" == "$GLAZE_SHARED_ROOT" && "$GLAZE_SHARED_ROOT" != "$GLAZE_ROOT" ]]; then
+            echo "--- Shared Python dependencies already available in $GLAZE_SHARED_ROOT/.venv"
+        else
+            echo "--- Installing Python dependencies..."
+        fi
     fi
-    source "$GLAZE_ROOT/.venv/bin/activate"
-    echo "--- Installing Python dependencies..."
     rtk pip install -r "$GLAZE_ROOT/requirements-dev.txt" -q
 
     # Database
@@ -142,7 +228,21 @@ gz_setup() {
 
     # Node + web deps
     _gz_ensure_node
-    echo "--- Installing web dependencies..."
+    if [[ "$setup_mode" == "isolated" ]]; then
+        if _gz_remove_symlink_if_present "$GLAZE_ROOT/web/node_modules"; then
+            echo "--- Replacing shared web/node_modules symlink with isolated worktree dependencies"
+        fi
+        echo "--- Installing web dependencies into the isolated worktree..."
+    else
+        if _gz_link_shared_dir_if_missing "web/node_modules"; then
+            echo "--- Reusing shared web/node_modules from $GLAZE_SHARED_ROOT/web/node_modules"
+        fi
+        if [[ -d "$GLAZE_ROOT/web/node_modules" ]]; then
+            echo "--- Web dependencies already available"
+        else
+            echo "--- Installing web dependencies..."
+        fi
+    fi
     (cd "$GLAZE_ROOT/web" && rtk npm install --silent)
 
     echo "=== Setup complete ==="
@@ -156,7 +256,7 @@ gz_setup() {
 
 gz_manage() {        # gz_manage <subcommand> [args…]
     (
-        source "$GLAZE_ROOT/.venv/bin/activate"
+        source "$(_gz_venv_root)/.venv/bin/activate"
         cd "$GLAZE_ROOT"
         python manage.py "$@"
     )
@@ -184,7 +284,7 @@ gz_prod_dbshell()    { gz_prod dbshell "$@"; }
 
 gz_test_common() {
     (
-        source "$GLAZE_ROOT/.venv/bin/activate"
+        source "$(_gz_venv_root)/.venv/bin/activate"
         cd "$GLAZE_ROOT"
         pytest tests/ "$@"
     )
@@ -192,7 +292,7 @@ gz_test_common() {
 
 gz_test_backend() {
     (
-        source "$GLAZE_ROOT/.venv/bin/activate"
+        source "$(_gz_venv_root)/.venv/bin/activate"
         cd "$GLAZE_ROOT"
         pytest api/ "$@"
     )
@@ -214,7 +314,7 @@ gz_lint() {
 # Auto-fix: reformat Python files and apply ruff auto-fixes in one step.
 gz_format() {
     (
-        source "$GLAZE_ROOT/.venv/bin/activate"
+        source "$(_gz_venv_root)/.venv/bin/activate"
         cd "$GLAZE_ROOT"
         ruff format .
         ruff check --fix .
@@ -232,8 +332,11 @@ gz_build() {
 # ---------------------------------------------------------------------------
 
 gz_backend() {
+    local venv_root env_root
+    venv_root="$(_gz_venv_root)"
+    env_root="$(_gz_preferred_root_for ".env.local")"
     _gz_start backend "$_GLAZE_LOGS/backend.log" \
-        bash -c "source '$GLAZE_ROOT/.venv/bin/activate' && cd '$GLAZE_ROOT' && set -a && [ -f '$GLAZE_ROOT/.env.local' ] && source '$GLAZE_ROOT/.env.local'; set +a && python manage.py load_public_library --skip-if-missing && python manage.py runserver 8080"
+        bash -c "source '$venv_root/.venv/bin/activate' && cd '$GLAZE_ROOT' && set -a && [ -f '$env_root/.env.local' ] && source '$env_root/.env.local'; set +a && python manage.py load_public_library --skip-if-missing && python manage.py runserver 8080"
 }
 
 gz_web() {
@@ -302,7 +405,7 @@ gz_gentypes() {
     _gz_ensure_node
     echo "Exporting OpenAPI schema..."
     (
-        source "$GLAZE_ROOT/.venv/bin/activate"
+        source "$(_gz_venv_root)/.venv/bin/activate"
         cd "$GLAZE_ROOT"
         python manage.py spectacular --format openapi-json --file "$schema_path"
     ) || {
@@ -328,7 +431,7 @@ gz_gentypes() {
 _GZ_SHORTCUTS=(
     "gz_help           — show this list of shortcuts"
     "gz_install_mcp_tools — install MCP tool dependencies (jq, curl, git, gh)"
-    "gz_setup          — first-time setup (venv, deps, migrations, node)"
+    "gz_setup [--isolated] — setup (shared reuse by default; --isolated for per-worktree deps)"
     "gz_manage <cmd>   — run any manage.py subcommand"
     "gz_migrate        — migrate"
     "gz_makemigrations — makemigrations"


### PR DESCRIPTION
## Summary
- make `env-agent.sh` and `env.sh` worktree-aware so repo-local worktrees inherit shared `.env.local` and dependency roots by default
- bootstrap the first local dev user as admin and seed a few representative pieces for faster manual testing
- standardize docs on repo-local `.agent-worktrees/` and `.agent-config/codex/`, and add `gz_setup --isolated` for branches that need worktree-local Python or Node dependencies

## Why
Issue #178 asks for a smoother dev-server experience in agent-spawned worktrees, especially around env setup, admin creation, and initial data.

## Validation
- `bash -n env.sh env-agent.sh`
- `gz_setup --shared`
- `rtk bazel test //...`
- `rtk bazel build --config=lint //...`
- `gz_build`

Closes #178