### PR TITLE
[codex] Fix UI issues #200-#203

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -344,7 +344,11 @@ class PieceDetailSerializer(PieceSummarySerializer):
 
 class PieceCreateSerializer(serializers.ModelSerializer):
     notes = serializers.CharField(
-        required=False, default="", allow_blank=True, max_length=300
+        required=False,
+        default="",
+        allow_blank=True,
+        max_length=300,
+        trim_whitespace=False,
     )
     current_location = serializers.CharField(
         required=False, allow_blank=True, allow_null=True, default=None
@@ -382,6 +386,7 @@ class PieceCreateSerializer(serializers.ModelSerializer):
 
 class PieceStateCreateSerializer(serializers.ModelSerializer):
     state = serializers.ChoiceField(choices=sorted(VALID_STATES))
+    notes = serializers.CharField(required=False, allow_blank=True, trim_whitespace=False)
     images = CaptionedImageSerializer(many=True, required=False, default=list)
     additional_fields = serializers.JSONField(required=False, default=dict)
 
@@ -535,7 +540,11 @@ def _write_global_ref_rows(
 class PieceStateUpdateSerializer(serializers.Serializer):
     """Partial update of the current PieceState's editable fields."""
 
-    notes = serializers.CharField(required=False, allow_blank=True)
+    notes = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        trim_whitespace=False,
+    )
     images = CaptionedImageSerializer(many=True, required=False)
     additional_fields = serializers.JSONField(required=False)
 

--- a/api/tests/test_patch_current_state.py
+++ b/api/tests/test_patch_current_state.py
@@ -23,6 +23,15 @@ class TestPatchCurrentState:
         assert response.status_code == 200
         assert response.json()['current_state']['notes'] == 'Updated notes'
 
+    def test_update_notes_preserves_trailing_spaces(self, client, piece):
+        response = client.patch(
+            f'/api/pieces/{piece.id}/state/',
+            {'notes': 'Updated notes  '},
+            format='json',
+        )
+        assert response.status_code == 200
+        assert response.json()['current_state']['notes'] == 'Updated notes  '
+
     def test_update_images(self, client, piece):
         images = [{'url': 'http://example.com/img.jpg', 'caption': 'Test', 'created': '2024-01-01T00:00:00Z'}]
         response = client.patch(

--- a/api/tests/test_piece_detail.py
+++ b/api/tests/test_piece_detail.py
@@ -168,3 +168,41 @@ class TestPieceDetail:
         PieceState.objects.create(piece=foreign_piece, state=ENTRY_STATE)
         response = client.get(f'/api/pieces/{foreign_piece.id}/')
         assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /api/pieces/{id}/current_state/
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestPieceCurrentStateDetail:
+    def test_get(self, client, piece):
+        response = client.get(f'/api/pieces/{piece.id}/current_state/')
+        assert response.status_code == 200
+        data = response.json()
+        assert data['state'] == 'designed'
+        assert 'notes' in data
+        assert 'images' in data
+        assert 'additional_fields' in data
+        assert 'previous_state' in data
+        assert 'next_state' in data
+
+    def test_not_found(self, client):
+        response = client.get(f'/api/pieces/{uuid.uuid4()}/current_state/')
+        assert response.status_code == 404
+
+    def test_piece_with_no_states_returns_404(self, client, user):
+        from api.models import Piece
+
+        piece = Piece.objects.create(user=user, name='No History Yet')
+        response = client.get(f'/api/pieces/{piece.id}/current_state/')
+        assert response.status_code == 404
+        assert response.json() == {'detail': 'Piece has no states.'}
+
+    def test_cannot_read_other_users_piece(self, client, other_user):
+        from api.models import ENTRY_STATE, Piece, PieceState
+
+        foreign_piece = Piece.objects.create(user=other_user, name='Other User Piece')
+        PieceState.objects.create(piece=foreign_piece, state=ENTRY_STATE)
+        response = client.get(f'/api/pieces/{foreign_piece.id}/current_state/')
+        assert response.status_code == 404

--- a/api/urls.py
+++ b/api/urls.py
@@ -16,6 +16,11 @@ urlpatterns = [
     path('pieces/', views.pieces, name='pieces'),
     path('pieces/<uuid:piece_id>/', views.piece_detail, name='piece-detail'),
     path('pieces/<uuid:piece_id>/states/', views.piece_states, name='piece-states'),
+    path(
+        'pieces/<uuid:piece_id>/current_state/',
+        views.piece_current_state_detail,
+        name='piece-current-state-detail',
+    ),
     path('pieces/<uuid:piece_id>/state/', views.piece_current_state, name='piece-current-state'),
     path(
         'uploads/cloudinary/widget-config/',

--- a/api/views.py
+++ b/api/views.py
@@ -38,6 +38,7 @@ from .serializers import (
     PieceCreateSerializer,
     PieceDetailSerializer,
     PieceStateCreateSerializer,
+    PieceStateSerializer,
     PieceStateUpdateSerializer,
     PieceSummarySerializer,
     PieceUpdateSerializer,
@@ -161,6 +162,22 @@ def piece_states(request: Request, piece_id: str) -> Response:
     # Reload to pick up updated last_modified on current_state
     piece.refresh_from_db()
     return Response(PieceDetailSerializer(piece).data, status=status.HTTP_201_CREATED)
+
+
+@extend_schema(
+    methods=["GET"],
+    responses={200: PieceStateSerializer},
+)
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def piece_current_state_detail(request: Request, piece_id: str) -> Response:
+    piece = get_object_or_404(_piece_queryset(request), pk=piece_id)
+    current = piece.current_state
+    if current is None:
+        return Response(
+            {"detail": "Piece has no states."}, status=status.HTTP_404_NOT_FOUND
+        )
+    return Response(PieceStateSerializer(current).data)
 
 
 @extend_schema(

--- a/docs/agents/glaze-domain.md
+++ b/docs/agents/glaze-domain.md
@@ -257,10 +257,17 @@ Name uniqueness for public globals is enforced with two conditional DB constrain
 - `POST /api/auth/google/` → Google OAuth 2.0 login via JWT credential
 - `GET /api/pieces/` → list of `PieceSummary`
 - `GET /api/pieces/<id>/` → `PieceDetail`
+- `GET /api/pieces/<id>/current_state/` → the current editable `PieceState` only
 - `POST /api/pieces/` → create a new piece (always starts in `designed` state; accepts `name`, optional `thumbnail`, and optional `notes`)
 - `POST /api/pieces/<id>/states/` → record a new state transition
 - `PATCH /api/pieces/<id>/` → update piece-level editable fields (currently location)
 - `PATCH /api/pieces/<id>/state/` → update current state's editable fields
+
+**Piece vs. current-state access pattern:**
+
+- Use `GET /api/pieces/<id>/` when the screen needs the whole piece aggregate: piece metadata, current state, and history together.
+- Use `GET /api/pieces/<id>/current_state/` when a child workflow editor owns only the editable current-state slice and does not need to refetch the parent `PieceDetail` payload or full history.
+- Do not introduce `GET /api/piece-states/<state_id>/` as a primary client access pattern. Past states are sealed history; the API surface should stay centered on the piece aggregate plus its single current editable state.
 - `GET /api/globals/<global_name>/` → for private-only globals returns only the user's private objects; for public globals returns the user's private objects union all public objects (`user=NULL`), sorted by display field. Each item includes `is_public: bool`. **`global_entries` is the canonical list endpoint for all global types — do not add a separate `/api/<global-name>/` list route.**
   - Models may opt in to richer GET responses by declaring a `filter_queryset(qs, request)` classmethod (for query-param filtering) and registering a serializer in `_GLOBAL_ENTRY_SERIALIZERS` in `api/views.py`. `GlazeCombination` uses both: it supports `?glaze_type_ids=`, `?is_food_safe=`, `?runs=`, `?highlights_grooves=`, `?is_different_on_white_and_brown_clay=` query params and returns additional fields (`test_tile_image`, filter booleans, `glaze_types` list, `is_favorite`).
 - `POST /api/globals/<global_name>/` → get-or-create a private record owned by the requesting user. For public globals, a private entry with the same name as a public entry is permitted — the two scopes are independent.

--- a/docs/agents/typescript-react-vite.md
+++ b/docs/agents/typescript-react-vite.md
@@ -71,6 +71,35 @@ This is a Single Page Application (SPA). Routing is handled client-side via Reac
 - **Maximum JSX nesting depth of 4.** If a component's JSX tree would exceed 4 levels of element nesting, extract the deeper subtree into a named child component with typed props. This also sidesteps TypeScript narrowing limitations: instead of narrowing a `string | undefined` inside a callback nested in a ternary branch, pass the already-narrowed value as a `string` prop to a child component.
 - Before splitting a large component, decide what the new boundary owns. Good splits usually create either a pure presentational subtree or a child that owns a coherent slice of state and business logic. Bad splits mostly move JSX into another file while still threading parent-owned state and setters through every layer.
 
+## Local state shape
+
+- Prefer plain `useState` when the component has one or two independent fields and the update rules are obvious from the setter call site.
+- Migrate to `useReducer` when the local state behaves like a small state machine: several fields must change together, updates depend on the previous draft and the previous server snapshot, or multiple event sources can advance the same state differently.
+- A reducer is usually justified when you see any of these:
+  - More than two sibling `useState` values that conceptually form one draft or workflow.
+  - Repeated "if X changed, also patch Y and maybe reset Z" logic spread across handlers and effects.
+  - Async server responses racing with local user edits, especially when "hydrate from server unless the user already changed this field" rules appear.
+  - Effects that exist mostly to observe one piece of React state and synchronously push updates into another piece of React state.
+- Do not migrate to a reducer just because a component is long. If the state is simple and the complexity is mostly rendering, extract child components first.
+
+## Reducer migration checklist
+
+When migrating a drafty or workflow-heavy component from multiple setters to a reducer, check these explicitly:
+
+- Define the reducer around domain events, not UI implementation details. Good action names look like `hydrate`, `edit_notes`, `select_tag`, `save_succeeded`, `save_failed`.
+- Keep one authoritative draft object when the fields conceptually travel together. Avoid parallel `useState` values plus a reducer unless there is a clear ownership boundary.
+- Audit old observer-style `useEffect` code carefully. Effects that used to watch state and call sibling setters are often the reason to adopt a reducer in the first place.
+- Preserve the source-of-truth boundary. Derived values from props or server data should usually stay derived; the reducer should own the editable draft, not duplicate every computed value.
+- Be explicit about hydration semantics. Decide what happens when new server data arrives while the user has unsaved edits:
+  - replace everything
+  - merge only untouched fields
+  - ignore stale responses entirely
+- Cover async races in tests. Add at least one test where a local edit exists and a stale or partial upstream update arrives afterward.
+- Re-check dirty-state logic after the migration. Reducers often change object identity patterns, which can accidentally make "is dirty?" checks always true or always false.
+- Re-check autosave/manual-save triggers after the migration. Make sure the reducer did not introduce effect loops or duplicate saves.
+- Re-check lint pressure from `react-hooks/set-state-in-effect`. If an effect still exists after the migration, it should usually bridge React to an external system or dispatch a single domain event rather than synchronously juggling multiple local setters.
+- Re-check callback ownership. If you are tempted to "just dispatch in the async callback instead of in an effect," verify that the callback is the only path that can update the upstream data. If props can also change because of parent refreshes, route changes, optimistic rollbacks, or sibling saves, keep a prop-to-reducer synchronization path.
+
 ## Custom hooks
 
 Extract reusable logic into custom hooks rather than duplicating it across components. A `useAsync` hook is the idiomatic Axios-native pattern for managing loading/error/data state without a server-state library:

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -339,6 +339,7 @@ js_library(
     name = "workflow_state_src",
     srcs = [
         "src/components/WorkflowState.tsx",
+        "src/components/workflowStateDraft.ts",
     ],
     deps = [
         ":autosave_src",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -513,9 +513,13 @@ function AppShell({
       maxWidth="lg"
       sx={{
         minHeight: "100dvh",
-        py: 2,
+        pt: {
+          xs: "max(12px, calc(env(safe-area-inset-top) + 8px))",
+          sm: 2,
+        },
+        pb: 2,
         px: {
-          xs: "max(16px, env(safe-area-inset-left))",
+          xs: "max(16px, env(safe-area-inset-left)) max(16px, env(safe-area-inset-right))",
           sm: 3,
         },
       }}
@@ -556,6 +560,7 @@ function AppShell({
           label={displayName}
           color="primary"
           variant="outlined"
+          size="small"
           onClick={(e) => setMenuAnchor(e.currentTarget)}
           onDelete={(e) => setMenuAnchor(e.currentTarget)}
           deleteIcon={<ExpandMoreIcon />}

--- a/web/src/components/GlobalEntryDialog.tsx
+++ b/web/src/components/GlobalEntryDialog.tsx
@@ -128,6 +128,10 @@ function createDisplayTitle(globalName: string): string {
   return `Browse ${formatWorkflowFieldLabel(globalName)}s`;
 }
 
+function getVisibilityLabel(entry: GenericGlobalEntry): string {
+  return entry.is_public ? "Public" : "Private";
+}
+
 // One dialog handles both "pick an existing entry" and "create a new entry"
 // flows so every global-ref field can share the same behavior and tests.
 export default function GlobalEntryDialog({
@@ -558,7 +562,8 @@ export default function GlobalEntryDialog({
                       <Typography variant="body1" fontWeight="medium" noWrap>
                         {entry.name}
                       </Typography>
-                      {relatedFilterDefs.some((rf) => entry[rf.entryKey]) && (
+                      {(relatedFilterDefs.some((rf) => entry[rf.entryKey]) ||
+                        typeof entry.is_public === "boolean") && (
                         <Box
                           sx={{
                             display: "flex",
@@ -586,8 +591,12 @@ export default function GlobalEntryDialog({
                               />
                             );
                           })}
-                          {entry.is_public && (
-                            <Chip label="public" size="small" variant="outlined" />
+                          {typeof entry.is_public === "boolean" && (
+                            <Chip
+                              label={getVisibilityLabel(entry)}
+                              size="small"
+                              variant={entry.is_public ? "outlined" : "filled"}
+                            />
                           )}
                         </Box>
                       )}

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -463,7 +463,7 @@ function PieceDetailContent({
         <SectionCard>
           <WorkflowState
             key={currentState.state + currentState.created.toISOString()}
-            pieceState={currentState}
+            initialPieceState={currentState}
             pieceId={piece.id}
             onSaved={onPieceUpdated}
             onDirtyChange={setIsDirty}

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -165,10 +165,11 @@ function SelectorPanel({
 
 type PieceListItemProps = {
   piece: PieceSummary;
+  activeTagIds: string[];
 };
 
 const PieceListItem = (props: PieceListItemProps) => {
-  const { piece } = props;
+  const { piece, activeTagIds } = props;
   const detailPath = `/pieces/${piece.id}`;
 
   return (
@@ -220,7 +221,11 @@ const PieceListItem = (props: PieceListItemProps) => {
               variant="current"
               isTerminal={isTerminalState(piece.current_state.state)}
             />
-            <TagChipList tags={piece.tags ?? []} />
+            <TagChipList
+              tags={piece.tags ?? []}
+              maxVisible={3}
+              alwaysVisibleTagIds={activeTagIds}
+            />
           </CardContent>
         </CardActionArea>
       </Card>
@@ -352,7 +357,11 @@ const PieceList = (props: PieceListingProps) => {
       </Box>
       <Grid container spacing={1} alignItems="stretch" role="rowgroup">
         {filteredPieces.map((piece) => (
-          <PieceListItem key={piece.id} piece={piece} />
+          <PieceListItem
+            key={piece.id}
+            piece={piece}
+            activeTagIds={activeTags.map((tag) => tag.id)}
+          />
         ))}
       </Grid>
     </>

--- a/web/src/components/TagChipList.tsx
+++ b/web/src/components/TagChipList.tsx
@@ -1,22 +1,84 @@
+import { useMemo, useState } from "react";
 import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
 
 import TagChip from "./TagChip";
 import type { TagEntry } from "../util/types";
 
 interface TagChipListProps {
   tags: TagEntry[];
+  maxVisible?: number;
+  alwaysVisibleTagIds?: string[];
 }
 
-export default function TagChipList({ tags }: TagChipListProps) {
+export default function TagChipList({
+  tags,
+  maxVisible,
+  alwaysVisibleTagIds = [],
+}: TagChipListProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const { hiddenCount, visibleTags } = useMemo(() => {
+    if (maxVisible === undefined || tags.length <= maxVisible || expanded) {
+      return { visibleTags: tags, hiddenCount: 0 };
+    }
+
+    const forcedVisibleIds = new Set(alwaysVisibleTagIds);
+    const visibleIds = new Set<string>();
+    const targetVisibleCount = Math.max(
+      maxVisible,
+      tags.filter((tag) => forcedVisibleIds.has(tag.id)).length,
+    );
+
+    for (const tag of tags) {
+      if (forcedVisibleIds.has(tag.id)) {
+        visibleIds.add(tag.id);
+      }
+    }
+
+    for (const tag of tags) {
+      if (visibleIds.size >= targetVisibleCount) {
+        break;
+      }
+      visibleIds.add(tag.id);
+    }
+
+    const nextVisibleTags = tags.filter((tag) => visibleIds.has(tag.id));
+    return {
+      visibleTags: nextVisibleTags,
+      hiddenCount: Math.max(tags.length - nextVisibleTags.length, 0),
+    };
+  }, [alwaysVisibleTagIds, expanded, maxVisible, tags]);
+
   if (tags.length === 0) {
     return null;
   }
 
   return (
     <Box sx={{ display: "flex", gap: 0.5, flexWrap: "wrap" }}>
-      {tags.map((tag) => (
+      {visibleTags.map((tag) => (
         <TagChip key={tag.id} label={tag.name} color={tag.color} />
       ))}
+      {hiddenCount > 0 && (
+        <Button
+          size="small"
+          variant="text"
+          onClick={() => setExpanded(true)}
+          sx={{ minWidth: 0, px: 0.5, alignSelf: "center" }}
+        >
+          +{hiddenCount} more
+        </Button>
+      )}
+      {expanded && maxVisible !== undefined && tags.length > maxVisible && (
+        <Button
+          size="small"
+          variant="text"
+          onClick={() => setExpanded(false)}
+          sx={{ minWidth: 0, px: 0.5, alignSelf: "center" }}
+        >
+          Show less
+        </Button>
+      )}
     </Box>
   );
 }

--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
 import PhotoCameraOutlinedIcon from "@mui/icons-material/PhotoCameraOutlined";
 import { useTheme } from "@mui/material";
 import {
@@ -44,6 +44,21 @@ type WorkflowStateProps = {
 
 type AdditionalFieldInputMap = Record<string, string>;
 type GlobalRefPkMap = Record<string, string>;
+type DraftState = {
+  notes: string;
+  images: ImageEntry[];
+  additionalFieldInputs: AdditionalFieldInputMap;
+  globalRefPks: GlobalRefPkMap;
+};
+type DraftAction =
+  | {
+      type: "hydrate";
+      nextBaseDraft: DraftState;
+      previousBaseDraft: DraftState;
+    }
+  | { type: "set_notes"; notes: string }
+  | { type: "set_additional_field"; name: string; value: string }
+  | { type: "set_global_ref_pks"; globalRefPks: GlobalRefPkMap };
 
 // Global-ref objects always carry an id and name. Any object without a name
 // is not a valid global ref value — treat it as empty so callers receive a
@@ -156,6 +171,51 @@ function stateImages(pieceState: PieceState): ImageEntry[] {
   }));
 }
 
+function draftsMatch<T>(currentValue: T, previousValue: T): boolean {
+  return JSON.stringify(currentValue) === JSON.stringify(previousValue);
+}
+
+function draftReducer(state: DraftState, action: DraftAction): DraftState {
+  switch (action.type) {
+    case "hydrate":
+      return {
+        notes:
+          state.notes === action.previousBaseDraft.notes
+            ? action.nextBaseDraft.notes
+            : state.notes,
+        images: draftsMatch(state.images, action.previousBaseDraft.images)
+          ? action.nextBaseDraft.images
+          : state.images,
+        additionalFieldInputs: draftsMatch(
+          state.additionalFieldInputs,
+          action.previousBaseDraft.additionalFieldInputs,
+        )
+          ? action.nextBaseDraft.additionalFieldInputs
+          : state.additionalFieldInputs,
+        globalRefPks: draftsMatch(
+          state.globalRefPks,
+          action.previousBaseDraft.globalRefPks,
+        )
+          ? action.nextBaseDraft.globalRefPks
+          : state.globalRefPks,
+      };
+    case "set_notes":
+      return { ...state, notes: action.notes };
+    case "set_additional_field":
+      return {
+        ...state,
+        additionalFieldInputs: {
+          ...state.additionalFieldInputs,
+          [action.name]: action.value,
+        },
+      };
+    case "set_global_ref_pks":
+      return { ...state, globalRefPks: action.globalRefPks };
+    default:
+      return state;
+  }
+}
+
 // ── ImageUploader ─────────────────────────────────────────────────────────────
 
 type ImageUploaderProps = {
@@ -260,8 +320,6 @@ export default function WorkflowState({
   onDirtyChange,
   autosaveDelayMs,
 }: WorkflowStateProps) {
-  const [notes, setNotes] = useState(pieceState.notes);
-  const [images, setImages] = useState<ImageEntry[]>(stateImages(pieceState));
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [widgetLoading, setWidgetLoading] = useState(false);
   const additionalFieldDefs = useMemo(
@@ -280,12 +338,9 @@ export default function WorkflowState({
       globalRefPks: buildGlobalRefPkMap(additionalFieldDefs, additionalFields),
     };
   }, [additionalFieldDefs, pieceState]);
-  const [additionalFieldInputs, setAdditionalFieldInputs] = useState(
-    baseDraft.additionalFieldInputs,
-  );
-  const [globalRefPks, setGlobalRefPks] = useState<GlobalRefPkMap>(
-    baseDraft.globalRefPks,
-  );
+  const [draft, dispatch] = useReducer(draftReducer, baseDraft);
+  const previousBaseDraftRef = useRef(baseDraft);
+  const { notes, images, additionalFieldInputs, globalRefPks } = draft;
   const normalizedAdditionalFields = useMemo(
     () =>
       normalizeAdditionalFieldPayload(
@@ -312,10 +367,15 @@ export default function WorkflowState({
   const isMobileLayout = useMediaQuery(theme.breakpoints.down("sm"));
 
   useEffect(() => {
-    setNotes(baseDraft.notes);
-    setImages(baseDraft.images);
-    setAdditionalFieldInputs(baseDraft.additionalFieldInputs);
-    setGlobalRefPks(baseDraft.globalRefPks);
+    if (previousBaseDraftRef.current === baseDraft) {
+      return;
+    }
+    dispatch({
+      type: "hydrate",
+      nextBaseDraft: baseDraft,
+      previousBaseDraft: previousBaseDraftRef.current,
+    });
+    previousBaseDraftRef.current = baseDraft;
   }, [baseDraft]);
 
   const [savingImage, setSavingImage] = useState(false);
@@ -472,7 +532,7 @@ export default function WorkflowState({
   }
 
   function handleFieldChange(name: string, value: string) {
-    setAdditionalFieldInputs((prev) => ({ ...prev, [name]: value }));
+    dispatch({ type: "set_additional_field", name, value });
   }
 
   return (
@@ -490,7 +550,7 @@ export default function WorkflowState({
         multiline
         minRows={3}
         value={notes}
-        onChange={(e) => setNotes(e.target.value)}
+        onChange={(e) => dispatch({ type: "set_notes", notes: e.target.value })}
         slotProps={{ htmlInput: { maxLength: 2000 } }}
         fullWidth
       />
@@ -533,15 +593,16 @@ export default function WorkflowState({
                     value={value}
                     onSelect={(entry) => {
                       handleFieldChange(field.name, entryNameOrEmpty(entry));
-                      setGlobalRefPks((prev) =>
-                        entry
-                          ? { ...prev, [field.name]: entry.id }
+                      dispatch({
+                        type: "set_global_ref_pks",
+                        globalRefPks: entry
+                          ? { ...globalRefPks, [field.name]: entry.id }
                           : Object.fromEntries(
-                              Object.entries(prev).filter(
+                              Object.entries(globalRefPks).filter(
                                 ([key]) => key !== field.name,
                               ),
                             ),
-                      );
+                      });
                     }}
                     canCreate={Boolean(field.canCreate)}
                     helperText={helperText}

--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useState } from "react";
 import PhotoCameraOutlinedIcon from "@mui/icons-material/PhotoCameraOutlined";
 import { useTheme } from "@mui/material";
 import {
@@ -35,7 +35,7 @@ export type ImageEntry = {
 };
 
 type WorkflowStateProps = {
-  pieceState: PieceState;
+  initialPieceState: PieceState;
   pieceId: string;
   onSaved: (updated: PieceDetail) => void;
   onDirtyChange?: (dirty: boolean) => void;
@@ -45,17 +45,14 @@ type WorkflowStateProps = {
 type AdditionalFieldInputMap = Record<string, string>;
 type GlobalRefPkMap = Record<string, string>;
 type DraftState = {
+  baseState: PieceState;
   notes: string;
   images: ImageEntry[];
   additionalFieldInputs: AdditionalFieldInputMap;
   globalRefPks: GlobalRefPkMap;
 };
 type DraftAction =
-  | {
-      type: "hydrate";
-      nextBaseDraft: DraftState;
-      previousBaseDraft: DraftState;
-    }
+  | { type: "replace_base_state"; pieceState: PieceState }
   | { type: "set_notes"; notes: string }
   | { type: "set_additional_field"; name: string; value: string }
   | { type: "set_global_ref_pks"; globalRefPks: GlobalRefPkMap };
@@ -171,34 +168,25 @@ function stateImages(pieceState: PieceState): ImageEntry[] {
   }));
 }
 
-function draftsMatch<T>(currentValue: T, previousValue: T): boolean {
-  return JSON.stringify(currentValue) === JSON.stringify(previousValue);
+function buildDraftState(pieceState: PieceState): DraftState {
+  const additionalFieldDefs = getAdditionalFieldDefinitions(pieceState.state);
+  const additionalFields = pieceState.additional_fields ?? {};
+  return {
+    baseState: pieceState,
+    notes: pieceState.notes,
+    images: stateImages(pieceState),
+    additionalFieldInputs: buildAdditionalFieldInputMap(
+      additionalFieldDefs,
+      additionalFields,
+    ),
+    globalRefPks: buildGlobalRefPkMap(additionalFieldDefs, additionalFields),
+  };
 }
 
 function draftReducer(state: DraftState, action: DraftAction): DraftState {
   switch (action.type) {
-    case "hydrate":
-      return {
-        notes:
-          state.notes === action.previousBaseDraft.notes
-            ? action.nextBaseDraft.notes
-            : state.notes,
-        images: draftsMatch(state.images, action.previousBaseDraft.images)
-          ? action.nextBaseDraft.images
-          : state.images,
-        additionalFieldInputs: draftsMatch(
-          state.additionalFieldInputs,
-          action.previousBaseDraft.additionalFieldInputs,
-        )
-          ? action.nextBaseDraft.additionalFieldInputs
-          : state.additionalFieldInputs,
-        globalRefPks: draftsMatch(
-          state.globalRefPks,
-          action.previousBaseDraft.globalRefPks,
-        )
-          ? action.nextBaseDraft.globalRefPks
-          : state.globalRefPks,
-      };
+    case "replace_base_state":
+      return buildDraftState(action.pieceState);
     case "set_notes":
       return { ...state, notes: action.notes };
     case "set_additional_field":
@@ -314,7 +302,7 @@ function ImageUploader({
 // ── WorkflowState ─────────────────────────────────────────────────────────────
 
 export default function WorkflowState({
-  pieceState,
+  initialPieceState,
   pieceId,
   onSaved,
   onDirtyChange,
@@ -322,25 +310,16 @@ export default function WorkflowState({
 }: WorkflowStateProps) {
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [widgetLoading, setWidgetLoading] = useState(false);
-  const additionalFieldDefs = useMemo(
-    () => getAdditionalFieldDefinitions(pieceState.state),
-    [pieceState.state],
+  const [draft, dispatch] = useReducer(
+    draftReducer,
+    initialPieceState,
+    buildDraftState,
   );
-  const baseDraft = useMemo(() => {
-    const additionalFields = pieceState.additional_fields ?? {};
-    return {
-      notes: pieceState.notes,
-      images: stateImages(pieceState),
-      additionalFieldInputs: buildAdditionalFieldInputMap(
-        additionalFieldDefs,
-        additionalFields,
-      ),
-      globalRefPks: buildGlobalRefPkMap(additionalFieldDefs, additionalFields),
-    };
-  }, [additionalFieldDefs, pieceState]);
-  const [draft, dispatch] = useReducer(draftReducer, baseDraft);
-  const previousBaseDraftRef = useRef(baseDraft);
-  const { notes, images, additionalFieldInputs, globalRefPks } = draft;
+  const { baseState, notes, images, additionalFieldInputs, globalRefPks } = draft;
+  const additionalFieldDefs = useMemo(
+    () => getAdditionalFieldDefinitions(baseState.state),
+    [baseState.state],
+  );
   const normalizedAdditionalFields = useMemo(
     () =>
       normalizeAdditionalFieldPayload(
@@ -354,10 +333,18 @@ export default function WorkflowState({
     () =>
       normalizeAdditionalFieldPayload(
         additionalFieldDefs,
-        baseDraft.additionalFieldInputs,
-        baseDraft.globalRefPks,
+        draft.baseState.additional_fields
+          ? buildAdditionalFieldInputMap(
+              additionalFieldDefs,
+              draft.baseState.additional_fields,
+            )
+          : {},
+        buildGlobalRefPkMap(
+          additionalFieldDefs,
+          draft.baseState.additional_fields ?? {},
+        ),
       ),
-    [additionalFieldDefs, baseDraft],
+    [additionalFieldDefs, draft.baseState.additional_fields],
   );
   const additionalFieldsDirty =
     JSON.stringify(normalizedAdditionalFields) !==
@@ -366,22 +353,10 @@ export default function WorkflowState({
   const theme = useTheme();
   const isMobileLayout = useMediaQuery(theme.breakpoints.down("sm"));
 
-  useEffect(() => {
-    if (previousBaseDraftRef.current === baseDraft) {
-      return;
-    }
-    dispatch({
-      type: "hydrate",
-      nextBaseDraft: baseDraft,
-      previousBaseDraft: previousBaseDraftRef.current,
-    });
-    previousBaseDraftRef.current = baseDraft;
-  }, [baseDraft]);
-
   const [savingImage, setSavingImage] = useState(false);
   const [imageError, setImageError] = useState<string | null>(null);
 
-  const isDirty = notes !== pieceState.notes || additionalFieldsDirty;
+  const isDirty = notes !== baseState.notes || additionalFieldsDirty;
 
   useEffect(() => {
     onDirtyChange?.(isDirty);
@@ -394,13 +369,14 @@ export default function WorkflowState({
       additional_fields: normalizedAdditionalFields,
     };
     const result = await updateCurrentState(pieceId, payload);
+    dispatch({ type: "replace_base_state", pieceState: result.current_state });
     onSaved(result);
   }, [
+    pieceId,
     images,
     normalizedAdditionalFields,
     notes,
     onSaved,
-    pieceId,
   ]);
 
   const autosaveKey = useMemo(
@@ -520,7 +496,13 @@ export default function WorkflowState({
             images: [...images, newImage],
             additional_fields: normalizedAdditionalFields,
           })
-            .then(onSaved)
+            .then((result) => {
+              dispatch({
+                type: "replace_base_state",
+                pieceState: result.current_state,
+              });
+              onSaved(result);
+            })
             .catch(() =>
               setImageError("Failed to save image. Please try again."),
             )

--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -19,7 +19,6 @@ import {
   updateCurrentState,
 } from "../util/api";
 import {
-  type ResolvedAdditionalField,
   getAdditionalFieldDefinitions,
 } from "../util/workflow";
 import { entryNameOrEmpty } from "../util/optionalValues";
@@ -27,12 +26,11 @@ import GlobalEntryField from "./GlobalEntryField";
 import AutosaveStatus from "./AutosaveStatus";
 import { useAutosave } from "./useAutosave";
 import { usePieceDetailSaveStatus } from "./usePieceDetailSaveStatus";
-
-export type ImageEntry = {
-  url: string;
-  caption: string;
-  cloudinary_public_id?: string | null;
-};
+import {
+  buildDraftState,
+  draftReducer,
+  normalizeAdditionalFieldPayload,
+} from "./workflowStateDraft";
 
 type WorkflowStateProps = {
   initialPieceState: PieceState;
@@ -42,167 +40,6 @@ type WorkflowStateProps = {
   autosaveDelayMs?: number;
 };
 
-type AdditionalFieldInputMap = Record<string, string>;
-type GlobalRefPkMap = Record<string, string>;
-type DraftState = {
-  baseState: PieceState;
-  notes: string;
-  images: ImageEntry[];
-  additionalFieldInputs: AdditionalFieldInputMap;
-  globalRefPks: GlobalRefPkMap;
-};
-type DraftAction =
-  | { type: "replace_base_state"; pieceState: PieceState }
-  | { type: "set_notes"; notes: string }
-  | { type: "set_additional_field"; name: string; value: string }
-  | { type: "set_global_ref_pks"; globalRefPks: GlobalRefPkMap };
-
-// Global-ref objects always carry an id and name. Any object without a name
-// is not a valid global ref value — treat it as empty so callers receive a
-// typed contract rather than a runtime fallback.
-function formatAdditionalFieldValue(
-  value: unknown,
-  type: ResolvedAdditionalField["type"],
-): string {
-  if (value === null || value === undefined) {
-    return "";
-  }
-  if (typeof value === "object") {
-    const obj = value as Record<string, unknown>;
-    if (typeof obj.name === "string") {
-      return obj.name;
-    }
-    // Objects without a name field are not representable as a string input.
-    return "";
-  }
-  if (type === "boolean") {
-    return value ? "true" : "false";
-  }
-  return String(value);
-}
-
-function extractGlobalRefPk(value: unknown): string | undefined {
-  if (typeof value === "object" && value !== null && "id" in value) {
-    const id = (value as { id: unknown }).id;
-    return typeof id === "string" ? id : undefined;
-  }
-  return undefined;
-}
-
-function buildAdditionalFieldInputMap(
-  defs: ResolvedAdditionalField[],
-  values: Record<string, unknown>,
-): AdditionalFieldInputMap {
-  const map: AdditionalFieldInputMap = {};
-  defs.forEach((def) => {
-    map[def.name] = formatAdditionalFieldValue(values[def.name], def.type);
-  });
-  return map;
-}
-
-function buildGlobalRefPkMap(
-  defs: ResolvedAdditionalField[],
-  values: Record<string, unknown>,
-): GlobalRefPkMap {
-  const map: GlobalRefPkMap = {};
-  defs.forEach((def) => {
-    if (def.isGlobalRef) {
-      const pk = extractGlobalRefPk(values[def.name]);
-      if (pk) map[def.name] = pk;
-    }
-  });
-  return map;
-}
-
-function normalizeAdditionalFieldPayload(
-  defs: ResolvedAdditionalField[],
-  inputs: AdditionalFieldInputMap,
-  globalRefPks: GlobalRefPkMap,
-): Record<string, string | number | boolean | null> {
-  const payload: Record<string, string | number | boolean | null> = {};
-  defs.forEach((def) => {
-    if (def.isGlobalRef) {
-      const pk = globalRefPks[def.name];
-      payload[def.name] = pk || null;
-      return;
-    }
-    // buildAdditionalFieldInputMap initializes all def names, so `raw` is
-    // always a string here. Guard is defensive for future call sites.
-    const raw = inputs[def.name] ?? "";
-    const trimmed = raw.trim();
-    if (trimmed === "") {
-      return;
-    }
-    if (def.type === "integer") {
-      const parsed = parseInt(trimmed, 10);
-      if (!Number.isNaN(parsed)) {
-        payload[def.name] = parsed;
-      }
-      return;
-    }
-    if (def.type === "number") {
-      const parsed = Number(trimmed);
-      if (!Number.isNaN(parsed)) {
-        payload[def.name] = parsed;
-      }
-      return;
-    }
-    if (def.type === "boolean") {
-      if (trimmed === "true") {
-        payload[def.name] = true;
-      } else if (trimmed === "false") {
-        payload[def.name] = false;
-      }
-      return;
-    }
-    payload[def.name] = raw;
-  });
-  return payload;
-}
-
-function stateImages(pieceState: PieceState): ImageEntry[] {
-  return pieceState.images.map((img) => ({
-    url: img.url,
-    caption: img.caption,
-    cloudinary_public_id: img.cloudinary_public_id ?? null,
-  }));
-}
-
-function buildDraftState(pieceState: PieceState): DraftState {
-  const additionalFieldDefs = getAdditionalFieldDefinitions(pieceState.state);
-  const additionalFields = pieceState.additional_fields ?? {};
-  return {
-    baseState: pieceState,
-    notes: pieceState.notes,
-    images: stateImages(pieceState),
-    additionalFieldInputs: buildAdditionalFieldInputMap(
-      additionalFieldDefs,
-      additionalFields,
-    ),
-    globalRefPks: buildGlobalRefPkMap(additionalFieldDefs, additionalFields),
-  };
-}
-
-function draftReducer(state: DraftState, action: DraftAction): DraftState {
-  switch (action.type) {
-    case "replace_base_state":
-      return buildDraftState(action.pieceState);
-    case "set_notes":
-      return { ...state, notes: action.notes };
-    case "set_additional_field":
-      return {
-        ...state,
-        additionalFieldInputs: {
-          ...state.additionalFieldInputs,
-          [action.name]: action.value,
-        },
-      };
-    case "set_global_ref_pks":
-      return { ...state, globalRefPks: action.globalRefPks };
-    default:
-      return state;
-  }
-}
 
 // ── ImageUploader ─────────────────────────────────────────────────────────────
 
@@ -316,6 +153,7 @@ export default function WorkflowState({
     buildDraftState,
   );
   const { baseState, notes, images, additionalFieldInputs, globalRefPks } = draft;
+  const baseDraft = useMemo(() => buildDraftState(baseState), [baseState]);
   const additionalFieldDefs = useMemo(
     () => getAdditionalFieldDefinitions(baseState.state),
     [baseState.state],
@@ -333,18 +171,10 @@ export default function WorkflowState({
     () =>
       normalizeAdditionalFieldPayload(
         additionalFieldDefs,
-        draft.baseState.additional_fields
-          ? buildAdditionalFieldInputMap(
-              additionalFieldDefs,
-              draft.baseState.additional_fields,
-            )
-          : {},
-        buildGlobalRefPkMap(
-          additionalFieldDefs,
-          draft.baseState.additional_fields ?? {},
-        ),
+        baseDraft.additionalFieldInputs,
+        baseDraft.globalRefPks,
       ),
-    [additionalFieldDefs, draft.baseState.additional_fields],
+    [additionalFieldDefs, baseDraft.additionalFieldInputs, baseDraft.globalRefPks],
   );
   const additionalFieldsDirty =
     JSON.stringify(normalizedAdditionalFields) !==

--- a/web/src/components/__tests__/GlobalEntryDialog.test.tsx
+++ b/web/src/components/__tests__/GlobalEntryDialog.test.tsx
@@ -140,6 +140,29 @@ describe("GlobalEntryDialog", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it("shows whether matching entries are public or private", async () => {
+    vi.mocked(api.fetchGlobalEntriesWithFilters).mockResolvedValue([
+      makeCombo({ id: "public-entry", name: "Studio White", is_public: true }),
+      makeCombo({ id: "private-entry", name: "Studio White", is_public: false }),
+    ]);
+
+    render(
+      <GlobalEntryDialog
+        globalName="glaze_combination"
+        open
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getAllByText("Studio White")).toHaveLength(2),
+    );
+
+    expect(screen.getByText("Public")).toBeInTheDocument();
+    expect(screen.getByText("Private")).toBeInTheDocument();
+  });
+
   it("toggles favorites from the browse tab", async () => {
     render(
       <GlobalEntryDialog

--- a/web/src/components/__tests__/PieceDetail.test.tsx
+++ b/web/src/components/__tests__/PieceDetail.test.tsx
@@ -11,6 +11,7 @@ import {
 import { ThemeProvider, createTheme } from "@mui/material/styles";
 import { createMemoryRouter, RouterProvider } from "react-router-dom";
 import PieceDetail from "../PieceDetail";
+import WorkflowState from "../WorkflowState";
 import type {
   PieceDetail as PieceDetailType,
   PieceState,
@@ -196,6 +197,38 @@ describe("PieceDetail", () => {
   it("renders piece name", async () => {
     await renderPieceDetail();
     expect(screen.getByText("Test Bowl")).toBeInTheDocument();
+  });
+
+  it("does not overwrite newer note drafts when stale piece state props arrive", async () => {
+    const onSaved = vi.fn();
+    const initialState = makeState({ notes: "Trim foot" });
+    const { rerender } = render(
+      <ThemeProvider theme={TEST_THEME}>
+        <WorkflowState
+          pieceState={initialState}
+          pieceId="piece-id-1"
+          onSaved={onSaved}
+          autosaveDelayMs={60_000}
+        />
+      </ThemeProvider>,
+    );
+
+    fireEvent.change(screen.getByLabelText("Notes"), {
+      target: { value: "Trim foot  " },
+    });
+
+    rerender(
+      <ThemeProvider theme={TEST_THEME}>
+        <WorkflowState
+          pieceState={makeState({ notes: "Trim foot " })}
+          pieceId="piece-id-1"
+          onSaved={onSaved}
+          autosaveDelayMs={60_000}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByLabelText("Notes")).toHaveValue("Trim foot  ");
   });
 
   it("renders current state label", async () => {

--- a/web/src/components/__tests__/PieceDetail.test.tsx
+++ b/web/src/components/__tests__/PieceDetail.test.tsx
@@ -205,7 +205,7 @@ describe("PieceDetail", () => {
     const { rerender } = render(
       <ThemeProvider theme={TEST_THEME}>
         <WorkflowState
-          pieceState={initialState}
+          initialPieceState={initialState}
           pieceId="piece-id-1"
           onSaved={onSaved}
           autosaveDelayMs={60_000}
@@ -220,7 +220,7 @@ describe("PieceDetail", () => {
     rerender(
       <ThemeProvider theme={TEST_THEME}>
         <WorkflowState
-          pieceState={makeState({ notes: "Trim foot " })}
+          initialPieceState={makeState({ notes: "Trim foot " })}
           pieceId="piece-id-1"
           onSaved={onSaved}
           autosaveDelayMs={60_000}

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -88,6 +88,15 @@ describe("PieceList", () => {
       expect(screen.getByText("Gift")).toBeInTheDocument();
       expect(screen.getByText("Functional")).toBeInTheDocument();
     });
+
+    it("renders a piece card without tag chips when the piece has no tags", () => {
+      renderPieceList([makePiece({ tags: [] })]);
+      const pieceCard = screen.getByRole("navigation", { name: "Clay Bowl" });
+      expect(within(pieceCard).queryByText("Gift")).not.toBeInTheDocument();
+      expect(
+        within(pieceCard).queryByRole("button", { name: /\+\d+ more/i }),
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe("with multiple pieces", () => {

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -373,5 +373,52 @@ describe("PieceList", () => {
         expect(screen.queryByLabelText("Tags")).not.toBeInTheDocument();
       });
     });
+
+    it("collapses piece tags behind an expand button when there are many", async () => {
+      const user = userEvent.setup();
+      renderPieceList([
+        makePiece({
+          tags: [
+            { id: "gift", name: "Gift", color: "#2A9D8F" },
+            { id: "sale", name: "For Sale", color: "#4FC3F7" },
+            { id: "sold", name: "Sold", color: "#F4A261" },
+            { id: "blue", name: "Blue", color: "#457B9D" },
+          ],
+        }),
+      ]);
+
+      expect(screen.getByText("Gift")).toBeInTheDocument();
+      expect(screen.getByText("For Sale")).toBeInTheDocument();
+      expect(screen.getByText("Sold")).toBeInTheDocument();
+      expect(screen.queryByText("Blue")).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "+1 more" }));
+
+      expect(screen.getByText("Blue")).toBeInTheDocument();
+    });
+
+    it("keeps currently filtered tags visible even when the list is collapsed", async () => {
+      const user = userEvent.setup();
+      renderPieceList([
+        makePiece({
+          id: "id-1",
+          name: "Bowl",
+          tags: [
+            { id: "gift", name: "Gift", color: "#2A9D8F" },
+            { id: "sale", name: "For Sale", color: "#4FC3F7" },
+            { id: "sold", name: "Sold", color: "#F4A261" },
+            { id: "blue", name: "Blue", color: "#457B9D" },
+          ],
+        }),
+      ]);
+
+      await user.click(screen.getByRole("button", { name: /show tags/i }));
+      await user.click(screen.getByLabelText("Tags"));
+      await user.click(screen.getByRole("option", { name: "Blue" }));
+      await user.keyboard("{Escape}");
+
+      const pieceCard = screen.getByRole("navigation", { name: "Bowl" });
+      expect(within(pieceCard).getByText("Blue")).toBeInTheDocument();
+    });
   });
 });

--- a/web/src/components/__tests__/TagComponents.test.tsx
+++ b/web/src/components/__tests__/TagComponents.test.tsx
@@ -42,6 +42,12 @@ describe("TagChipList", () => {
     expect(screen.getByText("Sold")).toBeInTheDocument();
     expect(screen.getByText("Blue")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Show less" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Show less" }));
+
+    expect(screen.queryByText("Sold")).not.toBeInTheDocument();
+    expect(screen.queryByText("Blue")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "+2 more" })).toBeInTheDocument();
   });
 });
 

--- a/web/src/components/__tests__/TagComponents.test.tsx
+++ b/web/src/components/__tests__/TagComponents.test.tsx
@@ -17,6 +17,32 @@ describe("TagChipList", () => {
     expect(screen.getByText("Gift")).toBeInTheDocument();
     expect(screen.getByText("For Sale")).toBeInTheDocument();
   });
+
+  it("collapses overflow and can expand hidden tags", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TagChipList
+        tags={[
+          ...TAGS,
+          { id: "sold", name: "Sold", color: "#F4A261" },
+          { id: "blue", name: "Blue", color: "#457B9D" },
+        ]}
+        maxVisible={2}
+      />,
+    );
+
+    expect(screen.getByText("Gift")).toBeInTheDocument();
+    expect(screen.getByText("For Sale")).toBeInTheDocument();
+    expect(screen.queryByText("Sold")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "+2 more" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "+2 more" }));
+
+    expect(screen.getByText("Sold")).toBeInTheDocument();
+    expect(screen.getByText("Blue")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Show less" })).toBeInTheDocument();
+  });
 });
 
 describe("TagAutocomplete", () => {

--- a/web/src/components/__tests__/WorkflowState.test.tsx
+++ b/web/src/components/__tests__/WorkflowState.test.tsx
@@ -10,6 +10,7 @@ import userEvent from "@testing-library/user-event";
 import WorkflowState from "../WorkflowState";
 import type { ResolvedAdditionalField } from "../../util/workflow";
 import {
+  buildAdditionalFieldInputMap,
   buildDraftState,
   draftReducer,
   normalizeAdditionalFieldPayload,
@@ -330,6 +331,45 @@ describe("WorkflowState", () => {
     expect(draft.globalRefPks).toEqual({ kiln_location: "loc-1" });
   });
 
+  it("buildAdditionalFieldInputMap stringifies boolean values for boolean fields", () => {
+    const defs: ResolvedAdditionalField[] = [
+      {
+        name: "food_safe",
+        label: "Food Safe",
+        type: "boolean",
+        required: false,
+        isGlobalRef: false,
+        isStateRef: false,
+      },
+    ];
+    expect(
+      buildAdditionalFieldInputMap(defs, {
+        food_safe: true,
+      }),
+    ).toEqual({ food_safe: "true" });
+
+    expect(
+      buildAdditionalFieldInputMap(defs, {
+        food_safe: false,
+      }),
+    ).toEqual({ food_safe: "false" });
+  });
+
+  it("buildDraftState keeps a global ref label but omits missing or non-string ids", () => {
+    const draft = buildDraftState(
+      makeState({
+        state: "submitted_to_bisque_fire",
+        additional_fields: {
+          kiln_location: { id: 123, name: "Unsaved Kiln" },
+        } as PieceState["additional_fields"],
+      }),
+    );
+    expect(draft.additionalFieldInputs).toEqual(
+      expect.objectContaining({ kiln_location: "Unsaved Kiln" }),
+    );
+    expect(draft.globalRefPks).toEqual({});
+  });
+
   it("buildDraftState ignores non-string objects for inline fields", () => {
     const draft = buildDraftState(
       makeState({
@@ -375,6 +415,20 @@ describe("WorkflowState", () => {
         {},
       ),
     ).toEqual({ food_safe: false });
+  });
+
+  it("normalizeAdditionalFieldPayload tolerates sparse input maps", () => {
+    const defs: ResolvedAdditionalField[] = [
+      {
+        name: "notes_label",
+        label: "Notes Label",
+        type: "string",
+        required: false,
+        isGlobalRef: false,
+        isStateRef: false,
+      },
+    ];
+    expect(normalizeAdditionalFieldPayload(defs, {}, {})).toEqual({});
   });
 
   it("normalizeAdditionalFieldPayload drops NaN integers and numbers", () => {

--- a/web/src/components/__tests__/WorkflowState.test.tsx
+++ b/web/src/components/__tests__/WorkflowState.test.tsx
@@ -8,7 +8,12 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import WorkflowState from "../WorkflowState";
-import { buildDraftState, draftReducer } from "../workflowStateDraft";
+import type { ResolvedAdditionalField } from "../../util/workflow";
+import {
+  buildDraftState,
+  draftReducer,
+  normalizeAdditionalFieldPayload,
+} from "../workflowStateDraft";
 import type { PieceState, PieceDetail } from "../../util/types";
 import * as api from "../../util/api";
 
@@ -323,6 +328,95 @@ describe("WorkflowState", () => {
       expect.objectContaining({ kiln_location: "Kiln A" }),
     );
     expect(draft.globalRefPks).toEqual({ kiln_location: "loc-1" });
+  });
+
+  it("buildDraftState ignores non-string objects for inline fields", () => {
+    const draft = buildDraftState(
+      makeState({
+        state: "bisque_fired",
+        additional_fields: {
+          kiln_temperature_c: { bad: "shape" },
+          cone: { name: 4 },
+        } as PieceState["additional_fields"],
+      }),
+    );
+    expect(draft.additionalFieldInputs).toEqual({
+      kiln_temperature_c: "",
+      cone: "",
+    });
+  });
+
+  it("normalizeAdditionalFieldPayload trims and parses boolean strings", () => {
+    const defs: ResolvedAdditionalField[] = [
+      {
+        name: "food_safe",
+        label: "Food Safe",
+        type: "boolean",
+        required: false,
+        isGlobalRef: false,
+        isStateRef: false,
+      },
+    ];
+    expect(
+      normalizeAdditionalFieldPayload(
+        defs,
+        {
+          food_safe: " true ",
+        },
+        {},
+      ),
+    ).toEqual({ food_safe: true });
+    expect(
+      normalizeAdditionalFieldPayload(
+        defs,
+        {
+          food_safe: "false",
+        },
+        {},
+      ),
+    ).toEqual({ food_safe: false });
+  });
+
+  it("normalizeAdditionalFieldPayload drops NaN integers and numbers", () => {
+    const defs: ResolvedAdditionalField[] = [
+      {
+        name: "kiln_temperature_c",
+        label: "Kiln Temperature C",
+        type: "integer",
+        required: false,
+        isGlobalRef: false,
+        isStateRef: false,
+      },
+    ];
+    expect(
+      normalizeAdditionalFieldPayload(
+        defs,
+        {
+          kiln_temperature_c: "twelve hundred",
+        },
+        {},
+      ),
+    ).toEqual({});
+
+    const numberDefs: ResolvedAdditionalField[] = [
+      {
+        name: "clay_weight_lbs",
+        label: "Clay Weight Lbs",
+        type: "number",
+        required: false,
+        isGlobalRef: false,
+        isStateRef: false,
+      },
+    ];
+    expect(
+      normalizeAdditionalFieldPayload(
+        numberDefs,
+        {
+          clay_weight_lbs: "not-a-number",
+        },
+        {},
+      ),
+    ).toEqual({});
   });
 
   it("draftReducer throws on an unhandled action", () => {

--- a/web/src/components/__tests__/WorkflowState.test.tsx
+++ b/web/src/components/__tests__/WorkflowState.test.tsx
@@ -8,6 +8,7 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import WorkflowState from "../WorkflowState";
+import { buildDraftState, draftReducer } from "../workflowStateDraft";
 import type { PieceState, PieceDetail } from "../../util/types";
 import * as api from "../../util/api";
 
@@ -303,6 +304,36 @@ beforeEach(() => {
 });
 
 describe("WorkflowState", () => {
+  it("buildDraftState leaves additional field maps empty for states without additional fields", () => {
+    const draft = buildDraftState(makeState({ state: "designed" }));
+    expect(draft.additionalFieldInputs).toEqual({});
+    expect(draft.globalRefPks).toEqual({});
+  });
+
+  it("buildDraftState populates additional field maps for states with additional fields", () => {
+    const draft = buildDraftState(
+      makeState({
+        state: "submitted_to_bisque_fire",
+        additional_fields: {
+          kiln_location: { id: "loc-1", name: "Kiln A" },
+        },
+      }),
+    );
+    expect(draft.additionalFieldInputs).toEqual(
+      expect.objectContaining({ kiln_location: "Kiln A" }),
+    );
+    expect(draft.globalRefPks).toEqual({ kiln_location: "loc-1" });
+  });
+
+  it("draftReducer throws on an unhandled action", () => {
+    expect(() =>
+      draftReducer(
+        buildDraftState(makeState()),
+        { type: "not-real" } as never,
+      ),
+    ).toThrow("Unhandled DraftAction");
+  });
+
   it("renders without crashing", async () => {
     let container: HTMLElement;
     await act(async () => {
@@ -466,6 +497,21 @@ describe("WorkflowState", () => {
       );
     });
     expect(screen.getByLabelText("Notes")).toHaveValue("Some notes");
+  });
+
+  it("renders no additional field inputs for states without additional fields", async () => {
+    await act(async () => {
+      render(
+        <WorkflowState
+          {...defaultProps}
+          initialPieceState={makeState({ state: "designed" })}
+        />,
+      );
+    });
+    expect(screen.queryByLabelText("Kiln Location")).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Trimmed Weight Lbs"),
+    ).not.toBeInTheDocument();
   });
 
   it("shows pending autosave after editing notes", async () => {

--- a/web/src/components/__tests__/WorkflowState.test.tsx
+++ b/web/src/components/__tests__/WorkflowState.test.tsx
@@ -217,7 +217,7 @@ function makePieceDetail(overrides: Partial<PieceDetail> = {}): PieceDetail {
 }
 
 const defaultProps = {
-  pieceState: makeState(),
+  initialPieceState: makeState(),
   pieceId: "test-piece-id",
   onSaved: vi.fn(),
   onDirtyChange: vi.fn(),
@@ -328,7 +328,7 @@ describe("WorkflowState", () => {
       },
     });
     await act(async () => {
-      render(<WorkflowState {...defaultProps} pieceState={bisqueState} />);
+      render(<WorkflowState {...defaultProps} initialPieceState={bisqueState} />);
     });
     const tempInput = screen.getByLabelText("Kiln Temperature C");
     expect(tempInput).toBeInTheDocument();
@@ -345,7 +345,7 @@ describe("WorkflowState", () => {
       },
     });
     await act(async () => {
-      render(<WorkflowState {...defaultProps} pieceState={trimmedState} />);
+      render(<WorkflowState {...defaultProps} initialPieceState={trimmedState} />);
     });
     expect(screen.getByLabelText("Trimmed Weight Lbs")).toHaveValue(900);
     expect(screen.getByLabelText("Pre-trim Weight Lbs")).toHaveValue(1200);
@@ -357,7 +357,7 @@ describe("WorkflowState", () => {
       additional_fields: { pre_trim_weight_lbs: 1200 },
     });
     await act(async () => {
-      render(<WorkflowState {...defaultProps} pieceState={trimmedState} />);
+      render(<WorkflowState {...defaultProps} initialPieceState={trimmedState} />);
     });
     expect(screen.getByLabelText("Pre-trim Weight Lbs")).toBeDisabled();
   });
@@ -368,7 +368,7 @@ describe("WorkflowState", () => {
       additional_fields: { trimmed_weight_lbs: 900 },
     });
     await act(async () => {
-      render(<WorkflowState {...defaultProps} pieceState={trimmedState} />);
+      render(<WorkflowState {...defaultProps} initialPieceState={trimmedState} />);
     });
     expect(screen.getByLabelText("Trimmed Weight Lbs")).not.toBeDisabled();
   });
@@ -381,7 +381,7 @@ describe("WorkflowState", () => {
       state: "submitted_to_bisque_fire",
       additional_fields: { kiln_location: "" },
     });
-    render(<WorkflowState {...defaultProps} pieceState={globalState} />);
+    render(<WorkflowState {...defaultProps} initialPieceState={globalState} />);
     await userEvent.click(
       screen.getByRole("button", { name: "Browse Kiln Location" }),
     );
@@ -403,7 +403,7 @@ describe("WorkflowState", () => {
       state: "submitted_to_bisque_fire",
       additional_fields: { kiln_location: "" },
     });
-    render(<WorkflowState {...defaultProps} pieceState={globalState} />);
+    render(<WorkflowState {...defaultProps} initialPieceState={globalState} />);
     await userEvent.click(
       screen.getByRole("button", { name: "Browse Kiln Location" }),
     );
@@ -430,7 +430,7 @@ describe("WorkflowState", () => {
       state: "submitted_to_bisque_fire",
       additional_fields: { kiln_location: "" },
     });
-    render(<WorkflowState {...defaultProps} pieceState={withGlobalRef} />);
+    render(<WorkflowState {...defaultProps} initialPieceState={withGlobalRef} />);
     await userEvent.click(
       screen.getByRole("button", { name: "Browse Kiln Location" }),
     );
@@ -461,7 +461,7 @@ describe("WorkflowState", () => {
       render(
         <WorkflowState
           {...defaultProps}
-          pieceState={makeState({ notes: "Some notes" })}
+          initialPieceState={makeState({ notes: "Some notes" })}
         />,
       );
     });
@@ -508,6 +508,39 @@ describe("WorkflowState", () => {
       target: { value: "New notes" },
     });
     await waitFor(() => expect(onSaved).toHaveBeenCalledWith(updated));
+  });
+
+  it("adopts the server-returned current state as the new base after save", async () => {
+    const updated = makePieceDetail({
+      current_state: makeState({ notes: "Server canonical notes" }),
+    });
+    vi.mocked(api.updateCurrentState).mockResolvedValue(updated);
+
+    render(
+      <WorkflowState
+        {...defaultProps}
+        initialPieceState={makeState({ notes: "Original notes" })}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Notes"), {
+      target: { value: "Locally edited notes" },
+    });
+
+    await waitFor(() =>
+      expect(api.updateCurrentState).toHaveBeenCalledWith(
+        "test-piece-id",
+        expect.objectContaining({ notes: "Locally edited notes" }),
+      ),
+    );
+    await waitFor(() =>
+      expect(screen.getByLabelText("Notes")).toHaveValue(
+        "Server canonical notes",
+      ),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("autosave-status")).toHaveTextContent("Saved"),
+    );
   });
 
   it("shows error message on save failure", async () => {
@@ -560,7 +593,7 @@ describe("WorkflowState", () => {
       render(
         <WorkflowState
           {...defaultProps}
-          pieceState={makeState({ notes: "original" })}
+          initialPieceState={makeState({ notes: "original" })}
           onDirtyChange={onDirtyChange}
         />,
       );
@@ -721,7 +754,7 @@ describe("WorkflowState", () => {
       render(
         <WorkflowState
           {...defaultProps}
-          pieceState={makeState({
+          initialPieceState={makeState({
             images: [
               {
                 url: "http://example.com/img.jpg",
@@ -741,7 +774,7 @@ describe("WorkflowState", () => {
   it("renders enum and number additional fields for bisque_fired state", async () => {
     vi.mocked(api.fetchGlobalEntries).mockResolvedValue([]);
     await act(async () => {
-      render(<WorkflowState {...defaultProps} pieceState={makeState({ state: "bisque_fired", additional_fields: {} })} />);
+      render(<WorkflowState {...defaultProps} initialPieceState={makeState({ state: "bisque_fired", additional_fields: {} })} />);
     });
     // cone is an enum field — verify select renders
     const coneField = screen.getByLabelText("Cone");
@@ -755,7 +788,7 @@ describe("WorkflowState", () => {
         <WorkflowState
           {...defaultProps}
           onDirtyChange={onDirtyChange}
-          pieceState={makeState({
+          initialPieceState={makeState({
             state: "trimmed",
             additional_fields: { trimmed_weight_lbs: 900 },
           })}
@@ -766,6 +799,43 @@ describe("WorkflowState", () => {
       target: { value: "950" },
     });
     expect(onDirtyChange).toHaveBeenCalledWith(true);
+  });
+
+  it("replaces saved additional fields from the server after a successful save", async () => {
+    vi.mocked(api.updateCurrentState).mockResolvedValue(
+      makePieceDetail({
+        current_state: makeState({
+          state: "trimmed",
+          additional_fields: { trimmed_weight_lbs: 975 },
+        }),
+      }),
+    );
+
+    render(
+      <WorkflowState
+        {...defaultProps}
+        initialPieceState={makeState({
+          state: "trimmed",
+          additional_fields: { trimmed_weight_lbs: 900 },
+        })}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Trimmed Weight Lbs"), {
+      target: { value: "950" },
+    });
+
+    await waitFor(() =>
+      expect(api.updateCurrentState).toHaveBeenCalledWith(
+        "test-piece-id",
+        expect.objectContaining({
+          additional_fields: { trimmed_weight_lbs: 950 },
+        }),
+      ),
+    );
+    await waitFor(() =>
+      expect(screen.getByLabelText("Trimmed Weight Lbs")).toHaveValue(975),
+    );
   });
 
   it("accepts any valid workflow state", async () => {
@@ -781,7 +851,7 @@ describe("WorkflowState", () => {
           render(
             <WorkflowState
               {...defaultProps}
-              pieceState={makeState({ state })}
+              initialPieceState={makeState({ state })}
             />,
           ),
         ).not.toThrow();
@@ -793,7 +863,7 @@ describe("WorkflowState", () => {
     it("renders a Browse button instead of a text input for thumbnail-backed globals", async () => {
       const glazedState = makeState({ state: "glazed", additional_fields: {} });
       await act(async () => {
-        render(<WorkflowState {...defaultProps} pieceState={glazedState} />);
+        render(<WorkflowState {...defaultProps} initialPieceState={glazedState} />);
       });
       expect(
         screen.getByRole("button", { name: "Browse Glaze Combination" }),
@@ -812,7 +882,7 @@ describe("WorkflowState", () => {
         },
       });
       await act(async () => {
-        render(<WorkflowState {...defaultProps} pieceState={glazedState} />);
+        render(<WorkflowState {...defaultProps} initialPieceState={glazedState} />);
       });
       expect(screen.getByText("Iron Red!Clear")).toBeInTheDocument();
       expect(
@@ -828,7 +898,7 @@ describe("WorkflowState", () => {
         },
       });
       await act(async () => {
-        render(<WorkflowState {...defaultProps} pieceState={glazedState} />);
+        render(<WorkflowState {...defaultProps} initialPieceState={glazedState} />);
       });
       const chip = screen.getByRole("button", { name: /iron red!clear/i });
       // MUI adds MuiChip-deletable when onDelete is wired up
@@ -851,7 +921,7 @@ describe("WorkflowState", () => {
         },
       });
       await act(async () => {
-        render(<WorkflowState {...defaultProps} pieceState={glazedState} />);
+        render(<WorkflowState {...defaultProps} initialPieceState={glazedState} />);
       });
       const chip = screen.getByRole("button", { name: /iron red!clear/i });
       // The MUI Chip cancel SVG icon is the last child element of the chip
@@ -879,7 +949,7 @@ describe("WorkflowState", () => {
 
     it("opens the browse dialog when Browse button is clicked", async () => {
       const glazedState = makeState({ state: "glazed", additional_fields: {} });
-      render(<WorkflowState {...defaultProps} pieceState={glazedState} />);
+      render(<WorkflowState {...defaultProps} initialPieceState={glazedState} />);
       await userEvent.click(
         screen.getByRole("button", { name: "Browse Glaze Combination" }),
       );
@@ -892,7 +962,7 @@ describe("WorkflowState", () => {
 
     it("keeps glaze combination browse-only when can_create is not set", async () => {
       const glazedState = makeState({ state: "glazed", additional_fields: {} });
-      render(<WorkflowState {...defaultProps} pieceState={glazedState} />);
+      render(<WorkflowState {...defaultProps} initialPieceState={glazedState} />);
       await userEvent.click(
         screen.getByRole("button", { name: "Browse Glaze Combination" }),
       );

--- a/web/src/components/workflowStateDraft.ts
+++ b/web/src/components/workflowStateDraft.ts
@@ -1,0 +1,173 @@
+import type { PieceState } from "../util/types";
+import {
+  type ResolvedAdditionalField,
+  getAdditionalFieldDefinitions,
+} from "../util/workflow";
+
+export type ImageEntry = {
+  url: string;
+  caption: string;
+  cloudinary_public_id?: string | null;
+};
+
+type AdditionalFieldInputMap = Record<string, string>;
+type GlobalRefPkMap = Record<string, string>;
+
+export type DraftState = {
+  baseState: PieceState;
+  notes: string;
+  images: ImageEntry[];
+  additionalFieldInputs: AdditionalFieldInputMap;
+  globalRefPks: GlobalRefPkMap;
+};
+
+export type DraftAction =
+  | { type: "replace_base_state"; pieceState: PieceState }
+  | { type: "set_notes"; notes: string }
+  | { type: "set_additional_field"; name: string; value: string }
+  | { type: "set_global_ref_pks"; globalRefPks: GlobalRefPkMap };
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled DraftAction: ${JSON.stringify(value)}`);
+}
+
+function formatAdditionalFieldValue(
+  value: unknown,
+  type: ResolvedAdditionalField["type"],
+): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    if (typeof obj.name === "string") {
+      return obj.name;
+    }
+    return "";
+  }
+  if (type === "boolean") {
+    return value ? "true" : "false";
+  }
+  return String(value);
+}
+
+function extractGlobalRefPk(value: unknown): string | undefined {
+  if (typeof value === "object" && value !== null && "id" in value) {
+    const id = (value as { id: unknown }).id;
+    return typeof id === "string" ? id : undefined;
+  }
+  return undefined;
+}
+
+function buildAdditionalFieldInputMap(
+  defs: ResolvedAdditionalField[],
+  values: Record<string, unknown>,
+): AdditionalFieldInputMap {
+  const map: AdditionalFieldInputMap = {};
+  defs.forEach((def) => {
+    map[def.name] = formatAdditionalFieldValue(values[def.name], def.type);
+  });
+  return map;
+}
+
+export function buildGlobalRefPkMap(
+  defs: ResolvedAdditionalField[],
+  values: Record<string, unknown>,
+): GlobalRefPkMap {
+  const map: GlobalRefPkMap = {};
+  defs.forEach((def) => {
+    if (def.isGlobalRef) {
+      const pk = extractGlobalRefPk(values[def.name]);
+      if (pk) map[def.name] = pk;
+    }
+  });
+  return map;
+}
+
+export function normalizeAdditionalFieldPayload(
+  defs: ResolvedAdditionalField[],
+  inputs: AdditionalFieldInputMap,
+  globalRefPks: GlobalRefPkMap,
+): Record<string, string | number | boolean | null> {
+  const payload: Record<string, string | number | boolean | null> = {};
+  defs.forEach((def) => {
+    if (def.isGlobalRef) {
+      const pk = globalRefPks[def.name];
+      payload[def.name] = pk || null;
+      return;
+    }
+    const raw = inputs[def.name] ?? "";
+    const trimmed = raw.trim();
+    if (trimmed === "") {
+      return;
+    }
+    if (def.type === "integer") {
+      const parsed = parseInt(trimmed, 10);
+      if (!Number.isNaN(parsed)) {
+        payload[def.name] = parsed;
+      }
+      return;
+    }
+    if (def.type === "number") {
+      const parsed = Number(trimmed);
+      if (!Number.isNaN(parsed)) {
+        payload[def.name] = parsed;
+      }
+      return;
+    }
+    if (def.type === "boolean") {
+      if (trimmed === "true") {
+        payload[def.name] = true;
+      } else if (trimmed === "false") {
+        payload[def.name] = false;
+      }
+      return;
+    }
+    payload[def.name] = raw;
+  });
+  return payload;
+}
+
+function stateImages(pieceState: PieceState): ImageEntry[] {
+  return pieceState.images.map((img) => ({
+    url: img.url,
+    caption: img.caption,
+    cloudinary_public_id: img.cloudinary_public_id ?? null,
+  }));
+}
+
+export function buildDraftState(pieceState: PieceState): DraftState {
+  const additionalFieldDefs = getAdditionalFieldDefinitions(pieceState.state);
+  const additionalFields = pieceState.additional_fields;
+  return {
+    baseState: pieceState,
+    notes: pieceState.notes,
+    images: stateImages(pieceState),
+    additionalFieldInputs: buildAdditionalFieldInputMap(
+      additionalFieldDefs,
+      additionalFields,
+    ),
+    globalRefPks: buildGlobalRefPkMap(additionalFieldDefs, additionalFields),
+  };
+}
+
+export function draftReducer(state: DraftState, action: DraftAction): DraftState {
+  switch (action.type) {
+    case "replace_base_state":
+      return buildDraftState(action.pieceState);
+    case "set_notes":
+      return { ...state, notes: action.notes };
+    case "set_additional_field":
+      return {
+        ...state,
+        additionalFieldInputs: {
+          ...state.additionalFieldInputs,
+          [action.name]: action.value,
+        },
+      };
+    case "set_global_ref_pks":
+      return { ...state, globalRefPks: action.globalRefPks };
+    default:
+      return assertNever(action);
+  }
+}

--- a/web/src/components/workflowStateDraft.ts
+++ b/web/src/components/workflowStateDraft.ts
@@ -59,7 +59,7 @@ function extractGlobalRefPk(value: unknown): string | undefined {
   return undefined;
 }
 
-function buildAdditionalFieldInputMap(
+export function buildAdditionalFieldInputMap(
   defs: ResolvedAdditionalField[],
   values: Record<string, unknown>,
 ): AdditionalFieldInputMap {

--- a/web/src/components/workflowStateDraft.ts
+++ b/web/src/components/workflowStateDraft.ts
@@ -96,6 +96,8 @@ export function normalizeAdditionalFieldPayload(
       payload[def.name] = pk || null;
       return;
     }
+    // buildDraftState populates every known field name, but this helper is
+    // exported and can still be called with a sparse runtime map.
     const raw = inputs[def.name] ?? "";
     const trimmed = raw.trim();
     if (trimmed === "") {


### PR DESCRIPTION
## Summary

This PR addresses four small but related UI issues in one pass:

- fixes the authenticated shell safe-area padding so the header stops crowding iOS installed-PWA status areas
- restores a visible public/private distinction in the unified global entry dialog
- preserves trailing spaces in current-state notes during autosave flows
- adds collapsible tag overflow in `PieceList` while keeping actively filtered tags visible

## Why

These issues were all lightweight UI polish items opened together on April 29-30, 2026 and they touched adjacent frontend surfaces.

The notes bug had two contributors:

- DRF was trimming note whitespace by default on write
- the `WorkflowState` draft sync could overwrite a newer local draft when an older save response arrived

## User impact

- Installed iOS PWA users get a header that respects safe-area insets more consistently.
- Users can distinguish public vs. private globals with the same name again.
- Notes editing no longer drops trailing spaces mid-typing.
- Pieces with many tags stay compact in the list, but selected filter tags remain visible.

## Validation

- `rtk bazel test //...`
- `rtk bazel build --config=lint //...`

Fixes #200
Fixes #201
Fixes #202
Fixes #203