### PR TITLE
[codex] Redesign PieceDetail page

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Launch Chrome against localhost",
+            "url": "http://localhost:5173",
+            "webRoot": "${workspaceFolder}/web/src"
+        }
+    ]
+}

--- a/api/registry.py
+++ b/api/registry.py
@@ -29,7 +29,9 @@ def global_entry_serializer(model_cls: type[django_models.Model]):
         class GlazeCombinationEntrySerializer(serializers.ModelSerializer):
             ...
     """
+
     def decorator(cls: type[serializers.Serializer]):
         _GLOBAL_ENTRY_SERIALIZERS[model_cls] = cls
         return cls
+
     return decorator

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -116,6 +116,7 @@ class FiringTemperatureRefSerializer(serializers.ModelSerializer):
         fields = ["id", "name", "cone", "temperature_c", "atmosphere"]
 
 
+@global_entry_serializer(Tag)
 class TagEntrySerializer(serializers.ModelSerializer):
     id = serializers.SerializerMethodField()
     is_public = serializers.SerializerMethodField()

--- a/api/views.py
+++ b/api/views.py
@@ -235,9 +235,15 @@ def _global_entries_impl(request: Request, global_name: str) -> Response:
             favorite_ids = (
                 fav_model.get_favorite_ids_for(request.user) if fav_model else set()
             )
-            objects = list(
-                base_qs.prefetch_related("layers__glaze_type").order_by("name")
-            )
+
+            # TODO(187): Use a registry to delegate instead of hardcoding.
+            if model_cls == GlazeCombination:
+                objects = list(
+                    base_qs.prefetch_related("layers__glaze_type").order_by("name")
+                )
+            else:
+                objects = base_qs.order_by(display_field)
+
             return Response(
                 entry_serializer_cls(
                     objects,

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -237,6 +237,8 @@ js_library(
     name = "autosave_src",
     srcs = [
         "src/components/AutosaveStatus.tsx",
+        "src/components/PieceDetailSaveStatusContext.tsx",
+        "src/components/usePieceDetailSaveStatus.ts",
         "src/components/useAutosave.ts",
     ],
     deps = [
@@ -342,9 +344,21 @@ js_library(
 )
 
 js_library(
+    name = "piece_photo_gallery_src",
+    srcs = ["src/components/PiecePhotoGallery.tsx"],
+    deps = [
+        ":cloudinary_image_src",
+        ":generated_types",
+        ":image_lightbox_src",
+        ":node_modules",
+    ],
+)
+
+js_library(
     name = "tag_manager_src",
     srcs = ["src/components/TagManager.tsx"],
     deps = [
+        ":autosave_src",
         ":generated_types",
         ":node_modules",
         ":tag_src",
@@ -378,10 +392,12 @@ js_library(
     name = "piece_detail_src",
     srcs = ["src/components/PieceDetail.tsx"],
     deps = [
+        ":autosave_src",
         ":cloudinary_image_src",
         ":generated_types",
         ":node_modules",
         ":piece_history_src",
+        ":piece_photo_gallery_src",
         ":primitive_src",
         ":state_transition_src",
         ":tag_manager_src",
@@ -519,6 +535,17 @@ vitest_test(
     tags = ["ibazel_notify_changes"],
     deps = [
         ":workflow_state_src",
+    ],
+)
+
+vitest_test(
+    name = "web_piece_photo_gallery_test",
+    srcs = [
+        "src/components/__tests__/PiecePhotoGallery.test.tsx",
+    ],
+    tags = ["ibazel_notify_changes"],
+    deps = [
+        ":piece_photo_gallery_src",
     ],
 )
 

--- a/web/index.html
+++ b/web/index.html
@@ -1,16 +1,22 @@
 <!doctype html>
-<html lang="en" style="background-color: #121212">
+<html lang="en" style="background-color: #211b19">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="manifest" href="/site.webmanifest" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, viewport-fit=cover"
     />
     <meta name="referrer" content="origin" />
-    <meta name="theme-color" content="#121212" />
+    <meta name="theme-color" content="#211b19" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta
@@ -29,7 +35,7 @@
       type="text/javascript"
     ></script>
   </head>
-  <body style="background-color: #121212">
+  <body style="background-color: #211b19">
     <div id="root"></div>
     <script type="module" src="./src/main.tsx"></script>
   </body>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -72,21 +72,106 @@ declare global {
 }
 
 const DARK_THEME = createTheme({
-  palette: { mode: "dark" },
+  palette: {
+    mode: "dark",
+    primary: {
+      main: "#c97a4d",
+      light: "#d59a71",
+      dark: "#8f5230",
+    },
+    secondary: {
+      main: "#8ca6a3",
+    },
+    background: {
+      default: "#211b19",
+      paper: "#2a2321",
+    },
+    text: {
+      primary: "#f3ebe1",
+      secondary: "#bbaea1",
+    },
+    divider: "rgba(255, 245, 235, 0.09)",
+    success: {
+      main: "#8eb89a",
+    },
+    warning: {
+      main: "#c97a4d",
+    },
+  },
+  typography: {
+    fontFamily: [
+      "Manrope",
+      "Avenir Next",
+      "Segoe UI",
+      "sans-serif",
+    ].join(","),
+    h1: { fontWeight: 650, letterSpacing: "-0.03em" },
+    h2: { fontWeight: 650, letterSpacing: "-0.03em" },
+    h3: { fontWeight: 620, letterSpacing: "-0.03em" },
+    h4: { fontWeight: 620, letterSpacing: "-0.025em" },
+    h5: { fontWeight: 610, letterSpacing: "-0.02em" },
+    h6: { fontWeight: 600, letterSpacing: "-0.015em" },
+    button: {
+      textTransform: "none",
+      fontWeight: 600,
+    },
+    caption: {
+      letterSpacing: "0.08em",
+    },
+  },
+  shape: {
+    borderRadius: 6,
+  },
   components: {
+    MuiCssBaseline: {
+      styleOverrides: {
+        body: {
+          background:
+            "radial-gradient(circle at top, rgba(201,122,77,0.14) 0%, rgba(33,27,25,0) 34%), #211b19",
+        },
+      },
+    },
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          backgroundImage: "none",
+        },
+      },
+    },
+    MuiOutlinedInput: {
+      styleOverrides: {
+        root: {
+          backgroundColor: alpha("#0f0b0a", 0.22),
+        },
+      },
+    },
     MuiButton: {
       variants: [
         {
           props: { variant: "contained" },
           style: ({ theme }) => ({
-            boxShadow: `0 8px 18px ${alpha(theme.palette.common.black, 0.35)}`,
+            boxShadow: `0 10px 24px ${alpha(theme.palette.common.black, 0.34)}`,
             border: `1px solid ${alpha(theme.palette.common.white, 0.08)}`,
             "&:hover": {
-              boxShadow: `0 10px 22px ${alpha(theme.palette.common.black, 0.42)}`,
+              boxShadow: `0 14px 28px ${alpha(theme.palette.common.black, 0.4)}`,
             },
           }),
         },
       ],
+    },
+    MuiButtonBase: {
+      defaultProps: {
+        disableRipple: true,
+      },
+    },
+    MuiChip: {
+      styleOverrides: {
+        root: ({ theme }) => ({
+          borderRadius: 999,
+          backgroundColor: alpha(theme.palette.common.black, 0.18),
+          border: `1px solid ${alpha(theme.palette.common.white, 0.08)}`,
+        }),
+      },
     },
   },
 });

--- a/web/src/components/AutosaveStatus.tsx
+++ b/web/src/components/AutosaveStatus.tsx
@@ -2,7 +2,14 @@ import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
 import PendingIcon from "@mui/icons-material/Pending";
 import SyncIcon from "@mui/icons-material/Sync";
-import { Box, CircularProgress, Typography } from "@mui/material";
+import {
+  alpha,
+  Box,
+  CircularProgress,
+  Paper,
+  Portal,
+  Typography,
+} from "@mui/material";
 import type React from "react";
 import type { AutosaveStatus as AutosaveStatusValue } from "./useAutosave";
 
@@ -10,6 +17,7 @@ type AutosaveStatusProps = {
   status: AutosaveStatusValue;
   error?: string | null;
   lastSavedAt?: Date | null;
+  variant?: "inline" | "floating";
 };
 
 function formatSavedTime(date: Date | null | undefined): string {
@@ -24,6 +32,7 @@ export default function AutosaveStatus({
   status,
   error,
   lastSavedAt,
+  variant = "inline",
 }: AutosaveStatusProps) {
   const statusConfig = {
     idle: {
@@ -57,7 +66,7 @@ export default function AutosaveStatus({
   >;
   const config = statusConfig[status];
 
-  return (
+  const content = (
     <Box
       data-testid="autosave-status"
       role="status"
@@ -74,4 +83,49 @@ export default function AutosaveStatus({
       <Typography variant="body2">{config.label}</Typography>
     </Box>
   );
+
+  if (variant === "floating" && status === "idle") {
+    return null;
+  }
+
+  if (variant === "floating") {
+    return (
+      <Portal>
+        <Paper
+          elevation={8}
+          sx={(theme) => ({
+            position: "fixed",
+            top: "max(16px, calc(env(safe-area-inset-top) + 8px))",
+            left: "50%",
+            transform: "translateX(-50%)",
+            zIndex: theme.zIndex.snackbar,
+            px: 1.5,
+            py: 1,
+            borderRadius: 999,
+            border: "1px solid",
+            borderColor: alpha(theme.palette.common.white, 0.08),
+            backgroundColor: alpha(theme.palette.background.paper, 0.94),
+            backdropFilter: "blur(16px)",
+            boxShadow: `0 18px 42px ${alpha(theme.palette.common.black, 0.34)}`,
+            animation:
+              status === "saved"
+                ? "autosaveFadeOut 220ms ease-out 1s forwards"
+                : "autosaveFadeIn 160ms ease-out",
+            "@keyframes autosaveFadeIn": {
+              from: { opacity: 0, transform: "translate(-50%, -8px)" },
+              to: { opacity: 1, transform: "translate(-50%, 0)" },
+            },
+            "@keyframes autosaveFadeOut": {
+              from: { opacity: 1, transform: "translate(-50%, 0)" },
+              to: { opacity: 0, transform: "translate(-50%, -6px)" },
+            },
+          })}
+        >
+          {content}
+        </Paper>
+      </Portal>
+    );
+  }
+
+  return content;
 }

--- a/web/src/components/CloudinaryImage.tsx
+++ b/web/src/components/CloudinaryImage.tsx
@@ -8,7 +8,9 @@
  *
  * Context-specific sizing:
  *   thumbnail — 64×64 fill, used in image lists and history rows
+ *   gallery   — tile-sized fill, used in the Piece photo gallery grid
  *   lightbox  — constrained to 90 vw × 80 vh, for the full-screen viewer
+ *   detail    — fills the local container, for the PieceDetail hero image
  *   preview   — 64×64 fill, used for the upload preview before saving
  */
 import { Cloudinary } from "@cloudinary/url-gen";
@@ -86,7 +88,12 @@ function parseCloudinaryUrl(
 // Component
 // ---------------------------------------------------------------------------
 
-export type CloudinaryImageContext = "thumbnail" | "lightbox" | "preview";
+export type CloudinaryImageContext =
+  | "thumbnail"
+  | "gallery"
+  | "lightbox"
+  | "detail"
+  | "preview";
 
 export type CloudinaryImageProps = {
   /** Full delivery URL — always required as fallback. */
@@ -96,6 +103,8 @@ export type CloudinaryImageProps = {
   alt?: string;
   /** Rendering context determines the requested dimensions. */
   context: CloudinaryImageContext;
+  requestedWidth?: number;
+  requestedHeight?: number;
   style?: React.CSSProperties;
   className?: string;
   onLoad?: React.ReactEventHandler<HTMLImageElement>;
@@ -108,6 +117,8 @@ export default function CloudinaryImage({
   cloudinary_public_id,
   alt = "",
   context,
+  requestedWidth,
+  requestedHeight,
   style,
   className,
   onLoad,
@@ -167,6 +178,20 @@ export default function CloudinaryImage({
           maxWidth: LIGHTBOX_MAX_WIDTH,
           maxHeight: LIGHTBOX_MAX_HEIGHT,
         }
+      : context === "detail"
+        ? {
+            position: "relative",
+            display: "block",
+            width: "100%",
+            height: "100%",
+          }
+      : context === "gallery"
+        ? {
+            position: "relative",
+            display: "block",
+            width: "100%",
+            height: "100%",
+          }
       : {
           position: "relative",
           display: "inline-flex",
@@ -210,12 +235,26 @@ export default function CloudinaryImage({
           ? Math.round(window.innerHeight * window.devicePixelRatio * 0.8)
           : 900;
       img.resize(fit().width(vw).height(vh));
+    } else if (context === "detail") {
+      const vw =
+        typeof window !== "undefined"
+          ? Math.round(window.innerWidth * window.devicePixelRatio)
+          : 1400;
+      const vh =
+        typeof window !== "undefined"
+          ? Math.round(window.innerHeight * window.devicePixelRatio * 0.65)
+          : 1000;
+      img.resize(fit().width(vw).height(vh));
     } else {
-      // thumbnail or preview — 64×64 fill with auto gravity
+      const targetWidth =
+        context === "gallery" ? (requestedWidth ?? 320) : THUMBNAIL_SIZE;
+      const targetHeight =
+        context === "gallery" ? (requestedHeight ?? 240) : THUMBNAIL_SIZE;
+      // thumbnail, gallery, or preview — cropped fill with auto gravity
       img.resize(
         fill()
-          .width(THUMBNAIL_SIZE)
-          .height(THUMBNAIL_SIZE)
+          .width(targetWidth)
+          .height(targetHeight)
           .gravity(autoGravity()),
       );
     }

--- a/web/src/components/GlobalEntryField.tsx
+++ b/web/src/components/GlobalEntryField.tsx
@@ -11,6 +11,7 @@ export interface GlobalEntryFieldProps {
   helperText?: string;
   required?: boolean;
   canCreate?: boolean;
+  hideLabel?: boolean;
   sx?: SxProps<Theme>;
 }
 
@@ -24,20 +25,13 @@ export default function GlobalEntryField({
   helperText,
   required = false,
   canCreate = false,
+  hideLabel = false,
   sx,
 }: GlobalEntryFieldProps) {
   const [open, setOpen] = useState(false);
 
   return (
     <Box sx={sx}>
-      <Typography
-        variant="caption"
-        color="text.secondary"
-        sx={{ display: "block", mb: 0.5 }}
-      >
-        {label}
-        {required && " *"}
-      </Typography>
       <Box
         sx={{
           display: "flex",
@@ -46,6 +40,16 @@ export default function GlobalEntryField({
           flexWrap: "wrap",
         }}
       >
+        {!hideLabel && (
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ flexShrink: 0 }}
+          >
+            {label}
+            {required && " *"}
+          </Typography>
+        )}
         {value && <Chip label={value} onDelete={() => onSelect(null)} />}
         <Button
           variant="outlined"
@@ -58,7 +62,11 @@ export default function GlobalEntryField({
         </Button>
       </Box>
       {helperText && (
-        <Typography variant="caption" color="text.secondary">
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{ display: "block", mt: 0.25, pl: 1, fontStyle: "italic", fontSize: "0.7rem" }}
+        >
           {helperText}
         </Typography>
       )}

--- a/web/src/components/ImageLightbox.tsx
+++ b/web/src/components/ImageLightbox.tsx
@@ -100,10 +100,8 @@ export default function ImageLightbox({
             userSelect: "none",
           }}
         />
-        {image.caption && (
-          <Typography variant="body2" sx={{ color: "rgba(255,255,255,0.8)" }}>
-            {image.caption}
-          </Typography>
+        {footerActions && (
+          <Box onClick={(e) => e.stopPropagation()}>{footerActions(index)}</Box>
         )}
         {onSetAsThumbnail && (
           <Box onClick={(e) => e.stopPropagation()}>
@@ -126,9 +124,6 @@ export default function ImageLightbox({
                   : "Set as thumbnail"}
             </Button>
           </Box>
-        )}
-        {footerActions && (
-          <Box onClick={(e) => e.stopPropagation()}>{footerActions(index)}</Box>
         )}
         {!isTouchDevice && images.length > 1 && (
           <Box

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -1,6 +1,7 @@
-import { useRef, useState } from "react";
+import { type ReactNode, useRef, useState } from "react";
 import {
   Alert,
+  alpha,
   Box,
   Button,
   Dialog,
@@ -12,6 +13,7 @@ import {
   IconButton,
   TextField,
   Typography,
+  useTheme,
 } from "@mui/material";
 import EditIcon from "@mui/icons-material/Edit";
 import CheckIcon from "@mui/icons-material/Check";
@@ -19,22 +21,136 @@ import CloseIcon from "@mui/icons-material/Close";
 import { useBlocker } from "react-router-dom";
 import type { PieceDetail as PieceDetailType } from "../util/types";
 import { formatState, isTerminalState } from "../util/types";
-import { addPieceState, updatePiece } from "../util/api";
+import { addPieceState, updateCurrentState, updatePiece } from "../util/api";
 import CloudinaryImage from "./CloudinaryImage";
 import WorkflowState from "./WorkflowState";
 import TagManager from "./TagManager";
 import StateTransition from "./StateTransition";
 import PieceHistory from "./PieceHistory";
+import GlobalEntryField from "./GlobalEntryField";
+import PiecePhotoGallery, {
+  type PiecePhotoGalleryImage,
+} from "./PiecePhotoGallery";
+import { PieceDetailSaveStatusProvider } from "./PieceDetailSaveStatusContext";
+import { usePieceDetailSaveStatus } from "./usePieceDetailSaveStatus";
 
 type PieceDetailProps = {
   piece: PieceDetailType;
   onPieceUpdated: (updated: PieceDetailType) => void;
 };
 
+type SectionCardProps = {
+  eyebrow?: string;
+  title?: string;
+  subtitle?: string;
+  children: ReactNode;
+};
+
+function SectionCard({
+  eyebrow,
+  title,
+  subtitle,
+  children,
+}: SectionCardProps) {
+  return (
+    <Box
+      sx={(theme) => ({
+        borderRadius: "6px",
+        border: "1px solid",
+        borderColor: "divider",
+        backgroundColor: alpha(theme.palette.background.paper, 0.66),
+        backdropFilter: "blur(14px)",
+        boxShadow: `0 14px 34px ${alpha(theme.palette.common.black, 0.14)}`,
+        overflow: "hidden",
+      })}
+    >
+      <Box sx={{ px: { xs: 1.5, sm: 2 }, pt: 1.25, pb: 0.75 }}>
+        {(eyebrow || title || subtitle) && (
+          <>
+            {eyebrow && (
+              <Typography
+                variant="caption"
+                sx={{
+                  display: "block",
+                  mb: 0.25,
+                  color: "text.secondary",
+                  letterSpacing: "0.14em",
+                  textTransform: "uppercase",
+                }}
+              >
+                {eyebrow}
+              </Typography>
+            )}
+            {(title || subtitle) && (
+              <Box
+                sx={{
+                  display: "flex",
+                  gap: 1,
+                  alignItems: "baseline",
+                  justifyContent: "space-between",
+                  flexWrap: "wrap",
+                }}
+              >
+                {title ? (
+                  <Typography variant="h6" component="h3">
+                    {title}
+                  </Typography>
+                ) : (
+                  <Box />
+                )}
+                {subtitle && (
+                  <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                    {subtitle}
+                  </Typography>
+                )}
+              </Box>
+            )}
+          </>
+        )}
+      </Box>
+      <Box sx={{ px: { xs: 1.5, sm: 2 }, pb: 1.5 }}>{children}</Box>
+    </Box>
+  );
+}
+
+function normalizeAdditionalFields(
+  fields: Record<string, unknown>,
+): Record<string, string | number | boolean | null> {
+  const result: Record<string, string | number | boolean | null> = {};
+  for (const [key, value] of Object.entries(fields)) {
+    if (typeof value === "object" && value !== null && "id" in value) {
+      const id = (value as { id: unknown }).id;
+      result[key] = typeof id === "string" ? id : null;
+    } else if (
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean" ||
+      value === null
+    ) {
+      result[key] = value;
+    } else {
+      result[key] = null;
+    }
+  }
+  return result;
+}
+
 export default function PieceDetail({
   piece,
   onPieceUpdated,
 }: PieceDetailProps) {
+  return (
+    <PieceDetailSaveStatusProvider>
+      <PieceDetailContent piece={piece} onPieceUpdated={onPieceUpdated} />
+    </PieceDetailSaveStatusProvider>
+  );
+}
+
+function PieceDetailContent({
+  piece,
+  onPieceUpdated,
+}: PieceDetailProps) {
+  const theme = useTheme();
   const [isDirty, setIsDirty] = useState(false);
   const [transitioning, setTransitioning] = useState(false);
   const [transitionError, setTransitionError] = useState<string | null>(null);
@@ -42,10 +158,40 @@ export default function PieceDetail({
   const [nameValue, setNameValue] = useState(piece.name);
   const [nameSaving, setNameSaving] = useState(false);
   const [nameError, setNameError] = useState<string | null>(null);
+  const [locationSaving, setLocationSaving] = useState(false);
+  const [locationError, setLocationError] = useState<string | null>(null);
   const nameInputRef = useRef<HTMLInputElement>(null);
+  const pieceDetailSaveStatus = usePieceDetailSaveStatus();
   const currentState = piece.current_state;
   const isTerminal = isTerminalState(currentState.state);
   const pastHistory = piece.history.slice(0, -1);
+  function formatDate(d: Date): string {
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, "0");
+    const day = String(d.getDate()).padStart(2, "0");
+    return `${y}/${m}/${day}`;
+  }
+  const createdLabel = formatDate(piece.created);
+  const modifiedLabel = formatDate(piece.last_modified);
+  const galleryImages: PiecePhotoGalleryImage[] = piece.history.flatMap((state) => {
+    const isCurrentState =
+      state.created.getTime() === currentState.created.getTime() &&
+      state.state === currentState.state;
+    return state.images.map((image, imageIndex) => ({
+      ...image,
+      stateLabel: formatState(state.state),
+      editableCurrentStateIndex: isCurrentState ? imageIndex : null,
+    }));
+  });
+  const editButtonSx = {
+    width: 22,
+    height: 22,
+    borderRadius: "4px",
+    border: "1px solid",
+    borderColor: "divider",
+    color: "text.secondary",
+    backgroundColor: alpha(theme.palette.background.paper, 0.38),
+  } as const;
 
   const blocker = useBlocker(isDirty);
 
@@ -91,7 +237,10 @@ export default function PieceDetail({
     setNameSaving(true);
     setNameError(null);
     try {
-      const updated = await updatePiece(piece.id, { name: trimmed });
+      const saveNameRequest = () => updatePiece(piece.id, { name: trimmed });
+      const updated = pieceDetailSaveStatus
+        ? await pieceDetailSaveStatus.runManualSave(saveNameRequest)
+        : await saveNameRequest();
       onPieceUpdated(updated);
       setEditingName(false);
     } catch {
@@ -101,140 +250,337 @@ export default function PieceDetail({
     }
   }
 
+  async function handleLocationSelect(entry: { id: string; name: string } | null) {
+    setLocationSaving(true);
+    setLocationError(null);
+    try {
+      const saveLocationRequest = () =>
+        updatePiece(piece.id, {
+          current_location: entry?.name ?? "",
+        });
+      const updated = pieceDetailSaveStatus
+        ? await pieceDetailSaveStatus.runManualSave(saveLocationRequest)
+        : await saveLocationRequest();
+      onPieceUpdated(updated);
+    } catch {
+      setLocationError("Failed to save location. Please try again.");
+    } finally {
+      setLocationSaving(false);
+    }
+  }
+
   return (
-    <Box sx={{ textAlign: "left" }}>
-      {/* Header */}
-      <Box sx={{ display: "flex", alignItems: "center", gap: 2, mb: 0 }}>
-        {piece.thumbnail && (
-          <CloudinaryImage
-            url={piece.thumbnail.url}
-            cloudinary_public_id={piece.thumbnail.cloudinary_public_id}
-            alt={piece.name}
-            context="thumbnail"
-            style={{ objectFit: "cover", borderRadius: 4 }}
-          />
-        )}
+    <Box
+      sx={{
+        textAlign: "left",
+        px: { xs: 1.5, sm: 2.5 },
+        pb: 4,
+      }}
+    >
+      <Box sx={{ mx: "auto", maxWidth: 980, background: "transparent" }}>
+        {/* Desktop: two-column hero+info; Mobile: stacked */}
         <Box
           sx={{
-            display: "flex",
-            flexWrap: "wrap",
-            width: "100%",
-            alignItems: "center",
+            display: { xs: "grid", md: "grid" },
+            gridTemplateColumns: { xs: "1fr", md: "1fr 1fr" },
+            gridTemplateAreas: {
+              xs: '"hero" "info"',
+              md: '"info hero"',
+            },
+            gap: { md: 3 },
+            alignItems: "start",
+            mb: { xs: 0, md: 2 },
           }}
         >
-          <Box sx={{ minWidth: 0, flexBasis: "100%" }}>
-            {editingName ? (
-              <Box sx={{ display: "flex", alignItems: "center" }}>
-                <TextField
-                  inputRef={nameInputRef}
-                  value={nameValue}
-                  onChange={(e) => setNameValue(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") saveName();
-                    if (e.key === "Escape") cancelEditingName();
+          {/* Left column (desktop) / bottom (mobile): title + tags + states */}
+          <Box sx={{ pt: { xs: 1.75, md: 0 }, pb: 0.5, gridArea: "info" }}>
+            <Typography
+              variant="caption"
+              sx={{
+                display: "block",
+                mb: 0.5,
+                color: "text.secondary",
+                letterSpacing: "0.12em",
+                textTransform: "uppercase",
+              }}
+            >
+              Created {createdLabel} · Modified {modifiedLabel}
+            </Typography>
+            <Box sx={{ minWidth: 0, mb: 1.25 }}>
+              {editingName ? (
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "flex-start",
+                    gap: 1,
+                    flexWrap: "wrap",
                   }}
-                  size="small"
-                  error={!!nameError}
-                  helperText={nameError}
-                  disabled={nameSaving}
-                  slotProps={{
-                    htmlInput: { "aria-label": "Piece name", maxLength: 255 },
-                  }}
-                  sx={{ minWidth: 200 }}
+                >
+                  <TextField
+                    inputRef={nameInputRef}
+                    value={nameValue}
+                    onChange={(e) => setNameValue(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") saveName();
+                      if (e.key === "Escape") cancelEditingName();
+                    }}
+                    size="small"
+                    error={!!nameError}
+                    helperText={nameError}
+                    disabled={nameSaving}
+                    slotProps={{
+                      htmlInput: { "aria-label": "Piece name", maxLength: 255 },
+                    }}
+                    sx={{
+                      minWidth: 220,
+                      flex: 1,
+                      maxWidth: 460,
+                    }}
+                  />
+                  <Box sx={{ display: "flex", alignItems: "center" }}>
+                    <IconButton
+                      aria-label="Save name"
+                      onClick={saveName}
+                      disabled={nameSaving}
+                      size="small"
+                      color="primary"
+                    >
+                      <CheckIcon fontSize="small" />
+                    </IconButton>
+                    <IconButton
+                      aria-label="Cancel name edit"
+                      onClick={cancelEditingName}
+                      disabled={nameSaving}
+                      size="small"
+                    >
+                      <CloseIcon fontSize="small" />
+                    </IconButton>
+                  </Box>
+                </Box>
+              ) : (
+                <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                  <Typography
+                    variant="h3"
+                    component="h2"
+                    sx={{
+                      fontSize: { xs: "2rem", sm: "2.6rem", md: "2rem" },
+                      lineHeight: 1.05,
+                      letterSpacing: "-0.03em",
+                      textWrap: "balance",
+                    }}
+                  >
+                    {piece.name}
+                  </Typography>
+                  <IconButton
+                    aria-label="Edit piece name"
+                    onClick={startEditingName}
+                    size="small"
+                    sx={{ ...editButtonSx, alignSelf: "center" }}
+                  >
+                    <EditIcon sx={{ fontSize: 14 }} />
+                  </IconButton>
+                </Box>
+              )}
+            </Box>
+            <TagManager
+              pieceId={piece.id}
+              initialTags={piece.tags ?? []}
+              onSaved={onPieceUpdated}
+            />
+            <Box sx={{ mt: 2, mb: 1.5 }}>
+              <StateTransition
+                currentStateName={currentState.state}
+                disabled={isDirty}
+                transitioning={transitioning}
+                transitionError={transitionError}
+                onTransition={handleTransition}
+              />
+            </Box>
+            <Box sx={{ mb: 1.5 }}>
+              <SectionCard>
+                <GlobalEntryField
+                  globalName="location"
+                  label="Current location"
+                  value={piece.current_location ?? ""}
+                  onSelect={(entry) => void handleLocationSelect(entry)}
+                  sx={{ opacity: locationSaving ? 0.7 : 1 }}
                 />
-                <IconButton
-                  aria-label="Save name"
-                  onClick={saveName}
-                  disabled={nameSaving}
-                  size="small"
-                  color="primary"
-                >
-                  <CheckIcon fontSize="small" />
-                </IconButton>
-                <IconButton
-                  aria-label="Cancel name edit"
-                  onClick={cancelEditingName}
-                  disabled={nameSaving}
-                  size="small"
-                >
-                  <CloseIcon fontSize="small" />
-                </IconButton>
-              </Box>
-            ) : (
-              <Box sx={{ display: "flex", alignItems: "center" }}>
-                <Typography variant="h5" component="h2">
-                  {piece.name}
-                </Typography>
-                <IconButton
-                  aria-label="Edit piece name"
-                  onClick={startEditingName}
-                  size="small"
-                  sx={{ color: "text.secondary" }}
-                >
-                  <EditIcon fontSize="small" />
-                </IconButton>
-              </Box>
-            )}
+                {locationError && (
+                  <Typography variant="body2" color="error" sx={{ mt: 0.75 }}>
+                    {locationError}
+                  </Typography>
+                )}
+              </SectionCard>
+            </Box>
           </Box>
-          <TagManager
-            pieceId={piece.id}
-            initialTags={piece.tags ?? []}
-            onSaved={onPieceUpdated}
-          />
+
+          {/* Right column (desktop) / top (mobile): hero image */}
+          <Box sx={{ gridArea: "hero" }}>
+            <Box
+              sx={(theme) => ({
+                position: "relative",
+                overflow: "hidden",
+                borderRadius: { xs: "8px", md: "10px" },
+                minHeight: { xs: 200, sm: 260 },
+                aspectRatio: { md: "4 / 3" },
+                backgroundColor: alpha(theme.palette.background.paper, 0.46),
+                boxShadow: `0 24px 60px ${alpha(theme.palette.common.black, 0.22)}`,
+              })}
+            >
+              {piece.thumbnail ? (
+                <Box sx={{ position: "absolute", inset: 0 }}>
+                  <CloudinaryImage
+                    url={piece.thumbnail.url}
+                    cloudinary_public_id={piece.thumbnail.cloudinary_public_id}
+                    alt={piece.name}
+                    context="detail"
+                    style={{
+                      width: "100%",
+                      height: "100%",
+                      objectFit: "cover",
+                      display: "block",
+                    }}
+                  />
+                </Box>
+              ) : null}
+              <Box
+                sx={(theme) => ({
+                  position: "absolute",
+                  inset: 0,
+                  background: piece.thumbnail
+                    ? `linear-gradient(180deg, ${alpha(theme.palette.common.black, 0.24)} 0%, transparent 40%)`
+                    : alpha(theme.palette.background.default, 0.9),
+                })}
+              />
+              {/* Photo gallery button — inside hero on mobile only */}
+              <Box
+                sx={{
+                  display: { xs: "flex", md: "none" },
+                  position: "relative",
+                  zIndex: 1,
+                  justifyContent: "flex-end",
+                  p: { xs: 1.5, sm: 2 },
+                }}
+              >
+                <PiecePhotoGallery
+                  images={galleryImages}
+                  currentThumbnailUrl={piece.thumbnail?.url}
+                  onSetAsThumbnail={async (image) => {
+                    const updated = await updatePiece(piece.id, {
+                      thumbnail: {
+                        url: image.url,
+                        cloudinary_public_id: image.cloudinary_public_id ?? null,
+                      },
+                    });
+                    onPieceUpdated(updated);
+                  }}
+                  onSaveCaption={async (currentStateImageIndex, caption) => {
+                    const updatedImages = currentState.images.map((image, index) => ({
+                      url: image.url,
+                      caption: index === currentStateImageIndex ? caption.trim() : image.caption,
+                      cloudinary_public_id: image.cloudinary_public_id ?? null,
+                    }));
+                    const updated = await updateCurrentState(piece.id, {
+                      notes: currentState.notes,
+                      images: updatedImages,
+                      additional_fields: normalizeAdditionalFields(currentState.additional_fields ?? {}),
+                    });
+                    onPieceUpdated(updated);
+                  }}
+                  onDeleteImage={async (currentStateImageIndex) => {
+                    const updatedImages = currentState.images
+                      .filter((_image, index) => index !== currentStateImageIndex)
+                      .map((image) => ({
+                        url: image.url,
+                        caption: image.caption,
+                        cloudinary_public_id: image.cloudinary_public_id ?? null,
+                      }));
+                    const updated = await updateCurrentState(piece.id, {
+                      notes: currentState.notes,
+                      images: updatedImages,
+                      additional_fields: normalizeAdditionalFields(currentState.additional_fields ?? {}),
+                    });
+                    onPieceUpdated(updated);
+                  }}
+                />
+              </Box>
+            </Box>
+            {/* Photo gallery + upload trigger — below hero on desktop only */}
+            <Box sx={{ display: { xs: "none", md: "flex" }, alignItems: "center", gap: 1, mt: 1 }}>
+              <Box id="piece-upload-trigger" />
+              <PiecePhotoGallery
+                images={galleryImages}
+                currentThumbnailUrl={piece.thumbnail?.url}
+                onSetAsThumbnail={async (image) => {
+                  const updated = await updatePiece(piece.id, {
+                    thumbnail: {
+                      url: image.url,
+                      cloudinary_public_id: image.cloudinary_public_id ?? null,
+                    },
+                  });
+                  onPieceUpdated(updated);
+                }}
+                onSaveCaption={async (currentStateImageIndex, caption) => {
+                  const updatedImages = currentState.images.map((image, index) => ({
+                    url: image.url,
+                    caption: index === currentStateImageIndex ? caption.trim() : image.caption,
+                    cloudinary_public_id: image.cloudinary_public_id ?? null,
+                  }));
+                  const updated = await updateCurrentState(piece.id, {
+                    notes: currentState.notes,
+                    images: updatedImages,
+                    additional_fields: normalizeAdditionalFields(currentState.additional_fields ?? {}),
+                  });
+                  onPieceUpdated(updated);
+                }}
+                onDeleteImage={async (currentStateImageIndex) => {
+                  const updatedImages = currentState.images
+                    .filter((_image, index) => index !== currentStateImageIndex)
+                    .map((image) => ({
+                      url: image.url,
+                      caption: image.caption,
+                      cloudinary_public_id: image.cloudinary_public_id ?? null,
+                    }));
+                  const updated = await updateCurrentState(piece.id, {
+                    notes: currentState.notes,
+                    images: updatedImages,
+                    additional_fields: normalizeAdditionalFields(currentState.additional_fields ?? {}),
+                  });
+                  onPieceUpdated(updated);
+                }}
+              />
+            </Box>
+          </Box>
+
         </Box>
+
+        <SectionCard>
+          <WorkflowState
+            key={currentState.state + currentState.created.toISOString()}
+            pieceState={currentState}
+            pieceId={piece.id}
+            onSaved={onPieceUpdated}
+            onDirtyChange={setIsDirty}
+          />
+        </SectionCard>
+
+        <Divider sx={{ my: 2, opacity: 0.4 }} />
+
+        {isTerminal && (
+          <Alert severity="info" sx={{ mb: 2.5, borderRadius: 3 }}>
+            This piece is in a terminal state (
+            <strong>{formatState(currentState.state)}</strong>). No further
+            transitions are possible.
+          </Alert>
+        )}
+
+        <SectionCard
+          title="Timeline"
+          subtitle={`${pastHistory.length} completed state${pastHistory.length === 1 ? "" : "s"}`}
+        >
+          <PieceHistory pastHistory={pastHistory} />
+        </SectionCard>
       </Box>
-
-      <StateTransition
-        currentStateName={currentState.state}
-        disabled={isDirty}
-        transitioning={transitioning}
-        transitionError={transitionError}
-        onTransition={handleTransition}
-      />
-
-      {/* Current state form */}
-      <WorkflowState
-        key={currentState.state + currentState.created.toISOString()}
-        pieceState={currentState}
-        pieceId={piece.id}
-        onSaved={onPieceUpdated}
-        onDirtyChange={setIsDirty}
-        currentLocation={piece.current_location ?? ""}
-        currentThumbnail={piece.thumbnail}
-        onSetAsThumbnail={async (image) => {
-          const updated = await updatePiece(piece.id, {
-            thumbnail: {
-              url: image.url,
-              cloudinary_public_id: image.cloudinary_public_id ?? null,
-            },
-          });
-          onPieceUpdated(updated);
-        }}
-      />
-
-      <Divider sx={{ my: 3 }} />
-
-      {isTerminal && (
-        <Alert severity="info" sx={{ mb: 2 }}>
-          This piece is in a terminal state (
-          <strong>{formatState(currentState.state)}</strong>). No further
-          transitions are possible.
-        </Alert>
-      )}
-
-      <PieceHistory
-        pastHistory={pastHistory}
-        currentThumbnailUrl={piece.thumbnail?.url}
-        onSetAsThumbnail={async (image) => {
-          const updated = await updatePiece(piece.id, {
-            thumbnail: {
-              url: image.url,
-              cloudinary_public_id: image.cloudinary_public_id ?? null,
-            },
-          });
-          onPieceUpdated(updated);
-        }}
-      />
 
       {/* Navigation blocker dialog */}
       <Dialog open={blocker.state === "blocked"}>

--- a/web/src/components/PieceDetailSaveStatusContext.tsx
+++ b/web/src/components/PieceDetailSaveStatusContext.tsx
@@ -1,0 +1,135 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import AutosaveStatus from "./AutosaveStatus";
+import {
+  PieceDetailSaveStatusContext,
+  type SaveStatusSnapshot,
+} from "./usePieceDetailSaveStatus";
+
+const RESET_DELAY_MS = 1800;
+
+const defaultSnapshot: SaveStatusSnapshot = {
+  status: "idle",
+  error: null,
+  lastSavedAt: null,
+};
+
+function useResetTimer() {
+  const resetTimerRef = useRef<number | null>(null);
+
+  const clearResetTimer = useCallback(() => {
+    if (resetTimerRef.current !== null) {
+      window.clearTimeout(resetTimerRef.current);
+      resetTimerRef.current = null;
+    }
+  }, []);
+
+  const scheduleReset = useCallback((callback: () => void) => {
+    clearResetTimer();
+    resetTimerRef.current = window.setTimeout(() => {
+      resetTimerRef.current = null;
+      callback();
+    }, RESET_DELAY_MS);
+  }, [clearResetTimer]);
+
+  useEffect(() => clearResetTimer, [clearResetTimer]);
+
+  return { clearResetTimer, scheduleReset };
+}
+
+export function PieceDetailSaveStatusProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [workflowStatus, setWorkflowStatus] =
+    useState<SaveStatusSnapshot>(defaultSnapshot);
+  const [manualStatus, setManualStatus] =
+    useState<SaveStatusSnapshot>(defaultSnapshot);
+  const manualRunIdRef = useRef(0);
+  const { clearResetTimer, scheduleReset } = useResetTimer();
+
+  const publishWorkflowStatus = useCallback((snapshot: SaveStatusSnapshot) => {
+    setWorkflowStatus(snapshot);
+  }, []);
+
+  const runManualSave = useCallback(
+    async <T,>(save: () => Promise<T>) => {
+      manualRunIdRef.current += 1;
+      const runId = manualRunIdRef.current;
+      clearResetTimer();
+      setManualStatus({
+        status: "pending",
+        error: null,
+        lastSavedAt: null,
+      });
+
+      await new Promise<void>((resolve) => window.setTimeout(resolve, 0));
+      if (manualRunIdRef.current !== runId) {
+        return save();
+      }
+
+      setManualStatus({
+        status: "saving",
+        error: null,
+        lastSavedAt: null,
+      });
+
+      try {
+        const result = await save();
+        if (manualRunIdRef.current !== runId) {
+          return result;
+        }
+        const lastSavedAt = new Date();
+        setManualStatus({
+          status: "saved",
+          error: null,
+          lastSavedAt,
+        });
+        scheduleReset(() => {
+          setManualStatus(defaultSnapshot);
+        });
+        return result;
+      } catch (error) {
+        if (manualRunIdRef.current === runId) {
+          setManualStatus({
+            status: "error",
+            error: "Save failed. Please try again.",
+            lastSavedAt: null,
+          });
+        }
+        throw error;
+      }
+    },
+    [clearResetTimer, scheduleReset],
+  );
+
+  const visibleStatus =
+    manualStatus.status === "idle" ? workflowStatus : manualStatus;
+
+  const value = useMemo(
+    () => ({
+      publishWorkflowStatus,
+      runManualSave,
+    }),
+    [publishWorkflowStatus, runManualSave],
+  );
+
+  return (
+    <PieceDetailSaveStatusContext.Provider value={value}>
+      {children}
+      <AutosaveStatus
+        status={visibleStatus.status}
+        error={visibleStatus.error}
+        lastSavedAt={visibleStatus.lastSavedAt}
+        variant="floating"
+      />
+    </PieceDetailSaveStatusContext.Provider>
+  );
+}

--- a/web/src/components/PieceHistory.tsx
+++ b/web/src/components/PieceHistory.tsx
@@ -1,137 +1,83 @@
-import { useMemo, useState } from "react";
-import {
-  Box,
-  Button,
-  Collapse,
-  List,
-  ListItem,
-  ListItemText,
-  Typography,
-} from "@mui/material";
-import type { CaptionedImage, PieceState } from "../util/types";
+import { useState } from "react";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import { alpha, Box, Collapse, List, ListItem, ListItemText, Typography } from "@mui/material";
+import type { PieceState } from "../util/types";
 import { formatPastState } from "../util/types";
-import CloudinaryImage from "./CloudinaryImage";
-import ImageLightbox from "./ImageLightbox";
 
 type PieceHistoryProps = {
   pastHistory: PieceState[];
-  currentThumbnailUrl?: string;
-  onSetAsThumbnail: (image: CaptionedImage) => Promise<void>;
 };
 
-export default function PieceHistory({
-  pastHistory,
-  currentThumbnailUrl,
-  onSetAsThumbnail,
-}: PieceHistoryProps) {
+export default function PieceHistory({ pastHistory }: PieceHistoryProps) {
   const [historyOpen, setHistoryOpen] = useState(false);
-  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
-
-  const allHistoryImages = useMemo<CaptionedImage[]>(
-    () => pastHistory.flatMap((ps) => ps.images),
-    [pastHistory],
-  );
 
   if (pastHistory.length === 0) return null;
 
   return (
     <Box>
-      <Button
-        variant="text"
+      <Box
+        component="button"
+        type="button"
         onClick={() => setHistoryOpen((o) => !o)}
-        sx={{ mb: 1 }}
+        aria-expanded={historyOpen}
+        sx={(theme) => ({
+          display: "flex",
+          alignItems: "center",
+          gap: 0.5,
+          mb: 1.5,
+          px: 0,
+          py: 0.5,
+          background: "none",
+          border: "none",
+          cursor: "pointer",
+          color: theme.palette.text.secondary,
+          textAlign: "left",
+        })}
       >
-        {historyOpen ? "Hide" : "Show"} history ({pastHistory.length} past
-        state{pastHistory.length !== 1 ? "s" : ""})
-      </Button>
+        <ExpandMoreIcon
+          sx={{
+            fontSize: 16,
+            transition: "transform 0.2s",
+            transform: historyOpen ? "rotate(180deg)" : "rotate(0deg)",
+          }}
+        />
+        <Typography variant="body2" sx={{ color: "inherit" }}>
+          {historyOpen ? "Hide" : "Show"} history ({pastHistory.length} past
+          state{pastHistory.length !== 1 ? "s" : ""})
+        </Typography>
+      </Box>
       <Collapse in={historyOpen}>
-        <List dense>
-          {
-            pastHistory.reduce<{ offset: number; items: React.ReactNode[] }>(
-              ({ offset, items }, ps, i) => {
-                const stateOffset = offset;
-                items.push(
-                  <ListItem
-                    key={i}
-                    disableGutters
-                    sx={{ flexDirection: "column", alignItems: "flex-start" }}
-                  >
-                    <ListItemText
-                      primary={formatPastState(ps.state)}
-                      secondary={`${ps.created.toLocaleString()}${ps.notes ? " — " + ps.notes : ""}`}
-                      slotProps={{
-                        primary: { sx: { color: "text.primary" } },
-                        secondary: { sx: { color: "text.secondary" } },
-                      }}
-                    />
-                    {ps.images.length > 0 && (
-                      <Box
-                        sx={{
-                          display: "flex",
-                          flexDirection: "row",
-                          flexWrap: "wrap",
-                          gap: 1,
-                          mt: 0.5,
-                        }}
-                      >
-                        {ps.images.map((img, j) => (
-                          <Box
-                            key={j}
-                            component="button"
-                            onClick={() => setLightboxIndex(stateOffset + j)}
-                            aria-label={`View image ${stateOffset + j + 1}`}
-                            sx={{
-                              p: 0,
-                              border: "none",
-                              background: "none",
-                              cursor: "pointer",
-                              display: "flex",
-                              flexDirection: "column",
-                              alignItems: "center",
-                              maxWidth: 80,
-                            }}
-                          >
-                            <CloudinaryImage
-                              url={img.url}
-                              cloudinary_public_id={img.cloudinary_public_id}
-                              alt={img.caption || ""}
-                              context="thumbnail"
-                              style={{ objectFit: "cover", borderRadius: 4 }}
-                            />
-                            {img.caption && (
-                              <Typography
-                                variant="caption"
-                                sx={{
-                                  color: "text.secondary",
-                                  textAlign: "center",
-                                  wordBreak: "break-word",
-                                }}
-                              >
-                                {img.caption}
-                              </Typography>
-                            )}
-                          </Box>
-                        ))}
-                      </Box>
-                    )}
-                  </ListItem>,
-                );
-                return { offset: offset + ps.images.length, items };
-              },
-              { offset: 0, items: [] },
-            ).items
-          }
+        <List dense sx={{ display: "grid", gap: 1.25 }}>
+          {pastHistory.map((ps, i) => (
+            <ListItem
+              key={i}
+              disableGutters
+              sx={(theme) => ({
+                px: 1.5,
+                py: 1.5,
+                borderRadius: 3,
+                border: "1px solid",
+                borderColor: "divider",
+                backgroundColor: alpha(
+                  theme.palette.background.default,
+                  0.34,
+                ),
+                flexDirection: "column",
+                alignItems: "flex-start",
+              })}
+            >
+              <ListItemText
+                primary={formatPastState(ps.state)}
+                secondary={`${ps.created.toLocaleString()}${ps.notes ? " — " + ps.notes : ""}`}
+                slotProps={{
+                  primary: { sx: { color: "text.primary" } },
+                  secondary: { sx: { color: "text.secondary" } },
+                }}
+              />
+            </ListItem>
+          ))}
         </List>
       </Collapse>
-      {lightboxIndex !== null && (
-        <ImageLightbox
-          images={allHistoryImages}
-          initialIndex={lightboxIndex}
-          onClose={() => setLightboxIndex(null)}
-          currentThumbnailUrl={currentThumbnailUrl}
-          onSetAsThumbnail={onSetAsThumbnail}
-        />
-      )}
     </Box>
   );
 }

--- a/web/src/components/PiecePhotoGallery.tsx
+++ b/web/src/components/PiecePhotoGallery.tsx
@@ -1,0 +1,381 @@
+import { useEffect, useState } from "react";
+import CloseIcon from "@mui/icons-material/Close";
+import PhotoLibraryOutlinedIcon from "@mui/icons-material/PhotoLibraryOutlined";
+import EditIcon from "@mui/icons-material/Edit";
+import {
+  alpha,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  IconButton,
+  TextField,
+  Tooltip,
+  Typography,
+  useTheme,
+} from "@mui/material";
+import type { CaptionedImage } from "../util/types";
+import CloudinaryImage from "./CloudinaryImage";
+import ImageLightbox from "./ImageLightbox";
+
+export type PiecePhotoGalleryImage = CaptionedImage & {
+  stateLabel: string;
+  editableCurrentStateIndex?: number | null;
+};
+
+type PiecePhotoGalleryProps = {
+  images: PiecePhotoGalleryImage[];
+  currentThumbnailUrl?: string;
+  onSetAsThumbnail: (image: CaptionedImage) => Promise<void>;
+  onSaveCaption?: (currentStateImageIndex: number, caption: string) => Promise<void>;
+  onDeleteImage?: (currentStateImageIndex: number) => Promise<void>;
+};
+
+export default function PiecePhotoGallery({
+  images,
+  currentThumbnailUrl,
+  onSetAsThumbnail,
+  onSaveCaption,
+  onDeleteImage,
+}: PiecePhotoGalleryProps) {
+  const theme = useTheme();
+  const [galleryOpen, setGalleryOpen] = useState(false);
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+  const [captionDraft, setCaptionDraft] = useState("");
+  const [captionEditing, setCaptionEditing] = useState(false);
+  const [captionSaving, setCaptionSaving] = useState(false);
+  const [captionSaveError, setCaptionSaveError] = useState<string | null>(null);
+  const [deleteDialogIndex, setDeleteDialogIndex] = useState<number | null>(null);
+  const [deleteSaving, setDeleteSaving] = useState(false);
+  const [viewportWidth, setViewportWidth] = useState(
+    typeof window === "undefined" ? 768 : window.innerWidth,
+  );
+  const pixelRatio =
+    typeof window === "undefined" ? 1 : Math.max(window.devicePixelRatio || 1, 1);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+    function syncWidth() {
+      setViewportWidth(window.innerWidth);
+    }
+    window.addEventListener("resize", syncWidth);
+    return () => window.removeEventListener("resize", syncWidth);
+  }, []);
+
+  useEffect(() => {
+    if (lightboxIndex === null) return;
+    setCaptionEditing(false);
+    setCaptionSaveError(null);
+    setCaptionDraft(images[lightboxIndex]?.caption ?? "");
+  }, [images, lightboxIndex]);
+
+  const photoCount = images.length;
+  const columns = viewportWidth < 600 ? 2 : 3;
+  const tileWidth = Math.max(
+    120,
+    Math.floor((Math.min(viewportWidth, 900) - 32 - (columns - 1) * 10) / columns),
+  );
+  const requestedWidth = Math.round(tileWidth * pixelRatio);
+  const requestedHeight = Math.round(tileWidth * 0.8 * pixelRatio);
+
+  const activeImage =
+    lightboxIndex !== null ? images[lightboxIndex] : null;
+  const editableCurrentStateIndex =
+    activeImage?.editableCurrentStateIndex ?? null;
+
+  async function handleSaveCaption() {
+    if (
+      lightboxIndex === null ||
+      editableCurrentStateIndex === null ||
+      !onSaveCaption
+    ) {
+      return;
+    }
+    setCaptionSaving(true);
+    setCaptionSaveError(null);
+    try {
+      await onSaveCaption(editableCurrentStateIndex, captionDraft);
+      setCaptionEditing(false);
+    } catch {
+      setCaptionSaveError("Failed to save caption. Please try again.");
+    } finally {
+      setCaptionSaving(false);
+    }
+  }
+
+  async function handleDeleteImage() {
+    if (deleteDialogIndex === null || !onDeleteImage) {
+      return;
+    }
+    const image = images[deleteDialogIndex];
+    const currentStateImageIndex = image?.editableCurrentStateIndex;
+    if (currentStateImageIndex === null || currentStateImageIndex === undefined) {
+      return;
+    }
+    setDeleteSaving(true);
+    try {
+      await onDeleteImage(currentStateImageIndex);
+      if (lightboxIndex === deleteDialogIndex) {
+        setLightboxIndex(null);
+      }
+      setDeleteDialogIndex(null);
+    } finally {
+      setDeleteSaving(false);
+    }
+  }
+
+  const triggerLabel = `${photoCount} photo${photoCount === 1 ? "" : "s"}`;
+
+  const canEditCaption =
+    editableCurrentStateIndex !== null && onSaveCaption !== undefined;
+
+  const footer = activeImage ? (
+    <Box sx={{ display: "grid", gap: 0.75, justifyItems: "center" }}>
+      {/* Caption editor — shown above state label */}
+      {captionEditing ? (
+        <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
+          <TextField
+            size="small"
+            value={captionDraft}
+            onChange={(event) => setCaptionDraft(event.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void handleSaveCaption();
+              if (e.key === "Escape") setCaptionEditing(false);
+            }}
+            autoFocus
+            slotProps={{
+              htmlInput: { "aria-label": "Edit photo caption" },
+            }}
+            sx={{
+              minWidth: 220,
+              "& .MuiOutlinedInput-root": {
+                backgroundColor: "rgba(255,255,255,0.08)",
+                color: "white",
+              },
+            }}
+          />
+          <Button
+            size="small"
+            variant="contained"
+            onClick={() => void handleSaveCaption()}
+            disabled={captionSaving}
+          >
+            {captionSaving ? "Saving…" : "Save"}
+          </Button>
+        </Box>
+      ) : activeImage.caption ? (
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+          <Typography variant="body2" sx={{ color: "rgba(255,255,255,0.85)" }}>
+            {activeImage.caption}
+          </Typography>
+          {canEditCaption && (
+            <Tooltip title="Edit caption">
+              <IconButton
+                size="small"
+                onClick={() => setCaptionEditing(true)}
+                aria-label="Edit caption"
+                sx={{ color: "rgba(255,255,255,0.6)", "&:hover": { color: "white" } }}
+              >
+                <EditIcon sx={{ fontSize: 14 }} />
+              </IconButton>
+            </Tooltip>
+          )}
+        </Box>
+      ) : canEditCaption ? (
+        <Button
+          size="small"
+          variant="outlined"
+          startIcon={<EditIcon fontSize="small" />}
+          onClick={() => { setCaptionDraft(""); setCaptionEditing(true); }}
+          sx={{ color: "white", borderColor: "rgba(255,255,255,0.35)" }}
+        >
+          Add caption
+        </Button>
+      ) : null}
+      {captionSaveError && (
+        <Typography variant="caption" sx={{ color: "error.light" }}>
+          {captionSaveError}
+        </Typography>
+      )}
+      {/* State label — below caption */}
+      <Typography variant="caption" sx={{ color: "rgba(255,255,255,0.55)" }}>
+        {editableCurrentStateIndex !== null
+          ? "Added in current state"
+          : `Added in ${activeImage.stateLabel}`}
+      </Typography>
+    </Box>
+  ) : null;
+
+  return (
+    <>
+      <Box
+        component="button"
+        type="button"
+        onClick={() => photoCount > 0 && setGalleryOpen(true)}
+        disabled={photoCount === 0}
+        aria-label={triggerLabel}
+        sx={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 0.75,
+          px: 1.25,
+          py: 0.75,
+          borderRadius: 999,
+          backgroundColor: alpha(theme.palette.background.default, 0.56),
+          color: "text.secondary",
+          backdropFilter: "blur(8px)",
+          border: "1px solid",
+          borderColor: "divider",
+          cursor: photoCount > 0 ? "pointer" : "default",
+          opacity: photoCount > 0 ? 1 : 0.7,
+        }}
+      >
+        <PhotoLibraryOutlinedIcon sx={{ fontSize: 16 }} />
+        <Typography variant="caption">{triggerLabel}</Typography>
+      </Box>
+
+      <Dialog
+        open={galleryOpen}
+        onClose={() => setGalleryOpen(false)}
+        maxWidth="md"
+        fullWidth
+        aria-label="Piece photos"
+        PaperProps={{ sx: { height: "80vh", borderRadius: "8px" } }}
+      >
+        <DialogContent sx={{ p: 2 }}>
+          {images.length > 0 ? (
+            <Box
+              sx={{
+                display: "grid",
+                gridTemplateColumns: {
+                  xs: "repeat(2, minmax(0, 1fr))",
+                  sm: "repeat(3, minmax(0, 1fr))",
+                },
+                gap: 1.25,
+              }}
+            >
+              {images.map((image, index) => (
+                <Box
+                  key={`${image.url}-${index}`}
+                  sx={{
+                    position: "relative",
+                    border: "1px solid",
+                    borderColor: "divider",
+                    borderRadius: "8px",
+                    overflow: "hidden",
+                  }}
+                >
+                  <Box
+                    component="button"
+                    type="button"
+                    onClick={() => setLightboxIndex(index)}
+                    aria-label={`Open piece photo ${index + 1}`}
+                    sx={{
+                      p: 0,
+                      border: "none",
+                      width: "100%",
+                      background: "transparent",
+                      display: "block",
+                      lineHeight: 0,
+                      cursor: "pointer",
+                    }}
+                  >
+                    <Box sx={{ position: "relative", aspectRatio: "5 / 4" }}>
+                      <CloudinaryImage
+                        url={image.url}
+                        cloudinary_public_id={image.cloudinary_public_id}
+                        alt={image.caption || image.stateLabel}
+                        context="gallery"
+                        requestedWidth={requestedWidth}
+                        requestedHeight={requestedHeight}
+                        style={{
+                          width: "100%",
+                          height: "100%",
+                          objectFit: "cover",
+                          display: "block",
+                        }}
+                      />
+                    </Box>
+                  </Box>
+                  {image.editableCurrentStateIndex !== null &&
+                    image.editableCurrentStateIndex !== undefined &&
+                    onDeleteImage && (
+                      <IconButton
+                        aria-label={`Delete piece photo ${index + 1}`}
+                        onClick={() => setDeleteDialogIndex(index)}
+                        size="small"
+                        sx={{
+                          position: "absolute",
+                          top: 8,
+                          right: 8,
+                          width: 28,
+                          height: 28,
+                          color: "common.white",
+                          backgroundColor: "rgba(0,0,0,0.52)",
+                          backdropFilter: "blur(6px)",
+                          "&:hover": {
+                            backgroundColor: "rgba(0,0,0,0.68)",
+                          },
+                        }}
+                      >
+                        <CloseIcon fontSize="small" />
+                      </IconButton>
+                    )}
+                </Box>
+              ))}
+            </Box>
+          ) : (
+            <Typography variant="body2" sx={{ color: "text.secondary" }}>
+              No images for this piece yet.
+            </Typography>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setGalleryOpen(false)}>Close</Button>
+        </DialogActions>
+      </Dialog>
+
+      {lightboxIndex !== null && (
+        <ImageLightbox
+          images={images}
+          initialIndex={lightboxIndex}
+          onClose={() => setLightboxIndex(null)}
+          currentThumbnailUrl={currentThumbnailUrl}
+          onSetAsThumbnail={onSetAsThumbnail}
+          footerActions={() => footer}
+        />
+      )}
+
+      <Dialog
+        open={deleteDialogIndex !== null}
+        onClose={() => !deleteSaving && setDeleteDialogIndex(null)}
+      >
+        <DialogTitle>Remove Image</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Remove this image? This action cannot be undone.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => setDeleteDialogIndex(null)}
+            disabled={deleteSaving}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => void handleDeleteImage()}
+            color="error"
+            variant="contained"
+            disabled={deleteSaving}
+          >
+            Remove
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/web/src/components/StateChip.tsx
+++ b/web/src/components/StateChip.tsx
@@ -74,7 +74,7 @@ export default function StateChip({
   })();
 
   const chipSx: SxProps<Theme> = {
-    borderRadius: 999,
+    borderRadius: "6px",
     border: "1px solid",
     borderColor: outlineColor,
     display: "inline-flex",
@@ -97,14 +97,18 @@ export default function StateChip({
     boxShadow: "none",
     opacity: disabled ? 0.6 : 1,
     transition:
-      "background-color 120ms ease, border-color 120ms ease, color 120ms ease",
+      "background-color 120ms ease, border-color 120ms ease, color 120ms ease, transform 180ms ease, box-shadow 180ms ease",
     ...(interactive
       ? {
           "&:hover": {
             backgroundColor: `color-mix(in oklab, ${baseColor} 16%, transparent)`,
             borderStyle: "solid",
+            boxShadow: `0 8px 22px color-mix(in oklab, ${baseColor} 20%, transparent)`,
             ".state-chip-dot": {
-              backgroundColor: baseColor,
+              "&::after": {
+                animationDuration: "1.2s",
+                opacity: 1,
+              },
             },
           },
         }
@@ -117,13 +121,41 @@ export default function StateChip({
         component="span"
         className="state-chip-dot"
         sx={{
+          position: "relative",
           width: 8,
           height: 8,
           borderRadius: "50%",
           border: `1.5px solid ${outlineColor}`,
           backgroundColor: dotFillColor,
+          overflow: "hidden",
           flexShrink: 0,
           transition: "background-color 120ms ease, border-color 120ms ease",
+          ...(interactive
+            ? {
+                backgroundColor: "transparent",
+                "&::after": {
+                  content: '""',
+                  position: "absolute",
+                  inset: 1,
+                  borderRadius: "50%",
+                  backgroundColor: baseColor,
+                  transformOrigin: "center",
+                  animation: disabled
+                    ? "none"
+                    : "stateChipDotPulse 2.1s ease-in-out infinite",
+                },
+                "@keyframes stateChipDotPulse": {
+                  "0%, 100%": {
+                    transform: "scale(0.28)",
+                    opacity: 0.18,
+                  },
+                  "50%": {
+                    transform: "scale(1)",
+                    opacity: 0.95,
+                  },
+                },
+              }
+            : {}),
         }}
       />
       <Box component="span">{label}</Box>

--- a/web/src/components/StateTransition.tsx
+++ b/web/src/components/StateTransition.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import ArrowOutwardIcon from "@mui/icons-material/ArrowOutward";
 import {
   Box,
   Button,
@@ -17,45 +18,94 @@ import {
   SUCCESSORS,
 } from "../util/types";
 
+// Fixed height for each successor chip row — must match the sx on the wrapper Box below.
+const SUCCESSOR_ROW_HEIGHT = 36;
+// Gap between rows — must match gap:1 (8px) on the successor flex column.
+const SUCCESSOR_ROW_GAP = 8;
+
 type StateBranchConnectorProps = {
   count: number;
 };
 
 function StateBranchConnector({ count }: StateBranchConnectorProps) {
   const connectorCount = Math.max(count, 1);
-  const height = connectorCount === 1 ? 24 : connectorCount * 28 - 4;
-  const centerY = height / 2;
-  const targetYs =
+  const chipHeight = SUCCESSOR_ROW_HEIGHT;
+  const chipGap = SUCCESSOR_ROW_GAP;
+  const height =
     connectorCount === 1
-      ? [centerY]
-      : Array.from({ length: connectorCount }, (_, index) => {
-          const start = 10;
-          const end = height - 10;
-          return start + ((end - start) * index) / (connectorCount - 1);
-        });
+      ? chipHeight
+      : connectorCount * chipHeight + (connectorCount - 1) * chipGap;
+
+  // Y center of each successor chip
+  const chipCenters = Array.from(
+    { length: connectorCount },
+    (_, i) => chipHeight / 2 + i * (chipHeight + chipGap),
+  );
+  const firstY = chipCenters[0];
+  const lastY = chipCenters[connectorCount - 1];
+  // Trunk x-position (left side, close to current chip)
+  const trunkX = 8;
 
   return (
     <Box
       component="svg"
       aria-hidden="true"
+      preserveAspectRatio="none"
       sx={(theme) => ({
-        width: 24,
+        flex: 1,
+        minWidth: 24,
         height,
-        flexShrink: 0,
+        alignSelf: "flex-start",
+        display: "block",
         overflow: "visible",
         "--line": theme.palette.divider,
       })}
-      viewBox={`0 0 24 ${height}`}
+      viewBox={`0 0 40 ${height}`}
     >
-      {targetYs.map((targetY) => (
+      {connectorCount === 1 ? (
+        // Single successor: straight horizontal line
         <path
-          key={targetY}
-          d={`M 0 ${centerY} Q 12 ${centerY} 24 ${targetY}`}
+          d={`M 0 ${firstY} H 40`}
           stroke="var(--line)"
           fill="none"
-          strokeWidth="1"
+          strokeWidth="1.2"
+          strokeLinecap="round"
+          vectorEffect="non-scaling-stroke"
         />
-      ))}
+      ) : (
+        <>
+          {/* Horizontal entry to trunk */}
+          <path
+            d={`M 0 ${firstY} H ${trunkX}`}
+            stroke="var(--line)"
+            fill="none"
+            strokeWidth="1.2"
+            strokeLinecap="round"
+            vectorEffect="non-scaling-stroke"
+          />
+          {/* Vertical trunk */}
+          <path
+            d={`M ${trunkX} ${firstY} V ${lastY}`}
+            stroke="var(--line)"
+            fill="none"
+            strokeWidth="1.2"
+            strokeLinecap="square"
+            vectorEffect="non-scaling-stroke"
+          />
+          {/* Horizontal tick to each successor */}
+          {chipCenters.map((cy) => (
+            <path
+              key={cy}
+              d={`M ${trunkX} ${cy} H 40`}
+              stroke="var(--line)"
+              fill="none"
+              strokeWidth="1.2"
+              strokeLinecap="round"
+              vectorEffect="non-scaling-stroke"
+            />
+          ))}
+        </>
+      )}
     </Box>
   );
 }
@@ -117,44 +167,79 @@ export default function StateTransition({
       <Box
         aria-label="State flow"
         role="group"
-        sx={{ mb: 2, display: "flex", alignItems: "center", gap: 1.25 }}
+        sx={{ mb: 0.75 }}
       >
-        <StateChip
-          state={currentStateName}
-          label={formatState(currentStateName)}
-          description={getStateDescription(currentStateName)}
-          variant="current"
-          isTerminal={isTerminalState(currentStateName)}
-          muted={hoveredSuccessor !== null}
-        />
-        {!isTerminal && <StateBranchConnector count={successors.length} />}
-        {!isTerminal && (
+        <Box sx={{ minWidth: 0, flex: 1 }}>
           <Box
             sx={{
               display: "flex",
-              flexDirection: "column",
               alignItems: "flex-start",
-              gap: 0.75,
+              // Gap only between current chip and connector; SVG is flush
+              // with the successor column so ticks reach the chip border.
+              gap: 0,
             }}
           >
-            {successors.map((next) => (
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                minWidth: 0,
+                height: SUCCESSOR_ROW_HEIGHT,
+                mr: 1.5,
+              }}
+            >
               <StateChip
-                key={next}
-                state={next}
-                label={formatState(next)}
-                description={getStateDescription(next)}
-                variant="future"
-                isTerminal={isTerminalState(next)}
-                onClick={() => openDialog(next)}
-                disabled={disabled || transitioning}
-                onHoverStart={() => setHoveredSuccessor(next)}
-                onHoverEnd={() =>
-                  setHoveredSuccessor((value) => (value === next ? null : value))
-                }
+                state={currentStateName}
+                label={formatState(currentStateName)}
+                description={getStateDescription(currentStateName)}
+                variant="current"
+                isTerminal={isTerminalState(currentStateName)}
+                muted={hoveredSuccessor !== null}
               />
-            ))}
+            </Box>
+            {!isTerminal && <StateBranchConnector count={successors.length} />}
+            {!isTerminal && (
+              // pl provides the visual gap between the connector's right edge
+              // and each chip's left border. Row boxes are full-width so this
+              // gap is consistent regardless of individual chip width.
+              <Box
+                sx={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: `${SUCCESSOR_ROW_GAP}px`,
+                  pl: "4px",
+                }}
+              >
+                {successors.map((next) => (
+                  <Box
+                    key={next}
+                    sx={{
+                      height: SUCCESSOR_ROW_HEIGHT,
+                      display: "flex",
+                      alignItems: "center",
+                    }}
+                  >
+                    <StateChip
+                      state={next}
+                      label={formatState(next)}
+                      description={getStateDescription(next)}
+                      variant="future"
+                      isTerminal={isTerminalState(next)}
+                      onClick={() => openDialog(next)}
+                      disabled={disabled || transitioning}
+                      onHoverStart={() => setHoveredSuccessor(next)}
+                      onHoverEnd={() =>
+                        setHoveredSuccessor((value) =>
+                          value === next ? null : value,
+                        )
+                      }
+                    />
+                  </Box>
+                ))}
+              </Box>
+            )}
           </Box>
-        )}
+        </Box>
       </Box>
 
       {transitionError && (
@@ -196,6 +281,11 @@ export default function StateTransition({
             onClick={confirmTransition}
             variant="contained"
             color={pendingTransition === "recycled" ? "error" : "primary"}
+            endIcon={
+              pendingTransition === "recycled" ? undefined : (
+                <ArrowOutwardIcon fontSize="small" />
+              )
+            }
             disabled={transitioning}
           >
             Confirm

--- a/web/src/components/TagAutocomplete.tsx
+++ b/web/src/components/TagAutocomplete.tsx
@@ -1,15 +1,21 @@
 import Autocomplete from "@mui/material/Autocomplete";
 import TextField from "@mui/material/TextField";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
 import type { SxProps, Theme } from "@mui/material/styles";
 
 import TagChip from "./TagChip";
 import type { TagEntry } from "../util/types";
+
+const CREATE_NEW_ID = "__create_new__";
+const CREATE_NEW_OPTION: TagEntry = { id: CREATE_NEW_ID, name: "+ New tag" };
 
 interface TagAutocompleteProps {
   label: string;
   options: TagEntry[];
   value: TagEntry[];
   onChange: (value: TagEntry[]) => void;
+  onCreateNew?: () => void;
   disabled?: boolean;
   sx?: SxProps<Theme>;
 }
@@ -19,27 +25,77 @@ export default function TagAutocomplete({
   options,
   value,
   onChange,
+  onCreateNew,
   disabled = false,
   sx,
 }: TagAutocompleteProps) {
+  const optionsWithCreate: TagEntry[] = onCreateNew
+    ? [...options, CREATE_NEW_OPTION]
+    : options;
+
   return (
     <Autocomplete
       multiple
       size="small"
-      options={options}
+      options={optionsWithCreate}
       value={value}
-      onChange={(_event, nextValue) => onChange(nextValue)}
+      onChange={(_event, nextValue) => {
+        const hasCreate = nextValue.some((v) => v.id === CREATE_NEW_ID);
+        if (hasCreate) {
+          onCreateNew?.();
+          onChange(nextValue.filter((v) => v.id !== CREATE_NEW_ID));
+        } else {
+          onChange(nextValue);
+        }
+      }}
       getOptionLabel={(option) => option.name}
       isOptionEqualToValue={(option, selected) => option.id === selected.id}
-      renderTags={(selected, getTagProps) =>
+      renderOption={(props, option) => {
+        if (option.id === CREATE_NEW_ID) {
+          const { key, ...restProps } = props as { key: React.Key } & React.HTMLAttributes<HTMLLIElement>;
+          return (
+            <Box
+              component="li"
+              key={key}
+              {...restProps}
+              sx={{
+                display: "inline-flex !important",
+                alignItems: "center",
+                px: "12px !important",
+                py: "6px !important",
+              }}
+            >
+              <Typography
+                variant="caption"
+                sx={{
+                  px: 1,
+                  py: 0.25,
+                  borderRadius: "4px",
+                  border: "1px dashed",
+                  borderColor: "divider",
+                  color: "text.secondary",
+                  background: "transparent",
+                }}
+              >
+                + New tag
+              </Typography>
+            </Box>
+          );
+        }
+        const { key, ...restProps } = props as { key: React.Key } & React.HTMLAttributes<HTMLLIElement>;
+        return (
+          <Box component="li" key={key} {...restProps}>
+            {option.name}
+          </Box>
+        );
+      }}
+      renderValue={(selected, getTagProps) =>
         selected.map((option, index) => (
           <TagChip
             key={option.id}
             label={option.name}
             color={option.color}
-            onDelete={() => {
-              getTagProps({ index }).onDelete?.({} as never);
-            }}
+            onDelete={() => getTagProps({ index }).onDelete?.({} as never)}
           />
         ))
       }

--- a/web/src/components/TagChip.tsx
+++ b/web/src/components/TagChip.tsx
@@ -1,4 +1,7 @@
-import Chip from "@mui/material/Chip";
+import CloseIcon from "@mui/icons-material/Close";
+import Box from "@mui/material/Box";
+import IconButton from "@mui/material/IconButton";
+import Typography from "@mui/material/Typography";
 
 export interface TagChipProps {
   label: string;
@@ -14,11 +17,46 @@ export default function TagChip({
   onDelete,
 }: TagChipProps) {
   return (
-    <Chip
-      label={label}
-      size={size}
-      onDelete={onDelete}
-      sx={{ backgroundColor: color || undefined, color: "common.black" }}
-    />
+    <Box
+      component="span"
+      style={{ backgroundColor: color || undefined }}
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 0.25,
+        pl: size === "small" ? 1 : 1.5,
+        pr: onDelete ? 0.25 : (size === "small" ? 1 : 1.5),
+        py: size === "small" ? 0.25 : 0.5,
+        border: "1px solid",
+        borderColor: "divider",
+        borderRadius: "4px",
+        verticalAlign: "middle",
+        margin: "2px",
+      }}
+    >
+      <Typography
+        component="span"
+        variant="caption"
+        sx={{ color: color ? "common.black" : "text.primary", lineHeight: 1.5 }}
+      >
+        {label}
+      </Typography>
+      {onDelete && (
+        <IconButton
+          component="span"
+          size="small"
+          onClick={onDelete}
+          aria-label={`Remove ${label}`}
+          sx={{
+            p: 0.25,
+            color: color ? "common.black" : "text.secondary",
+            opacity: 0.7,
+            "&:hover": { opacity: 1 },
+          }}
+        >
+          <CloseIcon sx={{ fontSize: 12 }} />
+        </IconButton>
+      )}
+    </Box>
   );
 }

--- a/web/src/components/TagManager.tsx
+++ b/web/src/components/TagManager.tsx
@@ -1,6 +1,10 @@
 import { useState, useCallback, useEffect } from "react";
-import { Box, Button, IconButton, Snackbar, Typography } from "@mui/material";
-import EditIcon from "@mui/icons-material/Edit";
+import {
+  Box,
+  Button,
+  Snackbar,
+  Typography,
+} from "@mui/material";
 import type { PieceDetail, TagEntry } from "../util/types";
 import { createTagEntry, fetchGlobalEntries, updatePiece } from "../util/api";
 import { useAsync } from "../util/useAsync";
@@ -8,6 +12,7 @@ import TagAutocomplete from "./TagAutocomplete";
 import CreateTagDialog from "./CreateTagDialog";
 import TagChipList from "./TagChipList";
 import { pickDefaultTagColor } from "./tagPalette";
+import { usePieceDetailSaveStatus } from "./usePieceDetailSaveStatus";
 
 const DUPLICATE_TAG_ERROR =
   "A tag with that name already exists. Choose the existing tag or enter a different name.";
@@ -40,7 +45,13 @@ export default function TagManager({
   onSaved,
 }: TagManagerProps) {
   const fetchTags = useCallback(() => fetchGlobalEntries("tag"), []);
-  const { data: rawAvailableTags, error: tagsLoadError } = useAsync(fetchTags);
+  const pieceDetailSaveStatus = usePieceDetailSaveStatus();
+  const [shouldLoadTags, setShouldLoadTags] = useState(false);
+  const {
+    data: rawAvailableTags,
+    error: tagsLoadError,
+    setData: setRawAvailableTags,
+  } = useAsync(fetchTags, [], { enabled: shouldLoadTags });
   const availableTags: TagEntry[] = (rawAvailableTags ?? []).map(toTagEntry);
 
   const [selectedTags, setSelectedTags] = useState<TagEntry[]>(initialTags);
@@ -63,6 +74,9 @@ export default function TagManager({
   }, [initialTags]);
 
   function startEditingTags() {
+    if (!shouldLoadTags) {
+      setShouldLoadTags(true);
+    }
     setDraftTags(selectedTags);
     setTagError(null);
     setEditingTags(true);
@@ -71,9 +85,13 @@ export default function TagManager({
   async function saveTags(nextTags: TagEntry[]) {
     setTagSaving(true);
     try {
-      const updated = await updatePiece(pieceId, {
-        tags: nextTags.map((tag) => tag.id),
-      });
+      const saveTagsRequest = () =>
+        updatePiece(pieceId, {
+          tags: nextTags.map((tag) => tag.id),
+        });
+      const updated = pieceDetailSaveStatus
+        ? await pieceDetailSaveStatus.runManualSave(saveTagsRequest)
+        : await saveTagsRequest();
       setSelectedTags(nextTags);
       onSaved(updated);
       setEditingTags(false);
@@ -107,6 +125,15 @@ export default function TagManager({
         name: trimmed,
         color: newTagColor,
       });
+      setRawAvailableTags((prev) => [
+        ...(prev ?? []),
+        {
+          id: created.id,
+          name: created.name,
+          color: created.color,
+          isPublic: false,
+        },
+      ]);
       const createdTag: TagEntry = {
         id: created.id,
         name: created.name,
@@ -139,32 +166,15 @@ export default function TagManager({
       )}
       {editingTags ? (
         <Box sx={{ mb: 2 }}>
-          <Box
-            sx={{
-              display: "grid",
-              gap: 1,
-              gridTemplateColumns: { xs: "1fr", sm: "minmax(0, 1fr) auto" },
-              alignItems: "start",
-            }}
-          >
-            <TagAutocomplete
-              label="Tags"
-              options={availableTags}
-              value={draftTags}
-              onChange={setDraftTags}
-              disabled={tagSaving}
-              sx={{ minWidth: 0 }}
-            />
-            <Button
-              variant="outlined"
-              size="small"
-              onClick={() => setTagDialogOpen(true)}
-              disabled={tagSaving}
-              sx={{ minWidth: { sm: 88 } }}
-            >
-              New
-            </Button>
-          </Box>
+          <TagAutocomplete
+            label="Tags"
+            options={availableTags}
+            value={draftTags}
+            onChange={setDraftTags}
+            onCreateNew={() => setTagDialogOpen(true)}
+            disabled={tagSaving}
+            sx={{ minWidth: 0 }}
+          />
           <Button
             variant="contained"
             size="small"
@@ -179,28 +189,38 @@ export default function TagManager({
       ) : (
         <Box
           sx={{
-            mb: 2,
+            mb: 0.25,
             display: "flex",
             alignItems: "center",
             flexWrap: "wrap",
+            gap: 0.75,
           }}
         >
-          {selectedTags.length > 0 ? (
-            <TagChipList tags={selectedTags} />
-          ) : (
-            <Typography variant="body2" sx={{ color: "text.secondary", mr: 0 }}>
-              Add some tags!
-            </Typography>
-          )}
-          <IconButton
-            aria-label="Edit tags"
+          {selectedTags.length > 0 && <TagChipList tags={selectedTags} />}
+          <Box
+            component="button"
+            type="button"
             onClick={startEditingTags}
             disabled={tagSaving}
-            size="small"
-            sx={{ color: "text.secondary" }}
+            aria-label="Add or edit tags"
+            sx={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 0.5,
+              px: 1,
+              py: 0.375,
+              background: "transparent",
+              border: "1px dashed",
+              borderColor: "divider",
+              borderRadius: "4px",
+              cursor: "pointer",
+              color: "text.secondary",
+              fontFamily: "inherit",
+              fontSize: "0.75rem",
+            }}
           >
-            <EditIcon fontSize="small" />
-          </IconButton>
+            + tag
+          </Box>
         </Box>
       )}
 

--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -1,41 +1,33 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import PhotoCameraOutlinedIcon from "@mui/icons-material/PhotoCameraOutlined";
 import { useTheme } from "@mui/material";
 import {
   Box,
   Button,
   CircularProgress,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
-  IconButton,
-  List,
-  ListItem,
-  ListItemText,
+  Fab,
   MenuItem,
+  Portal,
   TextField,
   Typography,
+  useMediaQuery,
 } from "@mui/material";
-import EditIcon from "@mui/icons-material/Edit";
-import ImageLightbox from "./ImageLightbox";
-import CloudinaryImage from "./CloudinaryImage";
 import type { PieceDetail, PieceState } from "../util/types";
 import {
   fetchCloudinaryWidgetConfig,
   signCloudinaryWidgetParams,
   updateCurrentState,
-  updatePiece,
 } from "../util/api";
 import {
   type ResolvedAdditionalField,
   formatWorkflowFieldLabel,
   getAdditionalFieldDefinitions,
 } from "../util/workflow";
-import { entryNameOrEmpty, normalizeOptionalText, undefinedIfBlank } from "../util/optionalValues";
+import { entryNameOrEmpty } from "../util/optionalValues";
 import GlobalEntryField from "./GlobalEntryField";
 import AutosaveStatus from "./AutosaveStatus";
 import { useAutosave } from "./useAutosave";
+import { usePieceDetailSaveStatus } from "./usePieceDetailSaveStatus";
 
 export type ImageEntry = {
   url: string;
@@ -48,9 +40,6 @@ type WorkflowStateProps = {
   pieceId: string;
   onSaved: (updated: PieceDetail) => void;
   onDirtyChange?: (dirty: boolean) => void;
-  currentLocation?: string;
-  currentThumbnail?: import("../util/types").Thumbnail | null;
-  onSetAsThumbnail?: (image: ImageEntry) => Promise<void>;
   autosaveDelayMs?: number;
 };
 
@@ -168,109 +157,6 @@ function stateImages(pieceState: PieceState): ImageEntry[] {
   }));
 }
 
-// ── ImageList ─────────────────────────────────────────────────────────────────
-
-type ImageListProps = {
-  images: ImageEntry[];
-  onRemove: (index: number) => void;
-  onViewLightbox: (index: number) => void;
-  onEditCaption: (index: number) => void;
-  editingCaptionIndex: number | null;
-  editingCaptionValue: string;
-  onCaptionValueChange: (value: string) => void;
-  onCaptionCommit: (index: number, value: string) => void;
-  onCaptionCancel: () => void;
-};
-
-function ImageList({
-  images,
-  onRemove,
-  onViewLightbox,
-  onEditCaption,
-  editingCaptionIndex,
-  editingCaptionValue,
-  onCaptionValueChange,
-  onCaptionCommit,
-  onCaptionCancel,
-}: ImageListProps) {
-  if (images.length === 0) return null;
-  return (
-    <List dense disablePadding>
-      {images.map((img, i) => (
-        <ListItem key={i} disableGutters>
-          <Box sx={{ display: "flex", gap: 1, alignItems: "center", width: "100%" }}>
-            <IconButton
-              aria-label="remove image"
-              onClick={() => onRemove(i)}
-              size="small"
-            >
-              ✕
-            </IconButton>
-            <Box
-              component="button"
-              onClick={() => onViewLightbox(i)}
-              aria-label={`View image ${i + 1}`}
-              sx={{
-                p: 0,
-                border: "none",
-                background: "none",
-                cursor: "pointer",
-                borderRadius: 0.5,
-                display: "block",
-                flexShrink: 0,
-              }}
-            >
-              <CloudinaryImage
-                url={img.url}
-                cloudinary_public_id={img.cloudinary_public_id}
-                alt={img.caption || "Pottery image"}
-                context="thumbnail"
-                style={{ objectFit: "cover", borderRadius: 4, display: "block" }}
-              />
-            </Box>
-            {editingCaptionIndex === i ? (
-              <TextField
-                value={editingCaptionValue}
-                onChange={(e) => onCaptionValueChange(e.target.value)}
-                onBlur={() => onCaptionCommit(i, editingCaptionValue)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    onCaptionCommit(i, editingCaptionValue);
-                  }
-                  if (e.key === "Escape") {
-                    e.preventDefault();
-                    onCaptionCancel();
-                  }
-                }}
-                size="small"
-                autoFocus
-                sx={{ flex: 1 }}
-                slotProps={{ htmlInput: { "aria-label": "Edit caption" } }}
-              />
-            ) : (
-              <>
-                <ListItemText
-                  primary={img.caption || "(no caption)"}
-                  slotProps={{ primary: { sx: { color: "text.primary" } } }}
-                />
-                <IconButton
-                  aria-label="edit caption"
-                  onClick={() => onEditCaption(i)}
-                  size="small"
-                  sx={{ ml: "auto", flexShrink: 0 }}
-                >
-                  <EditIcon fontSize="small" />
-                </IconButton>
-              </>
-            )}
-          </Box>
-        </ListItem>
-      ))}
-    </List>
-  );
-}
-
 // ── ImageUploader ─────────────────────────────────────────────────────────────
 
 type ImageUploaderProps = {
@@ -278,6 +164,7 @@ type ImageUploaderProps = {
   widgetLoading: boolean;
   uploadError: string | null;
   imageError: string | null;
+  mobile: boolean;
   onUploadClick: () => void;
 };
 
@@ -286,32 +173,76 @@ function ImageUploader({
   widgetLoading,
   uploadError,
   imageError,
+  mobile,
   onUploadClick,
 }: ImageUploaderProps) {
+  const buttonDisabled = saving || widgetLoading;
+  const statusMessage = saving ? "Saving…" : "Upload Image";
+
   return (
     <Box>
-      <Button
-        variant="outlined"
-        size="small"
-        onClick={onUploadClick}
-        disabled={saving || widgetLoading}
-        startIcon={
-          saving ? <CircularProgress size={14} color="inherit" /> : undefined
-        }
-        sx={{ position: "relative", mt: 1 }}
-      >
-        <Box sx={{ opacity: widgetLoading ? 0 : 1 }}>
-          {saving ? "Saving…" : "Upload Image"}
-        </Box>
-        {widgetLoading && (
-          <CircularProgress
-            aria-hidden
-            size={14}
-            color="inherit"
-            sx={{ position: "absolute" }}
-          />
-        )}
-      </Button>
+      {mobile ? (
+        <Portal>
+          <Fab
+            color="primary"
+            aria-label="Upload Image"
+            onClick={onUploadClick}
+            disabled={buttonDisabled}
+            sx={{
+              position: "fixed",
+              right: 24,
+              bottom: 24,
+              zIndex: (theme) => theme.zIndex.speedDial,
+              boxShadow: (theme) => theme.shadows[8],
+            }}
+          >
+            {widgetLoading ? (
+              <CircularProgress aria-hidden size={20} color="inherit" />
+            ) : (
+              <PhotoCameraOutlinedIcon />
+            )}
+            <Box
+              component="span"
+              sx={{
+                position: "absolute",
+                width: 1,
+                height: 1,
+                p: 0,
+                m: -1,
+                overflow: "hidden",
+                clip: "rect(0 0 0 0)",
+                whiteSpace: "nowrap",
+                border: 0,
+              }}
+            >
+              {statusMessage}
+            </Box>
+          </Fab>
+        </Portal>
+      ) : (
+        <Portal container={() => document.getElementById("piece-upload-trigger")}>
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={onUploadClick}
+            disabled={buttonDisabled}
+            startIcon={
+              saving ? <CircularProgress size={14} color="inherit" /> : undefined
+            }
+            sx={{ position: "relative" }}
+          >
+            <Box sx={{ opacity: widgetLoading ? 0 : 1 }}>{statusMessage}</Box>
+            {widgetLoading && (
+              <CircularProgress
+                aria-hidden
+                size={14}
+                color="inherit"
+                sx={{ position: "absolute" }}
+              />
+            )}
+          </Button>
+        </Portal>
+      )}
       {(uploadError || imageError) && (
         <Typography color="error" variant="body2" sx={{ mt: 1 }}>
           {uploadError ?? imageError}
@@ -328,44 +259,34 @@ export default function WorkflowState({
   pieceId,
   onSaved,
   onDirtyChange,
-  currentLocation: currentLocationProp = "",
-  currentThumbnail,
-  onSetAsThumbnail: onSetAsThumbnailProp,
   autosaveDelayMs,
 }: WorkflowStateProps) {
-  const normalizedCurrentLocationProp = normalizeOptionalText(currentLocationProp);
   const [notes, setNotes] = useState(pieceState.notes);
   const [images, setImages] = useState<ImageEntry[]>(stateImages(pieceState));
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [widgetLoading, setWidgetLoading] = useState(false);
-  const [editingCaptionIndex, setEditingCaptionIndex] = useState<number | null>(null);
-  const [editingCaptionValue, setEditingCaptionValue] = useState("");
-  const [removeDialogIndex, setRemoveDialogIndex] = useState<number | null>(null);
-  const [currentLocation, setCurrentLocation] = useState(normalizedCurrentLocationProp);
   const additionalFieldDefs = useMemo(
     () => getAdditionalFieldDefinitions(pieceState.state),
     [pieceState.state],
   );
-  const baseAdditionalFieldInputs = useMemo(
-    () =>
-      buildAdditionalFieldInputMap(
+  const baseDraft = useMemo(() => {
+    const additionalFields = pieceState.additional_fields ?? {};
+    return {
+      notes: pieceState.notes,
+      images: stateImages(pieceState),
+      additionalFieldInputs: buildAdditionalFieldInputMap(
         additionalFieldDefs,
-        pieceState.additional_fields ?? {},
+        additionalFields,
       ),
-    [additionalFieldDefs, pieceState.additional_fields],
-  );
-  const baseGlobalRefPks = useMemo(
-    () =>
-      buildGlobalRefPkMap(
-        additionalFieldDefs,
-        pieceState.additional_fields ?? {},
-      ),
-    [additionalFieldDefs, pieceState.additional_fields],
-  );
+      globalRefPks: buildGlobalRefPkMap(additionalFieldDefs, additionalFields),
+    };
+  }, [additionalFieldDefs, pieceState]);
   const [additionalFieldInputs, setAdditionalFieldInputs] = useState(
-    baseAdditionalFieldInputs,
+    baseDraft.additionalFieldInputs,
   );
-  const [globalRefPks, setGlobalRefPks] = useState<GlobalRefPkMap>(baseGlobalRefPks);
+  const [globalRefPks, setGlobalRefPks] = useState<GlobalRefPkMap>(
+    baseDraft.globalRefPks,
+  );
   const normalizedAdditionalFields = useMemo(
     () =>
       normalizeAdditionalFieldPayload(
@@ -379,52 +300,29 @@ export default function WorkflowState({
     () =>
       normalizeAdditionalFieldPayload(
         additionalFieldDefs,
-        baseAdditionalFieldInputs,
-        baseGlobalRefPks,
+        baseDraft.additionalFieldInputs,
+        baseDraft.globalRefPks,
       ),
-    [additionalFieldDefs, baseAdditionalFieldInputs, baseGlobalRefPks],
+    [additionalFieldDefs, baseDraft],
   );
   const additionalFieldsDirty =
     JSON.stringify(normalizedAdditionalFields) !==
     JSON.stringify(normalizedBaseAdditionalFields);
-  const locationDirty =
-    currentLocation.trim() !== normalizedCurrentLocationProp.trim();
 
   const theme = useTheme();
-  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
-
-  async function handleSetAsThumbnail(image: ImageEntry) {
-    if (onSetAsThumbnailProp) {
-      await onSetAsThumbnailProp(image);
-      return;
-    }
-    const updated = await updatePiece(pieceId, {
-      thumbnail: {
-        url: image.url,
-        cloudinary_public_id: image.cloudinary_public_id ?? null,
-      },
-    });
-    onSaved(updated);
-  }
+  const isMobileLayout = useMediaQuery(theme.breakpoints.down("sm"));
 
   useEffect(() => {
-    setNotes(pieceState.notes);
-    setImages(stateImages(pieceState));
-    setAdditionalFieldInputs(baseAdditionalFieldInputs);
-    setGlobalRefPks(baseGlobalRefPks);
-    setCurrentLocation(normalizedCurrentLocationProp);
-  }, [
-    pieceState,
-    baseAdditionalFieldInputs,
-    baseGlobalRefPks,
-    normalizedCurrentLocationProp,
-  ]);
+    setNotes(baseDraft.notes);
+    setImages(baseDraft.images);
+    setAdditionalFieldInputs(baseDraft.additionalFieldInputs);
+    setGlobalRefPks(baseDraft.globalRefPks);
+  }, [baseDraft]);
 
   const [savingImage, setSavingImage] = useState(false);
   const [imageError, setImageError] = useState<string | null>(null);
 
-  const isDirty =
-    notes !== pieceState.notes || additionalFieldsDirty || locationDirty;
+  const isDirty = notes !== pieceState.notes || additionalFieldsDirty;
 
   useEffect(() => {
     onDirtyChange?.(isDirty);
@@ -437,17 +335,9 @@ export default function WorkflowState({
       additional_fields: normalizedAdditionalFields,
     };
     const result = await updateCurrentState(pieceId, payload);
-    let finalResult = result;
-    if (locationDirty) {
-      finalResult = await updatePiece(pieceId, {
-        current_location: undefinedIfBlank(currentLocation),
-      });
-    }
-    onSaved(finalResult);
+    onSaved(result);
   }, [
-    currentLocation,
     images,
-    locationDirty,
     normalizedAdditionalFields,
     notes,
     onSaved,
@@ -460,9 +350,8 @@ export default function WorkflowState({
         notes,
         images,
         additional_fields: normalizedAdditionalFields,
-        current_location: currentLocation.trim(),
       }),
-    [currentLocation, images, normalizedAdditionalFields, notes],
+    [images, normalizedAdditionalFields, notes],
   );
 
   const autosave = useAutosave({
@@ -471,63 +360,20 @@ export default function WorkflowState({
     save: saveWorkflowState,
     delayMs: autosaveDelayMs,
   });
+  const pieceDetailSaveStatus = usePieceDetailSaveStatus();
 
-  function openRemoveDialog(index: number) {
-    setRemoveDialogIndex(index);
-  }
-
-  function closeRemoveDialog() {
-    setRemoveDialogIndex(null);
-  }
-
-  async function confirmRemoveImage() {
-    if (removeDialogIndex === null) return;
-    const index = removeDialogIndex;
-    closeRemoveDialog();
-    const updatedImages = images.filter((_, i) => i !== index);
-    setSavingImage(true);
-    setImageError(null);
-    try {
-      const result = await updateCurrentState(pieceId, {
-        notes,
-        images: updatedImages,
-        additional_fields: normalizedAdditionalFields,
-      });
-      onSaved(result);
-    } catch {
-      setImageError("Failed to remove image. Please try again.");
-    } finally {
-      setSavingImage(false);
-    }
-  }
-
-  function startEditingCaption(index: number) {
-    setEditingCaptionIndex(index);
-    setEditingCaptionValue(images[index].caption);
-  }
-
-  async function commitCaptionEdit(index: number, value: string) {
-    setEditingCaptionIndex(null);
-    const newCaption = value.trim();
-    if (newCaption === images[index].caption) return;
-    const updatedImages = images.map((img, i) =>
-      i === index ? { ...img, caption: newCaption } : img,
-    );
-    setSavingImage(true);
-    setImageError(null);
-    try {
-      const result = await updateCurrentState(pieceId, {
-        notes,
-        images: updatedImages,
-        additional_fields: normalizedAdditionalFields,
-      });
-      onSaved(result);
-    } catch {
-      setImageError("Failed to save caption. Please try again.");
-    } finally {
-      setSavingImage(false);
-    }
-  }
+  useEffect(() => {
+    pieceDetailSaveStatus?.publishWorkflowStatus({
+      status: autosave.status,
+      error: autosave.error,
+      lastSavedAt: autosave.lastSavedAt,
+    });
+  }, [
+    autosave.error,
+    autosave.lastSavedAt,
+    autosave.status,
+    pieceDetailSaveStatus,
+  ]);
 
   async function handleUploadWidgetClick() {
     setUploadError(null);
@@ -649,22 +495,8 @@ export default function WorkflowState({
         slotProps={{ htmlInput: { maxLength: 2000 } }}
         fullWidth
       />
-
-      <GlobalEntryField
-        globalName="location"
-        label="Current location"
-        value={currentLocation}
-        onSelect={(entry) => setCurrentLocation(entryNameOrEmpty(entry))}
-      />
-
       {additionalFieldDefs.length > 0 && (
         <Box>
-          <Typography
-            variant="subtitle2"
-            sx={{ color: "text.secondary", mb: 1 }}
-          >
-            State details
-          </Typography>
           <Box
             sx={{
               display: "grid",
@@ -792,64 +624,23 @@ export default function WorkflowState({
         </Box>
       )}
 
-      <AutosaveStatus
-        status={autosave.status}
-        error={autosave.error}
-        lastSavedAt={autosave.lastSavedAt}
-      />
-
-      {/* Images */}
-      <Box>
-        <ImageList
-          images={images}
-          onRemove={openRemoveDialog}
-          onViewLightbox={setLightboxIndex}
-          onEditCaption={startEditingCaption}
-          editingCaptionIndex={editingCaptionIndex}
-          editingCaptionValue={editingCaptionValue}
-          onCaptionValueChange={setEditingCaptionValue}
-          onCaptionCommit={commitCaptionEdit}
-          onCaptionCancel={() => setEditingCaptionIndex(null)}
-        />
-        <ImageUploader
-          saving={savingImage}
-          widgetLoading={widgetLoading}
-          uploadError={uploadError}
-          imageError={imageError}
-          onUploadClick={handleUploadWidgetClick}
-        />
-      </Box>
-
-      {/* Remove image confirmation dialog */}
-      <Dialog open={removeDialogIndex !== null} onClose={closeRemoveDialog}>
-        <DialogTitle>Remove Image</DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            Remove this image? This action cannot be undone.
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={closeRemoveDialog}>Cancel</Button>
-          <Button
-            onClick={() => void confirmRemoveImage()}
-            color="error"
-            variant="contained"
-          >
-            Remove
-          </Button>
-        </DialogActions>
-      </Dialog>
-
-      {/* Lightbox */}
-      {lightboxIndex !== null && (
-        <ImageLightbox
-          images={images}
-          initialIndex={lightboxIndex}
-          onClose={() => setLightboxIndex(null)}
-          currentThumbnailUrl={currentThumbnail?.url}
-          onSetAsThumbnail={handleSetAsThumbnail}
+      {!pieceDetailSaveStatus && (
+        <AutosaveStatus
+          status={autosave.status}
+          error={autosave.error}
+          lastSavedAt={autosave.lastSavedAt}
+          variant="floating"
         />
       )}
+
+      <ImageUploader
+        saving={savingImage}
+        widgetLoading={widgetLoading}
+        uploadError={uploadError}
+        imageError={imageError}
+        mobile={isMobileLayout}
+        onUploadClick={handleUploadWidgetClick}
+      />
     </Box>
   );
 }

--- a/web/src/components/__tests__/ImageLightbox.test.tsx
+++ b/web/src/components/__tests__/ImageLightbox.test.tsx
@@ -46,9 +46,9 @@ describe("ImageLightbox", () => {
       expect(img).toHaveAttribute("alt", "Second");
     });
 
-    it("shows caption when present", () => {
+    it("uses the caption as image alt text when present", () => {
       renderLightbox(ONE_IMAGE, 0);
-      expect(screen.getByText("First")).toBeInTheDocument();
+      expect(screen.getByRole("img")).toHaveAttribute("alt", "First");
     });
 
     it("does not show a caption element when caption is empty", () => {

--- a/web/src/components/__tests__/PieceDetail.test.tsx
+++ b/web/src/components/__tests__/PieceDetail.test.tsx
@@ -206,9 +206,45 @@ describe("PieceDetail", () => {
     ).toBe(true);
   });
 
+  it("counts all piece images in the hero chip and opens the gallery", async () => {
+    const designed = makeState({
+      state: "designed",
+      images: [
+        {
+          url: "http://example.com/one.jpg",
+          caption: "First image",
+          created: new Date("2024-01-15T10:00:00Z"),
+          cloudinary_public_id: null,
+        },
+      ],
+    });
+    const thrown = makeState({
+      state: "wheel_thrown",
+      images: [
+        {
+          url: "http://example.com/two.jpg",
+          caption: "Second image",
+          created: new Date("2024-01-16T10:00:00Z"),
+          cloudinary_public_id: null,
+        },
+      ],
+    });
+    await renderPieceDetail(
+      makePiece({
+        current_state: thrown,
+        history: [designed, thrown],
+      }),
+    );
+    await userEvent.click(screen.getAllByRole("button", { name: /2 photos/i })[0]);
+    expect(screen.getByLabelText("Piece photos")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: /open piece photo/i })).toHaveLength(2);
+  });
+
   it("renders current location controls", async () => {
     await renderPieceDetail();
-    expect(screen.getByText("Current location")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Browse Current location" }),
+    ).toBeInTheDocument();
   });
 
   it("keeps current location browse-only when create is not enabled by workflow metadata", async () => {
@@ -240,7 +276,6 @@ describe("PieceDetail", () => {
       expect(screen.getByText("Studio 7")).toBeInTheDocument(),
     );
     await userEvent.click(screen.getByText("Studio 7"));
-    await waitFor(() => expect(screen.getByText("Studio 7")).toBeInTheDocument());
     await waitFor(() =>
       expect(api.updatePiece).toHaveBeenCalledWith("piece-id-1", {
         current_location: "Studio 7",
@@ -503,7 +538,7 @@ describe("PieceDetail", () => {
 
       expect(screen.getByText("Gift")).toBeInTheDocument();
       expect(
-        screen.getByRole("button", { name: "Edit tags" }),
+        screen.getByRole("button", { name: "Add or edit tags" }),
       ).toBeInTheDocument();
       expect(screen.queryByLabelText("Tags")).not.toBeInTheDocument();
     });
@@ -511,10 +546,15 @@ describe("PieceDetail", () => {
     it("shows the tag editor when the edit button is pressed", async () => {
       await renderPieceDetail();
 
-      fireEvent.click(screen.getByRole("button", { name: "Edit tags" }));
+      fireEvent.click(
+        screen.getByRole("button", { name: "Add or edit tags" }),
+      );
 
       expect(screen.getByLabelText("Tags")).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "New" })).toBeInTheDocument();
+      await userEvent.click(screen.getByRole("button", { name: "Open" }));
+      expect(
+        screen.getByRole("option", { name: "+ New tag" }),
+      ).toBeInTheDocument();
       expect(
         screen.getByRole("button", { name: "Save tags" }),
       ).toBeInTheDocument();

--- a/web/src/components/__tests__/PieceHistory.test.tsx
+++ b/web/src/components/__tests__/PieceHistory.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { act, render, screen, fireEvent } from "@testing-library/react";
 import PieceHistory from "../PieceHistory";
-import type { PieceState, CaptionedImage } from "../../util/types";
+import type { PieceState } from "../../util/types";
 
 vi.mock("../../../workflow.yml", () => ({
   default: {
@@ -28,34 +28,6 @@ vi.mock("../../../workflow.yml", () => ({
   },
 }));
 
-vi.mock("../CloudinaryImage", () => ({
-  default: ({ url, alt }: { url: string; alt: string }) => (
-    <img src={url} alt={alt} />
-  ),
-}));
-
-vi.mock("../ImageLightbox", () => ({
-  default: ({
-    onClose,
-    onSetAsThumbnail,
-    images,
-    initialIndex,
-  }: {
-    onClose: () => void;
-    onSetAsThumbnail: (img: CaptionedImage) => Promise<void>;
-    images: CaptionedImage[];
-    initialIndex: number;
-  }) => (
-    <div data-testid="lightbox">
-      <button onClick={onClose}>Close</button>
-      <button onClick={() => void onSetAsThumbnail(images[initialIndex])}>
-        Set as thumbnail
-      </button>
-      <span data-testid="lightbox-index">{initialIndex}</span>
-    </div>
-  ),
-}));
-
 function makeState(overrides: Partial<PieceState> = {}): PieceState {
   return {
     state: "designed",
@@ -79,7 +51,6 @@ describe("PieceHistory", () => {
     const { container } = render(
       <PieceHistory
         pastHistory={[]}
-        onSetAsThumbnail={vi.fn()}
       />,
     );
     expect(container).toBeEmptyDOMElement();
@@ -90,7 +61,6 @@ describe("PieceHistory", () => {
       render(
         <PieceHistory
           pastHistory={[makeState({ state: "designed" })]}
-          onSetAsThumbnail={vi.fn()}
         />,
       );
     });
@@ -107,7 +77,6 @@ describe("PieceHistory", () => {
             makeState({ state: "designed" }),
             makeState({ state: "wheel_thrown" }),
           ]}
-          onSetAsThumbnail={vi.fn()}
         />,
       );
     });
@@ -120,7 +89,6 @@ describe("PieceHistory", () => {
       render(
         <PieceHistory
           pastHistory={[makeState({ state: "designed" })]}
-          onSetAsThumbnail={vi.fn()}
         />,
       );
     });
@@ -135,7 +103,6 @@ describe("PieceHistory", () => {
       render(
         <PieceHistory
           pastHistory={[makeState({ state: "designed", notes: "Test note" })]}
-          onSetAsThumbnail={vi.fn()}
         />,
       );
     });
@@ -144,77 +111,30 @@ describe("PieceHistory", () => {
     expect(screen.getByText(/Test note/)).toBeInTheDocument();
   });
 
-  it("clicking a history image opens the lightbox at the correct index", async () => {
-    const img1: CaptionedImage = {
-      url: "http://example.com/img1.jpg",
-      caption: "First",
-      created: new Date(),
-      cloudinary_public_id: null,
-    };
-    const img2: CaptionedImage = {
-      url: "http://example.com/img2.jpg",
-      caption: "Second",
-      created: new Date(),
-      cloudinary_public_id: null,
-    };
+  it("does not render image thumbnails in the history list", async () => {
     await act(async () => {
       render(
         <PieceHistory
           pastHistory={[
-            makeState({ state: "designed", images: [img1] }),
-            makeState({ state: "wheel_thrown", images: [img2] }),
+            makeState({
+              state: "designed",
+              images: [
+                {
+                  url: "http://example.com/img1.jpg",
+                  caption: "First",
+                  created: new Date(),
+                  cloudinary_public_id: null,
+                },
+              ],
+            }),
           ]}
-          onSetAsThumbnail={vi.fn()}
         />,
       );
     });
     fireEvent.click(screen.getByRole("button", { name: /show history/i }));
-    fireEvent.click(screen.getByRole("button", { name: "View image 2" }));
-    expect(screen.getByTestId("lightbox")).toBeInTheDocument();
-    expect(screen.getByTestId("lightbox-index")).toHaveTextContent("1");
-  });
-
-  it("closing the lightbox hides it", async () => {
-    const img: CaptionedImage = {
-      url: "http://example.com/img.jpg",
-      caption: "",
-      created: new Date(),
-      cloudinary_public_id: null,
-    };
-    await act(async () => {
-      render(
-        <PieceHistory
-          pastHistory={[makeState({ state: "designed", images: [img] })]}
-          onSetAsThumbnail={vi.fn()}
-        />,
-      );
-    });
-    fireEvent.click(screen.getByRole("button", { name: /show history/i }));
-    fireEvent.click(screen.getByRole("button", { name: "View image 1" }));
-    fireEvent.click(screen.getByRole("button", { name: "Close" }));
-    expect(screen.queryByTestId("lightbox")).not.toBeInTheDocument();
-  });
-
-  it("setAsThumbnail calls the callback with the correct image", async () => {
-    const img: CaptionedImage = {
-      url: "http://example.com/thumb.jpg",
-      caption: "cap",
-      created: new Date(),
-      cloudinary_public_id: null,
-    };
-    const onSetAsThumbnail = vi.fn().mockResolvedValue(undefined);
-    await act(async () => {
-      render(
-        <PieceHistory
-          pastHistory={[makeState({ state: "designed", images: [img] })]}
-          currentThumbnailUrl="http://example.com/current.jpg"
-          onSetAsThumbnail={onSetAsThumbnail}
-        />,
-      );
-    });
-    fireEvent.click(screen.getByRole("button", { name: /show history/i }));
-    fireEvent.click(screen.getByRole("button", { name: "View image 1" }));
-    fireEvent.click(screen.getByRole("button", { name: "Set as thumbnail" }));
-    expect(onSetAsThumbnail).toHaveBeenCalledWith(img);
+    expect(
+      screen.queryByRole("button", { name: /view image/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("First")).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/__tests__/PiecePhotoGallery.test.tsx
+++ b/web/src/components/__tests__/PiecePhotoGallery.test.tsx
@@ -1,0 +1,134 @@
+import type { CSSProperties, ReactNode } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import PiecePhotoGallery, { type PiecePhotoGalleryImage } from "../PiecePhotoGallery";
+
+vi.mock("../CloudinaryImage", () => ({
+  default: ({
+    alt,
+    url,
+    style,
+  }: {
+    alt?: string;
+    url: string;
+    style?: CSSProperties;
+  }) => <img alt={alt} src={url} style={style} />,
+}));
+
+vi.mock("../ImageLightbox", () => ({
+  default: ({
+    images,
+    initialIndex,
+    footerActions,
+    onClose,
+  }: {
+    images: PiecePhotoGalleryImage[];
+    initialIndex: number;
+    footerActions?: (index: number) => ReactNode;
+    onClose: () => void;
+  }) => (
+    <div aria-label="Mock lightbox" role="dialog">
+      <div>{images[initialIndex].caption}</div>
+      {footerActions?.(initialIndex)}
+      <button onClick={onClose}>Close lightbox</button>
+    </div>
+  ),
+}));
+
+function makeImages(): PiecePhotoGalleryImage[] {
+  return [
+    {
+      url: "https://example.com/a.jpg",
+      caption: "Freshly thrown",
+      created: new Date("2024-01-16T10:00:00Z"),
+      cloudinary_public_id: "piece/a",
+      stateLabel: "Throwing",
+      editableCurrentStateIndex: 0,
+    },
+    {
+      url: "https://example.com/b.jpg",
+      caption: "Trimmed rim",
+      created: new Date("2024-01-17T10:00:00Z"),
+      cloudinary_public_id: "piece/b",
+      stateLabel: "Trimming",
+      editableCurrentStateIndex: null,
+    },
+  ];
+}
+
+describe("PiecePhotoGallery", () => {
+  it("opens a headerless gallery dialog from the photo count chip", async () => {
+    render(
+      <PiecePhotoGallery
+        images={makeImages()}
+        onSetAsThumbnail={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "2 photos" }));
+
+    expect(screen.getByLabelText("Piece photos")).toBeInTheDocument();
+    expect(screen.queryByText("Piece photos")).not.toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: /open piece photo/i })).toHaveLength(2);
+  });
+
+  it("shows the friendly state label in the lightbox footer", async () => {
+    render(
+      <PiecePhotoGallery
+        images={makeImages()}
+        onSetAsThumbnail={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "2 photos" }));
+    await userEvent.click(screen.getByRole("button", { name: "Open piece photo 2" }));
+
+    expect(screen.getByText("Added in Trimming")).toBeInTheDocument();
+  });
+
+  it("saves edited captions from the lightbox for current-state images", async () => {
+    const onSaveCaption = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <PiecePhotoGallery
+        images={makeImages()}
+        onSetAsThumbnail={vi.fn().mockResolvedValue(undefined)}
+        onSaveCaption={onSaveCaption}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "2 photos" }));
+    await userEvent.click(screen.getByRole("button", { name: "Open piece photo 1" }));
+    await userEvent.click(screen.getByLabelText("Edit caption"));
+    const captionInput = screen.getByLabelText("Edit photo caption", {
+      selector: "input",
+    });
+    fireEvent.change(captionInput, { target: { value: "Updated caption" } });
+    await userEvent.click(screen.getByText("Save"));
+
+    expect(onSaveCaption).toHaveBeenCalledWith(0, "Updated caption");
+  });
+
+  it("lets current-state gallery images be deleted through the confirmation dialog", async () => {
+    const onDeleteImage = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <PiecePhotoGallery
+        images={makeImages()}
+        onSetAsThumbnail={vi.fn().mockResolvedValue(undefined)}
+        onDeleteImage={onDeleteImage}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "2 photos" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Delete piece photo 1" }),
+    );
+
+    expect(screen.getByText("Remove Image")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Remove" }));
+
+    expect(onDeleteImage).toHaveBeenCalledWith(0);
+  });
+});

--- a/web/src/components/__tests__/TagManager.test.tsx
+++ b/web/src/components/__tests__/TagManager.test.tsx
@@ -7,6 +7,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import TagManager from "../TagManager";
 import type { PieceDetail, TagEntry } from "../../util/types";
 import * as api from "../../util/api";
@@ -78,24 +79,36 @@ describe("TagManager", () => {
       renderTagManager([{ id: "gift", name: "Gift", color: "#2A9D8F" }]);
     });
     expect(screen.getByText("Gift")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Edit tags" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Add or edit tags" }),
+    ).toBeInTheDocument();
     expect(screen.queryByLabelText("Tags")).not.toBeInTheDocument();
   });
 
-  it("shows placeholder text when no tags", async () => {
+  it("does not fetch tags until editing starts", async () => {
     await act(async () => {
       renderTagManager([]);
     });
-    expect(screen.getByText("Add some tags!")).toBeInTheDocument();
+    expect(api.fetchGlobalEntries).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add or edit tags" }));
+
+    await waitFor(() =>
+      expect(api.fetchGlobalEntries).toHaveBeenCalledWith("tag"),
+    );
+    expect(api.fetchGlobalEntries).toHaveBeenCalledTimes(1);
   });
 
   it("shows the tag editor when the edit button is pressed", async () => {
     await act(async () => {
       renderTagManager();
     });
-    fireEvent.click(screen.getByRole("button", { name: "Edit tags" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Add or edit tags" }),
+    );
     expect(screen.getByLabelText("Tags")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "New" })).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Open" }));
+    expect(screen.getByRole("option", { name: "+ New tag" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save tags" })).toBeInTheDocument();
   });
 
@@ -106,7 +119,7 @@ describe("TagManager", () => {
     await act(async () => {
       renderTagManager();
     });
-    fireEvent.click(screen.getByRole("button", { name: "Edit tags" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add or edit tags" }));
     fireEvent.mouseDown(screen.getByLabelText("Tags"));
     await waitFor(() => screen.getByRole("option", { name: "Gift" }));
     fireEvent.click(screen.getByRole("option", { name: "Gift" }));
@@ -118,7 +131,7 @@ describe("TagManager", () => {
     await act(async () => {
       renderTagManager([{ id: "gift", name: "Gift", color: "#2A9D8F" }]);
     });
-    fireEvent.click(screen.getByRole("button", { name: "Edit tags" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add or edit tags" }));
     expect(api.updatePiece).not.toHaveBeenCalled();
     fireEvent.click(screen.getByRole("button", { name: "Save tags" }));
     await waitFor(() =>
@@ -135,7 +148,7 @@ describe("TagManager", () => {
     await act(async () => {
       renderTagManager([{ id: "gift", name: "Gift", color: "#2A9D8F" }]);
     });
-    fireEvent.click(screen.getByRole("button", { name: "Edit tags" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add or edit tags" }));
     fireEvent.click(screen.getByRole("button", { name: "Save tags" }));
     await waitFor(() =>
       expect(screen.queryByLabelText("Tags")).not.toBeInTheDocument(),
@@ -148,7 +161,7 @@ describe("TagManager", () => {
     await act(async () => {
       renderTagManager([{ id: "gift", name: "Gift", color: "#2A9D8F" }]);
     });
-    fireEvent.click(screen.getByRole("button", { name: "Edit tags" }));
+    fireEvent.click(screen.getByRole("button", { name: "Add or edit tags" }));
     fireEvent.click(screen.getByRole("button", { name: "Save tags" }));
     await waitFor(() =>
       expect(
@@ -167,10 +180,13 @@ describe("TagManager", () => {
       renderTagManager();
     });
     // Wait for tags to load
+    await userEvent.click(
+      screen.getByRole("button", { name: "Add or edit tags" }),
+    );
     await waitFor(() => expect(api.fetchGlobalEntries).toHaveBeenCalled());
 
-    fireEvent.click(screen.getByRole("button", { name: "Edit tags" }));
-    fireEvent.click(screen.getByRole("button", { name: "New" }));
+    await userEvent.click(screen.getByRole("button", { name: "Open" }));
+    await userEvent.click(screen.getByRole("option", { name: "+ New tag" }));
 
     fireEvent.change(screen.getByLabelText("Tag name"), {
       target: { value: "gift" },
@@ -197,8 +213,11 @@ describe("TagManager", () => {
       renderTagManager();
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Edit tags" }));
-    fireEvent.click(screen.getByRole("button", { name: "New" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Add or edit tags" }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Open" }));
+    await userEvent.click(screen.getByRole("option", { name: "+ New tag" }));
 
     fireEvent.change(screen.getByLabelText("Tag name"), {
       target: { value: "For Sale" },

--- a/web/src/components/__tests__/WorkflowState.test.tsx
+++ b/web/src/components/__tests__/WorkflowState.test.tsx
@@ -222,6 +222,15 @@ const defaultProps = {
 
 const noop = () => {};
 
+function setScreenWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+  window.dispatchEvent(new Event("resize"));
+}
+
 // Helper to simulate a successful Cloudinary Upload Widget upload.
 // The widget fires display-changed (shown) then success when open() is called.
 function setupUploadWidget(
@@ -271,7 +280,20 @@ function setupControllableWidget() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  setScreenWidth(1024);
   vi.mocked(api.fetchGlobalEntries).mockResolvedValue([]);
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: query.includes("max-width:599.95px")
+      ? window.innerWidth <= 599
+      : false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
   // Reset window.cloudinary between tests
   window.cloudinary = undefined;
 });
@@ -412,42 +434,11 @@ describe("WorkflowState", () => {
     );
   });
 
-  it("updates current_location after selecting a browse result", async () => {
-    const updated = makePieceDetail({
-      current_state: makeState({ notes: "new" }),
-      current_location: "Shelf B",
-    });
-    vi.mocked(api.updateCurrentState).mockResolvedValue(updated);
-    vi.mocked(api.updatePiece).mockResolvedValue(updated);
-    vi.mocked(api.fetchGlobalEntriesWithFilters).mockResolvedValue([
-      { id: "shelf-z", name: "Shelf Z", isPublic: false },
-    ]);
-    render(
-      <WorkflowState
-        {...defaultProps}
-        onSaved={vi.fn()}
-        pieceState={makeState({ notes: "Original" })}
-      />,
-    );
-    await userEvent.click(
-      screen.getByRole("button", { name: "Browse Current location" }),
-    );
-    await waitFor(() => expect(screen.getByText("Shelf Z")).toBeInTheDocument());
-    await userEvent.click(screen.getByText("Shelf Z"));
-    await waitFor(() =>
-      expect(api.updatePiece).toHaveBeenCalledWith("test-piece-id", {
-        current_location: "Shelf Z",
-      }),
-    );
-  });
-
-  it("renders an autosave status", async () => {
+  it("keeps the floating autosave status hidden before any changes", async () => {
     await act(async () => {
       render(<WorkflowState {...defaultProps} />);
     });
-    expect(screen.getByTestId("autosave-status")).toHaveTextContent(
-      "All changes saved",
-    );
+    expect(screen.queryByTestId("autosave-status")).not.toBeInTheDocument();
   });
 
   it("does not save when there are no changes", async () => {
@@ -493,13 +484,11 @@ describe("WorkflowState", () => {
     );
   });
 
-  it("shows saved status when not dirty", async () => {
+  it("keeps the saved pill hidden when nothing has changed", async () => {
     await act(async () => {
       render(<WorkflowState {...defaultProps} />);
     });
-    expect(screen.getByTestId("autosave-status")).toHaveTextContent(
-      "All changes saved",
-    );
+    expect(screen.queryByTestId("autosave-status")).not.toBeInTheDocument();
   });
 
   it("calls onSaved after successful save", async () => {
@@ -546,35 +535,6 @@ describe("WorkflowState", () => {
     );
   });
 
-  it("remains dirty when piece API fails during save", async () => {
-    const updated = makePieceDetail();
-    vi.mocked(api.updateCurrentState).mockResolvedValue(updated);
-    vi.mocked(api.updatePiece).mockRejectedValue(new Error("Network error"));
-    vi.mocked(api.fetchGlobalEntriesWithFilters).mockResolvedValue([
-      { id: "1", name: "Shelf Z", isPublic: false },
-    ]);
-    render(<WorkflowState {...defaultProps} currentLocation="" />);
-    await userEvent.click(
-      screen.getByRole("button", { name: "Browse Current location" }),
-    );
-    await waitFor(() =>
-      expect(screen.getByText("Shelf Z")).toBeInTheDocument(),
-    );
-    await userEvent.click(screen.getByText("Shelf Z"));
-    await waitFor(() => expect(screen.getByText("Shelf Z")).toBeInTheDocument());
-    await waitFor(() =>
-      expect(
-        screen.getByText("Autosave failed. Your changes are still here."),
-      ).toBeInTheDocument(),
-    );
-    expect(screen.getByTestId("autosave-status")).toHaveTextContent(
-      "Autosave failed",
-    );
-    expect(api.updatePiece).toHaveBeenCalledWith("test-piece-id", {
-      current_location: "Shelf Z",
-    });
-  });
-
   it("calls onDirtyChange with true when dirty", async () => {
     const onDirtyChange = vi.fn();
     await act(async () => {
@@ -614,6 +574,16 @@ describe("WorkflowState", () => {
     expect(
       screen.getByRole("button", { name: "Upload Image" }),
     ).toBeInTheDocument();
+  });
+
+  it("shows a floating camera action on mobile layouts", async () => {
+    setScreenWidth(390);
+    await act(async () => {
+      render(<WorkflowState {...defaultProps} />);
+    });
+    const uploadAction = screen.getByRole("button", { name: "Upload Image" });
+    expect(uploadAction).toBeInTheDocument();
+    expect(uploadAction).toHaveClass("MuiFab-root");
   });
 
   it("successful widget upload immediately saves the image to state", async () => {
@@ -719,163 +689,7 @@ describe("WorkflowState", () => {
       ).toBeInTheDocument(),
     );
   });
-  it("clicking remove image opens the confirmation dialog", async () => {
-    render(
-      <WorkflowState
-        {...defaultProps}
-        pieceState={makeState({
-          images: [
-            {
-              url: "http://example.com/img.jpg",
-              caption: "To delete",
-              created: new Date(),
-            },
-          ],
-        })}
-      />,
-    );
-    fireEvent.click(screen.getByRole("button", { name: "remove image" }));
-    expect(screen.getByText("Remove Image")).toBeInTheDocument();
-    expect(screen.getByText(/Remove this image\? This action cannot be undone\./)).toBeInTheDocument();
-  });
-
-  it("cancelling the remove dialog does not remove the image", async () => {
-    render(
-      <WorkflowState
-        {...defaultProps}
-        pieceState={makeState({
-          images: [
-            {
-              url: "http://example.com/img.jpg",
-              caption: "Keep me",
-              created: new Date(),
-            },
-          ],
-        })}
-      />,
-    );
-    fireEvent.click(screen.getByRole("button", { name: "remove image" }));
-    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
-    expect(api.updateCurrentState).not.toHaveBeenCalled();
-    await waitFor(() =>
-      expect(screen.queryByText("Remove Image")).not.toBeInTheDocument(),
-    );
-    expect(screen.getByText("Keep me")).toBeInTheDocument();
-  });
-
-  it("confirming image removal calls updateCurrentState without the image", async () => {
-    const updated = makePieceDetail({
-      current_state: makeState({ images: [] }),
-    });
-    vi.mocked(api.updateCurrentState).mockResolvedValue(updated);
-    render(
-      <WorkflowState
-        {...defaultProps}
-        pieceState={makeState({
-          images: [
-            {
-              url: "http://example.com/img.jpg",
-              caption: "To delete",
-              created: new Date(),
-            },
-          ],
-        })}
-      />,
-    );
-    fireEvent.click(screen.getByRole("button", { name: "remove image" }));
-    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
-    await waitFor(() =>
-      expect(api.updateCurrentState).toHaveBeenCalledWith(
-        "test-piece-id",
-        expect.objectContaining({ images: [] }),
-      ),
-    );
-  });
-
-  it("clicking the pencil icon makes the caption editable", async () => {
-    await act(async () => {
-      render(
-        <WorkflowState
-          {...defaultProps}
-          pieceState={makeState({
-            images: [
-              {
-                url: "http://example.com/img.jpg",
-                caption: "My caption",
-                created: new Date(),
-              },
-            ],
-          })}
-        />,
-      );
-    });
-    fireEvent.click(screen.getByRole("button", { name: "edit caption" }));
-    expect(
-      screen.getByRole("textbox", { name: "Edit caption" }),
-    ).toBeInTheDocument();
-    expect(screen.queryByText("My caption")).not.toBeInTheDocument();
-  });
-
-  it("persists caption change on blur and exits edit mode", async () => {
-    const updated = makePieceDetail();
-    vi.mocked(api.updateCurrentState).mockResolvedValue(updated);
-    render(
-      <WorkflowState
-        {...defaultProps}
-        pieceState={makeState({
-          images: [
-            {
-              url: "http://example.com/img.jpg",
-              caption: "Old",
-              created: new Date(),
-            },
-          ],
-        })}
-      />,
-    );
-    fireEvent.click(screen.getByRole("button", { name: "edit caption" }));
-    const input = screen.getByRole("textbox", { name: "Edit caption" });
-    fireEvent.change(input, { target: { value: "New caption" } });
-    fireEvent.blur(input);
-    await waitFor(() =>
-      expect(api.updateCurrentState).toHaveBeenCalledWith(
-        "test-piece-id",
-        expect.objectContaining({
-          images: expect.arrayContaining([
-            expect.objectContaining({ caption: "New caption" }),
-          ]),
-        }),
-      ),
-    );
-    expect(
-      screen.queryByRole("textbox", { name: "Edit caption" }),
-    ).not.toBeInTheDocument();
-  });
-
-  it("skips server call when caption is unchanged on blur", async () => {
-    await act(async () => {
-      render(
-        <WorkflowState
-          {...defaultProps}
-          pieceState={makeState({
-            images: [
-              {
-                url: "http://example.com/img.jpg",
-                caption: "Same",
-                created: new Date(),
-              },
-            ],
-          })}
-        />,
-      );
-    });
-    fireEvent.click(screen.getByRole("button", { name: "edit caption" }));
-    const input = screen.getByRole("textbox", { name: "Edit caption" });
-    fireEvent.blur(input);
-    expect(api.updateCurrentState).not.toHaveBeenCalled();
-  });
-
-  it("pressing Escape exits edit mode without saving", async () => {
+  it("does not render uploaded image entries in the workflow section", async () => {
     await act(async () => {
       render(
         <WorkflowState
@@ -892,14 +706,9 @@ describe("WorkflowState", () => {
         />,
       );
     });
-    fireEvent.click(screen.getByRole("button", { name: "edit caption" }));
-    const input = screen.getByRole("textbox", { name: "Edit caption" });
-    fireEvent.change(input, { target: { value: "Changed" } });
-    fireEvent.keyDown(input, { key: "Escape" });
-    expect(api.updateCurrentState).not.toHaveBeenCalled();
-    expect(
-      screen.queryByRole("textbox", { name: "Edit caption" }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Photo 1")).not.toBeInTheDocument();
+    expect(screen.queryByText("Keep")).not.toBeInTheDocument();
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
   });
 
   it("renders enum and number additional fields for bisque_fired state", async () => {

--- a/web/src/components/usePieceDetailSaveStatus.ts
+++ b/web/src/components/usePieceDetailSaveStatus.ts
@@ -1,0 +1,20 @@
+import { createContext, useContext } from "react";
+import type { AutosaveStatus as AutosaveStatusValue } from "./useAutosave";
+
+export type SaveStatusSnapshot = {
+  status: AutosaveStatusValue;
+  error: string | null;
+  lastSavedAt: Date | null;
+};
+
+export type PieceDetailSaveStatusContextValue = {
+  publishWorkflowStatus: (snapshot: SaveStatusSnapshot) => void;
+  runManualSave: <T>(save: () => Promise<T>) => Promise<T>;
+};
+
+export const PieceDetailSaveStatusContext =
+  createContext<PieceDetailSaveStatusContextValue | null>(null);
+
+export function usePieceDetailSaveStatus() {
+  return useContext(PieceDetailSaveStatusContext);
+}


### PR DESCRIPTION
## Summary

Full redesign of the `PieceDetail` page — layout, interaction polish, and bug fixes across the component tree.

### Layout
- **Desktop two-column grid**: piece info (title, tags, state transition, location) on the left; hero image on the right; WorkflowState and Timeline span full width below
- **Mobile**: hero on top, info below — unchanged from the original stacked layout
- Hero image uses `aspectRatio: 4/3` on desktop; photo gallery button and upload trigger appear below the hero
- Upload Image button portals into `#piece-upload-trigger` on desktop (next to gallery button) — no prop changes to `WorkflowState`

### State transition UI
- Right-angle tree connector (SVG, `preserveAspectRatio="none"`) fills horizontal space between current state and successor chips
- Current state chip and first successor chip share the same vertical center line via fixed `height: SUCCESSOR_ROW_HEIGHT`
- Successor chips left-aligned within the group; group stays right-aligned

### Photo gallery & lightbox
- `PiecePhotoGallery` component extracted for gallery trigger + dialog + lightbox wiring
- Lightbox footer: caption editor/display above state label; "Set as thumbnail" button below all text
- Duplicate caption rendering removed from `ImageLightbox` (footer owns it)
- Caption and delete saves strip `created: Date` from image objects and normalize global-ref `additional_fields` (e.g. `glaze_combination`) from `{id, name}` objects to plain ID strings — fixes server 400 errors

### Other polish
- YYYY/MM/DD date format for Created/Modified
- Dashed `+ tag` chip replaces pencil icon in `TagManager`; `+ New tag` sentinel entry in `TagAutocomplete`
- Tag chips get a grey `divider` border for visual boundary
- `PieceHistory` uses a flat expand-down toggle (no left border bar)
- Piece name edit pencil is 22×22 px, vertically centered

## Test plan
- [ ] Desktop: verify two-column layout, upload button appears next to gallery button below hero
- [ ] Mobile: verify hero appears above info, upload FAB still visible
- [ ] Edit caption in lightbox — confirm save succeeds (no 400 from `additional_fields`)
- [ ] Delete image from gallery — confirm save succeeds
- [ ] State transition connector renders correctly for single and multiple successors
- [ ] Tag create/edit flow via `+ tag` chip and `+ New tag` autocomplete entry
- [ ] Location field appears in info column on both desktop and mobile

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)
