### PR TITLE
Add past_friendly_name to workflow states for history display

### DIFF
--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -107,6 +107,7 @@ def _state(state_id, **overrides):
         "id": state_id,
         "visible": True,
         "friendly_name": state_id.title(),
+        "past_friendly_name": state_id.title(),
         "description": f"{state_id} description",
     }
     state.update(overrides)
@@ -173,7 +174,18 @@ class TestSchemaValidation:
         bad = {
             "version": "1.0.0",
             "states": [
-                {"id": "a", "visible": True, "description": "desc", "successors": ["b"]},
+                {"id": "a", "visible": True, "past_friendly_name": "A", "description": "desc", "successors": ["b"]},
+                _state("b", terminal=True),
+            ],
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=bad, schema=schema)
+
+    def test_missing_past_friendly_name_fails(self, schema):
+        bad = {
+            "version": "1.0.0",
+            "states": [
+                {"id": "a", "visible": True, "friendly_name": "A", "description": "desc", "successors": ["b"]},
                 _state("b", terminal=True),
             ],
         }
@@ -184,7 +196,7 @@ class TestSchemaValidation:
         bad = {
             "version": "1.0.0",
             "states": [
-                {"id": "a", "visible": True, "friendly_name": "A", "successors": ["b"]},
+                {"id": "a", "visible": True, "friendly_name": "A", "past_friendly_name": "A", "successors": ["b"]},
                 _state("b", terminal=True),
             ],
         }

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -30,6 +30,7 @@ import type {
 } from "../util/types";
 import {
   formatState,
+  formatPastState,
   getStateDescription,
   isTerminalState,
   SUCCESSORS,
@@ -598,7 +599,7 @@ export default function PieceDetail({
                         }}
                       >
                         <ListItemText
-                          primary={formatState(ps.state)}
+                          primary={formatPastState(ps.state)}
                           secondary={`${ps.created.toLocaleString()}${ps.notes ? " — " + ps.notes : ""}`}
                           slotProps={{
                             primary: { sx: { color: "text.primary" } },

--- a/web/src/components/__tests__/PieceDetail.test.tsx
+++ b/web/src/components/__tests__/PieceDetail.test.tsx
@@ -326,7 +326,7 @@ describe("PieceDetail", () => {
     });
     await renderPieceDetail(piece);
     fireEvent.click(screen.getByRole("button", { name: /show history/i }));
-    expect(screen.getByText("Designing")).toBeInTheDocument();
+    expect(screen.getByText("Designed")).toBeInTheDocument();
   });
 
   it("no history panel when piece has only one state", async () => {

--- a/web/src/util/types.ts
+++ b/web/src/util/types.ts
@@ -2,6 +2,7 @@ import type { components } from "./generated-types";
 import workflow from "../../../workflow.yml";
 export {
   formatState,
+  formatPastState,
   getStateDescription,
   getStateMetadata,
   isTerminalState,
@@ -11,6 +12,7 @@ type WorkflowState = {
   id: string;
   visible: boolean;
   friendly_name: string;
+  past_friendly_name: string;
   description: string;
   successors?: string[];
   terminal?: boolean;

--- a/web/src/util/workflow.test.ts
+++ b/web/src/util/workflow.test.ts
@@ -62,6 +62,7 @@ vi.mock("../../../workflow.yml", () => ({
         id: "designed",
         visible: true,
         friendly_name: "Designing",
+        past_friendly_name: "Designed",
         description: "Dreaming it up.",
         successors: ["wheel_thrown", "handbuilt"],
       },
@@ -69,6 +70,7 @@ vi.mock("../../../workflow.yml", () => ({
         id: "wheel_thrown",
         visible: true,
         friendly_name: "Throwing",
+        past_friendly_name: "Thrown",
         description: "Fresh off the wheel.",
         successors: ["trimmed", "recycled"],
         fields: {
@@ -86,6 +88,7 @@ vi.mock("../../../workflow.yml", () => ({
         id: "submitted_to_bisque_fire",
         visible: true,
         friendly_name: "Queued → Bisque",
+        past_friendly_name: "Bisque Fired",
         description: "Waiting on the kiln...",
         successors: ["bisque_fired", "recycled"],
         fields: {
@@ -99,6 +102,7 @@ vi.mock("../../../workflow.yml", () => ({
         id: "trimmed",
         visible: true,
         friendly_name: "Trimming",
+        past_friendly_name: "Trimmed",
         description: "Ready for surface work.",
         successors: ["submitted_to_bisque_fire", "recycled"],
         fields: {
@@ -115,6 +119,7 @@ vi.mock("../../../workflow.yml", () => ({
         id: "bisque_fired",
         visible: true,
         friendly_name: "Planning → Glaze",
+        past_friendly_name: "Glaze Planned",
         description: "Done with the first firing!",
         successors: ["glazed", "recycled"],
         fields: {
@@ -131,6 +136,7 @@ vi.mock("../../../workflow.yml", () => ({
         id: "glaze_fired",
         visible: true,
         friendly_name: "Touching Up",
+        past_friendly_name: "Touched Up",
         description: "Final cleanup stretch.",
         successors: ["completed", "recycled"],
         fields: {
@@ -146,6 +152,7 @@ vi.mock("../../../workflow.yml", () => ({
         id: "recycled",
         visible: true,
         friendly_name: "Recycled",
+        past_friendly_name: "Recycled",
         description: "Oops! Next time.",
         terminal: true,
       },
@@ -155,6 +162,7 @@ vi.mock("../../../workflow.yml", () => ({
 
 import {
   formatState,
+  formatPastState,
   formatWorkflowFieldLabel,
   getStateDescription,
   getAdditionalFieldDefinitions,
@@ -184,6 +192,21 @@ describe("formatState", () => {
 
   it("returns an empty string for an unknown state instead of synthesizing a fallback", () => {
     expect(formatState("unknown_state")).toBe("");
+  });
+});
+
+describe("formatPastState", () => {
+  it("uses the workflow-authored past_friendly_name for history display", () => {
+    expect(formatPastState("submitted_to_bisque_fire")).toBe("Bisque Fired");
+  });
+
+  it("returns a distinct label from formatState for states with different past names", () => {
+    expect(formatPastState("bisque_fired")).toBe("Glaze Planned");
+    expect(formatState("bisque_fired")).toBe("Planning → Glaze");
+  });
+
+  it("returns an empty string for an unknown state", () => {
+    expect(formatPastState("unknown_state")).toBe("");
   });
 });
 

--- a/web/src/util/workflow.ts
+++ b/web/src/util/workflow.ts
@@ -49,6 +49,7 @@ interface WorkflowStateDefinition {
   id: string;
   visible: boolean;
   friendly_name: string;
+  past_friendly_name: string;
   description: string;
   terminal?: boolean;
   successors?: string[];
@@ -107,6 +108,7 @@ export type ResolvedAdditionalField = {
 export interface WorkflowStateMetadata {
   id: string;
   friendlyName: string;
+  pastFriendlyName: string;
   description: string;
   isTerminal: boolean;
 }
@@ -294,12 +296,21 @@ export function formatWorkflowFieldLabel(fieldName: string): string {
 }
 
 /**
- * Converts a state ID into the shared display label used throughout the UI.
+ * Converts a state ID into the current/upcoming display label (e.g. "Glazing").
  * State labels are required in workflow.yml; this helper intentionally does not
  * synthesize a fallback label from the state ID.
  */
 export function formatState(stateId: string): string {
   return STATE_MAP.get(stateId)?.friendly_name ?? "";
+}
+
+/**
+ * Converts a state ID into the past-tense display label used in history views
+ * (e.g. "Glazed"). State labels are required in workflow.yml; this helper
+ * intentionally does not synthesize a fallback label from the state ID.
+ */
+export function formatPastState(stateId: string): string {
+  return STATE_MAP.get(stateId)?.past_friendly_name ?? "";
 }
 
 export function getStateDescription(stateId: string): string {
@@ -320,6 +331,7 @@ export function getStateMetadata(
   return {
     id: state.id,
     friendlyName: state.friendly_name,
+    pastFriendlyName: state.past_friendly_name,
     description: state.description,
     isTerminal: !!state.terminal,
   };

--- a/workflow.schema.yml
+++ b/workflow.schema.yml
@@ -179,7 +179,7 @@ $defs:
 
   state:
     type: object
-    required: [id, visible, friendly_name, description]
+    required: [id, visible, friendly_name, past_friendly_name, description]
     additionalProperties: false
     properties:
       id:
@@ -192,9 +192,15 @@ $defs:
       friendly_name:
         type: string
         description: |
-          Human-friendly label for this state, used by clients when displaying
-          workflow state names. This is required so every visible state label is
+          Human-friendly label for this state used when the state is current or
+          upcoming (e.g. "Glazing"). Required so every visible state label is
           authored explicitly in workflow.yml rather than synthesized from the ID.
+      past_friendly_name:
+        type: string
+        description: |
+          Human-friendly label for this state used when it appears in history
+          (e.g. "Glazed"). Required so the past tense label is authored explicitly
+          in workflow.yml rather than synthesized from the state ID.
       description:
         type: string
         description: |

--- a/workflow.yml
+++ b/workflow.yml
@@ -245,6 +245,7 @@ states:
   - id: designed
     visible: true
     friendly_name: Designing
+    past_friendly_name: Designed
     description: Dreaming it up and deciding how this piece wants to begin.
     successors:
       - wheel_thrown
@@ -253,6 +254,7 @@ states:
   - id: wheel_thrown
     visible: true
     friendly_name: Throwing
+    past_friendly_name: Thrown
     description: The initial shaping on the wheel. Infinite possibilities ahead!
     successors:
       - recycled
@@ -271,7 +273,8 @@ states:
 
   - id: trimmed
     visible: true
-    friendly_name: Trimming 
+    friendly_name: Trimming
+    past_friendly_name: Trimmed
     description: Getting that shape just right.
     successors:
       - recycled
@@ -289,6 +292,7 @@ states:
   - id: handbuilt
     visible: true
     friendly_name: Handbuilding
+    past_friendly_name: Handbuilt
     description: Building by hand for that uniquely organic feel. No wheel required!
     successors:
       - recycled
@@ -304,6 +308,7 @@ states:
   - id: slip_applied
     visible: true
     friendly_name: Adding Slip
+    past_friendly_name: Slip Applied
     description: Slip is going on for color, contrast, and future carving fun.
     successors:
       - recycled
@@ -313,6 +318,7 @@ states:
   - id: carved
     visible: true
     friendly_name: Carving
+    past_friendly_name: Carved
     description: Carving time. A little more surface work and then off to bisque.
     successors:
       - recycled
@@ -322,6 +328,7 @@ states:
   - id: submitted_to_bisque_fire
     visible: true
     friendly_name: "Queued → Bisque"
+    past_friendly_name: Bisque Fired
     description: Ready for the first firing. Just waiting on the kiln...
     successors:
       - recycled
@@ -335,6 +342,7 @@ states:
   - id: bisque_fired
     visible: true
     friendly_name: "Planning → Glaze"
+    past_friendly_name: Glaze Planned
     description: Done with the first firing! Glazing comes next...
     successors:
       - recycled
@@ -352,6 +360,7 @@ states:
   - id: waxed
     visible: true
     friendly_name: Waxing
+    past_friendly_name: Waxed
     description: Wax resist is going on so the glaze behaves itself.
     successors:
       - recycled
@@ -360,6 +369,7 @@ states:
   - id: glazed
     visible: true
     friendly_name: Glazing
+    past_friendly_name: Glazed
     description: Applying glaze and getting ready for the final firing. The piece is really coming to life now!
     successors:
       - recycled
@@ -373,6 +383,7 @@ states:
   - id: submitted_to_glaze_fire
     visible: true
     friendly_name: "Queued → Glaze"
+    past_friendly_name: Glaze Fired
     description: Lined up for the glaze firing. Time to pray to the kiln gods!
     successors:
       - recycled
@@ -386,6 +397,7 @@ states:
   - id: glaze_fired
     visible: true
     friendly_name: Touching Up
+    past_friendly_name: Touched Up
     description: Out of the glaze kiln and into the final cleanup stretch.
     successors:
       - recycled
@@ -405,6 +417,7 @@ states:
   - id: sanded
     visible: true
     friendly_name: Sanding
+    past_friendly_name: Sanded
     description: Almost there. Smoothing the last rough spots before calling it done.
     successors:
       - recycled
@@ -413,11 +426,13 @@ states:
   - id: completed
     visible: true
     friendly_name: Completed
+    past_friendly_name: Completed
     description: All done and ready to admire.
     terminal: true
 
   - id: recycled
     visible: true
     friendly_name: Recycled
+    past_friendly_name: Recycled
     description: "Oops! Next time things will go better. :)"
     terminal: true


### PR DESCRIPTION
## Summary

- Adds `past_friendly_name` as a required field on every workflow state in `workflow.yml` and `workflow.schema.yml`, giving each state two distinct display labels
- Exposes a `formatPastState(stateId)` helper in `workflow.ts` (mirroring `formatState`) and exports it from `types.ts`
- Switches `PieceDetail.tsx` history list from `formatState` to `formatPastState` so past states render with their completed label (e.g. "Designed", "Thrown", "Glazed") rather than the in-progress label ("Designing", "Throwing", "Glazing")

The five exception labels from the issue are included:
| State | Past label |
|---|---|
| `wheel_thrown` | Thrown |
| `submitted_to_bisque_fire` | Bisque Fired |
| `bisque_fired` | Glaze Planned |
| `submitted_to_glaze_fire` | Glaze Fired |
| `glaze_fired` | Touched Up |

## Test plan

- [x] `workflow.schema.yml` updated — `past_friendly_name` is now required; schema test adds `test_missing_past_friendly_name_fails`
- [x] `workflow.test.ts` adds `formatPastState` unit tests covering the expected label, distinction from `formatState`, and unknown-state fallback
- [x] `PieceDetail.test.tsx` assertion updated to `"Designed"` (past form)
- [x] `bazel test //...` — all 23 tests pass
- [x] `bazel build --config=lint //...` — all linters pass

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)
