### PR TITLE
Extract get_or_create_location helper to eliminate duplicate logic

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -58,6 +58,7 @@ from .models import (
     models,
 )
 from .registry import global_entry_serializer
+from .utils import get_or_create_location
 from .workflow import (
     ENTRY_STATE,
     SUCCESSORS,
@@ -374,11 +375,7 @@ class PieceCreateSerializer(serializers.ModelSerializer):
         user = self.context["request"].user
         notes = validated_data.pop("notes", "")
         location_name = validated_data.pop("current_location", None)
-        location_obj = None
-        if location_name:
-            location_obj, _ = Location.objects.get_or_create(
-                user=user, name=location_name
-            )
+        location_obj = get_or_create_location(user, location_name)
         raw_thumbnail = validated_data.pop("thumbnail", None)
         thumbnail = (
             {"url": raw_thumbnail, "cloudinary_public_id": None}
@@ -631,15 +628,9 @@ class PieceUpdateSerializer(serializers.Serializer):
         if "name" in validated_data:
             instance.name = validated_data["name"]
         if "current_location" in validated_data:
-            location_name = validated_data["current_location"]
-            if location_name:
-                user = self.context["request"].user
-                location_obj, _ = Location.objects.get_or_create(
-                    user=user, name=location_name
-                )
-            else:
-                location_obj = None
-            instance.current_location = location_obj
+            instance.current_location = get_or_create_location(
+                self.context["request"].user, validated_data["current_location"]
+            )
         if "thumbnail" in validated_data:
             instance.thumbnail = validated_data["thumbnail"]
         instance.save()

--- a/api/tests/test_piece_detail.py
+++ b/api/tests/test_piece_detail.py
@@ -44,6 +44,45 @@ class TestPieceDetail:
         assert response.json()['current_location'] == 'Shelf Z'
         assert Location.objects.filter(name='Shelf Z').exists()
 
+    def test_patch_reuses_existing_location(self, client, piece, user):
+        existing = Location.objects.create(user=user, name='Shelf Z')
+        response = client.patch(
+            f'/api/pieces/{piece.id}/',
+            {'current_location': 'Shelf Z'},
+            format='json',
+        )
+        assert response.status_code == 200
+        assert response.json()['current_location'] == 'Shelf Z'
+        assert Location.objects.filter(name='Shelf Z').count() == 1
+        piece.refresh_from_db()
+        assert piece.current_location_id == existing.id
+
+    def test_patch_clears_location_with_null(self, client, piece, user):
+        piece.current_location = Location.objects.create(user=user, name='Studio')
+        piece.save()
+        response = client.patch(
+            f'/api/pieces/{piece.id}/',
+            {'current_location': None},
+            format='json',
+        )
+        assert response.status_code == 200
+        assert response.json()['current_location'] is None
+        piece.refresh_from_db()
+        assert piece.current_location is None
+
+    def test_patch_clears_location_with_blank(self, client, piece, user):
+        piece.current_location = Location.objects.create(user=user, name='Studio')
+        piece.save()
+        response = client.patch(
+            f'/api/pieces/{piece.id}/',
+            {'current_location': ''},
+            format='json',
+        )
+        assert response.status_code == 200
+        assert response.json()['current_location'] is None
+        piece.refresh_from_db()
+        assert piece.current_location is None
+
     def test_create_sets_initial_location(self, client):
         response = client.post(
             '/api/pieces/',
@@ -54,6 +93,29 @@ class TestPieceDetail:
         data = response.json()
         assert data['current_location'] == 'Kiln Garden'
         assert Location.objects.filter(name='Kiln Garden').exists()
+
+    def test_create_reuses_existing_location(self, client, user):
+        existing = Location.objects.create(user=user, name='Kiln Garden')
+        response = client.post(
+            '/api/pieces/',
+            {'name': 'New Mug', 'current_location': 'Kiln Garden'},
+            format='json',
+        )
+        assert response.status_code == 201
+        assert response.json()['current_location'] == 'Kiln Garden'
+        assert Location.objects.filter(name='Kiln Garden').count() == 1
+        from api.models import Piece
+        piece = Piece.objects.get(name='New Mug')
+        assert piece.current_location_id == existing.id
+
+    def test_create_without_location(self, client):
+        response = client.post(
+            '/api/pieces/',
+            {'name': 'Locationless Bowl'},
+            format='json',
+        )
+        assert response.status_code == 201
+        assert response.json()['current_location'] is None
 
     def test_patch_updates_name(self, client, piece):
         response = client.patch(

--- a/api/utils.py
+++ b/api/utils.py
@@ -30,6 +30,20 @@ SHARED_GLAZE_FIELDS: tuple[str, ...] = (
 )
 
 
+def get_or_create_location(user, name: str | None):
+    """Return a Location for *user* with the given *name*, creating it if needed.
+
+    Returns ``None`` when *name* is falsy so callers can assign the result
+    directly to ``piece.current_location``.
+    """
+    if not name:
+        return None
+    from .models import Location  # noqa: PLC0415
+
+    location, _ = Location.objects.get_or_create(user=user, name=name)
+    return location
+
+
 def sync_glaze_type_singleton_combination(
     glaze_type, *, old_name: str | None = None
 ) -> None:


### PR DESCRIPTION
## Summary

- Extracts a `get_or_create_location(user, name)` helper in `api/utils.py` that both serializers now share — eliminates the duplicated `Location.objects.get_or_create` logic.
- Returns `None` for falsy names so callers assign the result directly to `piece.current_location` without an extra conditional.
- Adds five new tests covering: reuse of an existing location row on PATCH and POST, clearing location via `null` and `""`, and creating a piece with no location.

## Test plan

- [x] `bazel test //api:api_test` — all 6 API test targets pass
- [x] `bazel build --config=lint //api/...` — linters clean

Closes #67
