### PR TITLE
Fix tsc_check: use ts_project to correctly type-check app source

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,6 +5,7 @@ module(
 
 bazel_dep(name = "rules_python", version = "1.1.0")
 bazel_dep(name = "aspect_rules_js", version = "3.0.3")
+bazel_dep(name = "aspect_rules_ts", version = "3.8.8")
 bazel_dep(name = "rules_nodejs", version = "6.7.4")
 bazel_dep(name = "aspect_rules_lint", version = "2.5.0")
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
@@ -47,6 +48,14 @@ npm.npm_translate_lock(
     verify_node_modules_ignored = "//:.bazelignore",
 )
 use_repo(npm, "npm")
+
+# ── TypeScript compiler for ts_project ───────────────────────────────────────
+
+rules_ts_ext = use_extension("@aspect_rules_ts//ts:extensions.bzl", "ext", dev_dependency = True)
+rules_ts_ext.deps(
+    ts_version_from = "//web:package.json",
+)
+use_repo(rules_ts_ext, "npm_typescript")
 
 # ── mypy type stubs (auto-generated from requirements.txt) ────────────────────
 # Generates @pip_types//:types.bzl — a map from pip package name to its

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -18,18 +18,23 @@
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.42.2/MODULE.bazel": "2e0d8ab25c57a14f56ace1c8e881b69050417ff91b2fb7718dc00d201f3c3478",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.0.0/MODULE.bazel": "e118477db5c49419a88d78ebc7a2c2cea9d49600fe0f490c1903324a2c16ecd9",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.14.0/MODULE.bazel": "2b31ffcc9bdc8295b2167e07a757dbbc9ac8906e7028e5170a3708cecaac119f",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.19.2/MODULE.bazel": "30dfabbfae0139b1f0036e01c201dd4c0167da3017f0b7ef3820d78e07622989",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.19.3/MODULE.bazel": "253d739ba126f62a5767d832765b12b59e9f8d2bc88cc1572f4a73e46eb298ca",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.22.0/MODULE.bazel": "7fe0191f047d4fe4a4a46c1107e2350cbb58a8fc2e10913aa4322d3190dec0bf",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.22.5/MODULE.bazel": "004ba890363d05372a97248c37205ae64b6fa31047629cd2c0895a9d0c7779e8",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.22.5/source.json": "ac2c3213df8f985785f1d0aeb7f0f73d5324e6e67d593d9b9470fb74a25d4a9b",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.7.7/MODULE.bazel": "491f8681205e31bb57892d67442ce448cda4f472a8e6b3dc062865e29a64f89c",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.8.1/MODULE.bazel": "812d2dd42f65dca362152101fbec418029cc8fd34cbad1a2fde905383d705838",
     "https://bcr.bazel.build/modules/aspect_rules_js/1.33.1/MODULE.bazel": "db3e7f16e471cf6827059d03af7c21859e7a0d2bc65429a3a11f005d46fc501b",
     "https://bcr.bazel.build/modules/aspect_rules_js/1.40.0/MODULE.bazel": "01a1014e95e6816b68ecee2584ae929c7d6a1b72e4333ab1ff2d2c6c30babdf1",
+    "https://bcr.bazel.build/modules/aspect_rules_js/2.0.0/MODULE.bazel": "b45b507574aa60a92796e3e13c195cd5744b3b8aff516a9c0cb5ae6a048161c5",
     "https://bcr.bazel.build/modules/aspect_rules_js/3.0.3/MODULE.bazel": "28a30e8fc33bf64a67835d64d124f6e05a7d59648dcb27b110fb3502f761e503",
     "https://bcr.bazel.build/modules/aspect_rules_js/3.0.3/source.json": "bb8fff9a304452e1042af9522ad1d54d6f1d1fdf71c5127deadb6fd156654193",
     "https://bcr.bazel.build/modules/aspect_rules_lint/0.12.0/MODULE.bazel": "e767c5dbfeb254ec03275a7701b5cfde2c4d2873676804bc7cb27ddff3728fed",
     "https://bcr.bazel.build/modules/aspect_rules_lint/2.5.0/MODULE.bazel": "24f49acb3b8375fa138ba6ab53bcf517ae92529770a04ab04d47c958ff47b63e",
     "https://bcr.bazel.build/modules/aspect_rules_lint/2.5.0/source.json": "8beadb1db5fa4b5e36769a5247c200a877fbc9f397dc10b5aa33e76099483070",
+    "https://bcr.bazel.build/modules/aspect_rules_ts/3.8.8/MODULE.bazel": "b52b929a948438665809d49af610f58d1b14f63d6d21ab748f47b6050be4c1f6",
+    "https://bcr.bazel.build/modules/aspect_rules_ts/3.8.8/source.json": "5414530b761a45ab7ca6c49f0a2a9cf8dc0da772f5037cf05ca18aaa64bb1b19",
     "https://bcr.bazel.build/modules/aspect_tools_telemetry/0.2.8/MODULE.bazel": "aa975a83e72bcaac62ee61ab12b788ea324a1d05c4aab28aadb202f647881679",
     "https://bcr.bazel.build/modules/aspect_tools_telemetry/0.3.3/MODULE.bazel": "37c764292861c2f70314efa9846bb6dbb44fc0308903b3285da6528305450183",
     "https://bcr.bazel.build/modules/aspect_tools_telemetry/0.3.3/source.json": "605086bbc197743a0d360f7ddc550a1d4dfa0441bc807236e17170f636153348",
@@ -187,6 +192,7 @@
     "https://bcr.bazel.build/modules/rules_multitool/0.11.0/MODULE.bazel": "8d9dda78d2398e136300d3ef4fbcc89ede7c32c158d8c016fa7d032df41c4aaf",
     "https://bcr.bazel.build/modules/rules_multitool/0.11.0/source.json": "0b86574a1eaff37c33aafaff095ea16d6ac846beb94ffc74c4fcf626f8f80681",
     "https://bcr.bazel.build/modules/rules_nodejs/5.8.2/MODULE.bazel": "6bc03c8f37f69401b888023bf511cb6ee4781433b0cb56236b2e55a21e3a026a",
+    "https://bcr.bazel.build/modules/rules_nodejs/6.2.0/MODULE.bazel": "ec27907f55eb34705adb4e8257952162a2d4c3ed0f0b3b4c3c1aad1fac7be35e",
     "https://bcr.bazel.build/modules/rules_nodejs/6.7.3/MODULE.bazel": "c22a48b2a0dbf05a9dc5f83837bbc24c226c1f6e618de3c3a610044c9f336056",
     "https://bcr.bazel.build/modules/rules_nodejs/6.7.4/MODULE.bazel": "e6a241a55c82e999145553d2e00a08fc6ebadf62b63d108fb5e984696ffd0bd2",
     "https://bcr.bazel.build/modules/rules_nodejs/6.7.4/source.json": "34e7a8a3b4c8d630ac0e0492b3fed9dba41fe008a0edf220b7d88fa38ac53698",
@@ -195,6 +201,7 @@
     "https://bcr.bazel.build/modules/rules_pkg/1.0.1/source.json": "bd82e5d7b9ce2d31e380dd9f50c111d678c3bdaca190cb76b0e1c71b05e1ba8a",
     "https://bcr.bazel.build/modules/rules_proto/4.0.0/MODULE.bazel": "a7a7b6ce9bee418c1a760b3d84f83a299ad6952f9903c67f19e4edd964894e06",
     "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.0/MODULE.bazel": "b531d7f09f58dce456cd61b4579ce8c86b38544da75184eadaf0a7cb7966453f",
     "https://bcr.bazel.build/modules/rules_proto/6.0.2/MODULE.bazel": "ce916b775a62b90b61888052a416ccdda405212b6aaeb39522f7dc53431a5e73",
     "https://bcr.bazel.build/modules/rules_proto/7.0.2/MODULE.bazel": "bf81793bd6d2ad89a37a40693e56c61b0ee30f7a7fdbaf3eabbf5f39de47dea2",
     "https://bcr.bazel.build/modules/rules_proto/7.1.0/MODULE.bazel": "002d62d9108f75bb807cd56245d45648f38275cb3a99dcd45dfb864c5d74cb96",
@@ -243,10 +250,47 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
+    "@@aspect_rules_ts~//ts:extensions.bzl%ext": {
+      "general": {
+        "bzlTransitiveDigest": "HKMVj1TG4O7hW/qkMUGevNijK2IpfzhTvuIV3FOWIbo=",
+        "usagesDigest": "jgXSyw2zB6hLAQDv/3Pr3kgPnN5jdzqcETRqehvo1aw=",
+        "recordedFileInputs": {
+          "@@//web/package.json": "ba9356388333533048bd794d57e67decae9bd46d02b9b189960b30db74f95330"
+        },
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "npm_typescript": {
+            "bzlFile": "@@aspect_rules_ts~//ts/private:npm_repositories.bzl",
+            "ruleClassName": "http_archive_version",
+            "attributes": {
+              "version": "",
+              "version_from": "@@//web:package.json",
+              "integrity": "",
+              "urls": [
+                "https://registry.npmjs.org/typescript/-/typescript-{}.tgz"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "aspect_rules_ts~",
+            "aspect_rules_ts",
+            "aspect_rules_ts~"
+          ],
+          [
+            "aspect_rules_ts~",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "@@aspect_tools_telemetry~//:extension.bzl%telemetry": {
       "general": {
         "bzlTransitiveDigest": "cl5A2O84vDL6Tt+Qga8FCj1DUDGqn+e7ly5rZ+4xvcc=",
-        "usagesDigest": "aar2Qyf4AlVEBCgrVPmAG2O2ZLYhOa4siNkEqEeJfNw=",
+        "usagesDigest": "uMJwtdKdBIcp5uxCPfzCr0l6YZAWMppzo85yVcTdzW4=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -257,6 +301,7 @@
             "attributes": {
               "deps": {
                 "aspect_rules_js": "3.0.3",
+                "aspect_rules_ts": "3.8.8",
                 "aspect_rules_lint": "2.5.0",
                 "aspect_tools_telemetry": "0.3.3"
               }

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@aspect_rules_js//js:defs.bzl", "js_binary", "js_library", "js_run_binary")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//web:eslint/package_json.bzl", eslint_pkg = "bin")
-load("@npm//web:typescript/package_json.bzl", typescript_pkg = "bin")
 load("@npm//web:vite/package_json.bzl", vite_pkg = "bin")
 load(":vitest.bzl", "vitest_test")
 
@@ -45,18 +45,26 @@ vite_pkg.vite(
     out_dirs = ["dist"],
 )
 
-typescript_pkg.tsc(
-    name = "tsc_run",
-    srcs = [
-        ":tsconfig.node.json",
-        ":web_lib",
-    ],
-    args = [
-        "--noEmit",
-        "--project",
-        "$(location :tsconfig.node.json)",
-    ],
-    stdout = "tsc_check.log",
+ts_project(
+    name = "tsc_typecheck",
+    srcs = glob(
+        [
+            "src/**/*.ts",
+            "src/**/*.tsx",
+        ],
+        exclude = [
+            "src/**/*.test.ts",
+            "src/**/*.test.tsx",
+            "src/test-setup.ts",
+            "src/util/generated-types.ts",  # genrule output, added via srcs below
+        ],
+    ) + [":generated_types_gen"],
+    tsconfig = ":tsconfig.app.json",
+    declaration = False,
+    no_emit = True,
+    resolve_json_module = True,
+    ts_build_info_file = "node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    deps = [":node_modules"],
     tags = ["lint"],
 )
 
@@ -704,7 +712,7 @@ alias(
 
 alias(
     name = "tsc_check",
-    actual = ":tsc_run",
+    actual = ":tsc_typecheck",
     tags = ["lint"],
 )
 

--- a/web/package.json
+++ b/web/package.json
@@ -55,7 +55,7 @@
     "jsdom": "^29.0.2",
     "openapi-typescript": "^7.13.0",
     "prettier": "3.8.3",
-    "typescript": "~5.9.3",
+    "typescript": "5.9.3",
     "typescript-eslint": "^8.57.0",
     "vite": "^8.0.1",
     "vitest": "^4.1.4"

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -130,7 +130,7 @@ importers:
         specifier: 3.8.3
         version: 3.8.3
       typescript:
-        specifier: ~5.9.3
+        specifier: 5.9.3
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.57.0

--- a/web/src/components/TagAutocomplete.tsx
+++ b/web/src/components/TagAutocomplete.tsx
@@ -8,7 +8,7 @@ import TagChip from "./TagChip";
 import type { TagEntry } from "../util/types";
 
 const CREATE_NEW_ID = "__create_new__";
-const CREATE_NEW_OPTION: TagEntry = { id: CREATE_NEW_ID, name: "+ New tag" };
+const CREATE_NEW_OPTION: TagEntry = { id: CREATE_NEW_ID, name: "+ New tag", is_public: false };
 
 interface TagAutocompleteProps {
   label: string;


### PR DESCRIPTION
## Summary

- **Root cause:** `tsc_check` was running `tsc --project tsconfig.node.json`, which only covers `vite.config.ts`. The entire `src/` app tree was never type-checked by Bazel, so errors silently passed CI before blowing up in the CD Docker build.
- **Fix:** Replace `typescript_pkg.tsc` with `ts_project` from `aspect_rules_ts`. `ts_project` explicitly declares all source files to Bazel, so the sandbox is set up correctly and `.d.ts` files (e.g. `yaml.d.ts`, `cloudinary-widget.d.ts`) are visible to the compiler.
- **Bug caught:** `tsc_check` now correctly surfaces a pre-existing type error in `TagAutocomplete.tsx` — `CREATE_NEW_OPTION` was missing the `is_public` field added to `TagEntry` — fixed in the same commit.

## Changes

| File | What changed |
|---|---|
| `MODULE.bazel` | Add `aspect_rules_ts 3.8.8`; wire up `rules_ts_ext` extension |
| `web/package.json` | Pin TypeScript to exact `5.9.3` (was `~5.9.3`) so `rules_ts` can resolve it |
| `web/pnpm-lock.yaml`, `MODULE.bazel.lock` | Regenerated after pin change |
| `web/BUILD.bazel` | Replace `tsc_run` (`typescript_pkg.tsc`) with `ts_project`; update `tsc_check` alias |
| `web/src/components/TagAutocomplete.tsx` | Add missing `is_public: false` to `CREATE_NEW_OPTION` |

## Test plan

- [x] `bazel build --config=lint //web:tsc_check` — passes (was silently wrong before)
- [x] `bazel build --config=lint //...` — all linters pass
- [x] `bazel test //...` — all 29 tests pass

Closes #189
