### PR TITLE
Migrate image build to Bazel rules_oci

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,7 @@
 # ── Common ────────────────────────────────────────────────────────────────────
 common --enable_bzlmod
 common --experimental_merged_skyframe_analysis_execution
+build --workspace_status_command=tools/workspace_status.sh
 common --spawn_strategy=local
 build --incompatible_enable_cc_toolchain_resolution
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,7 +39,7 @@ jobs:
           ssh-keyscan -H $(echo "${{ vars.DEPLOY_HOST }}" | cut -d@ -f2) >> ~/.ssh/known_hosts
 
       - name: Deploy
-        run: ./deploy.sh "${{ vars.DEPLOY_HOST }}"
+        run: ./deploy.sh "${{ vars.DEPLOY_HOST }}" "${{ env.DEPLOY_SHA }}"
 
       - name: Create GitHub Release
         env:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       sha:
-        description: 'Commit SHA to build and deploy (defaults to the selected branch HEAD)'
+        description: 'Commit SHA to deploy (defaults to the selected branch HEAD)'
         required: false
         default: ''
 
@@ -16,41 +16,10 @@ env:
   DEPLOY_SHA: ${{ github.event.workflow_run.head_sha || inputs.sha || github.sha }}
 
 jobs:
-  publish:
-    name: Publish Docker image
-    runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
-    permissions:
-      packages: write
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ env.DEPLOY_SHA }}
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          push: true
-          tags: |
-            ghcr.io/shaoster/glaze:latest
-            ghcr.io/shaoster/glaze:${{ env.DEPLOY_SHA }}
-          build-args: |
-            VITE_GOOGLE_CLIENT_ID=${{ secrets.VITE_GOOGLE_CLIENT_ID }}
-          labels: |
-            org.opencontainers.image.revision=${{ env.DEPLOY_SHA }}
-
   deploy:
     name: Deploy to droplet
     runs-on: ubuntu-latest
-    needs: [publish]
+    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
     environment: glaze-tailscale
     concurrency:
       group: deploy-production

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,39 @@ jobs:
           files: bazel-out/_coverage/_coverage_report.dat
           flags: backend,frontend
           fail_ci_if_error: false
+  publish:
+    name: Publish OCI image
+    needs: [preflight, test]
+    if: ${{ github.event_name == 'push' && needs.test.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Inject BuildBuddy API key into .bazelrc
+        run: |
+          echo "" >> .bazelrc
+          echo "common:ci --remote_header=x-buildbuddy-api-key=${{ secrets.BAZEL_REMOTE_API_KEY }}" >> .bazelrc
+
+      - name: Write Vite env file
+        run: printf 'VITE_GOOGLE_CLIENT_ID=%s\n' '${{ secrets.VITE_GOOGLE_CLIENT_ID }}' > web/.env.local
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push OCI image
+        run: |
+          bazel run --config=ci //:push -- \
+            --tag latest \
+            --tag ${{ github.sha }}
+
   record-fingerprint:
     name: Record successful fingerprint
     needs: [preflight, test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Build and push OCI image
         run: |
-          bazel run --config=ci //:push -- \
+          bazel run --config=ci --stamp //:push -- \
             --tag latest \
             --tag ${{ github.sha }}
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,6 @@
 load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 exports_files([
     "ruff.toml",
@@ -51,4 +53,103 @@ alias(
     name = "ruff",
     actual = "@aspect_rules_lint//lint:ruff",
     visibility = ["//visibility:public"],
+)
+
+# ── OCI container image ───────────────────────────────────────────────────────
+#
+# bazel build //:image        — assemble the OCI image locally
+# bazel run   //:push         — push to ghcr.io/shaoster/glaze:<tag>
+#
+# Image layout (all under /app):
+#   /app/                      Django project root (manage.py, backend/, api/, etc.)
+#   /app/web/dist/             Vite-built SPA (served by WhiteNoise at URL root)
+#   /app/site-packages/        pip-installed runtime deps (added to PYTHONPATH)
+#
+# collectstatic runs at container startup (docker-entrypoint.sh) because it
+# needs files from pip-installed packages (e.g. DRF browsable API assets) that
+# land in site-packages, not in the image layers we control at build time.
+
+# pip deps layer — install runtime deps into /app/site-packages using the
+# Bazel-managed Python 3.12 toolchain. Tagged no-sandbox because pip needs
+# network access to download wheels.
+genrule(
+    name = "pip_layer_tar",
+    srcs = ["//:requirements.lock"],
+    outs = ["pip_layer.tar"],
+    cmd = """
+        set -e
+        dest=$$(mktemp -d)
+        $(PYTHON3) -m pip install \
+            --quiet \
+            --require-hashes \
+            --no-deps \
+            --prefix="$$dest" \
+            -r $(location //:requirements.lock)
+        # Flatten site-packages to /app/site-packages in the tarball.
+        sp=$$(find "$$dest" -type d -name site-packages | head -1)
+        mkdir -p "$$dest/app"
+        mv "$$sp" "$$dest/app/site-packages"
+        tar -C "$$dest" -cf $@ app/site-packages
+        rm -rf "$$dest"
+    """,
+    toolchains = ["@rules_python//python:current_py_toolchain"],
+    tags = ["no-sandbox"],
+)
+
+# Django source layer — everything the app needs at runtime except deps and dist.
+pkg_tar(
+    name = "app_src_tar",
+    srcs = [
+        "manage.py",
+        "workflow.yml",
+        "workflow.schema.yml",
+        "docker-entrypoint.sh",
+    ] + glob(
+        [
+            "backend/**/*.py",
+            "api/**/*.py",
+            "api/migrations/**",
+            "api/static/**",
+            "api/fixtures/**",
+            "fixtures/**",
+        ],
+        allow_empty = False,
+    ),
+    strip_prefix = ".",
+    package_dir = "/app",
+)
+
+# Vite frontend layer — web/dist produced by the Bazel vite build.
+pkg_tar(
+    name = "web_dist_tar",
+    srcs = ["//web:web_build"],
+    strip_prefix = "web/dist",
+    package_dir = "/app/web/dist",
+)
+
+oci_image(
+    name = "image",
+    base = "@python312_slim",
+    tars = [
+        ":pip_layer_tar",
+        ":app_src_tar",
+        ":web_dist_tar",
+    ],
+    env = {
+        "PYTHONPATH": "/app/site-packages",
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "PYTHONUNBUFFERED": "1",
+        "DJANGO_SETTINGS_MODULE": "backend.settings",
+    },
+    workdir = "/app",
+    entrypoint = ["/bin/bash", "/app/docker-entrypoint.sh"],
+    exposed_ports = ["8000/tcp"],
+)
+
+oci_push(
+    name = "push",
+    image = ":image",
+    repository = "ghcr.io/shaoster/glaze",
+    # Tag is set at push time via --tag flag or OCI_TAG env var.
+    # Example: bazel run //:push -- --tag $(git rev-parse --short HEAD)
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -141,6 +141,11 @@ oci_image(
         "PYTHONUNBUFFERED": "1",
         "DJANGO_SETTINGS_MODULE": "backend.settings",
     },
+    # Stamp the commit SHA so deploy.sh can read it via `docker inspect`.
+    # {STABLE_GIT_COMMIT} is substituted from tools/workspace_status.sh when
+    # built with --stamp (CI uses `bazel run --stamp //:push`).
+    labels = {"org.opencontainers.image.revision": "{STABLE_GIT_COMMIT}"},
+    stamp = -1,  # respect --stamp flag; no-op in local builds without --stamp
     workdir = "/app",
     entrypoint = ["/bin/bash", "/app/docker-entrypoint.sh"],
     exposed_ports = ["8000/tcp"],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -133,10 +133,6 @@ oci_image(
         "PYTHONUNBUFFERED": "1",
         "DJANGO_SETTINGS_MODULE": "backend.settings",
     },
-    # Stamp the commit SHA so deploy.sh can read it via `docker inspect`.
-    # {STABLE_GIT_COMMIT} is substituted from tools/workspace_status.sh when
-    # built with --stamp (CI uses `bazel run --stamp //:push`).
-    labels = {"org.opencontainers.image.revision": "{STABLE_GIT_COMMIT}"},
     workdir = "/app",
     entrypoint = ["/bin/bash", "/app/docker-entrypoint.sh"],
     exposed_ports = ["8000/tcp"],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -104,17 +104,9 @@ pkg_tar(
         "workflow.yml",
         "workflow.schema.yml",
         "docker-entrypoint.sh",
-    ] + glob(
-        [
-            "backend/**/*.py",
-            "api/**/*.py",
-            "api/migrations/**",
-            "api/static/**",
-            "api/fixtures/**",
-            "fixtures/**",
-        ],
-        allow_empty = False,
-    ),
+        "//api:api_runtime_files",
+        "//backend:backend_runtime_files",
+    ] + glob(["fixtures/**"], allow_empty = True),
     strip_prefix = ".",
     package_dir = "/app",
 )
@@ -145,7 +137,6 @@ oci_image(
     # {STABLE_GIT_COMMIT} is substituted from tools/workspace_status.sh when
     # built with --stamp (CI uses `bazel run --stamp //:push`).
     labels = {"org.opencontainers.image.revision": "{STABLE_GIT_COMMIT}"},
-    stamp = -1,  # respect --stamp flag; no-op in local builds without --stamp
     workdir = "/app",
     entrypoint = ["/bin/bash", "/app/docker-entrypoint.sh"],
     exposed_ports = ["8000/tcp"],

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,7 +9,7 @@ bazel_dep(name = "aspect_rules_ts", version = "3.8.8")
 bazel_dep(name = "rules_nodejs", version = "6.7.4")
 bazel_dep(name = "aspect_rules_lint", version = "2.5.0")
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
-bazel_dep(name = "rules_oci", version = "2.3.1")
+bazel_dep(name = "rules_oci", version = "2.3.0")
 bazel_dep(name = "rules_pkg", version = "1.1.0")
 
 # ── Python toolchain ──────────────────────────────────────────────────────────

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,6 +9,8 @@ bazel_dep(name = "aspect_rules_ts", version = "3.8.8")
 bazel_dep(name = "rules_nodejs", version = "6.7.4")
 bazel_dep(name = "aspect_rules_lint", version = "2.5.0")
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
+bazel_dep(name = "rules_oci", version = "2.3.1")
+bazel_dep(name = "rules_pkg", version = "1.1.0")
 
 # ── Python toolchain ──────────────────────────────────────────────────────────
 
@@ -56,6 +58,17 @@ rules_ts_ext.deps(
     ts_version_from = "//web:package.json",
 )
 use_repo(rules_ts_ext, "npm_typescript")
+
+# ── OCI base image ───────────────────────────────────────────────────────────
+
+oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
+oci.pull(
+    name = "python312_slim",
+    image = "index.docker.io/library/python",
+    digest = "sha256:46cb7cc2877e60fbd5e21a9ae6115c30ace7a077b9f8772da879e4590c18c2e3",
+    platforms = ["linux/amd64"],
+)
+use_repo(oci, "python312_slim")
 
 # ── mypy type stubs (auto-generated from requirements.txt) ────────────────────
 # Generates @pip_types//:types.bzl — a map from pip package name to its

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ PotterDoc supports Docker Compose (self-hosted on any VPS/droplet).
 
 ### Docker Compose (self-hosted)
 
-The repo ships a [`Dockerfile`](Dockerfile) and [`docker-compose.yml`](docker-compose.yml) for self-hosting on a single VPS (e.g. DigitalOcean, Hetzner, Linode).
+The repo uses [`docker-compose.yml`](docker-compose.yml) for self-hosting on a single VPS (e.g. DigitalOcean, Hetzner, Linode). The container image is built by Bazel (`rules_oci`) — no Dockerfile needed.
 
 **Architecture:**
 
@@ -311,9 +311,9 @@ The repo ships a [`Dockerfile`](Dockerfile) and [`docker-compose.yml`](docker-co
 
 **How it works:**
 
-- Every push to `main` that passes all tests triggers a GitHub Actions `publish` job ([`ci.yml`](.github/workflows/ci.yml)) that builds the Docker image (with `VITE_GOOGLE_CLIENT_ID` baked in from a GitHub Actions secret) and pushes it to `ghcr.io/shaoster/glaze:latest`. On success, [`cd.yml`](.github/workflows/cd.yml) automatically deploys the new image to the droplet and creates a GitHub release marking the deployed SHA.
+- Every push to `main` that passes all tests triggers a `publish` job ([`ci.yml`](.github/workflows/ci.yml)) that builds the OCI image with Bazel (with `VITE_GOOGLE_CLIENT_ID` baked in from a GitHub Actions secret) and pushes it to `ghcr.io/shaoster/glaze:latest`. On success, [`cd.yml`](.github/workflows/cd.yml) automatically deploys the new image to the droplet and creates a GitHub release marking the deployed SHA.
 - The droplet never needs git, Node, or Python build tools — it just pulls the pre-built image.
-- Migrations run automatically inside the container on every start (via [`docker-entrypoint.sh`](docker-entrypoint.sh)).
+- Migrations and `collectstatic` run automatically inside the container on every start (via [`docker-entrypoint.sh`](docker-entrypoint.sh)).
 - Runtime secrets (`SECRET_KEY`, `DATABASE_URL`, `CLOUDINARY_*`, etc.) live only in `.env` on the droplet and are never part of the image.
 
 **One-time GitHub setup:**
@@ -344,10 +344,11 @@ docker compose up -d
 **Subsequent deploys** (from your local machine):
 
 ```bash
-./deploy.sh user@your-droplet
+# Add to .env.local:  GLAZE_PROD_HOST=user@your-droplet
+gz_deploy
 ```
 
-`deploy.sh` SSHes into the droplet, pulls the latest image from ghcr.io, and restarts the `web` service. No source code needed on the droplet.
+`gz_deploy` builds and pushes the OCI image (tagged with HEAD SHA and `:latest`), then SSHes into the droplet via [`deploy.sh`](deploy.sh) to pull the new image and restart the service. Pass `--no-push` to skip the build and redeploy the image already in the registry. No source code needed on the droplet.
 
 **Environment variables** (set in `.env` on the droplet):
 
@@ -500,10 +501,9 @@ web/
     App.tsx             Root component with MUI dark theme
 workflow.yml               Source of truth for piece states and valid transitions
 env.sh                     Development shell helpers
-Dockerfile                 Multi-stage build (builder + lean runtime image)
 docker-compose.yml         Production stack: web + Postgres
-docker-entrypoint.sh       Container startup: migrate then exec Gunicorn
-deploy.sh                  One-command deploy to a remote droplet via SSH
+docker-entrypoint.sh       Container startup: migrate, collectstatic, exec Gunicorn
+deploy.sh                  SSH deploy helper (called by gz_deploy)
 .env.production.example    Template for droplet secrets (copy to .env)
 render.yaml                Render Blueprint for managed PaaS deployment
 ```

--- a/api/BUILD.bazel
+++ b/api/BUILD.bazel
@@ -30,6 +30,23 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+# All runtime files needed in the OCI image layer (source + migrations + static).
+filegroup(
+    name = "api_runtime_files",
+    srcs = glob(
+        [
+            "**/*.py",
+            "migrations/**",
+            "static/**",
+        ],
+        exclude = [
+            "tests/**",
+            "**/test_*.py",
+        ],
+    ),
+    visibility = ["//visibility:public"],
+)
+
 # ── Shared test infrastructure ────────────────────────────────────────────────
 
 _TEST_DEPS = [

--- a/backend/BUILD.bazel
+++ b/backend/BUILD.bazel
@@ -32,3 +32,9 @@ py_library(
     ],
     visibility = ["//visibility:public"],
 )
+
+filegroup(
+    name = "backend_runtime_files",
+    srcs = glob(["*.py"]),
+    visibility = ["//visibility:public"],
+)

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 # Deploy the latest image to a droplet running Docker Compose.
 #
-# Usage: ./deploy.sh user@host
+# Usage: ./deploy.sh user@host [commit-sha]
+#
+# commit-sha: the SHA to sync docker-compose.yml from. When omitted, the
+#             script reads org.opencontainers.image.revision from the image
+#             label (CI path). gz_deploy passes it explicitly (local path).
 #
 # Prerequisites on the droplet:
 #   - Docker + Docker Compose plugin installed
@@ -11,9 +15,10 @@
 #       docker login ghcr.io -u shaoster -p <PAT with read:packages>
 set -euo pipefail
 
-HOST=${1:?Usage: ./deploy.sh user@host}
+HOST=${1:?Usage: ./deploy.sh user@host [commit-sha]}
+KNOWN_SHA=${2:-}
 
-ssh "$HOST" bash <<'REMOTE'
+ssh "$HOST" bash <<REMOTE
 set -euo pipefail
 cd ~/glaze
 
@@ -21,25 +26,25 @@ echo "--- pulling latest image ---"
 docker compose pull
 
 echo "--- syncing docker-compose.yml to image commit ---"
-SHA=$(docker inspect ghcr.io/shaoster/glaze:latest \
-    --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')
-if [[ -z "$SHA" ]]; then
-    echo "WARNING: image has no revision label, docker-compose.yml not updated"
+SHA="${KNOWN_SHA}"
+if [[ -z "\$SHA" ]]; then
+    SHA=\$(docker inspect ghcr.io/shaoster/glaze:latest \
+        --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' 2>/dev/null || true)
+fi
+if [[ -z "\$SHA" ]]; then
+    echo "WARNING: commit SHA unknown, docker-compose.yml not updated"
 else
-    echo "Image built from commit $SHA"
+    echo "Image built from commit \$SHA"
     curl -fsSL \
-        "https://raw.githubusercontent.com/shaoster/glaze/${SHA}/docker-compose.yml" \
+        "https://raw.githubusercontent.com/shaoster/glaze/\${SHA}/docker-compose.yml" \
         -o docker-compose.yml
 fi
 
 echo "--- restarting services ---"
-# Migrations run automatically in docker-entrypoint.sh on container start.
 docker compose up -d
 
 echo "--- pruning stopped containers and unused images ---"
-# Remove stopped containers (old versions) so their images become reclaimable.
 docker container prune -f
-# Remove dangling images (old pulled layers no longer tagged or referenced).
 docker image prune -f
 
 echo "--- deploy complete ---"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,6 +2,7 @@
 set -e
 
 python manage.py migrate --no-input
+python manage.py collectstatic --no-input
 python manage.py load_public_library --skip-if-missing
 
 exec python -m gunicorn backend.wsgi:application \

--- a/env.sh
+++ b/env.sh
@@ -351,10 +351,12 @@ gz_deploy() {
     # Usage: gz_deploy [--no-push]
     # Reads GLAZE_PROD_HOST from .env.local (e.g. GLAZE_PROD_HOST=user@host).
     local host="${GLAZE_PROD_HOST:?Set GLAZE_PROD_HOST=user@host in .env.local}"
+    local sha
+    sha=$(git -C "$GLAZE_ROOT" rev-parse HEAD) || return 1
     if [[ "${1:-}" != "--no-push" ]]; then
         gz_push --latest || return $?
     fi
-    "$GLAZE_ROOT/deploy.sh" "$host"
+    "$GLAZE_ROOT/deploy.sh" "$host" "$sha"
 }
 
 # ---------------------------------------------------------------------------

--- a/env.sh
+++ b/env.sh
@@ -246,7 +246,7 @@ gz_setup() {
     (cd "$GLAZE_ROOT/web" && rtk npm install --silent)
 
     echo "=== Setup complete ==="
-    echo "    Run 'gz_gentypes' to regenerate TypeScript types (requires the backend)."
+    echo "    Run 'gz_gentypes' to regenerate TypeScript types via Bazel (no backend)."
     echo "    Run 'gz_start' to start both servers."
 }
 
@@ -322,9 +322,17 @@ gz_format() {
 }
 
 gz_build() {
-    _gz_ensure_node
-    gz_gentypes || return $?
-    (cd "$GLAZE_ROOT/web" && npm run build "$@")
+    # Full production build via Bazel (CI-aligned).
+    # Symlinks web/dist → bazel-bin/web/dist for easy inspection.
+    rtk bazel build //... || return $?
+    local dist_src="$GLAZE_ROOT/bazel-bin/web/dist"
+    local dist_link="$GLAZE_ROOT/web/dist"
+    if [[ ! -L "$dist_link" && -e "$dist_link" ]]; then
+        echo "gz_build: warning: $dist_link exists and is not a symlink; skipping link"
+    else
+        ln -sfn "$dist_src" "$dist_link"
+        echo "gz_build: web/dist → $dist_src"
+    fi
 }
 
 # ---------------------------------------------------------------------------
@@ -398,34 +406,13 @@ gz_logs() {    # gz_logs [backend|web]  — defaults to both
 # ---------------------------------------------------------------------------
 
 gz_gentypes() {
-    local generated_path="$GLAZE_ROOT/web/src/util/generated-types.ts"
-    local schema_path
-    schema_path="$(mktemp "${TMPDIR:-/tmp}/glaze-openapi.XXXXXX.json")" || return 1
-
-    _gz_ensure_node
-    echo "Exporting OpenAPI schema..."
-    (
-        source "$(_gz_venv_root)/.venv/bin/activate"
-        cd "$GLAZE_ROOT"
-        python manage.py spectacular --format openapi-json --file "$schema_path"
-    ) || {
-        rm -f "$schema_path"
-        return 1
-    }
-
-    echo "Regenerating shared TypeScript types..."
-    (
-        cd "$GLAZE_ROOT/web" &&
-        GLAZE_SCHEMA_SOURCE="$schema_path" npm run generate-types
-    )
-    local exit_code=$?
-    rm -f "$schema_path"
-
-    if (( exit_code == 0 )) && [[ -f "$generated_path" ]]; then
-        echo "Generated: $generated_path"
-    fi
-
-    return $exit_code
+    # Regenerate generated-types.ts via Bazel, then symlink it into the source
+    # tree so the IDE and Vite dev server pick it up without a full build.
+    rtk bazel build //web:generated_types || return $?
+    local src="$GLAZE_ROOT/bazel-bin/web/src/util/generated-types.ts"
+    local dest="$GLAZE_ROOT/web/src/util/generated-types.ts"
+    ln -sfn "$src" "$dest"
+    echo "Generated: $dest → $src"
 }
 
 _GZ_SHORTCUTS=(
@@ -449,8 +436,8 @@ _GZ_SHORTCUTS=(
     "gz_test_web       — run the web tests only"
     "gz_lint           — run all linters via Bazel: ruff, eslint, tsc, mypy"
     "gz_format         — auto-fix: ruff format + ruff check --fix (Python)"
-    "gz_build          — run the CI-aligned web build (tsc -b && vite build)"
-    "gz_gentypes       — regenerate shared TypeScript types"
+    "gz_build          — full production build via Bazel (//...); symlinks web/dist"
+    "gz_gentypes       — regenerate TypeScript types via Bazel; symlinks into src/"
     "gz_start/stop     — start or stop backend + web"
     "gz_status         — show what services are running"
     "gz_logs [backend|web] — stream backend and/or web logs"

--- a/env.sh
+++ b/env.sh
@@ -335,6 +335,28 @@ gz_build() {
     fi
 }
 
+gz_push() {
+    # Build and push the OCI image to ghcr.io/shaoster/glaze.
+    # Usage: gz_push [--latest]
+    # Always tags with the current commit SHA; pass --latest to also tag :latest.
+    local sha
+    sha=$(git -C "$GLAZE_ROOT" rev-parse HEAD) || return 1
+    local tag_args=(--tag "$sha")
+    [[ "${1:-}" == "--latest" ]] && tag_args+=(--tag latest)
+    rtk bazel run --stamp //:push -- "${tag_args[@]}"
+}
+
+gz_deploy() {
+    # Push the current image and deploy it to the production droplet.
+    # Usage: gz_deploy [--no-push]
+    # Reads GLAZE_PROD_HOST from .env.local (e.g. GLAZE_PROD_HOST=user@host).
+    local host="${GLAZE_PROD_HOST:?Set GLAZE_PROD_HOST=user@host in .env.local}"
+    if [[ "${1:-}" != "--no-push" ]]; then
+        gz_push --latest || return $?
+    fi
+    "$GLAZE_ROOT/deploy.sh" "$host"
+}
+
 # ---------------------------------------------------------------------------
 # Servers
 # ---------------------------------------------------------------------------
@@ -438,6 +460,8 @@ _GZ_SHORTCUTS=(
     "gz_format         — auto-fix: ruff format + ruff check --fix (Python)"
     "gz_build          — full production build via Bazel (//...); symlinks web/dist"
     "gz_gentypes       — regenerate TypeScript types via Bazel; symlinks into src/"
+    "gz_push [--latest]— build + push OCI image tagged with HEAD sha (and :latest)"
+    "gz_deploy [--no-push] — push image + deploy to GLAZE_PROD_HOST droplet"
     "gz_start/stop     — start or stop backend + web"
     "gz_status         — show what services are running"
     "gz_logs [backend|web] — stream backend and/or web logs"

--- a/tools/workspace_status.sh
+++ b/tools/workspace_status.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Emits stable status variables consumed by Bazel workspace stamping.
+# Used by oci_image labels so docker inspect can read the build commit.
+set -euo pipefail
+
+git_sha=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
+echo "STABLE_GIT_COMMIT ${git_sha}"

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -39,7 +39,7 @@ genrule(
 
 vite_pkg.vite(
     name = "vite_run",
-    srcs = [":web_lib"],
+    srcs = [":web_lib"] + glob([".env.*"], allow_empty = True),
     args = ["build"],
     chdir = package_name(),
     out_dirs = ["dist"],


### PR DESCRIPTION
## Summary

- Replaces the manual `Dockerfile` + `docker/build-push-action` CD step with a fully Bazel-managed OCI image build using `rules_oci` and `rules_pkg`
- Adds `//:push` target (`bazel run --stamp //:push -- --tag <sha>`) that assembles and pushes the image to `ghcr.io/shaoster/glaze`
- Folds image publish into the CI workflow (runs on push to `main` after tests pass); CD workflow now only handles deployment
- Adds `gz_push`, `gz_deploy` shell helpers for local builds and deploys

## Image layer structure

| Layer | Contents | Path in image |
|---|---|---|
| pip deps | Runtime packages from `requirements.lock` | `/app/site-packages` |
| Django source | `manage.py`, `backend/`, `api/`, `workflow.yml`, entrypoint | `/app/` |
| Vite dist | Output of `//web:web_build` | `/app/web/dist` |

`PYTHONPATH=/app/site-packages` is set as an image env var. `collectstatic` and `migrate` run at container startup via `docker-entrypoint.sh`.

## CI/CD flow change

**Before:** CI → (workflow_run) → CD: publish (Dockerfile) → CD: deploy

**After:** CI: test → CI: publish (`bazel run --stamp //:push`) → (workflow_run) → CD: deploy

`VITE_GOOGLE_CLIENT_ID` is written to `web/.env.local` in the publish job from `secrets.VITE_GOOGLE_CLIENT_ID` before the Bazel build. Local builds use an untracked `web/.env.local` (picked up via `glob([".env.*"])` in the vite srcs).

## docker-compose.yml sync

`deploy.sh` now accepts an optional `$2` commit SHA to sync `docker-compose.yml` from the correct revision. `gz_deploy` passes `git rev-parse HEAD`; `cd.yml` passes `$DEPLOY_SHA`. The `docker inspect` label fallback remains for manual invocations.

## Local workflow helpers

```bash
gz_gentypes          # bazel build //web:generated_types; symlinks into src/
gz_build             # bazel build //...; symlinks web/dist → bazel-bin/web/dist
gz_push [--latest]   # build + push OCI image tagged with HEAD SHA (and :latest)
gz_deploy [--no-push]# gz_push --latest then deploy.sh $GLAZE_PROD_HOST
```

Set `GLAZE_PROD_HOST=user@host` in `.env.local` for `gz_deploy`.

## Test plan

- [x] `bazel build //:image` completes
- [x] `gz_push --latest` pushes an image tagged with HEAD SHA and `:latest`
- [x] `gz_deploy` pushes and deploys; `docker-compose.yml` syncs to correct commit
- [ ] Container starts, serves the SPA at `/` and admin at `/admin/`
- [ ] CI `publish` job runs on push to `main` and skips on PRs
- [ ] CD `deploy` job triggers after CI completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
