### PR TITLE
Add sort and infinite-scroll pagination to pieces list

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,8 @@
   },
   "permissions": {
     "allow": [
-      "Bash(python3 -c \"from pathlib import Path; p = Path\\('/home/phil/code/glaze/.agent-worktrees/claude/coverage-improvements/backend/settings.py'\\); print\\(p.resolve\\(\\).parent.parent\\)\")"
+      "Bash(python3 -c \"from pathlib import Path; p = Path\\('/home/phil/code/glaze/.agent-worktrees/claude/coverage-improvements/backend/settings.py'\\); print\\(p.resolve\\(\\).parent.parent\\)\")",
+      "Read(//home/phil/code/glaze/.claire/worktrees/issue+216-sort-pagination/web/src/components/__tests__/**)"
     ]
   }
 }

--- a/api/tests/test_auth.py
+++ b/api/tests/test_auth.py
@@ -151,7 +151,7 @@ class TestAuthEndpoints:
         user = User.objects.get(email="devadmin@example.com")
         assert user.is_staff is True
         assert user.is_superuser is True
-        assert Piece.objects.filter(user=user).count() == 3
+        assert Piece.objects.filter(user=user).count() == 75
 
     def test_login_bootstraps_existing_first_dev_user_when_enabled(self, settings):
         settings.DEV_BOOTSTRAP_ENABLED = True

--- a/api/tests/test_pieces_list.py
+++ b/api/tests/test_pieces_list.py
@@ -11,19 +11,22 @@ class TestPiecesList:
     def test_empty(self, client):
         response = client.get('/api/pieces/')
         assert response.status_code == 200
-        assert response.json() == []
+        data = response.json()
+        assert data['count'] == 0
+        assert data['results'] == []
 
     def test_returns_pieces(self, client, piece):
         response = client.get('/api/pieces/')
         assert response.status_code == 200
         data = response.json()
-        assert len(data) == 1
-        assert data[0]['name'] == 'Test Bowl'
-        assert data[0]['current_state']['state'] == ENTRY_STATE
+        assert data['count'] == 1
+        assert len(data['results']) == 1
+        assert data['results'][0]['name'] == 'Test Bowl'
+        assert data['results'][0]['current_state']['state'] == ENTRY_STATE
 
     def test_summary_shape(self, client, piece):
         data = client.get('/api/pieces/').json()
-        keys = set(data[0].keys())
+        keys = set(data['results'][0].keys())
         assert keys == {'id', 'name', 'created', 'current_location', 'last_modified', 'thumbnail', 'current_state', 'tags'}
 
     def test_does_not_include_other_users_pieces(self, client, other_user):
@@ -31,7 +34,9 @@ class TestPiecesList:
         PieceState.objects.create(piece=hidden, state=ENTRY_STATE)
         response = client.get('/api/pieces/')
         assert response.status_code == 200
-        assert response.json() == []
+        data = response.json()
+        assert data['count'] == 0
+        assert data['results'] == []
 
     def test_filters_by_all_tag_ids_and_deduplicates_results(self, client, piece, user):
         second_piece = Piece.objects.create(user=user, name='Second Bowl')
@@ -58,4 +63,60 @@ class TestPiecesList:
 
         assert response.status_code == 200
         data = response.json()
-        assert [entry['id'] for entry in data] == [str(piece.id)]
+        assert [entry['id'] for entry in data['results']] == [str(piece.id)]
+
+    def test_pagination_limit_and_offset(self, client, user):
+        pieces = [Piece.objects.create(user=user, name=f'Piece {i}') for i in range(5)]
+        for p in pieces:
+            PieceState.objects.create(piece=p, state=ENTRY_STATE)
+
+        response = client.get('/api/pieces/', {'limit': 2, 'offset': 0})
+        assert response.status_code == 200
+        data = response.json()
+        assert data['count'] == 5
+        assert len(data['results']) == 2
+
+        response2 = client.get('/api/pieces/', {'limit': 2, 'offset': 4})
+        assert response2.status_code == 200
+        data2 = response2.json()
+        assert data2['count'] == 5
+        assert len(data2['results']) == 1
+
+    def test_ordering_by_name(self, client, user):
+        names = ['Zebra Vase', 'Apple Mug', 'Mango Bowl']
+        for name in names:
+            p = Piece.objects.create(user=user, name=name)
+            PieceState.objects.create(piece=p, state=ENTRY_STATE)
+
+        response = client.get('/api/pieces/', {'ordering': 'name'})
+        assert response.status_code == 200
+        result_names = [r['name'] for r in response.json()['results']]
+        assert result_names == sorted(names)
+
+    def test_ordering_by_name_descending(self, client, user):
+        names = ['Zebra Vase', 'Apple Mug', 'Mango Bowl']
+        for name in names:
+            p = Piece.objects.create(user=user, name=name)
+            PieceState.objects.create(piece=p, state=ENTRY_STATE)
+
+        response = client.get('/api/pieces/', {'ordering': '-name'})
+        assert response.status_code == 200
+        result_names = [r['name'] for r in response.json()['results']]
+        assert result_names == sorted(names, reverse=True)
+
+    def test_ordering_by_created(self, client, user):
+        pieces = []
+        for i in range(3):
+            p = Piece.objects.create(user=user, name=f'Piece {i}')
+            PieceState.objects.create(piece=p, state=ENTRY_STATE)
+            pieces.append(p)
+
+        response = client.get('/api/pieces/', {'ordering': 'created'})
+        assert response.status_code == 200
+        result_ids = [r['id'] for r in response.json()['results']]
+        assert result_ids == [str(p.id) for p in pieces]
+
+    def test_invalid_ordering_falls_back_to_default(self, client, piece):
+        response = client.get('/api/pieces/', {'ordering': 'nonexistent_field'})
+        assert response.status_code == 200
+        assert response.json()['count'] == 1

--- a/api/utils.py
+++ b/api/utils.py
@@ -124,8 +124,12 @@ def bootstrap_dev_user(user) -> None:
 
 
 def _seed_dev_pieces(user) -> None:
-    """Create a few representative pieces for a newly bootstrapped dev user."""
-    from .models import ClayBody, GlazeCombination, GlazeType, Piece  # noqa: PLC0415
+    """Create 30 representative pieces for a newly bootstrapped dev user.
+
+    The volume exercises the default page size of 24 so infinite-scroll
+    pagination is immediately visible in the dev environment.
+    """
+    from .models import ClayBody, GlazeCombination, GlazeType, Location, Piece  # noqa: PLC0415
 
     clay_body, _ = ClayBody.objects.get_or_create(
         user=user,
@@ -133,6 +137,11 @@ def _seed_dev_pieces(user) -> None:
         defaults={
             "short_description": "Reliable mid-fire stoneware for local dev demos."
         },
+    )
+    porcelain, _ = ClayBody.objects.get_or_create(
+        user=user,
+        name="White Porcelain",
+        defaults={"short_description": "Smooth throwing porcelain."},
     )
     glaze_type, _ = GlazeType.objects.get_or_create(
         user=user,
@@ -147,105 +156,239 @@ def _seed_dev_pieces(user) -> None:
             "apply_thin": False,
         },
     )
-    glaze_combination, _ = GlazeCombination.get_or_create_with_components(
+    celadon, _ = GlazeType.objects.get_or_create(
         user=user,
-        glaze_types=[glaze_type],
+        name="Celadon Green",
+        defaults={
+            "short_description": "Soft celadon for porcelain.",
+            "test_tile_image": "",
+            "is_food_safe": True,
+            "runs": False,
+            "highlights_grooves": False,
+            "is_different_on_white_and_brown_clay": False,
+            "apply_thin": True,
+        },
     )
-
-    from .models import Location  # noqa: PLC0415
+    tenmoku, _ = GlazeType.objects.get_or_create(
+        user=user,
+        name="Tenmoku",
+        defaults={
+            "short_description": "Dark iron-rich glaze.",
+            "test_tile_image": "",
+            "is_food_safe": True,
+            "runs": True,
+            "highlights_grooves": True,
+            "is_different_on_white_and_brown_clay": True,
+            "apply_thin": False,
+        },
+    )
+    floating_blue_combo, _ = GlazeCombination.get_or_create_with_components(
+        user=user, glaze_types=[glaze_type]
+    )
+    celadon_combo, _ = GlazeCombination.get_or_create_with_components(
+        user=user, glaze_types=[celadon]
+    )
+    tenmoku_combo, _ = GlazeCombination.get_or_create_with_components(
+        user=user, glaze_types=[tenmoku]
+    )
 
     bisque_kiln, _ = Location.objects.get_or_create(user=user, name="Bisque Kiln")
     glaze_kiln, _ = Location.objects.get_or_create(user=user, name="Glaze Kiln")
+    shelf, _ = Location.objects.get_or_create(user=user, name="Drying Shelf")
 
-    trimmed_piece = Piece.objects.create(
-        user=user,
-        name="Trimmed Practice Bowl",
-        thumbnail={"url": DEV_THUMBNAIL_URLS["bowl"], "cloudinary_public_id": None},
-    )
-    _create_piece_state(trimmed_piece, "designed", notes="Starting a quick demo bowl.")
-    _create_piece_state(
-        trimmed_piece,
-        "wheel_thrown",
-        notes="Opened and pulled on the wheel.",
-        additional_fields={"clay_weight_lbs": 1250, "wall_thickness_mm": 7.5},
-        global_refs={"clay_body": ("clay_body", clay_body)},
-    )
-    _create_piece_state(
-        trimmed_piece,
-        "trimmed",
-        notes="Foot ring cleaned up and ready to dry.",
-        additional_fields={"trimmed_weight_lbs": 980, "pre_trim_weight_lbs": 1250},
-    )
+    T = DEV_THUMBNAIL_URLS
 
-    bisque_piece = Piece.objects.create(
-        user=user,
-        name="Bisque Queue Mug",
-        thumbnail={"url": DEV_THUMBNAIL_URLS["mug"], "cloudinary_public_id": None},
-    )
-    _create_piece_state(bisque_piece, "designed", notes="Planning a handbuilt mug.")
-    _create_piece_state(
-        bisque_piece,
-        "handbuilt",
-        notes="Walls are up and the handle is attached.",
-        global_refs={"clay_body": ("clay_body", clay_body)},
-    )
-    _create_piece_state(
-        bisque_piece,
-        "submitted_to_bisque_fire",
-        notes="Queued for the next bisque load.",
-        global_refs={"kiln_location": ("location", bisque_kiln)},
-    )
+    # -----------------------------------------------------------------------
+    # Pieces at various lifecycle stages.  30 total so the default page of 24
+    # leaves a second page for the infinite-scroll trigger to pick up.
+    # -----------------------------------------------------------------------
 
-    finished_piece = Piece.objects.create(
-        user=user,
-        name="Finished Test Plate",
-        thumbnail={"url": DEV_THUMBNAIL_URLS["plate"], "cloudinary_public_id": None},
-    )
-    _create_piece_state(
-        finished_piece, "designed", notes="Small plate for glaze testing."
-    )
-    _create_piece_state(
-        finished_piece,
-        "handbuilt",
-        notes="Slab-built and compressed.",
-        global_refs={"clay_body": ("clay_body", clay_body)},
-    )
-    _create_piece_state(
-        finished_piece,
-        "submitted_to_bisque_fire",
-        notes="Waiting for bisque firing.",
-        global_refs={"kiln_location": ("location", bisque_kiln)},
-    )
-    _create_piece_state(
-        finished_piece,
-        "bisque_fired",
-        notes="Bisque firing complete.",
-        additional_fields={"kiln_temperature_c": 1060, "cone": "04"},
-    )
-    _create_piece_state(
-        finished_piece,
-        "glazed",
-        notes="Floating Blue test coat applied.",
-        global_refs={"glaze_combination": ("glaze_combination", glaze_combination)},
-    )
-    _create_piece_state(
-        finished_piece,
-        "submitted_to_glaze_fire",
-        notes="Queued for glaze firing.",
-        global_refs={"kiln_location": ("location", glaze_kiln)},
-    )
-    _create_piece_state(
-        finished_piece,
-        "glaze_fired",
-        notes="Out of the kiln and looking promising.",
-        additional_fields={"kiln_temperature_c": 1060, "cone": "04"},
-        global_refs={"glaze_combination": ("glaze_combination", glaze_combination)},
-    )
-    _create_piece_state(
-        finished_piece,
-        "completed",
-        notes="Ready for quick UI smoke testing.",
-    )
+    def _bowl(name, *, clay=clay_body, thumb="bowl"):
+        p = Piece.objects.create(
+            user=user, name=name,
+            thumbnail={"url": T[thumb], "cloudinary_public_id": None},
+        )
+        return p, clay
+
+    def _mug(name, *, clay=clay_body, thumb="mug"):
+        p = Piece.objects.create(
+            user=user, name=name,
+            thumbnail={"url": T[thumb], "cloudinary_public_id": None},
+        )
+        return p, clay
+
+    def _plate(name, *, clay=clay_body, thumb="plate"):
+        p = Piece.objects.create(
+            user=user, name=name,
+            thumbnail={"url": T[thumb], "cloudinary_public_id": None},
+        )
+        return p, clay
+
+    def _vase(name, *, clay=clay_body, thumb="vase"):
+        p = Piece.objects.create(
+            user=user, name=name,
+            thumbnail={"url": T[thumb], "cloudinary_public_id": None},
+        )
+        return p, clay
+
+    # 1. Just designed
+    for label in [
+        "Morning Sketch Bowl",
+        "Teacup Concept",
+        "Platter Idea",
+    ]:
+        p = Piece.objects.create(
+            user=user, name=label,
+            thumbnail={"url": T["plate"], "cloudinary_public_id": None},
+        )
+        _create_piece_state(p, "designed", notes=f"Rough concept for {label}.")
+
+    # 2. Wheel thrown / handbuilt, drying
+    p, clay = _bowl("Throwing Practice Bowl")
+    _create_piece_state(p, "designed")
+    _create_piece_state(p, "wheel_thrown",
+        notes="Good centering, walls a bit uneven.",
+        additional_fields={"clay_weight_lbs": 1100, "wall_thickness_mm": 8.0},
+        global_refs={"clay_body": ("clay_body", clay)})
+
+    p, clay = _mug("Porcelain Yunomi", clay=porcelain)
+    _create_piece_state(p, "designed")
+    _create_piece_state(p, "wheel_thrown",
+        notes="Delicate thin walls.",
+        additional_fields={"clay_weight_lbs": 450, "wall_thickness_mm": 4.5},
+        global_refs={"clay_body": ("clay_body", clay)})
+
+    p, clay = _vase("Coil-Built Vase")
+    _create_piece_state(p, "designed")
+    _create_piece_state(p, "handbuilt", notes="Coils blended inside and out.",
+        global_refs={"clay_body": ("clay_body", clay)})
+
+    p, clay = _plate("Slab Tray")
+    _create_piece_state(p, "designed")
+    _create_piece_state(p, "handbuilt", notes="Rolled slab, edges folded.",
+        global_refs={"clay_body": ("clay_body", clay)})
+
+    # 3. Trimmed, drying
+    p, clay = _bowl("Trimmed Practice Bowl", clay=porcelain)
+    _create_piece_state(p, "designed")
+    _create_piece_state(p, "wheel_thrown",
+        additional_fields={"clay_weight_lbs": 900, "wall_thickness_mm": 6.0},
+        global_refs={"clay_body": ("clay_body", clay)})
+    _create_piece_state(p, "trimmed",
+        notes="Foot ring clean.",
+        additional_fields={"trimmed_weight_lbs": 720, "pre_trim_weight_lbs": 900})
+
+    p, clay = _mug("Trimmed Mug")
+    _create_piece_state(p, "designed")
+    _create_piece_state(p, "wheel_thrown",
+        additional_fields={"clay_weight_lbs": 600, "wall_thickness_mm": 6.5},
+        global_refs={"clay_body": ("clay_body", clay)})
+    _create_piece_state(p, "trimmed",
+        additional_fields={"trimmed_weight_lbs": 490, "pre_trim_weight_lbs": 600})
+
+    # 4. Queued / in bisque kiln
+    for label, thumb in [
+        ("Bisque Bowl #1", "bowl"),
+        ("Bisque Mug #1", "mug"),
+        ("Bisque Plate #1", "plate"),
+    ]:
+        p = Piece.objects.create(
+            user=user, name=label,
+            thumbnail={"url": T[thumb], "cloudinary_public_id": None},
+        )
+        _create_piece_state(p, "designed")
+        _create_piece_state(p, "wheel_thrown",
+            additional_fields={"clay_weight_lbs": 800, "wall_thickness_mm": 7.0},
+            global_refs={"clay_body": ("clay_body", clay_body)})
+        _create_piece_state(p, "trimmed",
+            additional_fields={"trimmed_weight_lbs": 650, "pre_trim_weight_lbs": 800})
+        _create_piece_state(p, "submitted_to_bisque_fire",
+            notes="In the next bisque load.",
+            global_refs={"kiln_location": ("location", bisque_kiln)})
+
+    # 5. Bisque-fired, planning glaze
+    for label, combo, thumb in [
+        ("Blue Bowl", floating_blue_combo, "bowl"),
+        ("Celadon Vase", celadon_combo, "vase"),
+        ("Tenmoku Mug", tenmoku_combo, "mug"),
+        ("Blue Plate", floating_blue_combo, "plate"),
+    ]:
+        p = Piece.objects.create(
+            user=user, name=label,
+            thumbnail={"url": T[thumb], "cloudinary_public_id": None},
+        )
+        _create_piece_state(p, "designed")
+        _create_piece_state(p, "wheel_thrown",
+            additional_fields={"clay_weight_lbs": 950, "wall_thickness_mm": 7.0},
+            global_refs={"clay_body": ("clay_body", clay_body)})
+        _create_piece_state(p, "trimmed",
+            additional_fields={"trimmed_weight_lbs": 780, "pre_trim_weight_lbs": 950})
+        _create_piece_state(p, "submitted_to_bisque_fire",
+            global_refs={"kiln_location": ("location", bisque_kiln)})
+        _create_piece_state(p, "bisque_fired",
+            notes="Bisque complete.",
+            additional_fields={"kiln_temperature_c": 1000, "cone": "06"})
+
+    # 6. Glazed and queued for glaze fire
+    p, _ = _bowl("Glazed Test Bowl", clay=porcelain)
+    _create_piece_state(p, "designed")
+    _create_piece_state(p, "wheel_thrown",
+        additional_fields={"clay_weight_lbs": 700, "wall_thickness_mm": 5.5},
+        global_refs={"clay_body": ("clay_body", porcelain)})
+    _create_piece_state(p, "trimmed",
+        additional_fields={"trimmed_weight_lbs": 570, "pre_trim_weight_lbs": 700})
+    _create_piece_state(p, "submitted_to_bisque_fire",
+        global_refs={"kiln_location": ("location", bisque_kiln)})
+    _create_piece_state(p, "bisque_fired",
+        additional_fields={"kiln_temperature_c": 1000, "cone": "06"})
+    _create_piece_state(p, "glazed",
+        notes="Celadon, single coat.",
+        global_refs={"glaze_combination": ("glaze_combination", celadon_combo)})
+    _create_piece_state(p, "submitted_to_glaze_fire",
+        notes="Ready for cone 6 fire.",
+        global_refs={"kiln_location": ("location", glaze_kiln)})
+
+    # 7. Completed pieces
+    for label, combo, thumb in [
+        ("Finished Blue Bowl", floating_blue_combo, "bowl"),
+        ("Finished Celadon Plate", celadon_combo, "plate"),
+        ("Finished Tenmoku Vase", tenmoku_combo, "vase"),
+    ]:
+        p = Piece.objects.create(
+            user=user, name=label,
+            thumbnail={"url": T[thumb], "cloudinary_public_id": None},
+        )
+        _create_piece_state(p, "designed")
+        _create_piece_state(p, "wheel_thrown",
+            additional_fields={"clay_weight_lbs": 1000, "wall_thickness_mm": 7.0},
+            global_refs={"clay_body": ("clay_body", clay_body)})
+        _create_piece_state(p, "trimmed",
+            additional_fields={"trimmed_weight_lbs": 820, "pre_trim_weight_lbs": 1000})
+        _create_piece_state(p, "submitted_to_bisque_fire",
+            global_refs={"kiln_location": ("location", bisque_kiln)})
+        _create_piece_state(p, "bisque_fired",
+            additional_fields={"kiln_temperature_c": 1000, "cone": "06"})
+        _create_piece_state(p, "glazed",
+            global_refs={"glaze_combination": ("glaze_combination", combo)})
+        _create_piece_state(p, "submitted_to_glaze_fire",
+            global_refs={"kiln_location": ("location", glaze_kiln)})
+        _create_piece_state(p, "glaze_fired",
+            notes="Out of the kiln.",
+            additional_fields={"kiln_temperature_c": 1240, "cone": "6"},
+            global_refs={"glaze_combination": ("glaze_combination", combo)})
+        _create_piece_state(p, "completed", notes="Ready to use.")
+
+    # 8. Recycled pieces
+    for label in ["Cracked Practice Bowl", "Collapsed Cylinder"]:
+        p = Piece.objects.create(
+            user=user, name=label,
+            thumbnail={"url": T["bowl"], "cloudinary_public_id": None},
+        )
+        _create_piece_state(p, "designed")
+        _create_piece_state(p, "wheel_thrown",
+            additional_fields={"clay_weight_lbs": 800, "wall_thickness_mm": 7.0},
+            global_refs={"clay_body": ("clay_body", clay_body)})
+        _create_piece_state(p, "recycled", notes="Reclaiming the clay.")
 
 
 def _create_piece_state(

--- a/api/utils.py
+++ b/api/utils.py
@@ -124,271 +124,181 @@ def bootstrap_dev_user(user) -> None:
 
 
 def _seed_dev_pieces(user) -> None:
-    """Create 30 representative pieces for a newly bootstrapped dev user.
+    """Create 75 pieces in random workflow states for a bootstrapped dev user.
 
-    The volume exercises the default page size of 24 so infinite-scroll
-    pagination is immediately visible in the dev environment.
+    75 pieces fills three full pages of 24 so infinite-scroll pagination is
+    immediately exercisable.  A seeded RNG makes the output reproducible across
+    dev database resets.
     """
+    import random  # noqa: PLC0415
+
     from .models import ClayBody, GlazeCombination, GlazeType, Location, Piece  # noqa: PLC0415
 
-    clay_body, _ = ClayBody.objects.get_or_create(
-        user=user,
-        name="Brown Stoneware",
-        defaults={
-            "short_description": "Reliable mid-fire stoneware for local dev demos."
-        },
-    )
-    porcelain, _ = ClayBody.objects.get_or_create(
-        user=user,
-        name="White Porcelain",
-        defaults={"short_description": "Smooth throwing porcelain."},
-    )
-    glaze_type, _ = GlazeType.objects.get_or_create(
-        user=user,
-        name="Floating Blue",
-        defaults={
-            "short_description": "Sample glaze for bootstrapped dev data.",
-            "test_tile_image": "",
-            "is_food_safe": True,
-            "runs": False,
-            "highlights_grooves": True,
-            "is_different_on_white_and_brown_clay": True,
-            "apply_thin": False,
-        },
-    )
-    celadon, _ = GlazeType.objects.get_or_create(
-        user=user,
-        name="Celadon Green",
-        defaults={
-            "short_description": "Soft celadon for porcelain.",
-            "test_tile_image": "",
-            "is_food_safe": True,
-            "runs": False,
-            "highlights_grooves": False,
-            "is_different_on_white_and_brown_clay": False,
-            "apply_thin": True,
-        },
-    )
-    tenmoku, _ = GlazeType.objects.get_or_create(
-        user=user,
-        name="Tenmoku",
-        defaults={
-            "short_description": "Dark iron-rich glaze.",
-            "test_tile_image": "",
-            "is_food_safe": True,
-            "runs": True,
-            "highlights_grooves": True,
-            "is_different_on_white_and_brown_clay": True,
-            "apply_thin": False,
-        },
-    )
-    floating_blue_combo, _ = GlazeCombination.get_or_create_with_components(
-        user=user, glaze_types=[glaze_type]
-    )
-    celadon_combo, _ = GlazeCombination.get_or_create_with_components(
-        user=user, glaze_types=[celadon]
-    )
-    tenmoku_combo, _ = GlazeCombination.get_or_create_with_components(
-        user=user, glaze_types=[tenmoku]
-    )
+    rng = random.Random(42)
+
+    # ------------------------------------------------------------------
+    # Reference data
+    # ------------------------------------------------------------------
+    clay_bodies = []
+    for name, desc in [
+        ("Brown Stoneware", "Reliable mid-fire stoneware."),
+        ("White Stoneware", "Smooth mid-fire stoneware."),
+        ("White Porcelain", "Translucent throwing porcelain."),
+        ("Speckled Buff", "Buff body with iron specks."),
+    ]:
+        cb, _ = ClayBody.objects.get_or_create(
+            user=user, name=name, defaults={"short_description": desc}
+        )
+        clay_bodies.append(cb)
+
+    glaze_defs = [
+        ("Floating Blue",  True,  False, True,  True,  False),
+        ("Celadon Green",  True,  False, False, False, True),
+        ("Tenmoku",        True,  True,  True,  True,  False),
+        ("Shino",          True,  False, False, False, True),
+        ("Copper Red",     False, True,  True,  True,  False),
+    ]
+    combos = []
+    for name, food_safe, runs, grooves, diff_clay, thin in glaze_defs:
+        gt, _ = GlazeType.objects.get_or_create(
+            user=user, name=name,
+            defaults={
+                "short_description": f"{name} — dev sample glaze.",
+                "test_tile_image": "",
+                "is_food_safe": food_safe,
+                "runs": runs,
+                "highlights_grooves": grooves,
+                "is_different_on_white_and_brown_clay": diff_clay,
+                "apply_thin": thin,
+            },
+        )
+        combo, _ = GlazeCombination.get_or_create_with_components(
+            user=user, glaze_types=[gt]
+        )
+        combos.append(combo)
 
     bisque_kiln, _ = Location.objects.get_or_create(user=user, name="Bisque Kiln")
     glaze_kiln, _ = Location.objects.get_or_create(user=user, name="Glaze Kiln")
-    shelf, _ = Location.objects.get_or_create(user=user, name="Drying Shelf")
+
+    # ------------------------------------------------------------------
+    # State-step definitions
+    #
+    # Each entry is (state_name, additional_fields_fn, global_refs_fn).
+    # The fns receive (rng, clay, combo) and return dicts (or None).
+    # ------------------------------------------------------------------
+    def _wheel_thrown_fields(r, clay, _combo):
+        weight = r.randint(400, 1800)
+        return (
+            {"clay_weight_lbs": weight, "wall_thickness_mm": round(r.uniform(4.0, 12.0), 1)},
+            {"clay_body": ("clay_body", clay)},
+        )
+
+    def _trimmed_fields(r, _clay, _combo):
+        pre = r.randint(400, 1800)
+        return (
+            {"trimmed_weight_lbs": int(pre * r.uniform(0.7, 0.95)),
+             "pre_trim_weight_lbs": pre},
+            None,
+        )
+
+    def _bisque_fields(r, _clay, _combo):
+        return (
+            {"kiln_temperature_c": r.randint(960, 1020), "cone": r.choice(["04", "03"])},
+            {"kiln_location": ("location", bisque_kiln)},
+        )
+
+    def _bisque_fired_fields(r, _clay, _combo):
+        return (
+            {"kiln_temperature_c": r.randint(960, 1020), "cone": r.choice(["04", "03"])},
+            None,
+        )
+
+    def _glazed_fields(_r, _clay, combo):
+        return (None, {"glaze_combination": ("glaze_combination", combo)})
+
+    def _glaze_fire_fields(_r, _clay, _combo):
+        return (None, {"kiln_location": ("location", glaze_kiln)})
+
+    def _glaze_fired_fields(r, _clay, combo):
+        return (
+            {"kiln_temperature_c": r.randint(1220, 1260), "cone": r.choice(["5", "6"])},
+            {"glaze_combination": ("glaze_combination", combo)},
+        )
+
+    # Two paths: wheel-thrown and handbuilt.  Each is a list of
+    # (state, additional_fields_fn, global_refs_fn) steps.
+    WHEEL_PATH = [
+        ("designed",               None,                 None),
+        ("wheel_thrown",           _wheel_thrown_fields, None),
+        ("trimmed",                _trimmed_fields,      None),
+        ("submitted_to_bisque_fire", lambda r,c,g: (None, {"kiln_location": ("location", bisque_kiln)}), None),
+        ("bisque_fired",           _bisque_fired_fields, None),
+        ("glazed",                 _glazed_fields,       None),
+        ("submitted_to_glaze_fire", _glaze_fire_fields,  None),
+        ("glaze_fired",            _glaze_fired_fields,  None),
+        ("completed",              None,                 None),
+    ]
+
+    HANDBUILT_PATH = [
+        ("designed",               None,                 None),
+        ("handbuilt",              lambda r,c,g: (None, {"clay_body": ("clay_body", c)}), None),
+        ("submitted_to_bisque_fire", lambda r,c,g: (None, {"kiln_location": ("location", bisque_kiln)}), None),
+        ("bisque_fired",           _bisque_fired_fields, None),
+        ("glazed",                 _glazed_fields,       None),
+        ("submitted_to_glaze_fire", _glaze_fire_fields,  None),
+        ("glaze_fired",            _glaze_fired_fields,  None),
+        ("completed",              None,                 None),
+    ]
+
+    FORMS = [
+        ("Bowl",    "bowl"),
+        ("Mug",     "mug"),
+        ("Vase",    "vase"),
+        ("Plate",   "plate"),
+        ("Cup",     "mug"),
+        ("Jug",     "vase"),
+        ("Platter", "plate"),
+        ("Jar",     "bowl"),
+        ("Pitcher", "vase"),
+        ("Dish",    "plate"),
+    ]
+
+    ADJECTIVES = [
+        "Tall", "Short", "Wide", "Rustic", "Delicate", "Heavy",
+        "Practice", "Test", "Study", "Small", "Large", "Faceted",
+        "Carved", "Slip-Trailed", "Fluted", "Altered", "Classic",
+    ]
 
     T = DEV_THUMBNAIL_URLS
 
-    # -----------------------------------------------------------------------
-    # Pieces at various lifecycle stages.  30 total so the default page of 24
-    # leaves a second page for the infinite-scroll trigger to pick up.
-    # -----------------------------------------------------------------------
+    for i in range(75):
+        adj   = rng.choice(ADJECTIVES)
+        form, thumb = rng.choice(FORMS)
+        clay  = rng.choice(clay_bodies)
+        combo = rng.choice(combos)
+        path  = rng.choice([WHEEL_PATH, HANDBUILT_PATH])
 
-    def _bowl(name, *, clay=clay_body, thumb="bowl"):
+        # How far along the path does this piece get?
+        # Weight distribution: more pieces in early/mid states, fewer completed.
+        stop = rng.choices(range(len(path)), weights=[3,4,3,3,3,2,2,2,1], k=1)[0]
+
+        # 10 % chance of recycling instead of stopping at the chosen state.
+        recycled = stop > 0 and rng.random() < 0.10
+
         p = Piece.objects.create(
-            user=user, name=name,
+            user=user,
+            name=f"{adj} {form} #{i + 1}",
             thumbnail={"url": T[thumb], "cloudinary_public_id": None},
         )
-        return p, clay
 
-    def _mug(name, *, clay=clay_body, thumb="mug"):
-        p = Piece.objects.create(
-            user=user, name=name,
-            thumbnail={"url": T[thumb], "cloudinary_public_id": None},
-        )
-        return p, clay
+        for step_state, fields_fn, _ in path[: stop + 1]:
+            af, gr = fields_fn(rng, clay, combo) if fields_fn else (None, None)
+            _create_piece_state(p, step_state,
+                additional_fields=af or {},
+                global_refs=gr or {})
 
-    def _plate(name, *, clay=clay_body, thumb="plate"):
-        p = Piece.objects.create(
-            user=user, name=name,
-            thumbnail={"url": T[thumb], "cloudinary_public_id": None},
-        )
-        return p, clay
-
-    def _vase(name, *, clay=clay_body, thumb="vase"):
-        p = Piece.objects.create(
-            user=user, name=name,
-            thumbnail={"url": T[thumb], "cloudinary_public_id": None},
-        )
-        return p, clay
-
-    # 1. Just designed
-    for label in [
-        "Morning Sketch Bowl",
-        "Teacup Concept",
-        "Platter Idea",
-    ]:
-        p = Piece.objects.create(
-            user=user, name=label,
-            thumbnail={"url": T["plate"], "cloudinary_public_id": None},
-        )
-        _create_piece_state(p, "designed", notes=f"Rough concept for {label}.")
-
-    # 2. Wheel thrown / handbuilt, drying
-    p, clay = _bowl("Throwing Practice Bowl")
-    _create_piece_state(p, "designed")
-    _create_piece_state(p, "wheel_thrown",
-        notes="Good centering, walls a bit uneven.",
-        additional_fields={"clay_weight_lbs": 1100, "wall_thickness_mm": 8.0},
-        global_refs={"clay_body": ("clay_body", clay)})
-
-    p, clay = _mug("Porcelain Yunomi", clay=porcelain)
-    _create_piece_state(p, "designed")
-    _create_piece_state(p, "wheel_thrown",
-        notes="Delicate thin walls.",
-        additional_fields={"clay_weight_lbs": 450, "wall_thickness_mm": 4.5},
-        global_refs={"clay_body": ("clay_body", clay)})
-
-    p, clay = _vase("Coil-Built Vase")
-    _create_piece_state(p, "designed")
-    _create_piece_state(p, "handbuilt", notes="Coils blended inside and out.",
-        global_refs={"clay_body": ("clay_body", clay)})
-
-    p, clay = _plate("Slab Tray")
-    _create_piece_state(p, "designed")
-    _create_piece_state(p, "handbuilt", notes="Rolled slab, edges folded.",
-        global_refs={"clay_body": ("clay_body", clay)})
-
-    # 3. Trimmed, drying
-    p, clay = _bowl("Trimmed Practice Bowl", clay=porcelain)
-    _create_piece_state(p, "designed")
-    _create_piece_state(p, "wheel_thrown",
-        additional_fields={"clay_weight_lbs": 900, "wall_thickness_mm": 6.0},
-        global_refs={"clay_body": ("clay_body", clay)})
-    _create_piece_state(p, "trimmed",
-        notes="Foot ring clean.",
-        additional_fields={"trimmed_weight_lbs": 720, "pre_trim_weight_lbs": 900})
-
-    p, clay = _mug("Trimmed Mug")
-    _create_piece_state(p, "designed")
-    _create_piece_state(p, "wheel_thrown",
-        additional_fields={"clay_weight_lbs": 600, "wall_thickness_mm": 6.5},
-        global_refs={"clay_body": ("clay_body", clay)})
-    _create_piece_state(p, "trimmed",
-        additional_fields={"trimmed_weight_lbs": 490, "pre_trim_weight_lbs": 600})
-
-    # 4. Queued / in bisque kiln
-    for label, thumb in [
-        ("Bisque Bowl #1", "bowl"),
-        ("Bisque Mug #1", "mug"),
-        ("Bisque Plate #1", "plate"),
-    ]:
-        p = Piece.objects.create(
-            user=user, name=label,
-            thumbnail={"url": T[thumb], "cloudinary_public_id": None},
-        )
-        _create_piece_state(p, "designed")
-        _create_piece_state(p, "wheel_thrown",
-            additional_fields={"clay_weight_lbs": 800, "wall_thickness_mm": 7.0},
-            global_refs={"clay_body": ("clay_body", clay_body)})
-        _create_piece_state(p, "trimmed",
-            additional_fields={"trimmed_weight_lbs": 650, "pre_trim_weight_lbs": 800})
-        _create_piece_state(p, "submitted_to_bisque_fire",
-            notes="In the next bisque load.",
-            global_refs={"kiln_location": ("location", bisque_kiln)})
-
-    # 5. Bisque-fired, planning glaze
-    for label, combo, thumb in [
-        ("Blue Bowl", floating_blue_combo, "bowl"),
-        ("Celadon Vase", celadon_combo, "vase"),
-        ("Tenmoku Mug", tenmoku_combo, "mug"),
-        ("Blue Plate", floating_blue_combo, "plate"),
-    ]:
-        p = Piece.objects.create(
-            user=user, name=label,
-            thumbnail={"url": T[thumb], "cloudinary_public_id": None},
-        )
-        _create_piece_state(p, "designed")
-        _create_piece_state(p, "wheel_thrown",
-            additional_fields={"clay_weight_lbs": 950, "wall_thickness_mm": 7.0},
-            global_refs={"clay_body": ("clay_body", clay_body)})
-        _create_piece_state(p, "trimmed",
-            additional_fields={"trimmed_weight_lbs": 780, "pre_trim_weight_lbs": 950})
-        _create_piece_state(p, "submitted_to_bisque_fire",
-            global_refs={"kiln_location": ("location", bisque_kiln)})
-        _create_piece_state(p, "bisque_fired",
-            notes="Bisque complete.",
-            additional_fields={"kiln_temperature_c": 1000, "cone": "04"})
-
-    # 6. Glazed and queued for glaze fire
-    p, _ = _bowl("Glazed Test Bowl", clay=porcelain)
-    _create_piece_state(p, "designed")
-    _create_piece_state(p, "wheel_thrown",
-        additional_fields={"clay_weight_lbs": 700, "wall_thickness_mm": 5.5},
-        global_refs={"clay_body": ("clay_body", porcelain)})
-    _create_piece_state(p, "trimmed",
-        additional_fields={"trimmed_weight_lbs": 570, "pre_trim_weight_lbs": 700})
-    _create_piece_state(p, "submitted_to_bisque_fire",
-        global_refs={"kiln_location": ("location", bisque_kiln)})
-    _create_piece_state(p, "bisque_fired",
-        additional_fields={"kiln_temperature_c": 1000, "cone": "04"})
-    _create_piece_state(p, "glazed",
-        notes="Celadon, single coat.",
-        global_refs={"glaze_combination": ("glaze_combination", celadon_combo)})
-    _create_piece_state(p, "submitted_to_glaze_fire",
-        notes="Ready for cone 6 fire.",
-        global_refs={"kiln_location": ("location", glaze_kiln)})
-
-    # 7. Completed pieces
-    for label, combo, thumb in [
-        ("Finished Blue Bowl", floating_blue_combo, "bowl"),
-        ("Finished Celadon Plate", celadon_combo, "plate"),
-        ("Finished Tenmoku Vase", tenmoku_combo, "vase"),
-    ]:
-        p = Piece.objects.create(
-            user=user, name=label,
-            thumbnail={"url": T[thumb], "cloudinary_public_id": None},
-        )
-        _create_piece_state(p, "designed")
-        _create_piece_state(p, "wheel_thrown",
-            additional_fields={"clay_weight_lbs": 1000, "wall_thickness_mm": 7.0},
-            global_refs={"clay_body": ("clay_body", clay_body)})
-        _create_piece_state(p, "trimmed",
-            additional_fields={"trimmed_weight_lbs": 820, "pre_trim_weight_lbs": 1000})
-        _create_piece_state(p, "submitted_to_bisque_fire",
-            global_refs={"kiln_location": ("location", bisque_kiln)})
-        _create_piece_state(p, "bisque_fired",
-            additional_fields={"kiln_temperature_c": 1000, "cone": "04"})
-        _create_piece_state(p, "glazed",
-            global_refs={"glaze_combination": ("glaze_combination", combo)})
-        _create_piece_state(p, "submitted_to_glaze_fire",
-            global_refs={"kiln_location": ("location", glaze_kiln)})
-        _create_piece_state(p, "glaze_fired",
-            notes="Out of the kiln.",
-            additional_fields={"kiln_temperature_c": 1240, "cone": "6"},
-            global_refs={"glaze_combination": ("glaze_combination", combo)})
-        _create_piece_state(p, "completed", notes="Ready to use.")
-
-    # 8. Recycled pieces
-    for label in ["Cracked Practice Bowl", "Collapsed Cylinder"]:
-        p = Piece.objects.create(
-            user=user, name=label,
-            thumbnail={"url": T["bowl"], "cloudinary_public_id": None},
-        )
-        _create_piece_state(p, "designed")
-        _create_piece_state(p, "wheel_thrown",
-            additional_fields={"clay_weight_lbs": 800, "wall_thickness_mm": 7.0},
-            global_refs={"clay_body": ("clay_body", clay_body)})
-        _create_piece_state(p, "recycled", notes="Reclaiming the clay.")
+        if recycled:
+            _create_piece_state(p, "recycled", notes="Reclaiming the clay.")
 
 
 def _create_piece_state(

--- a/api/utils.py
+++ b/api/utils.py
@@ -280,7 +280,8 @@ def _seed_dev_pieces(user) -> None:
 
         # How far along the path does this piece get?
         # Weight distribution: more pieces in early/mid states, fewer completed.
-        stop = rng.choices(range(len(path)), weights=[3,4,3,3,3,2,2,2,1], k=1)[0]
+        weights = [3, 4, 3, 3, 3, 2, 2, 2, 1]
+        stop = rng.choices(range(len(path)), weights=weights[: len(path)], k=1)[0]
 
         # 10 % chance of recycling instead of stopping at the chosen state.
         recycled = stop > 0 and rng.random() < 0.10

--- a/api/utils.py
+++ b/api/utils.py
@@ -327,7 +327,7 @@ def _seed_dev_pieces(user) -> None:
             global_refs={"kiln_location": ("location", bisque_kiln)})
         _create_piece_state(p, "bisque_fired",
             notes="Bisque complete.",
-            additional_fields={"kiln_temperature_c": 1000, "cone": "06"})
+            additional_fields={"kiln_temperature_c": 1000, "cone": "04"})
 
     # 6. Glazed and queued for glaze fire
     p, _ = _bowl("Glazed Test Bowl", clay=porcelain)
@@ -340,7 +340,7 @@ def _seed_dev_pieces(user) -> None:
     _create_piece_state(p, "submitted_to_bisque_fire",
         global_refs={"kiln_location": ("location", bisque_kiln)})
     _create_piece_state(p, "bisque_fired",
-        additional_fields={"kiln_temperature_c": 1000, "cone": "06"})
+        additional_fields={"kiln_temperature_c": 1000, "cone": "04"})
     _create_piece_state(p, "glazed",
         notes="Celadon, single coat.",
         global_refs={"glaze_combination": ("glaze_combination", celadon_combo)})
@@ -367,7 +367,7 @@ def _seed_dev_pieces(user) -> None:
         _create_piece_state(p, "submitted_to_bisque_fire",
             global_refs={"kiln_location": ("location", bisque_kiln)})
         _create_piece_state(p, "bisque_fired",
-            additional_fields={"kiln_temperature_c": 1000, "cone": "06"})
+            additional_fields={"kiln_temperature_c": 1000, "cone": "04"})
         _create_piece_state(p, "glazed",
             global_refs={"glaze_combination": ("glaze_combination", combo)})
         _create_piece_state(p, "submitted_to_glaze_fire",

--- a/api/views.py
+++ b/api/views.py
@@ -6,10 +6,12 @@ from collections import defaultdict
 from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model, login, logout
-from django.db.models import Q
+from django.db.models import DateTimeField, Q, Subquery, OuterRef
+from django.db.models.functions import Coalesce, Greatest
 from django.shortcuts import get_object_or_404
 from django.views.decorators.csrf import ensure_csrf_cookie
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import OpenApiParameter, extend_schema, inline_serializer
+from rest_framework import serializers as drf_serializers
 from google.auth.transport import requests as google_requests
 from google.oauth2 import id_token as google_id_token
 from rest_framework import status
@@ -93,15 +95,67 @@ _FAVORITES_REGISTRY = {
 }
 
 
+_PIECE_ORDERING_MAP = {
+    "last_modified": "computed_last_modified",
+    "-last_modified": "-computed_last_modified",
+    "name": "name",
+    "-name": "-name",
+    "created": "created",
+    "-created": "-created",
+}
+_DEFAULT_ORDERING = "-last_modified"
+_DEFAULT_PAGE_SIZE = 24
+
+
 def _piece_queryset(request: Request):
     return Piece.objects.prefetch_related("states", "tag_links__tag").filter(
         user=request.user
     )  # type: ignore[misc]
 
 
+def _apply_piece_ordering(qs, ordering_param: str):
+    db_ordering = _PIECE_ORDERING_MAP.get(ordering_param, _PIECE_ORDERING_MAP[_DEFAULT_ORDERING])
+    if "computed_last_modified" in db_ordering:
+        latest_state_lm = (
+            PieceState.objects.filter(piece=OuterRef("pk"))
+            .order_by("-last_modified")
+            .values("last_modified")[:1]
+        )
+        qs = qs.annotate(
+            computed_last_modified=Greatest(
+                "fields_last_modified",
+                Coalesce(
+                    Subquery(latest_state_lm, output_field=DateTimeField()),
+                    "fields_last_modified",
+                ),
+            )
+        )
+    return qs.order_by(db_ordering)
+
+
 @extend_schema(
     methods=["GET"],
-    responses={200: PieceSummarySerializer(many=True)},
+    parameters=[
+        OpenApiParameter(
+            name="ordering",
+            description="Sort order. Prefix with '-' for descending.",
+            required=False,
+            type=str,
+            enum=list(_PIECE_ORDERING_MAP.keys()),
+        ),
+        OpenApiParameter(name="limit", description="Page size.", required=False, type=int),
+        OpenApiParameter(name="offset", description="Pagination offset.", required=False, type=int),
+        OpenApiParameter(name="tag_ids", description="Comma-separated tag IDs (AND filter).", required=False, type=str),
+    ],
+    responses={
+        200: inline_serializer(
+            name="PiecePage",
+            fields={
+                "count": drf_serializers.IntegerField(),
+                "results": PieceSummarySerializer(many=True),
+            },
+        )
+    },
 )
 @extend_schema(
     methods=["POST"],
@@ -120,7 +174,17 @@ def pieces(request: Request) -> Response:
             ):
                 qs = qs.filter(tag_links__tag_id=tag_id)
             qs = qs.distinct()
-        return Response(PieceSummarySerializer(qs, many=True).data)
+        ordering_param = request.query_params.get("ordering", _DEFAULT_ORDERING)
+        qs = _apply_piece_ordering(qs, ordering_param)
+        try:
+            limit = max(1, min(100, int(request.query_params.get("limit", _DEFAULT_PAGE_SIZE))))
+            offset = max(0, int(request.query_params.get("offset", 0)))
+        except (ValueError, TypeError):
+            limit = _DEFAULT_PAGE_SIZE
+            offset = 0
+        count = qs.count()
+        page_qs = qs[offset : offset + limit]
+        return Response({"count": count, "results": PieceSummarySerializer(page_qs, many=True).data})
 
     serializer = PieceCreateSerializer(data=request.data, context={"request": request})
     serializer.is_valid(raise_exception=True)

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -331,7 +331,9 @@ js_library(
     srcs = ["src/pages/PieceListPage.tsx"],
     deps = [
         ":new_piece_dialog_src",
+        ":node_modules",
         ":piece_list_src",
+        ":util_lib",
     ],
 )
 

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Autocomplete from "@mui/material/Autocomplete";
 import AddIcon from "@mui/icons-material/Add";
 import SortIcon from "@mui/icons-material/Sort";
@@ -190,25 +190,24 @@ const PieceList = (props: PieceListingProps) => {
   const [activeTags, setActiveTags] = useState<TagEntry[]>([]);
   const [filterAnchor, setFilterAnchor] = useState<HTMLElement | null>(null);
   const [tagAnchor, setTagAnchor] = useState<HTMLElement | null>(null);
+  // Keep a ref so the observer callback always calls the latest handler without
+  // needing to be listed as an effect dependency (which would cause the
+  // observer to be torn down and recreated on every load completion).
   const onLoadMoreRef = useRef(onLoadMore);
   useEffect(() => { onLoadMoreRef.current = onLoadMore; }, [onLoadMore]);
 
-  // Stable sentinel ref — the observer is created once per hasMore change and
-  // always calls the latest onLoadMore via the ref, avoiding constant
-  // reconnection due to onLoadMore identity churn.
-  const sentinelRef = useCallback(
-    (node: HTMLDivElement | null) => {
-      if (!node || !hasMore) return;
-      const observer = new IntersectionObserver(
-        (entries) => { if (entries[0]?.isIntersecting) onLoadMoreRef.current?.(); },
-        { rootMargin: "200px" },
-      );
-      observer.observe(node);
-      // Disconnect when the element is removed or hasMore turns false.
-      return () => observer.disconnect();
-    },
-    [hasMore],
-  );
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel || !hasMore) return;
+    const observer = new IntersectionObserver(
+      (entries) => { if (entries[0]?.isIntersecting) onLoadMoreRef.current?.(); },
+      { rootMargin: "200px" },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasMore]);
 
   const activeFilterOptions = useMemo(
     () =>
@@ -439,9 +438,9 @@ const PieceList = (props: PieceListingProps) => {
         ))}
       </Grid>
 
-      {/* Invisible sentinel — triggers onLoadMore via IntersectionObserver when
-          scrolled into view with a 200 px lookahead. */}
-      {hasMore && <div ref={sentinelRef} style={{ height: 1 }} aria-hidden="true" />}
+      {/* Invisible sentinel — always in the DOM so the ref is populated when the
+          effect runs; the effect itself is a no-op when hasMore is false. */}
+      <div ref={sentinelRef} style={{ height: 1 }} aria-hidden="true" />
 
       {loadingMore && (
         <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -199,14 +199,17 @@ const PieceList = (props: PieceListingProps) => {
   const sentinelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const sentinel = sentinelRef.current;
-    if (!sentinel || !hasMore) return;
-    const observer = new IntersectionObserver(
-      (entries) => { if (entries[0]?.isIntersecting) onLoadMoreRef.current?.(); },
-      { rootMargin: "200px" },
-    );
-    observer.observe(sentinel);
-    return () => observer.disconnect();
+    if (!hasMore) return;
+    function check() {
+      const sentinel = sentinelRef.current;
+      if (!sentinel) return;
+      const rect = sentinel.getBoundingClientRect();
+      if (rect.top <= window.innerHeight + 300) onLoadMoreRef.current?.();
+    }
+    window.addEventListener("scroll", check, { passive: true });
+    // Also check immediately in case the sentinel is already in view.
+    check();
+    return () => window.removeEventListener("scroll", check);
   }, [hasMore]);
 
   const activeFilterOptions = useMemo(

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Autocomplete from "@mui/material/Autocomplete";
 import AddIcon from "@mui/icons-material/Add";
 import SortIcon from "@mui/icons-material/Sort";
@@ -19,6 +19,7 @@ import {
   Select,
   Stack,
   TextField,
+  Typography,
   useMediaQuery,
 } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
@@ -189,7 +190,25 @@ const PieceList = (props: PieceListingProps) => {
   const [activeTags, setActiveTags] = useState<TagEntry[]>([]);
   const [filterAnchor, setFilterAnchor] = useState<HTMLElement | null>(null);
   const [tagAnchor, setTagAnchor] = useState<HTMLElement | null>(null);
-  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const onLoadMoreRef = useRef(onLoadMore);
+  useEffect(() => { onLoadMoreRef.current = onLoadMore; }, [onLoadMore]);
+
+  // Stable sentinel ref — the observer is created once per hasMore change and
+  // always calls the latest onLoadMore via the ref, avoiding constant
+  // reconnection due to onLoadMore identity churn.
+  const sentinelRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (!node || !hasMore) return;
+      const observer = new IntersectionObserver(
+        (entries) => { if (entries[0]?.isIntersecting) onLoadMoreRef.current?.(); },
+        { rootMargin: "200px" },
+      );
+      observer.observe(node);
+      // Disconnect when the element is removed or hasMore turns false.
+      return () => observer.disconnect();
+    },
+    [hasMore],
+  );
 
   const activeFilterOptions = useMemo(
     () =>
@@ -221,19 +240,6 @@ const PieceList = (props: PieceListingProps) => {
     });
   }, [pieces, activeFilters, activeTags]);
 
-  useEffect(() => {
-    if (!onLoadMore || !hasMore) return;
-    const sentinel = sentinelRef.current;
-    if (!sentinel) return;
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0]?.isIntersecting) onLoadMore();
-      },
-      { rootMargin: "200px" },
-    );
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [onLoadMore, hasMore]);
 
   return (
     <>
@@ -433,11 +439,21 @@ const PieceList = (props: PieceListingProps) => {
         ))}
       </Grid>
 
-      <div ref={sentinelRef} style={{ height: 1 }} aria-hidden="true" />
+      {/* Invisible sentinel — triggers onLoadMore via IntersectionObserver when
+          scrolled into view with a 200 px lookahead. */}
+      {hasMore && <div ref={sentinelRef} style={{ height: 1 }} aria-hidden="true" />}
 
       {loadingMore && (
         <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
           <CircularProgress size={24} />
+        </Box>
+      )}
+
+      {!hasMore && !loadingMore && pieces.length > 0 && (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
+          <Typography variant="caption" color="text.disabled">
+            End of pieces
+          </Typography>
         </Box>
       )}
     </>

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -1,7 +1,7 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Autocomplete from "@mui/material/Autocomplete";
 import AddIcon from "@mui/icons-material/Add";
-import FilterListIcon from "@mui/icons-material/FilterList";
+import SortIcon from "@mui/icons-material/Sort";
 import {
   Box,
   Button,
@@ -10,10 +10,13 @@ import {
   CardContent,
   CardHeader,
   Chip,
+  CircularProgress,
   ClickAwayListener,
   Grid,
+  MenuItem,
   Paper,
   Popper,
+  Select,
   Stack,
   TextField,
   useMediaQuery,
@@ -26,6 +29,8 @@ import {
   isTerminalState,
   SUCCESSORS,
 } from "../util/types";
+import type { PieceSortOrder } from "../util/api";
+import { DEFAULT_PIECE_SORT, PIECE_SORT_OPTIONS } from "../util/api";
 import CloudinaryImage from "./CloudinaryImage";
 import StateChip from "./StateChip";
 import TagAutocomplete from "./TagAutocomplete";
@@ -161,16 +166,30 @@ const PieceListItem = (props: PieceListItemProps) => {
 type PieceListingProps = {
   pieces: PieceSummary[];
   onNewPiece?: () => void;
+  sortOrder?: PieceSortOrder;
+  onSortChange?: (order: PieceSortOrder) => void;
+  onLoadMore?: () => void;
+  hasMore?: boolean;
+  loadingMore?: boolean;
 };
 
 const PieceList = (props: PieceListingProps) => {
-  const { pieces, onNewPiece } = props;
+  const {
+    pieces,
+    onNewPiece,
+    sortOrder = DEFAULT_PIECE_SORT,
+    onSortChange,
+    onLoadMore,
+    hasMore = false,
+    loadingMore = false,
+  } = props;
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const [activeFilters, setActiveFilters] = useState<FilterCategory[]>([]);
   const [activeTags, setActiveTags] = useState<TagEntry[]>([]);
   const [filterAnchor, setFilterAnchor] = useState<HTMLElement | null>(null);
   const [tagAnchor, setTagAnchor] = useState<HTMLElement | null>(null);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
 
   const activeFilterOptions = useMemo(
     () =>
@@ -202,6 +221,20 @@ const PieceList = (props: PieceListingProps) => {
     });
   }, [pieces, activeFilters, activeTags]);
 
+  useEffect(() => {
+    if (!onLoadMore || !hasMore) return;
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) onLoadMore();
+      },
+      { rootMargin: "200px" },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [onLoadMore, hasMore]);
+
   return (
     <>
       <Box
@@ -226,7 +259,34 @@ const PieceList = (props: PieceListingProps) => {
             New Piece
           </Button>
         )}
-        <FilterListIcon fontSize="small" color="action" sx={{ flexShrink: 0 }} />
+
+        {onSortChange && (
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+            <SortIcon fontSize="small" color="action" sx={{ flexShrink: 0 }} />
+            <Select
+              value={sortOrder}
+              onChange={(e) => onSortChange(e.target.value as PieceSortOrder)}
+              size="small"
+              variant="standard"
+              disableUnderline
+              inputProps={{ "aria-label": "Sort order" }}
+              sx={{
+                fontSize: "0.8125rem",
+                color: "text.secondary",
+                "& .MuiSelect-select": { py: 0 },
+              }}
+            >
+              {PIECE_SORT_OPTIONS.map((opt) => (
+                <MenuItem key={opt.value} value={opt.value} sx={{ fontSize: "0.8125rem" }}>
+                  {opt.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </Box>
+        )}
+
+        <Box sx={{ width: "1px", height: "20px", bgcolor: "divider", flexShrink: 0, mx: 0.25 }} />
+
         {activeFilterOptions.length > 0 && (
           <Stack
             direction="row"
@@ -372,6 +432,14 @@ const PieceList = (props: PieceListingProps) => {
           />
         ))}
       </Grid>
+
+      <div ref={sentinelRef} style={{ height: 1 }} aria-hidden="true" />
+
+      {loadingMore && (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
+          <CircularProgress size={24} />
+        </Box>
+      )}
     </>
   );
 };

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -425,4 +425,59 @@ describe("PieceList", () => {
       expect(within(pieceCard).getByText("Blue")).toBeInTheDocument();
     });
   });
+
+  describe("sort selector", () => {
+    it("does not render the sort selector when onSortChange is not provided", () => {
+      renderPieceList([]);
+      expect(screen.queryByLabelText("Sort order")).not.toBeInTheDocument();
+    });
+
+    it("renders a sort selector when onSortChange is provided", () => {
+      const router = createMemoryRouter(
+        [
+          {
+            path: "/",
+            element: (
+              <PieceList
+                pieces={[]}
+                sortOrder="-last_modified"
+                onSortChange={vi.fn()}
+              />
+            ),
+          },
+        ],
+        { initialEntries: ["/"] },
+      );
+      render(<RouterProvider router={router} />);
+      expect(screen.getByLabelText("Sort order")).toBeInTheDocument();
+    });
+
+    it("calls onSortChange when a new sort option is selected", async () => {
+      const user = userEvent.setup();
+      const onSortChange = vi.fn();
+      const router = createMemoryRouter(
+        [
+          {
+            path: "/",
+            element: (
+              <PieceList
+                pieces={[]}
+                sortOrder="-last_modified"
+                onSortChange={onSortChange}
+              />
+            ),
+          },
+        ],
+        { initialEntries: ["/"] },
+      );
+      render(<RouterProvider router={router} />);
+
+      await user.click(screen.getByLabelText("Sort order"));
+      await user.click(screen.getByRole("option", { name: "Name A → Z" }));
+
+      await waitFor(() => {
+        expect(onSortChange).toHaveBeenCalledWith("name");
+      });
+    });
+  });
 });

--- a/web/src/pages/PieceListPage.tsx
+++ b/web/src/pages/PieceListPage.tsx
@@ -68,12 +68,11 @@ export default function PieceListPage() {
     setSortOrder(order);
   }
 
-  function handleLoadMore() {
+  const handleLoadMore = useCallback(() => {
     if (loadingMore || loading) return;
     const currentOffset = offsetRef.current;
-    if (currentOffset >= count) return;
     loadPage(sortOrder, currentOffset, false);
-  }
+  }, [loadingMore, loading, sortOrder, loadPage]);
 
   function handleCreated(piece: PieceDetail) {
     setPieces((prev) => [piece, ...prev]);

--- a/web/src/pages/PieceListPage.tsx
+++ b/web/src/pages/PieceListPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import AddIcon from "@mui/icons-material/Add";
 import {
   Box,
@@ -8,26 +8,79 @@ import {
   useMediaQuery,
 } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
-import { fetchPieces } from "../util/api";
-import { useAsync } from "../util/useAsync";
+import {
+  DEFAULT_PIECE_SORT,
+  PIECES_PAGE_SIZE,
+  fetchPieces,
+} from "../util/api";
+import type { PieceSortOrder } from "../util/api";
 import NewPieceDialog from "../components/NewPieceDialog";
 import PieceList from "../components/PieceList";
 import type { PieceDetail, PieceSummary } from "../util/types";
 
 export default function PieceListPage() {
-  const {
-    data: pieces,
-    loading,
-    error,
-    setData: setPieces,
-  } = useAsync<PieceSummary[]>(fetchPieces);
+  const [pieces, setPieces] = useState<PieceSummary[]>([]);
+  const [count, setCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sortOrder, setSortOrder] = useState<PieceSortOrder>(DEFAULT_PIECE_SORT);
   const [dialogOpen, setDialogOpen] = useState(false);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
-  function handleCreated(piece: PieceDetail) {
-    setPieces((prev) => [piece, ...(prev ?? [])]);
+  const offsetRef = useRef(0);
+  const sortOrderRef = useRef(sortOrder);
+
+  const loadPage = useCallback(
+    async (ordering: PieceSortOrder, offset: number, replace: boolean) => {
+      if (replace) setLoading(true);
+      else setLoadingMore(true);
+      setError(null);
+      try {
+        const page = await fetchPieces({
+          ordering,
+          limit: PIECES_PAGE_SIZE,
+          offset,
+        });
+        if (sortOrderRef.current !== ordering) return;
+        setCount(page.count);
+        setPieces((prev) => (replace ? page.results : [...prev, ...page.results]));
+        offsetRef.current = offset + page.results.length;
+      } catch {
+        setError("Failed to load pieces.");
+      } finally {
+        if (replace) setLoading(false);
+        else setLoadingMore(false);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    sortOrderRef.current = sortOrder;
+    offsetRef.current = 0;
+    setPieces([]);
+    loadPage(sortOrder, 0, true);
+  }, [sortOrder, loadPage]);
+
+  function handleSortChange(order: PieceSortOrder) {
+    setSortOrder(order);
   }
+
+  function handleLoadMore() {
+    if (loadingMore || loading) return;
+    const currentOffset = offsetRef.current;
+    if (currentOffset >= count) return;
+    loadPage(sortOrder, currentOffset, false);
+  }
+
+  function handleCreated(piece: PieceDetail) {
+    setPieces((prev) => [piece, ...prev]);
+    setCount((c) => c + 1);
+  }
+
+  const hasMore = pieces.length < count;
 
   return (
     <>
@@ -51,11 +104,16 @@ export default function PieceListPage() {
           <CircularProgress />
         </Box>
       )}
-      {error && <Typography color="error">Failed to load pieces.</Typography>}
+      {error && <Typography color="error">{error}</Typography>}
       {!loading && !error && (
         <PieceList
-          pieces={pieces ?? []}
+          pieces={pieces}
           onNewPiece={() => setDialogOpen(true)}
+          sortOrder={sortOrder}
+          onSortChange={handleSortChange}
+          onLoadMore={handleLoadMore}
+          hasMore={hasMore}
+          loadingMore={loadingMore}
         />
       )}
       <NewPieceDialog

--- a/web/src/pages/__tests__/PieceListPage.test.tsx
+++ b/web/src/pages/__tests__/PieceListPage.test.tsx
@@ -1,26 +1,39 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import PieceListPage from "../PieceListPage";
 import type { PieceDetail, PieceSummary } from "../../util/types";
+import type { PieceSortOrder } from "../../util/api";
 
-const mockUseAsync = vi.fn();
+const mockFetchPieces = vi.fn();
 
-vi.mock("../..//util/useAsync", () => ({
-  useAsync: (...args: unknown[]) => mockUseAsync(...args),
-}));
+vi.mock("../../util/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../util/api")>();
+  return {
+    ...actual,
+    fetchPieces: (...args: unknown[]) => mockFetchPieces(...args),
+  };
+});
 
 vi.mock("../../components/PieceList", () => ({
   default: ({
     pieces,
     onNewPiece,
+    onSortChange,
+    onLoadMore,
   }: {
     pieces: PieceSummary[];
     onNewPiece?: () => void;
+    onSortChange?: (order: PieceSortOrder) => void;
+    onLoadMore?: () => void;
   }) => (
     <div data-testid="piece-list">
       {onNewPiece && <button onClick={onNewPiece}>New Piece</button>}
+      {onSortChange && (
+        <button onClick={() => onSortChange("name")}>Sort by Name</button>
+      )}
+      {onLoadMore && <button onClick={onLoadMore}>Load More</button>}
       {pieces.map((piece) => piece.name).join(", ")}
     </div>
   ),
@@ -86,6 +99,17 @@ function installMatchMedia(matches: boolean) {
   });
 }
 
+const EXISTING_PIECE: PieceSummary = {
+  id: "piece-1",
+  name: "Existing Bowl",
+  created: new Date("2024-01-01T00:00:00Z"),
+  last_modified: new Date("2024-01-01T00:00:00Z"),
+  thumbnail: null,
+  current_state: { state: "designed" } as PieceSummary["current_state"],
+  current_location: null,
+  tags: [],
+};
+
 describe("PieceListPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -93,52 +117,32 @@ describe("PieceListPage", () => {
   });
 
   it("shows a loading spinner while pieces are loading", () => {
-    mockUseAsync.mockReturnValue({
-      data: null,
-      loading: true,
-      error: null,
-      setData: vi.fn(),
-    });
-
+    mockFetchPieces.mockReturnValue(new Promise(() => {}));
     render(<PieceListPage />);
-
     expect(screen.getByRole("progressbar")).toBeInTheDocument();
   });
 
-  it("shows an error message when loading pieces fails", () => {
-    mockUseAsync.mockReturnValue({
-      data: null,
-      loading: false,
-      error: new Error("boom"),
-      setData: vi.fn(),
-    });
-
+  it("shows an error message when loading pieces fails", async () => {
+    mockFetchPieces.mockRejectedValue(new Error("boom"));
     render(<PieceListPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Failed to load pieces.")).toBeInTheDocument();
+    });
+  });
 
-    expect(screen.getByText("Failed to load pieces.")).toBeInTheDocument();
+  it("renders pieces after successful load", async () => {
+    mockFetchPieces.mockResolvedValue({ count: 1, results: [EXISTING_PIECE] });
+    render(<PieceListPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Existing Bowl")).toBeInTheDocument();
+    });
   });
 
   it("opens the dialog from the desktop button and prepends created pieces", async () => {
-    const setData = vi.fn();
-    mockUseAsync.mockReturnValue({
-      data: [
-        {
-          id: "piece-1",
-          name: "Existing Bowl",
-          created: new Date("2024-01-01T00:00:00Z"),
-          last_modified: new Date("2024-01-01T00:00:00Z"),
-          thumbnail: null,
-          current_state: { state: "designed" },
-          current_location: null,
-          tags: [],
-        },
-      ],
-      loading: false,
-      error: null,
-      setData,
-    });
-
+    mockFetchPieces.mockResolvedValue({ count: 1, results: [EXISTING_PIECE] });
     render(<PieceListPage />);
+
+    await waitFor(() => screen.getByText("Existing Bowl"));
 
     await userEvent.click(screen.getByRole("button", { name: "New Piece" }));
     expect(screen.getByText("New Piece Dialog")).toBeInTheDocument();
@@ -147,33 +151,63 @@ describe("PieceListPage", () => {
       screen.getByRole("button", { name: "Finish Create" }),
     );
 
-    expect(setData).toHaveBeenCalledTimes(1);
-    const updateFn = setData.mock.calls[0][0] as (
-      prev: PieceSummary[] | null,
-    ) => PieceSummary[];
-    expect(
-      updateFn([{ id: "piece-1", name: "Existing Bowl" } as PieceSummary])[0]
-        .name,
-    ).toBe("Fresh Mug");
-    expect(
-      updateFn([{ id: "piece-1", name: "Existing Bowl" } as PieceSummary])[1]
-        .name,
-    ).toBe("Existing Bowl");
+    await waitFor(() => {
+      expect(screen.getByTestId("piece-list").textContent).toContain("Fresh Mug");
+    });
+    expect(screen.getByTestId("piece-list").textContent).toContain("Existing Bowl");
   });
 
-  it("shows the mobile fab on small screens", () => {
+  it("shows the mobile fab on small screens", async () => {
     installMatchMedia(true);
-    mockUseAsync.mockReturnValue({
-      data: [],
-      loading: false,
-      error: null,
-      setData: vi.fn(),
-    });
-
+    mockFetchPieces.mockResolvedValue({ count: 0, results: [] });
     render(<PieceListPage />);
 
-    // The FAB is the accessible button labeled "New Piece"
+    await waitFor(() => screen.getByTestId("piece-list"));
+
     const newPieceButtons = screen.getAllByRole("button", { name: "New Piece" });
     expect(newPieceButtons.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("re-fetches with new sort order when sort changes", async () => {
+    mockFetchPieces.mockResolvedValue({ count: 1, results: [EXISTING_PIECE] });
+    render(<PieceListPage />);
+
+    await waitFor(() => screen.getByTestId("piece-list"));
+
+    mockFetchPieces.mockResolvedValue({ count: 0, results: [] });
+    await userEvent.click(screen.getByRole("button", { name: "Sort by Name" }));
+
+    await waitFor(() => {
+      expect(mockFetchPieces).toHaveBeenCalledWith(
+        expect.objectContaining({ ordering: "name" }),
+      );
+    });
+  });
+
+  it("loads more pieces on scroll trigger", async () => {
+    const firstPage = Array.from({ length: 3 }, (_, i) => ({
+      ...EXISTING_PIECE,
+      id: `piece-${i}`,
+      name: `Piece ${i}`,
+    }));
+    mockFetchPieces.mockResolvedValueOnce({ count: 6, results: firstPage });
+    render(<PieceListPage />);
+
+    await waitFor(() => screen.getByTestId("piece-list"));
+
+    const secondPage = Array.from({ length: 3 }, (_, i) => ({
+      ...EXISTING_PIECE,
+      id: `piece-${i + 3}`,
+      name: `Piece ${i + 3}`,
+    }));
+    mockFetchPieces.mockResolvedValueOnce({ count: 6, results: secondPage });
+
+    await userEvent.click(screen.getByRole("button", { name: "Load More" }));
+
+    await waitFor(() => {
+      expect(mockFetchPieces).toHaveBeenCalledWith(
+        expect.objectContaining({ offset: 3 }),
+      );
+    });
   });
 });

--- a/web/src/util/__tests__/api.test.ts
+++ b/web/src/util/__tests__/api.test.ts
@@ -107,31 +107,43 @@ describe("client setup", () => {
 describe("piece endpoints", () => {
   it("fetchPieces maps wire data to PieceSummary values", async () => {
     const { fetchPieces } = await loadApiModule();
-    mockClient.get.mockResolvedValue({ data: [wirePieceSummary] });
+    mockClient.get.mockResolvedValue({ data: { count: 1, results: [wirePieceSummary] } });
 
     const result = await fetchPieces();
 
-    expect(mockClient.get).toHaveBeenCalledWith("pieces/");
-    expect(result).toHaveLength(1);
-    expect(result[0].created).toBeInstanceOf(Date);
-    expect(result[0].last_modified).toBeInstanceOf(Date);
-    expect(result[0].current_state.state).toBe("designed");
-    expect(result[0].tags[0]).toMatchObject({
+    expect(mockClient.get).toHaveBeenCalledWith("pieces/", { params: undefined });
+    expect(result.count).toBe(1);
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].created).toBeInstanceOf(Date);
+    expect(result.results[0].last_modified).toBeInstanceOf(Date);
+    expect(result.results[0].current_state.state).toBe("designed");
+    expect(result.results[0].tags[0]).toMatchObject({
       name: "functional",
       color: "#aabbcc",
       is_public: true,
     });
   });
 
+  it("fetchPieces passes ordering and pagination params", async () => {
+    const { fetchPieces } = await loadApiModule();
+    mockClient.get.mockResolvedValue({ data: { count: 0, results: [] } });
+
+    await fetchPieces({ ordering: "name", limit: 10, offset: 20 });
+
+    expect(mockClient.get).toHaveBeenCalledWith("pieces/", {
+      params: { ordering: "name", limit: 10, offset: 20 },
+    });
+  });
+
   it("fetchPieces defaults missing tags to an empty array", async () => {
     const { fetchPieces } = await loadApiModule();
     mockClient.get.mockResolvedValue({
-      data: [{ ...wirePieceSummary, tags: undefined }],
+      data: { count: 1, results: [{ ...wirePieceSummary, tags: undefined }] },
     });
 
     const result = await fetchPieces();
 
-    expect(result[0].tags).toEqual([]);
+    expect(result.results[0].tags).toEqual([]);
   });
 
   it("fetchPiece maps nested dates, images, and navigation fields", async () => {

--- a/web/src/util/api.ts
+++ b/web/src/util/api.ts
@@ -141,9 +141,38 @@ function mapPieceDetail(raw: Wire<PieceDetail>): PieceDetail {
 // API calls
 // ---------------------------------------------------------------------------
 
-export async function fetchPieces(): Promise<PieceSummary[]> {
-  const { data } = await client.get<Wire<PieceSummary>[]>("pieces/");
-  return data.map(mapPieceSummary);
+export type PieceSortOrder =
+  | "last_modified"
+  | "-last_modified"
+  | "name"
+  | "-name"
+  | "created"
+  | "-created";
+
+export type PiecePage = { count: number; results: PieceSummary[] };
+
+export const PIECE_SORT_OPTIONS: { value: PieceSortOrder; label: string }[] = [
+  { value: "-last_modified", label: "Recently Modified" },
+  { value: "last_modified", label: "Oldest Modified" },
+  { value: "-created", label: "Newest First" },
+  { value: "created", label: "Oldest First" },
+  { value: "name", label: "Name A → Z" },
+  { value: "-name", label: "Name Z → A" },
+];
+
+export const DEFAULT_PIECE_SORT: PieceSortOrder = "-last_modified";
+export const PIECES_PAGE_SIZE = 24;
+
+export async function fetchPieces(params?: {
+  ordering?: PieceSortOrder;
+  limit?: number;
+  offset?: number;
+}): Promise<PiecePage> {
+  const { data } = await client.get<{
+    count: number;
+    results: Wire<PieceSummary>[];
+  }>("pieces/", { params });
+  return { count: data.count, results: data.results.map(mapPieceSummary) };
 }
 
 export async function ensureCsrfCookie(): Promise<void> {


### PR DESCRIPTION
## Summary

- `GET /api/pieces/` now accepts `ordering`, `limit`, and `offset` query params and returns `{ count, results }` — server-side sort and pagination
- `PieceList` gains a sort selector (last modified, name, created) in the filter toolbar
- `PieceListPage` loads the first page on mount and appends subsequent pages as the user scrolls; an "End of pieces" marker appears when all results are loaded
- Dev fixture seeds 75 random pieces across all workflow states on first login, giving three full pages to exercise pagination immediately

## Scroll implementation

The sentinel-based infinite scroll uses a `window` scroll event listener with `getBoundingClientRect` rather than `IntersectionObserver`. The scroll parent is resolved at effect time by walking up the DOM to find the nearest `overflow: auto/scroll` ancestor, falling back to `window`. An immediate check fires when `hasMore` becomes true so a short first page fills automatically without requiring a scroll.

## Manual testing

Start both servers, then wipe the dev DB so the fixture seeds on first login:

```bash
# Terminal 1 — backend
source env.sh
rm db.sqlite3 && python manage.py migrate && python manage.py runserver 8080

# Terminal 2 — frontend
cd web && npm run dev
```

Log in via Google OAuth (or create a superuser with `python manage.py createsuperuser` and log in with email/password). The bootstrap seeds 75 pieces on first login.

**What to verify:**
- First 24 pieces load immediately
- Scrolling to the bottom loads the next page (spinner appears briefly, then more cards)
- After all 75 pieces are loaded, "End of pieces" appears
- Changing the sort order in the toolbar resets to page 1 with the new ordering
- Verify with `curl` (swap in a real session cookie from devtools):

```bash
COOKIE="sessionid=<your-session-id>; csrftoken=<your-csrf-token>"

# First page — should return count:75, results:[24 items]
curl -s -H "Cookie: $COOKIE" \
  "http://localhost:8080/api/pieces/?ordering=-last_modified&limit=24&offset=0" \
  | python3 -m json.tool | grep -E '"count"|"id"' | head -5

# Second page
curl -s -H "Cookie: $COOKIE" \
  "http://localhost:8080/api/pieces/?ordering=-last_modified&limit=24&offset=24" \
  | python3 -m json.tool | grep '"count"'

# Sort by name
curl -s -H "Cookie: $COOKIE" \
  "http://localhost:8080/api/pieces/?ordering=name&limit=24&offset=0" \
  | python3 -m json.tool | grep '"name"' | head -5
```

## Test plan

- [x] `bazel test //...` — all suites pass
- [x] `bazel build --config=lint //...` — all linters pass
- [x] Backend: pagination limit/offset, ordering variants, invalid ordering fallback
- [x] Frontend: sort selector renders and fires callback; `onLoadMore` fires immediately when sentinel is in view; scroll events trigger load; "End of pieces" shows when `hasMore` is false
- [x] Dev fixture: 75 pieces seed correctly on first Google OAuth login; weight list trimmed to path length so `HANDBUILT_PATH` (8 steps) doesn't crash with a 9-element weight list

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)
