### PR TITLE
Add migration 0027 to backfill cloud_name for images and thumbnails

### DIFF
--- a/api/BUILD.bazel
+++ b/api/BUILD.bazel
@@ -110,6 +110,7 @@ py_test(
         "migrations/__init__.py",
         "migrations/0025_image_field_jsonfield.py",
         "migrations/0026_backfill_cloudinary_public_id.py",
+        "migrations/0027_backfill_cloud_name.py",
     ],
     args = [
         "api/tests/test_model_factory.py",

--- a/api/migrations/0027_backfill_cloud_name.py
+++ b/api/migrations/0027_backfill_cloud_name.py
@@ -1,0 +1,78 @@
+"""Backfill cloud_name for PieceState images and Piece thumbnails.
+
+Migration 0025 was rewritten in-place to add a cloud_name backfill step for
+PieceState.images and Piece.thumbnail.  Because Django tracks migrations by
+name, that step never ran on databases where 0025 was already applied — only
+the AlterField schema operations were recorded as pending and executed.
+
+This migration performs the backfill that 0025 should have run.  It is
+logically equivalent to migration 0025's piece_images_add_cloud_name
+RunPython step, but as a new migration that will actually execute.
+"""
+
+import re
+from urllib.parse import urlparse
+
+from django.db import migrations
+
+
+_CLOUDINARY_HOSTNAME = 'res.cloudinary.com'
+_TRANSFORM_RE = re.compile(r'^[a-z]{1,4}_')
+_VERSION_RE = re.compile(r'^v\d+$')
+
+
+def _parse_cloud_name(url: str) -> str | None:
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return None
+    if parsed.hostname != _CLOUDINARY_HOSTNAME:
+        return None
+    parts = parsed.path.split('/')
+    # parts: ['', cloud_name, 'image', 'upload', ...]
+    if len(parts) < 4 or parts[2] != 'image' or parts[3] != 'upload':
+        return None
+    return parts[1] or None
+
+
+def backfill_cloud_names(apps, schema_editor):
+    PieceState = apps.get_model('api', 'PieceState')
+    Piece = apps.get_model('api', 'Piece')
+
+    for ps in PieceState.objects.exclude(images=[]):
+        images = ps.images or []
+        updated = []
+        changed = False
+        for img in images:
+            if isinstance(img, dict) and 'cloud_name' not in img:
+                updated.append({**img, 'cloud_name': _parse_cloud_name(img.get('url', ''))})
+                changed = True
+            else:
+                updated.append(img)
+        if changed:
+            PieceState.objects.filter(pk=ps.pk).update(images=updated)
+
+    for piece in Piece.objects.filter(thumbnail__isnull=False):
+        t = piece.thumbnail
+        if isinstance(t, dict) and 'cloud_name' not in t:
+            Piece.objects.filter(pk=piece.pk).update(
+                thumbnail={**t, 'cloud_name': _parse_cloud_name(t.get('url', ''))}
+            )
+
+
+def reverse_backfill_cloud_names(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("api", "0026_backfill_cloudinary_public_id"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            backfill_cloud_names,
+            reverse_code=reverse_backfill_cloud_names,
+        ),
+    ]

--- a/api/tests/test_image_field_migration.py
+++ b/api/tests/test_image_field_migration.py
@@ -306,3 +306,89 @@ class TestBackfillPublicIds(TestCase):
 
         piece.refresh_from_db()
         assert piece.thumbnail['cloudinary_public_id'] == 'glaze_prod/photo'
+
+
+# ---------------------------------------------------------------------------
+# Migration 0027: backfill cloud_name where missing
+# ---------------------------------------------------------------------------
+
+_migration_0027 = importlib.import_module(
+    'api.migrations.0027_backfill_cloud_name'
+)
+_backfill_cloud_names = _migration_0027.backfill_cloud_names
+_parse_cloud_name_0027 = _migration_0027._parse_cloud_name
+
+
+class TestParseCloudName:
+    """Unit tests for the cloud_name extractor in migration 0027."""
+
+    def test_extracts_cloud_name(self):
+        url = 'https://res.cloudinary.com/mycloud/image/upload/v1/folder/img.jpg'
+        assert _parse_cloud_name_0027(url) == 'mycloud'
+
+    def test_returns_none_for_non_cloudinary(self):
+        assert _parse_cloud_name_0027('https://example.com/img.jpg') is None
+
+    def test_returns_none_for_empty_string(self):
+        assert _parse_cloud_name_0027('') is None
+
+
+class TestBackfillCloudNames(TestCase):
+    """Integration tests for the migration 0027 backfill function."""
+
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(username='test27@test.com', password='pw')
+
+    def _make_schema_editor(self):
+        return _FakeSchemaEditor()
+
+    def test_backfills_missing_cloud_name_in_piece_state_images(self):
+        url = 'https://res.cloudinary.com/mycloud27/image/upload/v1/glaze_prod/abc.jpg'
+        piece = Piece.objects.create(user=self.user, name='Piece27A')
+        ps = PieceState.objects.create(piece=piece, user=self.user, state=ENTRY_STATE)
+        PieceState.objects.filter(pk=ps.pk).update(images=[
+            {'url': url, 'cloudinary_public_id': 'glaze_prod/abc', 'caption': ''}
+        ])
+
+        _backfill_cloud_names(django_apps, self._make_schema_editor())
+
+        ps.refresh_from_db()
+        assert ps.images[0]['cloud_name'] == 'mycloud27'
+
+    def test_does_not_overwrite_existing_cloud_name(self):
+        url = 'https://res.cloudinary.com/mycloud27/image/upload/v1/glaze_prod/abc.jpg'
+        piece = Piece.objects.create(user=self.user, name='Piece27B')
+        ps = PieceState.objects.create(piece=piece, user=self.user, state=ENTRY_STATE)
+        PieceState.objects.filter(pk=ps.pk).update(images=[
+            {'url': url, 'cloudinary_public_id': 'glaze_prod/abc', 'cloud_name': 'explicit', 'caption': ''}
+        ])
+
+        _backfill_cloud_names(django_apps, self._make_schema_editor())
+
+        ps.refresh_from_db()
+        assert ps.images[0]['cloud_name'] == 'explicit'
+
+    def test_backfills_missing_cloud_name_in_piece_thumbnail(self):
+        url = 'https://res.cloudinary.com/mycloud27/image/upload/v1/glaze_prod/thumb.jpg'
+        piece = Piece.objects.create(user=self.user, name='Piece27C')
+        Piece.objects.filter(pk=piece.pk).update(thumbnail={
+            'url': url, 'cloudinary_public_id': 'glaze_prod/thumb'
+        })
+
+        _backfill_cloud_names(django_apps, self._make_schema_editor())
+
+        piece.refresh_from_db()
+        assert piece.thumbnail['cloud_name'] == 'mycloud27'
+
+    def test_does_not_overwrite_existing_thumbnail_cloud_name(self):
+        url = 'https://res.cloudinary.com/mycloud27/image/upload/v1/glaze_prod/thumb.jpg'
+        piece = Piece.objects.create(user=self.user, name='Piece27D')
+        Piece.objects.filter(pk=piece.pk).update(thumbnail={
+            'url': url, 'cloudinary_public_id': 'glaze_prod/thumb', 'cloud_name': 'original'
+        })
+
+        _backfill_cloud_names(django_apps, self._make_schema_editor())
+
+        piece.refresh_from_db()
+        assert piece.thumbnail['cloud_name'] == 'original'


### PR DESCRIPTION
Migration 0025 was rewritten in-place in PR #211 to add a cloud_name backfill RunPython step, but Django skips RunPython for already-applied migrations by name. On production DBs where 0025 was already recorded, the cloud_name field was never populated — causing CloudinaryImage to fall back to full-resolution plain <img> since it requires both cloud_name and cloudinary_public_id to use the Cloudinary pipeline.

Migration 0027 re-runs the cloud_name extraction for every image dict that is missing the field, deriving it from the stored Cloudinary URL. Covers PieceState.images and Piece.thumbnail.

Tests added for the _parse_cloud_name helper and the backfill function itself (with/without existing values) following the 0026 test patterns.