### PR TITLE
Fix null cloudinary_public_id breaking thumbnail sizing and HEIC images

### DIFF
--- a/api/BUILD.bazel
+++ b/api/BUILD.bazel
@@ -109,6 +109,7 @@ py_test(
         # it in srcs (not just data) so it is on the Python import path.
         "migrations/__init__.py",
         "migrations/0025_image_field_jsonfield.py",
+        "migrations/0026_backfill_cloudinary_public_id.py",
     ],
     args = [
         "api/tests/test_model_factory.py",

--- a/api/management/commands/restore_images_from_backup.py
+++ b/api/management/commands/restore_images_from_backup.py
@@ -33,7 +33,7 @@ from api.models import Piece, PieceState
 
 
 _CLOUDINARY_HOSTNAME = 'res.cloudinary.com'
-_TRANSFORM_RE = re.compile(r'^[a-z][a-z0-9]*_')
+_TRANSFORM_RE = re.compile(r'^[a-z]{1,4}_')
 _VERSION_RE = re.compile(r'^v\d+$')
 
 

--- a/api/management/commands/restore_images_from_backup.py
+++ b/api/management/commands/restore_images_from_backup.py
@@ -1,0 +1,221 @@
+"""Restore piece images and thumbnails from a pre-migration YAML backup.
+
+Usage:
+    python manage.py restore_images_from_backup <backup.yaml> [--dry-run]
+
+The backup YAML is a list of piece records (as produced by the data export)
+with full history and thumbnail fields.  For each piece/state found in the
+backup, this command checks whether the current DB record has lost images
+that were present in the backup, and restores them if so.
+
+Only the following are treated as restorable:
+  - PieceState.images: restored when the DB array is empty and the backup has
+    at least one image, OR when the DB array contains fewer images than the
+    backup and the extra backup images are not present at all in the DB list.
+  - Piece.thumbnail: restored when the DB thumbnail is null/empty and the
+    backup has a non-null, non-question-mark thumbnail.
+
+Images are written as {url, cloudinary_public_id, cloud_name} dicts; the
+command derives cloudinary_public_id and cloud_name from the URL using the
+same logic as migration 0026 so restored images are immediately usable.
+"""
+
+import re
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+import yaml
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from api.models import Piece, PieceState
+
+
+_CLOUDINARY_HOSTNAME = 'res.cloudinary.com'
+_TRANSFORM_RE = re.compile(r'^[a-z][a-z0-9]*_')
+_VERSION_RE = re.compile(r'^v\d+$')
+
+
+def _parse_cloudinary_url(url: str) -> tuple[str | None, str | None]:
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return None, None
+    if parsed.hostname != _CLOUDINARY_HOSTNAME:
+        return None, None
+    parts = parsed.path.split('/')
+    if len(parts) < 5 or parts[2] != 'image' or parts[3] != 'upload':
+        return None, None
+    cloud_name = parts[1] or None
+    after_upload = parts[4:]
+    i = 0
+    while i < len(after_upload) - 1 and (
+        _TRANSFORM_RE.match(after_upload[i]) or _VERSION_RE.match(after_upload[i])
+    ):
+        i += 1
+    public_id_parts = after_upload[i:]
+    if not public_id_parts:
+        return cloud_name, None
+    public_id_parts[-1] = re.sub(r'\.[^.]+$', '', public_id_parts[-1])
+    result = '/'.join(public_id_parts)
+    return cloud_name, (result or None)
+
+
+def _normalize_image(img: dict) -> dict:
+    """Ensure the image dict has cloudinary_public_id and cloud_name set."""
+    url = img.get('url') or ''
+    cloud_name = img.get('cloud_name')
+    public_id = img.get('cloudinary_public_id')
+    if not cloud_name or not public_id:
+        derived_cloud, derived_id = _parse_cloudinary_url(url)
+        cloud_name = cloud_name or derived_cloud
+        public_id = public_id or derived_id
+    return {
+        'url': url,
+        'cloudinary_public_id': public_id,
+        'cloud_name': cloud_name,
+        'caption': img.get('caption', ''),
+        'created': img.get('created'),
+    }
+
+
+def _is_placeholder_thumbnail(thumb: dict | None) -> bool:
+    if not thumb:
+        return True
+    url = thumb.get('url') or ''
+    return not url or 'question-mark' in url
+
+
+class Command(BaseCommand):
+    help = "Restore piece images and thumbnails from a pre-migration YAML backup."
+
+    def add_arguments(self, parser):
+        parser.add_argument('backup', type=Path, help='Path to the backup YAML file')
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            help='Show what would be changed without writing to the database',
+        )
+
+    def handle(self, *args, **options):
+        backup_path: Path = options['backup']
+        dry_run: bool = options['dry_run']
+
+        if not backup_path.exists():
+            raise CommandError(f"Backup file not found: {backup_path}")
+
+        with open(backup_path) as f:
+            records = yaml.safe_load(f)
+
+        if not isinstance(records, list):
+            raise CommandError("Backup YAML must be a list of piece records")
+
+        restored_states = 0
+        restored_thumbnails = 0
+        skipped = 0
+
+        for record in records:
+            piece_id = record.get('id')
+            if not piece_id:
+                continue
+
+            try:
+                piece = Piece.objects.get(pk=piece_id)
+            except Piece.DoesNotExist:
+                self.stdout.write(
+                    self.style.WARNING(f"Piece {piece_id} not found in DB — skipping")
+                )
+                skipped += 1
+                continue
+
+            history = record.get('history') or []
+
+            # --- Restore PieceState images ---
+            # Build a dict: state_name → list of state records from backup
+            # (a piece can pass through the same state multiple times, so we
+            # pair by position in creation order)
+            db_states = list(
+                PieceState.objects.filter(piece=piece).order_by('created')
+            )
+            backup_states = list(history)
+
+            # Match by index position (creation order preserved in backup)
+            for i, backup_state in enumerate(backup_states):
+                backup_images = backup_state.get('images') or []
+                if not backup_images:
+                    continue  # Nothing to restore for this state
+
+                if i >= len(db_states):
+                    self.stdout.write(
+                        self.style.WARNING(
+                            f"Piece {piece_id}: backup has more states than DB "
+                            f"(backup index {i}) — skipping extra"
+                        )
+                    )
+                    break
+
+                db_state = db_states[i]
+                db_images = db_state.images or []
+
+                # Check if DB images are missing entries found in backup
+                db_urls = {img.get('url') for img in db_images if isinstance(img, dict)}
+                missing = [
+                    img for img in backup_images
+                    if isinstance(img, dict) and img.get('url') not in db_urls
+                ]
+
+                if not missing:
+                    continue  # DB already has all backup images
+
+                # Merge: keep existing DB images, append missing ones from backup
+                restored = [_normalize_image(img) for img in missing]
+                new_images = db_images + restored
+
+                self.stdout.write(
+                    f"Piece {piece_id} / state {db_state.pk} ({backup_state.get('state')}): "
+                    f"restoring {len(missing)} image(s)"
+                )
+                if not dry_run:
+                    with transaction.atomic():
+                        PieceState.objects.filter(pk=db_state.pk).update(images=new_images)
+
+                restored_states += 1
+
+            # --- Restore thumbnail ---
+            backup_thumb_raw = record.get('thumbnail')
+            if isinstance(backup_thumb_raw, str):
+                import json as _json
+                try:
+                    backup_thumb = _json.loads(backup_thumb_raw)
+                except (ValueError, TypeError):
+                    backup_thumb = {'url': backup_thumb_raw, 'cloudinary_public_id': None, 'cloud_name': None}
+            elif isinstance(backup_thumb_raw, dict):
+                backup_thumb = backup_thumb_raw
+            else:
+                backup_thumb = None
+
+            if _is_placeholder_thumbnail(backup_thumb):
+                continue  # Backup thumb is a placeholder — nothing to restore
+
+            current_thumb = piece.thumbnail
+            if current_thumb and not _is_placeholder_thumbnail(current_thumb):
+                continue  # DB already has a real thumbnail
+
+            normalized = _normalize_image(backup_thumb)
+            self.stdout.write(
+                f"Piece {piece_id} ({record.get('name')}): restoring thumbnail {normalized['url']}"
+            )
+            if not dry_run:
+                with transaction.atomic():
+                    Piece.objects.filter(pk=piece_id).update(thumbnail=normalized)
+
+            restored_thumbnails += 1
+
+        prefix = "[DRY RUN] " if dry_run else ""
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{prefix}Done. Restored {restored_states} state image set(s), "
+                f"{restored_thumbnails} thumbnail(s). Skipped {skipped} missing piece(s)."
+            )
+        )

--- a/api/migrations/0026_backfill_cloudinary_public_id.py
+++ b/api/migrations/0026_backfill_cloudinary_public_id.py
@@ -1,0 +1,118 @@
+"""Backfill cloudinary_public_id for image fields where it is currently null.
+
+Migration 0025 added cloud_name to all image dicts but did not fix
+cloudinary_public_id when it was already null in existing JSON dicts.
+That left thumbnails and PieceState images without a public_id, causing
+CloudinaryImage to fall back to full-resolution plain <img> instead of
+requesting a size-appropriate rendition.  HEIC images became invisible
+entirely because browsers cannot display raw HEIC URLs.
+
+This migration re-runs the public_id extraction for every image dict that
+has a non-null Cloudinary URL but a null or missing cloudinary_public_id.
+"""
+
+import re
+from urllib.parse import urlparse
+
+from django.db import migrations
+
+
+_CLOUDINARY_HOSTNAME = 'res.cloudinary.com'
+_TRANSFORM_RE = re.compile(r'^[a-z][a-z0-9]*_')
+_VERSION_RE = re.compile(r'^v\d+$')
+
+
+def _parse_cloudinary_public_id(url: str) -> str | None:
+    """Return the public_id parsed from a Cloudinary delivery URL, or None."""
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return None
+    if parsed.hostname != _CLOUDINARY_HOSTNAME:
+        return None
+    parts = parsed.path.split('/')
+    # parts: ['', cloud_name, 'image', 'upload', ...rest]
+    if len(parts) < 5 or parts[2] != 'image' or parts[3] != 'upload':
+        return None
+    after_upload = parts[4:]
+    i = 0
+    # Skip leading transform segments (e.g. f_auto, w_100) and version segments.
+    while i < len(after_upload) - 1 and (
+        _TRANSFORM_RE.match(after_upload[i]) or _VERSION_RE.match(after_upload[i])
+    ):
+        i += 1
+    public_id_parts = after_upload[i:]
+    if not public_id_parts:
+        return None
+    # Strip file extension from the last segment.
+    public_id_parts[-1] = re.sub(r'\.[^.]+$', '', public_id_parts[-1])
+    result = '/'.join(public_id_parts)
+    return result or None
+
+
+def _fix_image_dict(img: dict) -> dict | None:
+    """Return an updated dict with cloudinary_public_id filled in, or None if no change needed."""
+    if not isinstance(img, dict):
+        return None
+    if img.get('cloudinary_public_id') is not None:
+        return None
+    url = img.get('url') or ''
+    public_id = _parse_cloudinary_public_id(url)
+    if public_id is None:
+        return None
+    return {**img, 'cloudinary_public_id': public_id}
+
+
+def backfill_public_ids(apps, schema_editor):
+    PieceState = apps.get_model('api', 'PieceState')
+    Piece = apps.get_model('api', 'Piece')
+    GlazeType = apps.get_model('api', 'GlazeType')
+    GlazeCombination = apps.get_model('api', 'GlazeCombination')
+
+    # Fix PieceState.images arrays.
+    for ps in PieceState.objects.exclude(images=[]):
+        images = ps.images or []
+        updated = []
+        changed = False
+        for img in images:
+            fixed = _fix_image_dict(img)
+            if fixed is not None:
+                updated.append(fixed)
+                changed = True
+            else:
+                updated.append(img)
+        if changed:
+            PieceState.objects.filter(pk=ps.pk).update(images=updated)
+
+    # Fix Piece.thumbnail dicts.
+    for piece in Piece.objects.filter(thumbnail__isnull=False):
+        fixed = _fix_image_dict(piece.thumbnail)
+        if fixed is not None:
+            Piece.objects.filter(pk=piece.pk).update(thumbnail=fixed)
+
+    # Fix GlazeType and GlazeCombination test_tile_image.
+    for Model in (GlazeType, GlazeCombination):
+        for obj in Model.objects.filter(test_tile_image__isnull=False):
+            fixed = _fix_image_dict(obj.test_tile_image)
+            if fixed is not None:
+                Model.objects.filter(pk=obj.pk).update(test_tile_image=fixed)
+
+
+def reverse_backfill_public_ids(apps, schema_editor):
+    # The reverse is a no-op: we cannot know which public_ids were originally
+    # null vs legitimately populated by the upload flow.
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("api", "0025_image_field_jsonfield"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            backfill_public_ids,
+            reverse_code=reverse_backfill_public_ids,
+        ),
+    ]

--- a/api/migrations/0026_backfill_cloudinary_public_id.py
+++ b/api/migrations/0026_backfill_cloudinary_public_id.py
@@ -18,7 +18,10 @@ from django.db import migrations
 
 
 _CLOUDINARY_HOSTNAME = 'res.cloudinary.com'
-_TRANSFORM_RE = re.compile(r'^[a-z][a-z0-9]*_')
+# Cloudinary transform keys are always 1–4 lowercase letters (e.g. f, w, dpr, fl).
+# Using {1,4} prevents folder segments like "glaze_prod" (5-char prefix) from
+# being misidentified as transforms.
+_TRANSFORM_RE = re.compile(r'^[a-z]{1,4}_')
 _VERSION_RE = re.compile(r'^v\d+$')
 
 

--- a/api/tests/test_image_field_migration.py
+++ b/api/tests/test_image_field_migration.py
@@ -1,4 +1,4 @@
-"""Tests for migration 0025: image field CharField → JSONField.
+"""Tests for migrations 0025 and 0026: image field conversion and public_id backfill.
 
 Exercises the data-migration helper functions (url_to_json / json_to_url) in
 isolation so that broken edge-cases are caught without touching the real DB
@@ -18,9 +18,10 @@ import importlib
 import json
 
 from django.apps import apps as django_apps
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-from api.models import GlazeCombination, GlazeType
+from api.models import GlazeCombination, GlazeType, Piece, PieceState
 
 # ---------------------------------------------------------------------------
 # Import the helper functions directly from the migration module.
@@ -192,3 +193,116 @@ class TestImageFieldStorageRoundTrip(TestCase):
         gt.refresh_from_db()
         assert gt.test_tile_image['cloudinary_public_id'] == EXPECTED_PUBLIC_ID
         assert gt.test_tile_image['cloud_name'] == EXPECTED_CLOUD_NAME
+
+
+# ---------------------------------------------------------------------------
+# Migration 0026: backfill cloudinary_public_id where null
+# ---------------------------------------------------------------------------
+
+_migration_0026 = importlib.import_module(
+    'api.migrations.0026_backfill_cloudinary_public_id'
+)
+_backfill = _migration_0026.backfill_public_ids
+_parse_public_id = _migration_0026._parse_cloudinary_public_id
+
+
+class TestParseCloudinaryPublicId:
+    """Unit tests for the public_id extractor in migration 0026."""
+
+    def test_extracts_public_id_without_version(self):
+        url = 'https://res.cloudinary.com/demo/image/upload/glaze_prod/tile.jpg'
+        assert _parse_public_id(url) == 'glaze_prod/tile'
+
+    def test_strips_version_segment(self):
+        url = 'https://res.cloudinary.com/demo/image/upload/v1776802576/glaze_prod/img.jpg'
+        assert _parse_public_id(url) == 'glaze_prod/img'
+
+    def test_skips_transform_segments(self):
+        url = 'https://res.cloudinary.com/demo/image/upload/f_auto/v123/folder/img.png'
+        assert _parse_public_id(url) == 'folder/img'
+
+    def test_heic_extension_stripped(self):
+        url = 'https://res.cloudinary.com/demo/image/upload/v1/glaze_prod/photo.heic'
+        assert _parse_public_id(url) == 'glaze_prod/photo'
+
+    def test_non_cloudinary_url_returns_none(self):
+        assert _parse_public_id('https://example.com/tile.jpg') is None
+
+    def test_empty_string_returns_none(self):
+        assert _parse_public_id('') is None
+
+    def test_svg_thumbnail_returns_none(self):
+        assert _parse_public_id('/thumbnails/mug.svg') is None
+
+
+class TestBackfillPublicIds(TestCase):
+    """Integration tests for the migration 0026 backfill function."""
+
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(username='test@test.com', password='pw')
+
+    def _make_schema_editor(self):
+        return _FakeSchemaEditor()
+
+    def test_backfills_null_public_id_in_piece_state_images(self):
+        url = 'https://res.cloudinary.com/mycloud/image/upload/v1776802576/glaze_prod/abc.jpg'
+        piece = Piece.objects.create(user=self.user, name='Test Piece')
+        ps = PieceState.objects.filter(piece=piece).order_by('created').first()
+        PieceState.objects.filter(pk=ps.pk).update(images=[
+            {'url': url, 'cloudinary_public_id': None, 'cloud_name': 'mycloud', 'caption': ''}
+        ])
+
+        _backfill(django_apps, self._make_schema_editor())
+
+        ps.refresh_from_db()
+        assert ps.images[0]['cloudinary_public_id'] == 'glaze_prod/abc'
+
+    def test_does_not_overwrite_existing_public_id(self):
+        piece = Piece.objects.create(user=self.user, name='Piece2')
+        ps = PieceState.objects.filter(piece=piece).order_by('created').first()
+        PieceState.objects.filter(pk=ps.pk).update(images=[
+            {'url': 'https://res.cloudinary.com/c/image/upload/v1/folder/img.jpg',
+             'cloudinary_public_id': 'explicit_id', 'cloud_name': 'c', 'caption': ''}
+        ])
+
+        _backfill(django_apps, self._make_schema_editor())
+
+        ps.refresh_from_db()
+        assert ps.images[0]['cloudinary_public_id'] == 'explicit_id'
+
+    def test_backfills_null_public_id_in_piece_thumbnail(self):
+        url = 'https://res.cloudinary.com/mycloud/image/upload/v1/glaze_prod/thumb.jpg'
+        piece = Piece.objects.create(user=self.user, name='Piece3')
+        Piece.objects.filter(pk=piece.pk).update(thumbnail={
+            'url': url, 'cloudinary_public_id': None, 'cloud_name': 'mycloud'
+        })
+
+        _backfill(django_apps, self._make_schema_editor())
+
+        piece.refresh_from_db()
+        assert piece.thumbnail['cloudinary_public_id'] == 'glaze_prod/thumb'
+
+    def test_backfills_null_public_id_in_glaze_type_image(self):
+        url = 'https://res.cloudinary.com/mycloud/image/upload/v1/glaze_prod/tile.jpg'
+        gt = GlazeType.objects.create(
+            user=None, name='BackfillTest',
+            test_tile_image={'url': url, 'cloudinary_public_id': None, 'cloud_name': 'mycloud'},
+        )
+
+        _backfill(django_apps, self._make_schema_editor())
+
+        gt.refresh_from_db()
+        assert gt.test_tile_image['cloudinary_public_id'] == 'glaze_prod/tile'
+
+    def test_heic_url_gets_correct_public_id(self):
+        url = 'https://res.cloudinary.com/mycloud/image/upload/v1/glaze_prod/photo.heic'
+        piece = Piece.objects.create(user=self.user, name='Piece4')
+        Piece.objects.filter(pk=piece.pk).update(thumbnail={
+            'url': url, 'cloudinary_public_id': None, 'cloud_name': 'mycloud'
+        })
+
+        _backfill(django_apps, self._make_schema_editor())
+
+        piece.refresh_from_db()
+        assert piece.thumbnail['cloudinary_public_id'] == 'glaze_prod/photo'

--- a/api/tests/test_image_field_migration.py
+++ b/api/tests/test_image_field_migration.py
@@ -21,7 +21,7 @@ from django.apps import apps as django_apps
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-from api.models import GlazeCombination, GlazeType, Piece, PieceState
+from api.models import ENTRY_STATE, GlazeCombination, GlazeType, Piece, PieceState
 
 # ---------------------------------------------------------------------------
 # Import the helper functions directly from the migration module.
@@ -248,7 +248,7 @@ class TestBackfillPublicIds(TestCase):
     def test_backfills_null_public_id_in_piece_state_images(self):
         url = 'https://res.cloudinary.com/mycloud/image/upload/v1776802576/glaze_prod/abc.jpg'
         piece = Piece.objects.create(user=self.user, name='Test Piece')
-        ps = PieceState.objects.filter(piece=piece).order_by('created').first()
+        ps = PieceState.objects.create(piece=piece, user=self.user, state=ENTRY_STATE)
         PieceState.objects.filter(pk=ps.pk).update(images=[
             {'url': url, 'cloudinary_public_id': None, 'cloud_name': 'mycloud', 'caption': ''}
         ])
@@ -260,7 +260,7 @@ class TestBackfillPublicIds(TestCase):
 
     def test_does_not_overwrite_existing_public_id(self):
         piece = Piece.objects.create(user=self.user, name='Piece2')
-        ps = PieceState.objects.filter(piece=piece).order_by('created').first()
+        ps = PieceState.objects.create(piece=piece, user=self.user, state=ENTRY_STATE)
         PieceState.objects.filter(pk=ps.pk).update(images=[
             {'url': 'https://res.cloudinary.com/c/image/upload/v1/folder/img.jpg',
              'cloudinary_public_id': 'explicit_id', 'cloud_name': 'c', 'caption': ''}


### PR DESCRIPTION
## Summary

- **Root cause**: Migration 0025 (rewritten in PR #211) backfilled `cloud_name` into existing image dicts but left `cloudinary_public_id: null` for images already stored as JSON objects from the prior schema migration. `CloudinaryImage` requires **both** `cloud_name` and `cloudinary_public_id` to use Cloudinary's delivery pipeline; with `public_id` null it fell back to full-resolution plain `<img>`. HEIC images stopped rendering entirely because browsers cannot display raw HEIC URLs without Cloudinary's `f_auto` format conversion.

- **Migration 0026** (`api/migrations/0026_backfill_cloudinary_public_id.py`): backfills `cloudinary_public_id` from the delivery URL for every image dict where it is currently null across `PieceState.images`, `Piece.thumbnail`, and `GlazeType`/`GlazeCombination.test_tile_image`. Also fixes the **version-segment bug** in the URL parser: `v1234567` path segments are now stripped before extracting the public_id (matching Cloudinary's own convention).

- **Management command** (`restore_images_from_backup`): reads a pre-migration YAML export and restores any `PieceState` image arrays or `Piece` thumbnails that are missing in the current DB but present in the backup. Derives `cloudinary_public_id` and `cloud_name` at restore time.

- **Tests**: unit tests for the new URL parser (including version-stripping and HEIC extension handling) and integration tests for the backfill forward function.

## Running the restore command

```bash
python manage.py restore_images_from_backup Piece-2026-04-30.yaml --dry-run
python manage.py restore_images_from_backup Piece-2026-04-30.yaml
```

## Test plan

- [x] `bazel test //api:api_model_test` — migration + backfill tests pass
- [x] `bazel test //...` — all 30 tests pass
- [ ] Run `python manage.py migrate` on a copy of the production DB and verify thumbnail images in PieceList render at 64×64 via Cloudinary
- [ ] Run `restore_images_from_backup` with `--dry-run` to review what would be restored, then without dry-run

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)
