### PR TITLE
Add api.ts unit tests and clean up frontend_common/mobile references

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A pottery workflow tracking application. Log pieces and record state transitions
 This guide assumes you already know the tools listed below and are familiar with [separation of concerns](https://en.wikipedia.org/wiki/Separation_of_concerns) and [abstraction](<https://en.wikipedia.org/wiki/Abstraction_(computer_science)>) as design principles; if any term is unfamiliar, click the linked docs to catch up quickly.
 
 - **[Django](https://www.djangoproject.com/)** is the Python web framework that owns the backend (`backend/`, `api/`). [Separation of concerns](https://en.wikipedia.org/wiki/Separation_of_concerns) keeps unrelated responsibilities apart so each layer stays simpler to reason about—for example, [`api/models.py`](api/models.py) defines the data schema, [`api/serializers.py`](api/serializers.py) translates between ORM objects and JSON payloads, and [`api/views.py`](api/views.py) wires those serializers into `/api/...` endpoints that enforce workflow rules from [`workflow.yml`](workflow.yml). That split keeps the REST API (powered by Django REST Framework, DRF) resilient even when one layer needs to change, while returning consistent data/validation to all clients.
-- **[React](https://react.dev/)** (web/src/) renders the SPA (Single Page Application) and consumes shared types/API helpers from [`frontend_common/src/types.ts`](frontend_common/src/types.ts) and [`frontend_common/src/api.ts`](frontend_common/src/api.ts). React follows a component-based paradigm where functions or classes receive props (inputs) and return HTML that the browser can render.
+- **[React](https://react.dev/)** (web/src/) renders the SPA (Single Page Application) and consumes shared types/API helpers from [`web/src/util/types.ts`](web/src/util/types.ts) and [`web/src/util/api.ts`](web/src/util/api.ts). React follows a component-based paradigm where functions or classes receive props (inputs) and return HTML that the browser can render.
 - **[Vite](https://vitejs.dev/)** (web tooling) bundles the React app. It provides fast dev reloads (hot module replacement) so UI changes appear immediately while you work, runs the local dev server that powers our web workbench, serves as the underlying runner for `npm test`, and produces optimized production builds (tree shaking, minification) so the deployed bundle is as small and performant as possible.
 - **[Material UI](https://mui.com/)** supplies the component library used everywhere in the UI for forms, dialogs, buttons, and layout.
 - **[Axios](https://axios-http.com/)** is the HTTP client library we use in the web to talk to REST APIs; it keeps things simple by handling the details of sending and receiving JSON so the UI code does not have to repeat that work. Benefits of Axios over raw `fetch` include centralized configuration of base URLs and headers, automatic JSON parsing/serialization, and built-in hooks for handling errors, cancellations, and retries. In this project that means [`WorkflowState.tsx`](web/src/components/WorkflowState.tsx) can rely on helpers like `updateCurrentState`/`updatePiece` instead of duplicating URLs or JSON logic, and we have a single place for surfaces errors before they hit the UI.
@@ -116,15 +116,13 @@ Keep local-only settings in `.env.local` files; they are gitignored by default:
 
 - `.env.local` (repo-wide defaults)
 - `web/.env.local` (web-only overrides)
-- `mobile/.env.local` (mobile-only overrides)
 
-`source env.sh` automatically loads all three (in that order) so you can inject Cloudinary/API config without committing secrets.
+`source env.sh` automatically loads both (in that order) so you can inject Cloudinary/API config without committing secrets.
 Use the checked-in templates:
 
 ```bash
 cp .env.example .env.local
 cp web/.env.example web/.env.local
-cp mobile/.env.example mobile/.env.local
 ```
 
 The app runs without any credentials — both optional services degrade gracefully when unconfigured:
@@ -189,7 +187,7 @@ Logs are written to `.dev-logs/` and rotated with a timestamp on each `gz_start`
 
 | Command       | Description                                                                                                                                                                              |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `gz_gentypes` | Regenerate [`frontend_common/src/generated-types.ts`](frontend_common/src/generated-types.ts) from the live OpenAPI schema. Starts the backend temporarily if it is not already running. |
+| `gz_gentypes` | Regenerate [`web/src/util/generated-types.ts`](web/src/util/generated-types.ts) from the live OpenAPI schema. Starts the backend temporarily if it is not already running. |
 
 Run `gz_help` to print the full list of shortcuts at any time.
 
@@ -423,10 +421,11 @@ After setup, the app is reachable at `https://<droplet-name>.tail<id>.ts.net` fr
 | [`test_globals.py`](api/tests/test_globals.py) | `GlobalModel` registry invariants (parameterised over all registered models): `name` field presence, user immutability, workflow consistency; `GET/POST /api/globals/<name>/` list and create |
 | [`test_glaze_combination.py`](api/tests/test_glaze_combination.py) | `GlazeCombination` computed `name` field, public/private FK constraint, `GlazeType.name` separator validation, API GET/POST |
 
-**Web** (`web/src/` and `frontend_common/src/`):
+**Web** (`web/src/`):
 | File | What it covers |
 |---|---|
-| [`frontend_common/src/workflow.test.ts`](frontend_common/src/workflow.test.ts) | `formatWorkflowFieldLabel`, `getGlobalDisplayField`, `getAdditionalFieldDefinitions` (inline, state ref, global ref) — decoupled from real `workflow.yml` via `vi.mock` |
+| [`web/src/util/workflow.test.ts`](web/src/util/workflow.test.ts) | `formatWorkflowFieldLabel`, `getGlobalDisplayField`, `getAdditionalFieldDefinitions` (inline, state ref, global ref) — decoupled from real `workflow.yml` via `vi.mock` |
+| [`web/src/util/__tests__/api.test.ts`](web/src/util/__tests__/api.test.ts) | HTTP functions (fetchPieces, fetchPiece, createPiece, transitions, globals, auth) — axios mocked via `vi.mock` |
 | [`__tests__/GlobalFieldPicker.test.tsx`](web/src/components/__tests__/GlobalFieldPicker.test.tsx) | Rendering, internal fetch, provided options, create sentinel, inline creation (success/error), selecting existing |
 | [`__tests__/PieceList.test.tsx`](web/src/components/__tests__/PieceList.test.tsx) | Column headers, empty state, per-row data, links |
 | [`__tests__/NewPieceDialog.test.tsx`](web/src/components/__tests__/NewPieceDialog.test.tsx) | Rendering, name/notes/location/thumbnail, save/cancel behavior |
@@ -490,14 +489,13 @@ Claude will read the comment, make the change, and push it to the branch.
 backend/          Django project settings, root URL config
 api/              Models, serializers, views, tests
   model_factories.py  Auto-generates GlobalModel subclasses from workflow.yml
-frontend_common/
-  src/
-    generated-types.ts  Auto-generated OpenAPI types (gitignored)
-    types.ts            Shared domain types/constants for web + mobile
-    api.ts              Shared HTTP calls; wire-type → domain-type mapping
-    workflow.ts         Shared workflow helpers from workflow.yml
 web/
   src/
+    util/
+      generated-types.ts  Auto-generated OpenAPI types (gitignored)
+      types.ts            Domain types/constants derived from generated-types.ts
+      api.ts              HTTP calls; wire-type → domain-type mapping
+      workflow.ts         Workflow helpers loaded from workflow.yml
     components/         React components
     App.tsx             Root component with MUI dark theme
 workflow.yml               Source of truth for piece states and valid transitions
@@ -519,7 +517,7 @@ The workflow state machine and all valid transitions are defined in [`workflow.y
 
 ### Authoring `additional_fields`
 
-When you add an `additional_fields` entry to a state in `workflow.yml`, the web automatically renders the inputs for you inside the `WorkflowState` component. Inline JSON primitives, state references, and global references are all interpreted through the helper utilities in [`frontend_common/src/workflow.ts`](frontend_common/src/workflow.ts) (`getAdditionalFieldDefinitions`, `formatWorkflowFieldLabel`, etc.) so the DSL does not need to be mentioned elsewhere in the code.
+When you add an `additional_fields` entry to a state in `workflow.yml`, the web automatically renders the inputs for you inside the `WorkflowState` component. Inline JSON primitives, state references, and global references are all interpreted through the helper utilities in [`web/src/util/workflow.ts`](web/src/util/workflow.ts) (`getAdditionalFieldDefinitions`, `formatWorkflowFieldLabel`, etc.) so the DSL does not need to be mentioned elsewhere in the code.
 
 1. **Inline fields** (give the field a `type`, optional `description`, `required`, and/or `enum`). They render as `TextField`s—numbers as numeric inputs, booleans as selects with `True`/`False`, enums as dropdowns—directly below Notes and above the image list.
 2. **State refs** (`$ref: "ancestor_state.field_name"`) carry a value forward from a reachable ancestor state; they render the referenced value while still allowing edits and backend validation just like inline fields.

--- a/codecov.yml
+++ b/codecov.yml
@@ -20,4 +20,3 @@ flags:
   frontend:
     paths:
       - web/src/
-      - frontend_common/src/

--- a/docs/agents/dev.md
+++ b/docs/agents/dev.md
@@ -185,7 +185,8 @@ Tests live in:
 - [`tests/test_workflow.py`](../../tests/test_workflow.py) — workflow schema/integrity validation
 - [`api/tests/`](../../api/tests/) — Django API tests (6 granular Bazel targets per concern)
 - [`web/src/components/__tests__/`](../../web/src/components/__tests__/) — React component tests (12 granular Bazel targets per component)
-- [`frontend_common/src/workflow.test.ts`](../../frontend_common/src/workflow.test.ts) — `workflow.ts` helper unit tests
+- [`web/src/util/workflow.test.ts`](../../web/src/util/workflow.test.ts) — `workflow.ts` helper unit tests
+- [`web/src/util/__tests__/api.test.ts`](../../web/src/util/__tests__/api.test.ts) — `api.ts` unit tests (axios mocked)
 
 ### Web build helper
 

--- a/docs/agents/glaze-domain.md
+++ b/docs/agents/glaze-domain.md
@@ -134,7 +134,7 @@ Each state in [`workflow.yml`](../../workflow.yml) must declare a `friendly_name
 
 ## Data Model
 
-These types are defined in [`frontend_common/src/types.ts`](../../frontend_common/src/types.ts) and mirror what the backend API should produce.
+These types are defined in [`web/src/util/types.ts`](../../web/src/util/types.ts) and mirror what the backend API should produce.
 
 **`PieceSummary`** — used in list views
 
@@ -288,11 +288,11 @@ Name uniqueness for public globals is enforced with two conditional DB constrain
 
 These supplement the generic TypeScript/React/Vite conventions.
 
-**Shared module alias:** Import shared types, API helpers, and workflow utilities using the `./util` path alias (`./util/types`, `./util/api`, `./util/workflow`) — never use relative `../../../frontend_common/src/...` paths. The alias resolves to `frontend_common/src/` and is configured in each app's tsconfig `paths` and bundler config. Note: This shared module cannot take direct dependencies on React, since React is only imported from `../../web/src/...`.
+**Module paths:** Import types, API helpers, and workflow utilities from the `./util` directory (`./util/types`, `./util/api`, `./util/workflow`). These live in `web/src/util/` and must not take direct dependencies on React.
 
 **State names and transitions:** Come from `workflow.yml` via the constants in `./util/types` (`STATES`, `SUCCESSORS`) — do not hardcode them in components.
 
-**HTTP calls:** All go through [`frontend_common/src/api.ts`](../../frontend_common/src/api.ts) (imported as `./util/api`). This is the single place where wire types (ISO date strings, etc.) are mapped to domain types. Components must never perform their own serialization or deserialization.
+**HTTP calls:** All go through [`web/src/util/api.ts`](../../web/src/util/api.ts) (imported as `./util/api`). This is the single place where wire types (ISO date strings, etc.) are mapped to domain types. Components must never perform their own serialization or deserialization.
 
 **Data-fetching pattern (`useAsync`):** Any component that loads data from the API on mount or when a dependency changes must use the `useAsync` hook from `../../web/src/util/useAsync`. Do not inline `useState` + `useEffect` + `.catch` + `.finally` for loading/error/data state management — use `useAsync` instead. It handles the cancellation flag, error normalization, and exposes `setData` for optimistic local mutations.
 
@@ -324,7 +324,7 @@ All data-fetching components must render a loading spinner (`<CircularProgress /
 **Shared UI extraction:** Treat route-level and detail/list container components such as `PieceDetail.tsx` and `PieceList.tsx` as orchestration layers, not homes for duplicated presentational subtrees. When a feature introduces the same UI concept in multiple places, extract a reusable component in `web/src/components/` rather than keeping separate inline implementations in each parent. If a new feature adds more than a small self-contained JSX block to one of these containers, prefer a named child component with typed props.
 
 **Workflow config interface (`workflow.ts`):**
-[`frontend_common/src/workflow.ts`](../../frontend_common/src/workflow.ts) loads `workflow.yml` at build time and exposes typed helpers — do not duplicate state or globals data elsewhere.
+[`web/src/util/workflow.ts`](../../web/src/util/workflow.ts) loads `workflow.yml` at build time and exposes typed helpers — do not duplicate state or globals data elsewhere.
 
 - `getAdditionalFieldDefinitions(stateId)` — resolves per-state additional field definitions into a form-ready structure; used by `WorkflowState` to render dynamic fields.
 - `getGlobalDisplayField(globalName)` — returns the display field name for a globals entry; used by `GlobalFieldPicker` to determine which field to write on create.
@@ -332,11 +332,11 @@ All data-fetching components must render a loading spinner (`<CircularProgress /
 
 **Type generation pipeline:**
 
-- [`frontend_common/src/generated-types.ts`](../../frontend_common/src/generated-types.ts) is auto-generated — do not edit by hand. It is gitignored.
+- [`web/src/util/generated-types.ts`](../../web/src/util/generated-types.ts) is auto-generated — do not edit by hand. It is gitignored.
 - Generation is driven by [`web/scripts/generate-types.mjs`](../../web/scripts/generate-types.mjs), which calls the `openapi-typescript` programmatic API with a `transform` that converts `format: date-time` fields to `Date`. Run `npm run generate-types` with Django on port 8080.
-- [`frontend_common/src/types.ts`](../../frontend_common/src/types.ts) derives domain types from `generated-types.ts` via intersection (no `Omit<>`). It also holds the `STATES` array and `SUCCESSORS` map from `workflow.yml`.
-- **When adding a new API field:** update the Django serializer → run `npm run generate-types` → update `frontend_common/src/types.ts` if semantic narrowing is needed → update mappers in `frontend_common/src/api.ts`.
-- [`frontend_common/src/api.ts`](../../frontend_common/src/api.ts) uses the `Wire<T>` generic to type raw Axios responses (dates as strings). Mappers convert `Wire<T>` → domain `T`. This is the only file that should contain deserialization logic.
+- [`web/src/util/types.ts`](../../web/src/util/types.ts) derives domain types from `generated-types.ts` via intersection (no `Omit<>`). It also holds the `STATES` array and `SUCCESSORS` map from `workflow.yml`.
+- **When adding a new API field:** update the Django serializer → run `npm run generate-types` → update `web/src/util/types.ts` if semantic narrowing is needed → update mappers in `web/src/util/api.ts`.
+- [`web/src/util/api.ts`](../../web/src/util/api.ts) uses the `Wire<T>` generic to type raw Axios responses (dates as strings). Mappers convert `Wire<T>` → domain `T`. This is the only file that should contain deserialization logic.
 - The OpenAPI schema is at `http://localhost:8080/api/schema/` and Swagger UI at `http://localhost:8080/api/schema/swagger/`.
 
 **Thumbnails:**
@@ -401,7 +401,8 @@ All data-fetching components must render a loading spinner (`<CircularProgress /
 **Frontend testing — Glaze-specific guidance:**
 
 - Every new or modified React component → add or update a test in `web/src/components/__tests__/`.
-- Every new or modified `workflow.ts` helper → add or update a test in `frontend_common/src/workflow.test.ts`, mocking `workflow.yml` with a minimal fixture. Never import `workflow.yml` directly in a test — always mock it.
+- Every new or modified `workflow.ts` helper → add or update a test in `web/src/util/workflow.test.ts`, mocking `workflow.yml` with a minimal fixture. Never import `workflow.yml` directly in a test — always mock it.
+- Every new or modified `api.ts` function → add or update a test in `web/src/util/__tests__/api.test.ts`, mocking axios via `vi.mock`.
 - Component tests that involve typing into a controlled MUI Autocomplete must use a stateful wrapper (see `Controlled` in `GlobalFieldPicker.test.tsx`).
 
 ---
@@ -423,7 +424,7 @@ Staff users have access to a browser-based bulk import workflow at `/tools/glaze
 
 `POST /api/admin/manual-square-crop-import/` — staff only (`is_staff`). Accepts a `multipart/form-data` body:
 
-- `payload` — JSON string `{ records: ManualSquareCropImportRecordPayload[] }` (see `frontend_common/src/api.ts` for the shape).
+- `payload` — JSON string `{ records: ManualSquareCropImportRecordPayload[] }` (see `web/src/util/api.ts` for the shape).
 - `crop_image__<client_id>` — one WebP file per record.
 
 The endpoint is implemented in `api/manual_tile_imports.py`. For each `glaze_type` record it creates a public `GlazeType` (and a matching single-layer `GlazeCombination`) and uploads the crop to Cloudinary. For each `glaze_combination` record it resolves the two referenced public `GlazeType` rows by name, creates a public `GlazeCombination`, and sets the ordered layers. **`runs` and `is_food_safe` from `parsed_fields` are written to both `GlazeType` and `GlazeCombination` on creation.** Existing public records with the same name are reported as `skipped_duplicate` (not updated).
@@ -458,7 +459,7 @@ These extend the generic GitHub interactions guide with Glaze-specific protected
 - All tests pass: `bazel test //...`
 - All linters pass (ruff, eslint, tsc, mypy): `bazel build --config=lint //...`
 - Auto-fix Python formatting and fixable lint issues before committing: `ruff format . && ruff check --fix .`
-- Serializer output matches the TypeScript types in [`frontend_common/src/types.ts`](../../frontend_common/src/types.ts)
+- Serializer output matches the TypeScript types in [`web/src/util/types.ts`](../../web/src/util/types.ts)
 - State names and transitions are derived from [`workflow.yml`](../../workflow.yml), not hardcoded
 - If `AGENTS.md` was modified, check whether [`README.md`](../../README.md) needs a corresponding update
 - If conventions or constraints change during PR work, append those changes to the relevant file under `docs/agents/` in a follow-up commit

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -557,6 +557,17 @@ vitest_test(
     ],
 )
 
+vitest_test(
+    name = "web_api_test",
+    srcs = [
+        "src/util/__tests__/api.test.ts",
+    ],
+    tags = ["ibazel_notify_changes"],
+    deps = [
+        ":util_lib",
+    ],
+)
+
 # ── Web test suite ────────────────────────────────────────────────────────────
 # Aggregate target: `bazel test //web:web_test` runs all web tests.
 # Individual targets above run only when their inputs change.
@@ -564,6 +575,7 @@ vitest_test(
 test_suite(
     name = "web_test",
     tests = [
+        ":web_api_test",
         ":web_cloudinary_image_test",
         ":web_glaze_gallery_test",
         ":web_glaze_import_test",

--- a/web/src/util/__tests__/api.test.ts
+++ b/web/src/util/__tests__/api.test.ts
@@ -1,0 +1,506 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import axios from "axios";
+
+// Mock axios.create to return a controlled mock client
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+const mockPatch = vi.fn();
+const mockDelete = vi.fn();
+
+vi.mock("axios", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("axios")>();
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      create: vi.fn(() => ({
+        get: mockGet,
+        post: mockPost,
+        patch: mockPatch,
+        delete: mockDelete,
+        defaults: {},
+      })),
+      isAxiosError: actual.default.isAxiosError,
+    },
+  };
+});
+
+// Import after mocking
+const {
+  fetchPieces,
+  fetchPiece,
+  createPiece,
+  addPieceState,
+  updateCurrentState,
+  updatePiece,
+  fetchGlobalEntries,
+  fetchGlazeCombinations,
+  toggleGlobalEntryFavorite,
+  createGlobalEntry,
+  fetchCurrentUser,
+  loginWithEmail,
+  logoutUser,
+} = await import("../api");
+
+// ---------------------------------------------------------------------------
+// Shared wire fixtures
+// ---------------------------------------------------------------------------
+
+const wireImage = {
+  url: "https://example.com/img.jpg",
+  caption: "a caption",
+  created: "2024-01-01T00:00:00Z",
+  cloudinary_public_id: "pub123",
+};
+
+const wirePieceState = {
+  state: "designed",
+  notes: "some notes",
+  created: "2024-01-01T00:00:00Z",
+  last_modified: "2024-01-02T00:00:00Z",
+  images: [wireImage],
+  previous_state: null,
+  next_state: null,
+  additional_fields: { clay_weight_grams: 500 },
+};
+
+const wirePieceSummary = {
+  id: "piece-1",
+  name: "My Vase",
+  created: "2024-01-01T00:00:00Z",
+  last_modified: "2024-01-02T00:00:00Z",
+  thumbnail: "/thumbnails/vase.svg",
+  current_state: { state: "designed" },
+  current_location: "Studio",
+  tags: [{ id: "t1", name: "functional", color: "#aabbcc" }],
+};
+
+const wirePieceDetail = {
+  ...wirePieceSummary,
+  current_state: wirePieceState,
+  history: [wirePieceState],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// fetchPieces
+// ---------------------------------------------------------------------------
+
+describe("fetchPieces", () => {
+  it("returns mapped PieceSummary array", async () => {
+    mockGet.mockResolvedValue({ data: [wirePieceSummary] });
+
+    const result = await fetchPieces();
+
+    expect(mockGet).toHaveBeenCalledWith("pieces/");
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("piece-1");
+    expect(result[0].created).toBeInstanceOf(Date);
+    expect(result[0].last_modified).toBeInstanceOf(Date);
+    expect(result[0].current_state.state).toBe("designed");
+    expect(result[0].tags[0].name).toBe("functional");
+  });
+
+  it("maps tags with empty array when missing", async () => {
+    mockGet.mockResolvedValue({
+      data: [{ ...wirePieceSummary, tags: undefined }],
+    });
+    const result = await fetchPieces();
+    expect(result[0].tags).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchPiece
+// ---------------------------------------------------------------------------
+
+describe("fetchPiece", () => {
+  it("returns mapped PieceDetail", async () => {
+    mockGet.mockResolvedValue({ data: wirePieceDetail });
+
+    const result = await fetchPiece("piece-1");
+
+    expect(mockGet).toHaveBeenCalledWith("pieces/piece-1/");
+    expect(result.id).toBe("piece-1");
+    expect(result.current_state.created).toBeInstanceOf(Date);
+    expect(result.current_state.images[0].created).toBeInstanceOf(Date);
+    expect(result.current_state.additional_fields).toEqual({
+      clay_weight_grams: 500,
+    });
+    expect(result.history).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createPiece
+// ---------------------------------------------------------------------------
+
+describe("createPiece", () => {
+  it("posts to pieces/ and returns mapped PieceDetail", async () => {
+    mockPost.mockResolvedValue({ data: wirePieceDetail });
+
+    const result = await createPiece({ name: "My Vase" });
+
+    expect(mockPost).toHaveBeenCalledWith("pieces/", { name: "My Vase" });
+    expect(result.name).toBe("My Vase");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addPieceState
+// ---------------------------------------------------------------------------
+
+describe("addPieceState", () => {
+  it("posts to pieces/<id>/states/ and returns mapped PieceDetail", async () => {
+    mockPost.mockResolvedValue({ data: wirePieceDetail });
+
+    const result = await addPieceState("piece-1", {
+      state: "wheel_thrown",
+      notes: "threw it",
+    });
+
+    expect(mockPost).toHaveBeenCalledWith("pieces/piece-1/states/", {
+      state: "wheel_thrown",
+      notes: "threw it",
+    });
+    expect(result.id).toBe("piece-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateCurrentState
+// ---------------------------------------------------------------------------
+
+describe("updateCurrentState", () => {
+  it("patches pieces/<id>/state/ and returns mapped PieceDetail", async () => {
+    mockPatch.mockResolvedValue({ data: wirePieceDetail });
+
+    const result = await updateCurrentState("piece-1", {
+      notes: "updated notes",
+    });
+
+    expect(mockPatch).toHaveBeenCalledWith("pieces/piece-1/state/", {
+      notes: "updated notes",
+    });
+    expect(result.id).toBe("piece-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updatePiece
+// ---------------------------------------------------------------------------
+
+describe("updatePiece", () => {
+  it("patches pieces/<id>/ with piece-level fields", async () => {
+    mockPatch.mockResolvedValue({ data: wirePieceDetail });
+
+    await updatePiece("piece-1", { name: "New Name" });
+
+    expect(mockPatch).toHaveBeenCalledWith("pieces/piece-1/", {
+      name: "New Name",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchGlobalEntries
+// ---------------------------------------------------------------------------
+
+describe("fetchGlobalEntries", () => {
+  it("maps snake_case is_public → camelCase isPublic", async () => {
+    mockGet.mockResolvedValue({
+      data: [
+        {
+          id: "g1",
+          name: "Cone 6",
+          is_public: true,
+          is_favorite: false,
+          color: "#ff0000",
+        },
+      ],
+    });
+
+    const result = await fetchGlobalEntries("glaze_type");
+
+    expect(mockGet).toHaveBeenCalledWith("globals/glaze_type/");
+    expect(result[0].isPublic).toBe(true);
+    expect(result[0].isFavorite).toBe(false);
+    expect(result[0].color).toBe("#ff0000");
+  });
+
+  it("omits isFavorite when is_favorite is absent", async () => {
+    mockGet.mockResolvedValue({
+      data: [{ id: "g2", name: "Studio B", is_public: false }],
+    });
+
+    const result = await fetchGlobalEntries("location");
+
+    expect("isFavorite" in result[0]).toBe(false);
+    expect("color" in result[0]).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchGlazeCombinations — filter parameter encoding
+// ---------------------------------------------------------------------------
+
+describe("fetchGlazeCombinations", () => {
+  it("calls globals/glaze_combination/ with no params when no filters given", async () => {
+    mockGet.mockResolvedValue({ data: [] });
+
+    await fetchGlazeCombinations();
+
+    expect(mockGet).toHaveBeenCalledWith("globals/glaze_combination/", {
+      params: {},
+    });
+  });
+
+  it("encodes glazeTypeIds as comma-joined string", async () => {
+    mockGet.mockResolvedValue({ data: [] });
+
+    await fetchGlazeCombinations({ glazeTypeIds: ["a", "b"] });
+
+    expect(mockGet).toHaveBeenCalledWith(
+      "globals/glaze_combination/",
+      expect.objectContaining({ params: { glaze_type_ids: "a,b" } }),
+    );
+  });
+
+  it("encodes boolean filters as strings", async () => {
+    mockGet.mockResolvedValue({ data: [] });
+
+    await fetchGlazeCombinations({
+      isFoodSafe: true,
+      runs: false,
+      highlightsGrooves: true,
+      isDifferentOnWhiteAndBrownClay: false,
+    });
+
+    expect(mockGet).toHaveBeenCalledWith(
+      "globals/glaze_combination/",
+      expect.objectContaining({
+        params: {
+          is_food_safe: "true",
+          runs: "false",
+          highlights_grooves: "true",
+          is_different_on_white_and_brown_clay: "false",
+        },
+      }),
+    );
+  });
+
+  it("omits filters whose values are undefined", async () => {
+    mockGet.mockResolvedValue({ data: [] });
+
+    await fetchGlazeCombinations({ isFoodSafe: undefined });
+
+    const call = mockGet.mock.calls[0];
+    expect(call[1].params).not.toHaveProperty("is_food_safe");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toggleGlobalEntryFavorite
+// ---------------------------------------------------------------------------
+
+describe("toggleGlobalEntryFavorite", () => {
+  it("POSTs to favorite when favorite=true", async () => {
+    mockPost.mockResolvedValue({});
+
+    await toggleGlobalEntryFavorite("glaze_combination", "gc-1", true);
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "globals/glaze_combination/gc-1/favorite/",
+    );
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it("DELETEs from favorite when favorite=false", async () => {
+    mockDelete.mockResolvedValue({});
+
+    await toggleGlobalEntryFavorite("glaze_combination", "gc-1", false);
+
+    expect(mockDelete).toHaveBeenCalledWith(
+      "globals/glaze_combination/gc-1/favorite/",
+    );
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createGlobalEntry
+// ---------------------------------------------------------------------------
+
+describe("createGlobalEntry", () => {
+  it("posts payload and maps the response", async () => {
+    mockPost.mockResolvedValue({
+      data: { id: "loc-1", name: "Studio B", is_public: false },
+    });
+
+    const result = await createGlobalEntry("location", {
+      field: "name",
+      value: "Studio B",
+    });
+
+    expect(mockPost).toHaveBeenCalledWith("globals/location/", {
+      field: "name",
+      value: "Studio B",
+    });
+    expect(result.id).toBe("loc-1");
+    expect(result.isPublic).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchCurrentUser — 401/403 → null, other errors rethrown
+// ---------------------------------------------------------------------------
+
+describe("fetchCurrentUser", () => {
+  it("returns user data on success", async () => {
+    mockGet.mockResolvedValue({
+      data: {
+        id: 1,
+        email: "user@example.com",
+        first_name: "Jane",
+        last_name: "Doe",
+        is_staff: false,
+        openid_subject: "",
+        profile_image_url: "",
+      },
+    });
+
+    const user = await fetchCurrentUser();
+    expect(user?.email).toBe("user@example.com");
+  });
+
+  it("returns null on 401", async () => {
+    const err = Object.assign(new Error("Unauthorized"), {
+      isAxiosError: true,
+      response: { status: 401 },
+    });
+    vi.spyOn(axios, "isAxiosError").mockReturnValue(true);
+    mockGet.mockRejectedValue(err);
+
+    const user = await fetchCurrentUser();
+    expect(user).toBeNull();
+  });
+
+  it("returns null on 403", async () => {
+    const err = Object.assign(new Error("Forbidden"), {
+      isAxiosError: true,
+      response: { status: 403 },
+    });
+    vi.spyOn(axios, "isAxiosError").mockReturnValue(true);
+    mockGet.mockRejectedValue(err);
+
+    const user = await fetchCurrentUser();
+    expect(user).toBeNull();
+  });
+
+  it("rethrows non-auth errors", async () => {
+    const err = Object.assign(new Error("Server Error"), {
+      isAxiosError: true,
+      response: { status: 500 },
+    });
+    vi.spyOn(axios, "isAxiosError").mockReturnValue(true);
+    mockGet.mockRejectedValue(err);
+
+    await expect(fetchCurrentUser()).rejects.toThrow("Server Error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loginWithEmail — calls ensureCsrfCookie first
+// ---------------------------------------------------------------------------
+
+describe("loginWithEmail", () => {
+  it("fetches CSRF cookie then POSTs credentials", async () => {
+    mockGet.mockResolvedValue({});
+    mockPost.mockResolvedValue({
+      data: {
+        id: 1,
+        email: "user@example.com",
+        first_name: "",
+        last_name: "",
+        is_staff: false,
+        openid_subject: "",
+        profile_image_url: "",
+      },
+    });
+
+    const user = await loginWithEmail("user@example.com", "secret");
+
+    expect(mockGet).toHaveBeenCalledWith("auth/csrf/");
+    expect(mockPost).toHaveBeenCalledWith("auth/login/", {
+      email: "user@example.com",
+      password: "secret",
+    });
+    expect(user.email).toBe("user@example.com");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// logoutUser — calls ensureCsrfCookie first
+// ---------------------------------------------------------------------------
+
+describe("logoutUser", () => {
+  it("fetches CSRF cookie then POSTs to logout", async () => {
+    mockGet.mockResolvedValue({});
+    mockPost.mockResolvedValue({});
+
+    await logoutUser();
+
+    expect(mockGet).toHaveBeenCalledWith("auth/csrf/");
+    expect(mockPost).toHaveBeenCalledWith("auth/logout/", {});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wire → domain mapping edge cases
+// ---------------------------------------------------------------------------
+
+describe("Wire → domain mapping", () => {
+  it("handles null cloudinary_public_id in images", async () => {
+    const wireWithNullId = {
+      ...wirePieceDetail,
+      current_state: {
+        ...wirePieceState,
+        images: [{ ...wireImage, cloudinary_public_id: null }],
+      },
+    };
+    mockGet.mockResolvedValue({ data: wireWithNullId });
+
+    const result = await fetchPiece("piece-1");
+    expect(result.current_state.images[0].cloudinary_public_id).toBeNull();
+  });
+
+  it("handles missing additional_fields (defaults to {})", async () => {
+    const wireNoFields = {
+      ...wirePieceDetail,
+      current_state: { ...wirePieceState, additional_fields: undefined },
+    };
+    mockGet.mockResolvedValue({ data: wireNoFields });
+
+    const result = await fetchPiece("piece-1");
+    expect(result.current_state.additional_fields).toEqual({});
+  });
+
+  it("maps previous_state and next_state through as-is", async () => {
+    const wireWithNav = {
+      ...wirePieceDetail,
+      current_state: {
+        ...wirePieceState,
+        previous_state: "designed",
+        next_state: "trimmed",
+      },
+    };
+    mockGet.mockResolvedValue({ data: wireWithNav });
+
+    const result = await fetchPiece("piece-1");
+    expect(result.current_state.previous_state).toBe("designed");
+    expect(result.current_state.next_state).toBe("trimmed");
+  });
+});

--- a/web/src/util/workflow.ts
+++ b/web/src/util/workflow.ts
@@ -1,12 +1,12 @@
 /**
- * Shared web/mobile interface to the workflow.yml configuration.
+ * Web interface to the workflow.yml configuration.
  *
  * This module loads workflow.yml at build time and exposes typed helpers that
- * the web and mobile apps use to drive dynamic behavior — field definitions
- * for per-state forms, display labels, and global type metadata. It is the
- * shared-app counterpart to the backend's `_STATE_MAP` / `_GLOBALS_MAP` in
+ * the web app uses to drive dynamic behavior — field definitions for per-state
+ * forms, display labels, and global type metadata. It is the frontend
+ * counterpart to the backend's `_STATE_MAP` / `_GLOBALS_MAP` in
  * `api/models.py`. Neither the state list nor the globals map should be
- * duplicated elsewhere in the apps; derive them from the exports here.
+ * duplicated elsewhere in the app; derive them from the exports here.
  */
 import workflow from "../../../workflow.yml";
 

--- a/web/tsconfig.test.json
+++ b/web/tsconfig.test.json
@@ -7,11 +7,7 @@
     "noUnusedParameters": false
   },
   "include": [
-    "src",
-    "../frontend_common/src/generated-types.ts",
-    "../frontend_common/src/types.ts",
-    "../frontend_common/src/api.ts",
-    "../frontend_common/src/workflow.ts"
+    "src"
   ],
   "exclude": ["node_modules"]
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -20,8 +20,6 @@ const root = isVitest ? __dirname : fs.realpathSync(__dirname);
 export default defineConfig({
   root,
   resolve: {
-    // frontend_common is outside web/, so bare imports inside it resolve from
-    // the repo root upward (not web/node_modules). Pin axios to web's install.
     alias: {
       axios: path.resolve(root, "node_modules/axios"),
     },


### PR DESCRIPTION
## Summary

- **New test file** `web/src/util/__tests__/api.test.ts`: 25 unit tests for `api.ts`, covering all HTTP functions (piece CRUD, state transitions, global entries, auth) plus `Wire<T>` → domain-type mapping edge cases. Axios is mocked with `vi.mock` so tests run without a server.
- **New Bazel target** `//web:web_api_test` wired into the `web_test` test suite aggregate.
- **Dead-path cleanup**: removed `frontend_common/src/` entries from `tsconfig.test.json` (those paths don't exist; the files are at `web/src/util/`). Dropped the stale axios alias comment in `vite.config.ts`, updated `workflow.ts` docstring, `codecov.yml`, `docs/agents/`, and `README.md` to use the correct `web/src/util/` paths. Removed the `mobile/.env.local` setup snippet from the README since there is no mobile app in this repo.

## Test plan

- [ ] `bazel test //web:web_api_test` passes (25/25 tests green)
- [ ] `bazel test //...` passes (all 24 test targets green)
- [ ] `bazel build --config=lint //...` passes (no lint errors)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
