### PR TITLE
Redesign PieceList: masonry cards, floating filter strip, mobile bottom tabs

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -271,6 +271,24 @@ def _seed_dev_pieces(user) -> None:
 
     T = DEV_THUMBNAIL_URLS
 
+    from .models import Tag  # noqa: PLC0415
+    PieceTag = apps.get_model("api", "PieceTag")
+
+    TAG_DEFS = [
+        ("gift",       "#E76F51"),
+        ("functional", "#2A9D8F"),
+        ("decorative", "#9b5de5"),
+        ("for sale",   "#457B9D"),
+        ("wabi-sabi",  "#6d4c41"),
+        ("practice",   "#78909c"),
+        ("commission", "#c0392b"),
+        ("series",     "#f4a261"),
+    ]
+    tags = []
+    for tag_name, tag_color in TAG_DEFS:
+        tag, _ = Tag.objects.get_or_create(user=user, name=tag_name, defaults={"color": tag_color})
+        tags.append(tag)
+
     for i in range(75):
         adj   = rng.choice(ADJECTIVES)
         form, thumb = rng.choice(FORMS)
@@ -291,6 +309,12 @@ def _seed_dev_pieces(user) -> None:
             name=f"{adj} {form} #{i + 1}",
             thumbnail={"url": T[thumb], "cloudinary_public_id": None},
         )
+
+        # Attach 0–3 random tags to each piece
+        n_tags = rng.choices([0, 1, 2, 3], weights=[3, 4, 2, 1])[0]
+        piece_tags = rng.sample(tags, min(n_tags, len(tags)))
+        for order, tag in enumerate(piece_tags):
+            PieceTag.objects.get_or_create(piece=p, tag=tag, defaults={"order": order})
 
         for step_state, fields_fn, _ in path[: stop + 1]:
             af, gr = fields_fn(rng, clay, combo) if fields_fn else (None, None)

--- a/api/views.py
+++ b/api/views.py
@@ -135,6 +135,7 @@ def _apply_piece_ordering(qs, ordering_param: str):
 
 @extend_schema(
     methods=["GET"],
+    operation_id="pieces_list",
     parameters=[
         OpenApiParameter(
             name="ordering",
@@ -192,7 +193,7 @@ def pieces(request: Request) -> Response:
     return Response(PieceDetailSerializer(piece).data, status=status.HTTP_201_CREATED)
 
 
-@extend_schema(responses={200: PieceDetailSerializer})
+@extend_schema(methods=["GET"], operation_id="pieces_retrieve", responses={200: PieceDetailSerializer})
 @extend_schema(
     methods=["PATCH"],
     request=PieceUpdateSerializer,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -518,8 +518,12 @@ function AppShell({
           sm: 2,
         },
         pb: 2,
-        px: {
-          xs: "max(16px, env(safe-area-inset-left)) max(16px, env(safe-area-inset-right))",
+        pl: {
+          xs: "max(16px, env(safe-area-inset-left))",
+          sm: 3,
+        },
+        pr: {
+          xs: "max(16px, env(safe-area-inset-right))",
           sm: 3,
         },
       }}

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -1,43 +1,33 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import Autocomplete from "@mui/material/Autocomplete";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import AddIcon from "@mui/icons-material/Add";
+import FilterListIcon from "@mui/icons-material/FilterList";
 import SortIcon from "@mui/icons-material/Sort";
 import {
   Box,
-  Button,
-  Card,
-  CardActionArea,
-  CardContent,
-  CardHeader,
   Chip,
   CircularProgress,
-  ClickAwayListener,
-  Grid,
   MenuItem,
-  Paper,
-  Popper,
   Select,
-  Stack,
-  TextField,
   Typography,
   useMediaQuery,
 } from "@mui/material";
-import { useTheme } from "@mui/material/styles";
+import { alpha, useTheme } from "@mui/material/styles";
 import type { PieceSummary, TagEntry } from "../util/types";
 import {
   formatState,
-  getStateDescription,
   isTerminalState,
   SUCCESSORS,
 } from "../util/types";
 import type { PieceSortOrder } from "../util/api";
 import { DEFAULT_PIECE_SORT, PIECE_SORT_OPTIONS } from "../util/api";
+import { Link } from "react-router-dom";
 import CloudinaryImage from "./CloudinaryImage";
-import StateChip from "./StateChip";
 import TagAutocomplete from "./TagAutocomplete";
 import TagChip from "./TagChip";
-import TagChipList from "./TagChipList";
 import { DEFAULT_THUMBNAIL } from "./thumbnailConstants";
+
+// Kiln-glow amber used for stale indicator
+const KILN_COLOR = "oklch(0.72 0.13 55)";
 
 type FilterCategory = "wip" | "completed" | "discarded";
 
@@ -47,9 +37,9 @@ interface FilterOption {
 }
 
 const FILTER_OPTIONS: FilterOption[] = [
-  { value: "wip", label: "Work in Progress" },
+  { value: "wip", label: "Active" },
   { value: "completed", label: "Completed" },
-  { value: "discarded", label: "Discarded" },
+  { value: "discarded", label: "Recycled" },
 ];
 
 function matchesFilter(piece: PieceSummary, filter: FilterCategory): boolean {
@@ -61,110 +51,187 @@ function matchesFilter(piece: PieceSummary, filter: FilterCategory): boolean {
   return false;
 }
 
-const ADD_BUTTON_BASE_SX = {
-  display: "inline-flex",
-  alignItems: "center",
-  background: "transparent",
-  border: "1px dashed",
-  borderColor: "divider",
-  cursor: "pointer",
-  color: "text.secondary",
-  fontFamily: "inherit",
-  flexShrink: 0,
-  "&:hover": { borderColor: "text.secondary" },
-} as const;
+function daysSince(date: Date): number {
+  return Math.floor((Date.now() - date.getTime()) / (1000 * 60 * 60 * 24));
+}
 
-// Matches MUI Chip size="small" pill shape (height 24px, borderRadius 12px)
-const ADD_FILTER_BUTTON_SX = {
-  ...ADD_BUTTON_BASE_SX,
-  px: "8px",
-  height: "24px",
-  borderRadius: "12px",
-  fontSize: "0.8125rem",
-} as const;
+// Variable card thumbnail height based on recency
+function thumbHeight(days: number, isTerminal: boolean): number {
+  if (isTerminal) return 110;
+  if (days <= 2) return 180;
+  if (days < 14) return 140;
+  return 110;
+}
 
-// Matches TagChip shape (borderRadius 4px, caption font size)
-const ADD_TAG_BUTTON_SX = {
-  ...ADD_BUTTON_BASE_SX,
-  px: 1,
-  py: 0.25,
-  borderRadius: "4px",
-  fontSize: "0.75rem",
-  margin: "2px",
-} as const;
-
-type PieceListItemProps = {
+interface PieceCardProps {
   piece: PieceSummary;
   activeTagIds: string[];
-};
+}
 
-const PieceListItem = (props: PieceListItemProps) => {
-  const { piece, activeTagIds } = props;
+const PieceCard = ({ piece }: PieceCardProps) => {
+  const theme = useTheme();
+  const isTerminal = isTerminalState(piece.current_state.state);
+  const days = daysSince(new Date(piece.last_modified));
+  const isStale = days >= 14 && !isTerminal;
+  const h = thumbHeight(days, isTerminal);
+  const label = formatState(piece.current_state.state);
   const detailPath = `/pieces/${piece.id}`;
 
+  // Tags: show 2 visible + dashed overflow chip (non-expandable in card)
+  const tags = piece.tags ?? [];
+  const visibleTags = tags.slice(0, 2);
+  const extra = tags.length - visibleTags.length;
+
+  const lastActivity = days === 0 ? "today" : `${days}d ago`;
+
+  const accentColor = theme.palette.primary.main;
+  const accentText = theme.palette.primary.contrastText;
+
   return (
-    <Grid
-      size={{ xs: 6, sm: 4, md: 3, lg: 2 }}
-      sx={{ display: "flex", flexDirection: "column" }}
-      role="row"
+    <Box
+      component={Link}
+      to={detailPath}
+      sx={{
+        display: "block",
+        breakInside: "avoid",
+        mb: 1,
+        borderRadius: 2,
+        overflow: "hidden",
+        bgcolor: "background.paper",
+        border: "1px solid",
+        borderColor: "divider",
+        textDecoration: "none",
+        color: "inherit",
+        opacity: isTerminal ? 0.78 : 1,
+        transition: "opacity 0.15s, filter 0.15s",
+        "&:hover": { opacity: isTerminal ? 0.9 : 1, filter: "brightness(1.07)" },
+      }}
     >
-      <Card
-        sx={{ cursor: "pointer", padding: 0, margin: 0, height: "100%" }}
-        data-state={piece.current_state.state}
-      >
-        <CardActionArea
+      {/* Thumbnail area */}
+      <Box sx={{ height: h, position: "relative", overflow: "hidden" }}>
+        <CloudinaryImage
+          url={piece.thumbnail?.url ?? DEFAULT_THUMBNAIL}
+          cloud_name={piece.thumbnail?.cloud_name}
+          cloudinary_public_id={piece.thumbnail?.cloudinary_public_id}
+          context="gallery"
+          requestedWidth={300}
+          requestedHeight={200}
+          style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+        />
+
+        {/* Bottom gradient scrim */}
+        <Box sx={{
+          position: "absolute", inset: 0,
+          background: "linear-gradient(to bottom, transparent 35%, rgba(0,0,0,0.55) 100%)",
+          pointerEvents: "none",
+        }} />
+
+        {/* Top-right: stale dot */}
+        {isStale && (
+          <Box sx={{
+            position: "absolute", top: 6, right: 6,
+            width: 8, height: 8, borderRadius: "50%",
+            bgcolor: KILN_COLOR,
+            boxShadow: `0 0 6px ${KILN_COLOR}`,
+          }} />
+        )}
+
+        {/* Bottom-left: state chip overlay */}
+        <Box sx={{
+          position: "absolute", bottom: 6, left: 6,
+          px: "8px", py: "3px",
+          borderRadius: 999,
+          bgcolor: isTerminal ? alpha("#000", 0.55) : accentColor,
+          color: isTerminal ? "text.secondary" : accentText,
+          backdropFilter: isTerminal ? "blur(6px)" : "none",
+          border: isTerminal ? "1px solid rgba(255,255,255,0.12)" : "none",
+          fontSize: "0.6875rem",
+          fontWeight: 600,
+          fontFamily: "'JetBrains Mono', 'Fira Mono', monospace",
+          letterSpacing: "0.02em",
+          display: "inline-flex",
+          alignItems: "center",
+          gap: "5px",
+          lineHeight: 1,
+        }}>
+          <Box sx={{
+            width: 5, height: 5, borderRadius: "50%", flexShrink: 0,
+            bgcolor: isTerminal ? accentColor : alpha(accentText, 0.7),
+          }} />
+          {label}
+        </Box>
+      </Box>
+
+      {/* Card body */}
+      <Box sx={{ px: 1.25, pt: 1, pb: 1.25 }}>
+        <Typography
+          variant="body2"
           sx={{
-            transition: "transform 0.15s ease-in-out",
-            padding: 1.5,
-            height: "100%",
+            fontWeight: 600,
+            lineHeight: 1.25,
+            letterSpacing: "-0.005em",
+            color: "text.primary",
           }}
-          href={detailPath}
-          role="navigation"
-          aria-label={piece.name}
         >
-          <CardHeader
-            title={<h4 style={{ margin: 0 }}>{piece.name}</h4>}
-            avatar={
-              <CloudinaryImage
-                url={piece.thumbnail?.url ?? DEFAULT_THUMBNAIL}
-                cloud_name={piece.thumbnail?.cloud_name}
-                cloudinary_public_id={piece.thumbnail?.cloudinary_public_id}
-                context="thumbnail"
-                style={{ borderRadius: 4, margin: 0 }}
-              />
-            }
-            sx={{ padding: 0, pb: 1 }}
-          />
-          <CardContent
-            sx={{
-              display: "flex",
-              flexDirection: "column",
-              gap: 1,
-              alignItems: "start",
-              padding: 0,
-              pb: 1,
-            }}
-          >
-            <StateChip
-              state={piece.current_state.state}
-              label={formatState(piece.current_state.state)}
-              description={getStateDescription(piece.current_state.state)}
-              variant="current"
-              isTerminal={isTerminalState(piece.current_state.state)}
-            />
-            <TagChipList
-              tags={piece.tags ?? []}
-              maxVisible={3}
-              alwaysVisibleTagIds={activeTagIds}
-            />
-          </CardContent>
-        </CardActionArea>
-      </Card>
-    </Grid>
+          {piece.name}
+        </Typography>
+
+        {/* Last-activity caption */}
+        <Box sx={{
+          mt: 0.5,
+          fontSize: "0.6875rem",
+          color: "text.disabled",
+          fontFamily: "'JetBrains Mono', 'Fira Mono', monospace",
+          display: "flex",
+          alignItems: "center",
+          gap: "4px",
+          flexWrap: "wrap",
+        }}>
+          <span>{lastActivity}</span>
+          {!isTerminal && (
+            <>
+              <span>·</span>
+              <span style={{ color: isStale ? KILN_COLOR : undefined }}>
+                {days}d in {label.toLowerCase()}
+              </span>
+            </>
+          )}
+        </Box>
+
+        {/* Tags */}
+        {tags.length > 0 && (
+          <Box sx={{ mt: 0.75, display: "flex", flexWrap: "wrap" }}>
+            {visibleTags.map((tag) => (
+              <TagChip key={tag.id} label={tag.name} color={tag.color} />
+            ))}
+            {extra > 0 && (
+              <Box
+                component="span"
+                sx={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  px: "7px",
+                  py: "3px",
+                  border: "1px dashed",
+                  borderColor: "divider",
+                  borderRadius: "4px",
+                  fontSize: "0.6875rem",
+                  fontFamily: "'JetBrains Mono', 'Fira Mono', monospace",
+                  color: "text.disabled",
+                  margin: "2px",
+                }}
+              >
+                +{extra}
+              </Box>
+            )}
+          </Box>
+        )}
+      </Box>
+    </Box>
   );
 };
 
-type PieceListingProps = {
+type PieceListProps = {
   pieces: PieceSummary[];
   onNewPiece?: () => void;
   sortOrder?: PieceSortOrder;
@@ -174,7 +241,7 @@ type PieceListingProps = {
   loadingMore?: boolean;
 };
 
-const PieceList = (props: PieceListingProps) => {
+const PieceList = (props: PieceListProps) => {
   const {
     pieces,
     onNewPiece,
@@ -188,14 +255,11 @@ const PieceList = (props: PieceListingProps) => {
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const [activeFilters, setActiveFilters] = useState<FilterCategory[]>([]);
   const [activeTags, setActiveTags] = useState<TagEntry[]>([]);
-  const [filterAnchor, setFilterAnchor] = useState<HTMLElement | null>(null);
-  const [tagAnchor, setTagAnchor] = useState<HTMLElement | null>(null);
-  // Keep a ref so the observer callback always calls the latest handler without
-  // needing to be listed as an effect dependency (which would cause the
-  // observer to be torn down and recreated on every load completion).
+  const [filterOpen, setFilterOpen] = useState(false);
+  const [tagPickerOpen, setTagPickerOpen] = useState(false);
+
   const onLoadMoreRef = useRef(onLoadMore);
   useEffect(() => { onLoadMoreRef.current = onLoadMore; }, [onLoadMore]);
-
   const sentinelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -207,16 +271,9 @@ const PieceList = (props: PieceListingProps) => {
       if (rect.top <= window.innerHeight + 300) onLoadMoreRef.current?.();
     }
     window.addEventListener("scroll", check, { passive: true });
-    // Also check immediately in case the sentinel is already in view.
     check();
     return () => window.removeEventListener("scroll", check);
   }, [hasMore]);
-
-  const activeFilterOptions = useMemo(
-    () =>
-      FILTER_OPTIONS.filter((option) => activeFilters.includes(option.value)),
-    [activeFilters],
-  );
 
   const availableTags = useMemo(() => {
     const deduped = new Map<string, TagEntry>();
@@ -242,214 +299,299 @@ const PieceList = (props: PieceListingProps) => {
     });
   }, [pieces, activeFilters, activeTags]);
 
+  const activeFilterLabel = useMemo(() => {
+    if (activeFilters.length === 0 && activeTags.length === 0) return "All";
+    const parts: string[] = [];
+    activeFilters.forEach((f) => {
+      const opt = FILTER_OPTIONS.find((o) => o.value === f);
+      if (opt) parts.push(opt.label);
+    });
+    activeTags.forEach((t) => parts.push(t.name));
+    return parts.join(", ");
+  }, [activeFilters, activeTags]);
+
+  const hasActiveFilters = activeFilters.length > 0 || activeTags.length > 0;
+
+  const toggleFilter = useCallback((filter: FilterCategory) => {
+    setActiveFilters((prev) =>
+      prev.includes(filter) ? prev.filter((f) => f !== filter) : [...prev, filter],
+    );
+  }, []);
+
+  const sortLabel = useMemo(() => {
+    return PIECE_SORT_OPTIONS.find((o) => o.value === sortOrder)?.label ?? sortOrder;
+  }, [sortOrder]);
 
   return (
     <>
-      <Box
-        sx={{
-          mb: 2,
-          display: "flex",
-          flexWrap: "wrap",
-          alignItems: "center",
-          gap: 0.75,
-        }}
-        role="toolbar"
-        aria-label="Filters and tags"
-      >
-        {!isMobile && onNewPiece && (
-          <Button
-            variant="contained"
-            size="small"
-            startIcon={<AddIcon />}
-            onClick={onNewPiece}
-            sx={{ flexShrink: 0 }}
-          >
-            New Piece
-          </Button>
-        )}
-
-        {onSortChange && (
-          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
-            <SortIcon fontSize="small" color="action" sx={{ flexShrink: 0 }} />
-            <Select
-              value={sortOrder}
-              onChange={(e) => onSortChange(e.target.value as PieceSortOrder)}
-              size="small"
-              variant="standard"
-              disableUnderline
-              inputProps={{ "aria-label": "Sort order" }}
+      {/* Condensed filter strip — sticky, collapses to the toggle button height only.
+          The expanded panel is absolutely positioned so it overlays the masonry
+          without pushing content down or causing the page to scroll. */}
+      <Box sx={{
+        position: "sticky",
+        top: 0,
+        zIndex: 10,
+        background: "transparent",
+        pt: 0.75,
+        pb: 0.75,
+        mb: 0,
+        borderBottom: "1px solid",
+        borderColor: "divider",
+      }}>
+        <Box
+          component="button"
+          type="button"
+          onClick={() => setFilterOpen((o) => !o)}
+          aria-expanded={filterOpen}
+          aria-label="Toggle filters"
+          sx={{
+            width: "100%",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 1,
+            px: 1.5,
+            py: 1,
+            borderRadius: 2,
+            bgcolor: alpha("#181210", 0.95),
+            border: "1px solid",
+            borderColor: "divider",
+            color: "text.secondary",
+            fontFamily: "inherit",
+            cursor: "pointer",
+            textAlign: "left",
+          }}
+        >
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1, overflow: "hidden" }}>
+            <FilterListIcon sx={{ fontSize: 15, flexShrink: 0, color: "text.disabled" }} />
+            <Typography
+              component="span"
               sx={{
                 fontSize: "0.8125rem",
-                color: "text.secondary",
-                "& .MuiSelect-select": { py: 0 },
+                fontWeight: hasActiveFilters ? 600 : 400,
+                color: hasActiveFilters ? "text.primary" : "text.secondary",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
               }}
             >
-              {PIECE_SORT_OPTIONS.map((opt) => (
-                <MenuItem key={opt.value} value={opt.value} sx={{ fontSize: "0.8125rem" }}>
-                  {opt.label}
-                </MenuItem>
+              {activeFilterLabel}
+            </Typography>
+            <Typography
+              component="span"
+              sx={{
+                fontSize: "0.6875rem",
+                color: "text.disabled",
+                fontFamily: "'JetBrains Mono', 'Fira Mono', monospace",
+                flexShrink: 0,
+              }}
+            >
+              · {filteredPieces.length}{hasMore ? "+" : ""} pieces
+            </Typography>
+          </Box>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, flexShrink: 0 }}>
+            <SortIcon sx={{ fontSize: 13, color: "text.disabled" }} />
+            <Typography
+              component="span"
+              sx={{
+                fontSize: "0.6875rem",
+                color: "text.disabled",
+                fontFamily: "'JetBrains Mono', 'Fira Mono', monospace",
+              }}
+            >
+              {sortLabel}
+            </Typography>
+          </Box>
+        </Box>
+
+        {/* Absolutely positioned so the panel overlays the masonry without
+            pushing it down or triggering a page scroll. */}
+        {filterOpen && (
+          <Box sx={{
+            position: "absolute",
+            top: "100%",
+            left: 0,
+            right: 0,
+            mt: 0,
+            p: 1.5,
+            borderRadius: "0 0 8px 8px",
+            bgcolor: alpha("#181210", 0.97),
+            border: "1px solid",
+            borderColor: "divider",
+            borderTop: "none",
+            display: "flex",
+            flexDirection: "column",
+            gap: 1.5,
+            zIndex: 11,
+          }}>
+            {/* Status filter chips */}
+            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.75 }}>
+              {FILTER_OPTIONS.map((opt) => {
+                const active = activeFilters.includes(opt.value);
+                return (
+                  <Chip
+                    key={opt.value}
+                    label={opt.label}
+                    size="small"
+                    onClick={() => toggleFilter(opt.value)}
+                    sx={{
+                      cursor: "pointer",
+                      bgcolor: active ? "primary.main" : alpha("#000", 0.18),
+                      color: active ? "primary.contrastText" : "text.secondary",
+                      border: "1px solid",
+                      borderColor: active ? "primary.main" : "divider",
+                      fontFamily: "'JetBrains Mono', 'Fira Mono', monospace",
+                      fontSize: "0.6875rem",
+                      "&:hover": { filter: "brightness(1.12)" },
+                    }}
+                  />
+                );
+              })}
+            </Box>
+
+            {/* Tag filter: chips for active tags + "+ tag" button to open picker */}
+            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.75, alignItems: "center" }}>
+              {activeTags.map((tag) => (
+                <TagChip
+                  key={tag.id}
+                  label={tag.name}
+                  color={tag.color}
+                  onDelete={() => setActiveTags((prev) => prev.filter((t) => t.id !== tag.id))}
+                />
               ))}
-            </Select>
+              {tagPickerOpen ? (
+                <Box sx={{ width: "100%", mt: activeTags.length > 0 ? 0.5 : 0 }}>
+                  <TagAutocomplete
+                    label="Filter by tag"
+                    options={availableTags}
+                    value={activeTags}
+                    onChange={(next) => { setActiveTags(next); setTagPickerOpen(false); }}
+                    sx={{ minWidth: 0 }}
+                  />
+                </Box>
+              ) : (
+                <Box
+                  component="button"
+                  type="button"
+                  onClick={() => setTagPickerOpen(true)}
+                  sx={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    px: "8px",
+                    height: 24,
+                    borderRadius: "12px",
+                    bgcolor: "transparent",
+                    border: "1px dashed",
+                    borderColor: "divider",
+                    color: "text.disabled",
+                    fontSize: "0.75rem",
+                    fontFamily: "inherit",
+                    cursor: "pointer",
+                    "&:hover": { borderColor: "text.secondary", color: "text.secondary" },
+                  }}
+                >
+                  + tag
+                </Box>
+              )}
+            </Box>
+
+            {/* Sort */}
+            {onSortChange && (
+              <Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+                <SortIcon fontSize="small" sx={{ color: "text.disabled" }} />
+                <Select
+                  value={sortOrder}
+                  onChange={(e) => onSortChange(e.target.value as PieceSortOrder)}
+                  size="small"
+                  variant="standard"
+                  disableUnderline
+                  inputProps={{ "aria-label": "Sort order" }}
+                  sx={{
+                    fontSize: "0.8125rem",
+                    color: "text.secondary",
+                    "& .MuiSelect-select": { py: 0 },
+                  }}
+                >
+                  {PIECE_SORT_OPTIONS.map((opt) => (
+                    <MenuItem key={opt.value} value={opt.value} sx={{ fontSize: "0.8125rem" }}>
+                      {opt.label}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </Box>
+            )}
+
+            {/* New Piece button (desktop only) */}
+            {!isMobile && onNewPiece && (
+              <Box
+                component="button"
+                type="button"
+                onClick={onNewPiece}
+                sx={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 0.5,
+                  px: 1.5,
+                  py: 0.75,
+                  alignSelf: "flex-start",
+                  borderRadius: 1.5,
+                  bgcolor: "primary.main",
+                  color: "primary.contrastText",
+                  border: "none",
+                  fontSize: "0.8125rem",
+                  fontWeight: 600,
+                  fontFamily: "inherit",
+                  cursor: "pointer",
+                  "&:hover": { filter: "brightness(1.1)" },
+                }}
+              >
+                <AddIcon sx={{ fontSize: 16 }} />
+                New Piece
+              </Box>
+            )}
           </Box>
         )}
-
-        <Box sx={{ width: "1px", height: "20px", bgcolor: "divider", flexShrink: 0, mx: 0.25 }} />
-
-        {activeFilterOptions.length > 0 && (
-          <Stack
-            direction="row"
-            spacing={0.75}
-            useFlexGap
-            flexWrap="wrap"
-            alignItems="center"
-          >
-            {activeFilterOptions.map((option) => (
-              <Chip
-                key={option.value}
-                label={option.label}
-                size="small"
-                onDelete={() =>
-                  setActiveFilters((prev) =>
-                    prev.filter((value) => value !== option.value),
-                  )
-                }
-              />
-            ))}
-          </Stack>
-        )}
-
-        <Box
-          component="button"
-          type="button"
-          onClick={(e) => {
-            setTagAnchor(null);
-            setFilterAnchor(filterAnchor ? null : e.currentTarget);
-          }}
-          aria-label="Add status filter"
-          aria-expanded={!!filterAnchor}
-          sx={ADD_FILTER_BUTTON_SX}
-        >
-          + filter
-        </Box>
-
-        {activeTags.length > 0 && (
-          <Stack
-            direction="row"
-            spacing={0.75}
-            useFlexGap
-            flexWrap="wrap"
-            alignItems="center"
-          >
-            {activeTags.map((tag) => (
-              <TagChip
-                key={tag.id}
-                label={tag.name}
-                color={tag.color}
-                onDelete={() =>
-                  setActiveTags((prev) => prev.filter((t) => t.id !== tag.id))
-                }
-              />
-            ))}
-          </Stack>
-        )}
-
-        <Box
-          component="button"
-          type="button"
-          onClick={(e) => {
-            setFilterAnchor(null);
-            setTagAnchor(tagAnchor ? null : e.currentTarget);
-          }}
-          aria-label="Add tag filter"
-          aria-expanded={!!tagAnchor}
-          sx={ADD_TAG_BUTTON_SX}
-        >
-          + tag
-        </Box>
       </Box>
 
-      <Popper
-        open={!!filterAnchor}
-        anchorEl={filterAnchor}
-        placement="bottom-start"
-        style={{ zIndex: 1300 }}
-      >
-        <ClickAwayListener onClickAway={() => setFilterAnchor(null)}>
-          <Paper elevation={3} sx={{ p: 1.5, mt: 0.5, minWidth: 260 }}>
-            <Autocomplete
-              multiple
-              disableCloseOnSelect
-              size="small"
-              options={FILTER_OPTIONS}
-              value={activeFilterOptions}
-              onChange={(_event, nextValue) => {
-                setActiveFilters(nextValue.map((option) => option.value));
-              }}
-              getOptionLabel={(option) => option.label}
-              isOptionEqualToValue={(option, selected) =>
-                option.value === selected.value
-              }
-              renderTags={(selected, getTagProps) =>
-                selected.map((option, index) => (
-                  <Chip
-                    {...getTagProps({ index })}
-                    key={option.value}
-                    label={option.label}
-                    size="small"
-                  />
-                ))
-              }
-              renderInput={(params) => (
-                <TextField
-                  {...params}
-                  label="Status filters"
-                  fullWidth
-                  autoFocus
-                />
-              )}
+      {/* 2-column masonry grid on mobile, more columns on wider screens */}
+      <Box sx={{ mt: 1.5 }} />
+      {/* Wrapper enables the loadingMore overlay without affecting layout */}
+      <Box sx={{ position: "relative" }}>
+        <Box sx={{
+          columnCount: isMobile ? 2 : { sm: 3, md: 4 },
+          columnGap: "8px",
+          // Dim the grid while loading more so the column redistribution
+          // that happens on append is masked behind the overlay.
+          opacity: loadingMore ? 0.35 : 1,
+          transition: "opacity 0.15s ease",
+          pointerEvents: loadingMore ? "none" : "auto",
+        }}>
+          {filteredPieces.map((piece) => (
+            <PieceCard
+              key={piece.id}
+              piece={piece}
+              activeTagIds={activeTags.map((t) => t.id)}
             />
-          </Paper>
-        </ClickAwayListener>
-      </Popper>
-
-      <Popper
-        open={!!tagAnchor}
-        anchorEl={tagAnchor}
-        placement="bottom-start"
-        style={{ zIndex: 1300 }}
-      >
-        <ClickAwayListener onClickAway={() => setTagAnchor(null)}>
-          <Paper elevation={3} sx={{ p: 1.5, mt: 0.5, minWidth: 260 }}>
-            <TagAutocomplete
-              label="Tags"
-              options={availableTags}
-              value={activeTags}
-              onChange={setActiveTags}
-              sx={{ minWidth: 0 }}
-            />
-          </Paper>
-        </ClickAwayListener>
-      </Popper>
-
-      <Grid container spacing={1} alignItems="stretch" role="rowgroup">
-        {filteredPieces.map((piece) => (
-          <PieceListItem
-            key={piece.id}
-            piece={piece}
-            activeTagIds={activeTags.map((tag) => tag.id)}
-          />
-        ))}
-      </Grid>
-
-      {/* Invisible sentinel — always in the DOM so the ref is populated when the
-          effect runs; the effect itself is a no-op when hasMore is false. */}
-      <div ref={sentinelRef} style={{ height: 1 }} aria-hidden="true" />
-
-      {loadingMore && (
-        <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
-          <CircularProgress size={24} />
+          ))}
         </Box>
-      )}
+
+        {/* Centered spinner overlay while fetching the next page */}
+        {loadingMore && (
+          <Box sx={{
+            position: "absolute",
+            inset: 0,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            minHeight: 80,
+          }}>
+            <CircularProgress size={32} />
+          </Box>
+        )}
+      </Box>
+
+      {/* Scroll sentinel — placed after the grid so it triggers near the bottom */}
+      <div ref={sentinelRef} style={{ height: 1 }} aria-hidden="true" />
 
       {!hasMore && !loadingMore && pieces.length > 0 && (
         <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
@@ -458,6 +600,7 @@ const PieceList = (props: PieceListingProps) => {
           </Typography>
         </Box>
       )}
+
     </>
   );
 };

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createMemoryRouter, RouterProvider } from "react-router-dom";
 import PieceList from "../PieceList";
@@ -37,12 +37,16 @@ function renderPieceList(pieces: PieceSummary[]) {
   return render(<RouterProvider router={router} />);
 }
 
+// Open the condensed filter panel
+async function openFilters(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button", { name: /toggle filters/i }));
+}
+
 describe("PieceList", () => {
   describe("with no pieces", () => {
-    it("renders an empty grid", () => {
+    it("renders the piece count as 0", () => {
       renderPieceList([]);
-      const container = screen.getByRole("rowgroup")!;
-      expect(container.children).toHaveLength(0);
+      expect(screen.getByText(/· 0 pieces/)).toBeInTheDocument();
     });
   });
 
@@ -60,18 +64,18 @@ describe("PieceList", () => {
     });
 
     it("renders the thumbnail image with correct src", () => {
-      renderPieceList([makePiece()]);
-      const imgs = screen.getAllByRole("presentation");
+      const { container } = renderPieceList([makePiece()]);
+      const imgs = container.querySelectorAll("img");
       expect(
-        imgs.some(
+        Array.from(imgs).some(
           (img) => img.getAttribute("src") === "https://example.com/bowl.jpg",
         ),
       ).toBe(true);
     });
 
-    it("name cell links to piece detail page", async () => {
+    it("card links to piece detail page", () => {
       renderPieceList([makePiece()]);
-      const link = screen.getByRole("navigation", { name: "Clay Bowl" });
+      const link = screen.getByRole("link");
       expect(link.getAttribute("href")).toBe(
         "/pieces/aaaaaaaa-0000-0000-0000-000000000001",
       );
@@ -81,8 +85,8 @@ describe("PieceList", () => {
       renderPieceList([
         makePiece({
           tags: [
-            { id: "tag-1", name: "Gift", color: "#2A9D8F" },
-            { id: "tag-2", name: "Functional", color: "#E76F51" },
+            { id: "tag-1", name: "Gift", color: "#2A9D8F", is_public: false },
+            { id: "tag-2", name: "Functional", color: "#E76F51", is_public: false },
           ],
         }),
       ]);
@@ -92,16 +96,12 @@ describe("PieceList", () => {
 
     it("renders a piece card without tag chips when the piece has no tags", () => {
       renderPieceList([makePiece({ tags: [] })]);
-      const pieceCard = screen.getByRole("navigation", { name: "Clay Bowl" });
-      expect(within(pieceCard).queryByText("Gift")).not.toBeInTheDocument();
-      expect(
-        within(pieceCard).queryByRole("button", { name: /\+\d+ more/i }),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /\+\d+/i })).not.toBeInTheDocument();
     });
   });
 
   describe("with multiple pieces", () => {
-    it("renders a row for each piece", () => {
+    it("renders a card for each piece", () => {
       const pieces = [
         makePiece({ id: "id-1", name: "Bowl" }),
         makePiece({ id: "id-2", name: "Mug" }),
@@ -113,75 +113,42 @@ describe("PieceList", () => {
       expect(screen.getByText("Vase")).toBeInTheDocument();
     });
 
-    it("renders each piece in its own table row", () => {
+    it("shows the state chip label on each card", () => {
       const pieces = [
-        makePiece({
-          id: "id-1",
-          name: "Bowl",
-          current_state: { state: "designed" },
-        }),
-        makePiece({
-          id: "id-2",
-          name: "Mug",
-          current_state: { state: "glazed" },
-        }),
+        makePiece({ id: "id-1", name: "Bowl", current_state: { state: "designed" } as any }),
+        makePiece({ id: "id-2", name: "Mug", current_state: { state: "glazed" } as any }),
       ];
       renderPieceList(pieces);
-      const rows = screen.getAllByRole("row");
-      expect(within(rows[0]).getByText("Bowl")).toBeInTheDocument();
-      expect(within(rows[0]).getByText("Designing")).toBeInTheDocument();
-      expect(within(rows[1]).getByText("Mug")).toBeInTheDocument();
-      expect(within(rows[1]).getByText("Glazing")).toBeInTheDocument();
+      expect(screen.getByText("Designing")).toBeInTheDocument();
+      expect(screen.getByText("Glazing")).toBeInTheDocument();
     });
   });
 
   describe("filter toolbar", () => {
-    it("renders + filter and + tag dashed buttons", () => {
+    it("renders the condensed filter toggle button", () => {
       renderPieceList([]);
       expect(
-        screen.getByRole("button", { name: /add status filter/i }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole("button", { name: /add tag filter/i }),
+        screen.getByRole("button", { name: /toggle filters/i }),
       ).toBeInTheDocument();
     });
 
-    it("autocomplete is not visible until + filter is clicked", () => {
+    it("filter panel is not expanded on initial render", () => {
       renderPieceList([]);
-      expect(screen.queryByLabelText("Status filters")).not.toBeInTheDocument();
+      expect(screen.queryByText("Active")).not.toBeInTheDocument();
     });
 
-    it("shows the filter autocomplete when + filter is clicked", async () => {
+    it("expands the filter panel when the toggle is clicked", async () => {
       const user = userEvent.setup();
       renderPieceList([]);
-      await user.click(screen.getByRole("button", { name: /add status filter/i }));
-      expect(screen.getByLabelText("Status filters")).toBeInTheDocument();
-    });
-
-    it("shows the tag autocomplete when + tag is clicked", async () => {
-      const user = userEvent.setup();
-      renderPieceList([]);
-      await user.click(screen.getByRole("button", { name: /add tag filter/i }));
-      expect(screen.getByLabelText("Tags")).toBeInTheDocument();
+      await openFilters(user);
+      expect(screen.getByText("Active")).toBeVisible();
     });
 
     it("shows all pieces when no filter is selected", () => {
       const pieces = [
-        makePiece({
-          id: "id-1",
-          name: "Bowl",
-          current_state: { state: "designed" } as any,
-        }),
-        makePiece({
-          id: "id-2",
-          name: "Mug",
-          current_state: { state: "completed" } as any,
-        }),
-        makePiece({
-          id: "id-3",
-          name: "Vase",
-          current_state: { state: "recycled" } as any,
-        }),
+        makePiece({ id: "id-1", name: "Bowl", current_state: { state: "designed" } as any }),
+        makePiece({ id: "id-2", name: "Mug", current_state: { state: "completed" } as any }),
+        makePiece({ id: "id-3", name: "Vase", current_state: { state: "recycled" } as any }),
       ];
       renderPieceList(pieces);
       expect(screen.getByText("Bowl")).toBeInTheDocument();
@@ -192,91 +159,58 @@ describe("PieceList", () => {
     it("filters to work in progress pieces only", async () => {
       const user = userEvent.setup();
       const pieces = [
-        makePiece({
-          id: "id-1",
-          name: "Bowl",
-          current_state: { state: "designed" } as any,
-        }),
-        makePiece({
-          id: "id-2",
-          name: "Mug",
-          current_state: { state: "completed" } as any,
-        }),
-        makePiece({
-          id: "id-3",
-          name: "Vase",
-          current_state: { state: "recycled" } as any,
-        }),
+        makePiece({ id: "id-1", name: "Bowl", current_state: { state: "designed" } as any }),
+        makePiece({ id: "id-2", name: "Mug", current_state: { state: "completed" } as any }),
+        makePiece({ id: "id-3", name: "Vase", current_state: { state: "recycled" } as any }),
       ];
       renderPieceList(pieces);
 
-      await user.click(screen.getByRole("button", { name: /add status filter/i }));
-      await user.click(screen.getByLabelText("Status filters"));
-      await user.click(screen.getByRole("option", { name: "Work in Progress" }));
-      await user.keyboard("{Escape}");
+      await openFilters(user);
+      // Click the "Active" chip inside the filter panel
+      const activeChip = screen.getAllByText("Active").find(
+        (el) => el.closest('[role="button"]'),
+      );
+      await user.click(activeChip!.closest('[role="button"]')!);
 
       expect(screen.getByText("Bowl")).toBeInTheDocument();
       expect(screen.queryByText("Mug")).not.toBeInTheDocument();
       expect(screen.queryByText("Vase")).not.toBeInTheDocument();
-      expect(screen.getAllByText("Work in Progress").length).toBeGreaterThan(0);
     });
 
     it("filters to completed pieces only", async () => {
       const user = userEvent.setup();
       const pieces = [
-        makePiece({
-          id: "id-1",
-          name: "Bowl",
-          current_state: { state: "designed" } as any,
-        }),
-        makePiece({
-          id: "id-2",
-          name: "Mug",
-          current_state: { state: "completed" } as any,
-        }),
-        makePiece({
-          id: "id-3",
-          name: "Vase",
-          current_state: { state: "recycled" } as any,
-        }),
+        makePiece({ id: "id-1", name: "Bowl", current_state: { state: "designed" } as any }),
+        makePiece({ id: "id-2", name: "Mug", current_state: { state: "completed" } as any }),
+        makePiece({ id: "id-3", name: "Vase", current_state: { state: "recycled" } as any }),
       ];
       renderPieceList(pieces);
 
-      await user.click(screen.getByRole("button", { name: /add status filter/i }));
-      await user.click(screen.getByLabelText("Status filters"));
-      await user.click(screen.getByRole("option", { name: "Completed" }));
-      await user.keyboard("{Escape}");
+      await openFilters(user);
+      const completedChip = screen.getAllByText("Completed").find(
+        (el) => el.closest('[role="button"]'),
+      );
+      await user.click(completedChip!.closest('[role="button"]')!);
 
       expect(screen.queryByText("Bowl")).not.toBeInTheDocument();
       expect(screen.getByText("Mug")).toBeInTheDocument();
       expect(screen.queryByText("Vase")).not.toBeInTheDocument();
     });
 
-    it("filters to discarded pieces only", async () => {
+    it("filters to recycled pieces only", async () => {
       const user = userEvent.setup();
       const pieces = [
-        makePiece({
-          id: "id-1",
-          name: "Bowl",
-          current_state: { state: "designed" } as any,
-        }),
-        makePiece({
-          id: "id-2",
-          name: "Mug",
-          current_state: { state: "completed" } as any,
-        }),
-        makePiece({
-          id: "id-3",
-          name: "Vase",
-          current_state: { state: "recycled" } as any,
-        }),
+        makePiece({ id: "id-1", name: "Bowl", current_state: { state: "designed" } as any }),
+        makePiece({ id: "id-2", name: "Mug", current_state: { state: "completed" } as any }),
+        makePiece({ id: "id-3", name: "Vase", current_state: { state: "recycled" } as any }),
       ];
       renderPieceList(pieces);
 
-      await user.click(screen.getByRole("button", { name: /add status filter/i }));
-      await user.click(screen.getByLabelText("Status filters"));
-      await user.click(screen.getByRole("option", { name: "Discarded" }));
-      await user.keyboard("{Escape}");
+      await openFilters(user);
+      const recycledChip = screen.getAllByText("Recycled").find(
+        (el) => el.closest('[role="button"]'),
+      );
+      await user.click(recycledChip!.closest('[role="button"]')!);
 
       expect(screen.queryByText("Bowl")).not.toBeInTheDocument();
       expect(screen.queryByText("Mug")).not.toBeInTheDocument();
@@ -286,60 +220,45 @@ describe("PieceList", () => {
     it("supports combining multiple filters", async () => {
       const user = userEvent.setup();
       const pieces = [
-        makePiece({
-          id: "id-1",
-          name: "Bowl",
-          current_state: { state: "designed" } as any,
-        }),
-        makePiece({
-          id: "id-2",
-          name: "Mug",
-          current_state: { state: "completed" } as any,
-        }),
-        makePiece({
-          id: "id-3",
-          name: "Vase",
-          current_state: { state: "recycled" } as any,
-        }),
+        makePiece({ id: "id-1", name: "Bowl", current_state: { state: "designed" } as any }),
+        makePiece({ id: "id-2", name: "Mug", current_state: { state: "completed" } as any }),
+        makePiece({ id: "id-3", name: "Vase", current_state: { state: "recycled" } as any }),
       ];
       renderPieceList(pieces);
 
-      await user.click(screen.getByRole("button", { name: /add status filter/i }));
-      await user.click(screen.getByLabelText("Status filters"));
-      await user.click(screen.getByRole("option", { name: "Completed" }));
-      await user.click(screen.getByRole("option", { name: "Discarded" }));
-      await user.keyboard("{Escape}");
+      await openFilters(user);
+      const completedChip = screen.getAllByText("Completed").find(
+        (el) => el.closest('[role="button"]'),
+      );
+      const recycledChip = screen.getAllByText("Recycled").find(
+        (el) => el.closest('[role="button"]'),
+      );
+      await user.click(completedChip!.closest('[role="button"]')!);
+      await user.click(recycledChip!.closest('[role="button"]')!);
 
       expect(screen.queryByText("Bowl")).not.toBeInTheDocument();
       expect(screen.getByText("Mug")).toBeInTheDocument();
       expect(screen.getByText("Vase")).toBeInTheDocument();
     });
 
-    it("shows all pieces again when a filter chip is removed", async () => {
+    it("shows all pieces again when a filter chip is toggled off", async () => {
       const user = userEvent.setup();
       const pieces = [
-        makePiece({
-          id: "id-1",
-          name: "Bowl",
-          current_state: { state: "designed" } as any,
-        }),
-        makePiece({
-          id: "id-2",
-          name: "Mug",
-          current_state: { state: "completed" } as any,
-        }),
+        makePiece({ id: "id-1", name: "Bowl", current_state: { state: "designed" } as any }),
+        makePiece({ id: "id-2", name: "Mug", current_state: { state: "completed" } as any }),
       ];
       renderPieceList(pieces);
 
-      await user.click(screen.getByRole("button", { name: /add status filter/i }));
-      await user.click(screen.getByLabelText("Status filters"));
-      await user.click(screen.getByRole("option", { name: "Completed" }));
-      await user.keyboard("{Escape}");
+      await openFilters(user);
+      const completedChip = screen.getAllByText("Completed").find(
+        (el) => el.closest('[role="button"]'),
+      );
+      // Activate filter
+      await user.click(completedChip!.closest('[role="button"]')!);
       expect(screen.queryByText("Bowl")).not.toBeInTheDocument();
 
-      // Deselect the option to clear the filter (Popper is still open after Escape)
-      await user.click(screen.getByLabelText("Status filters"));
-      await user.click(screen.getByRole("option", { name: "Completed" }));
+      // Deactivate filter
+      await user.click(completedChip!.closest('[role="button"]')!);
       await waitFor(() => {
         expect(screen.getByText("Bowl")).toBeInTheDocument();
       });
@@ -355,74 +274,50 @@ describe("PieceList", () => {
           id: "id-1",
           name: "Bowl",
           tags: [
-            { id: "gift", name: "Gift", color: "#2A9D8F" },
-            { id: "sale", name: "For Sale", color: "#4FC3F7" },
+            { id: "gift", name: "Gift", color: "#2A9D8F", is_public: false },
+            { id: "sale", name: "For Sale", color: "#4FC3F7", is_public: false },
           ],
         }),
         makePiece({
           id: "id-2",
           name: "Mug",
-          tags: [{ id: "gift", name: "Gift", color: "#2A9D8F" }],
+          tags: [{ id: "gift", name: "Gift", color: "#2A9D8F", is_public: false }],
         }),
       ];
       renderPieceList(pieces);
 
-      await user.click(screen.getByRole("button", { name: /add tag filter/i }));
-      await user.click(screen.getByLabelText("Tags"));
+      await openFilters(user);
+      // Open the tag picker then select a tag (picker auto-closes after selection)
+      await user.click(screen.getByRole("button", { name: /\+ tag/i }));
+      await user.click(screen.getByLabelText("Filter by tag"));
       await user.click(screen.getByRole("option", { name: "Gift" }));
-      await user.click(screen.getByLabelText("Tags"));
+      // Gift is now an active chip; open the picker again for the second tag
+      await user.click(screen.getByRole("button", { name: /\+ tag/i }));
+      await user.click(screen.getByLabelText("Filter by tag"));
       await user.click(screen.getByRole("option", { name: "For Sale" }));
-      await user.keyboard("{Escape}");
 
       expect(screen.getByText("Bowl")).toBeInTheDocument();
       expect(screen.queryByText("Mug")).not.toBeInTheDocument();
     });
 
-    it("collapses piece tags behind an expand button when there are many", async () => {
-      const user = userEvent.setup();
+    it("shows at most 2 tag chips per card with a dashed overflow chip", () => {
       renderPieceList([
         makePiece({
           tags: [
-            { id: "gift", name: "Gift", color: "#2A9D8F" },
-            { id: "sale", name: "For Sale", color: "#4FC3F7" },
-            { id: "sold", name: "Sold", color: "#F4A261" },
-            { id: "blue", name: "Blue", color: "#457B9D" },
+            { id: "gift", name: "Gift", color: "#2A9D8F", is_public: false },
+            { id: "sale", name: "For Sale", color: "#4FC3F7", is_public: false },
+            { id: "sold", name: "Sold", color: "#F4A261", is_public: false },
+            { id: "blue", name: "Blue", color: "#457B9D", is_public: false },
           ],
         }),
       ]);
 
       expect(screen.getByText("Gift")).toBeInTheDocument();
       expect(screen.getByText("For Sale")).toBeInTheDocument();
-      expect(screen.getByText("Sold")).toBeInTheDocument();
+      expect(screen.queryByText("Sold")).not.toBeInTheDocument();
       expect(screen.queryByText("Blue")).not.toBeInTheDocument();
-
-      await user.click(screen.getByRole("button", { name: "+1 more" }));
-
-      expect(screen.getByText("Blue")).toBeInTheDocument();
-    });
-
-    it("keeps currently filtered tags visible even when piece tags are collapsed", async () => {
-      const user = userEvent.setup();
-      renderPieceList([
-        makePiece({
-          id: "id-1",
-          name: "Bowl",
-          tags: [
-            { id: "gift", name: "Gift", color: "#2A9D8F" },
-            { id: "sale", name: "For Sale", color: "#4FC3F7" },
-            { id: "sold", name: "Sold", color: "#F4A261" },
-            { id: "blue", name: "Blue", color: "#457B9D" },
-          ],
-        }),
-      ]);
-
-      await user.click(screen.getByRole("button", { name: /add tag filter/i }));
-      await user.click(screen.getByLabelText("Tags"));
-      await user.click(screen.getByRole("option", { name: "Blue" }));
-      await user.keyboard("{Escape}");
-
-      const pieceCard = screen.getByRole("navigation", { name: "Bowl" });
-      expect(within(pieceCard).getByText("Blue")).toBeInTheDocument();
+      // Overflow chip shows +2
+      expect(screen.getByText("+2")).toBeInTheDocument();
     });
   });
 
@@ -432,7 +327,8 @@ describe("PieceList", () => {
       expect(screen.queryByLabelText("Sort order")).not.toBeInTheDocument();
     });
 
-    it("renders a sort selector when onSortChange is provided", () => {
+    it("renders a sort selector when onSortChange is provided", async () => {
+      const user = userEvent.setup();
       const router = createMemoryRouter(
         [
           {
@@ -449,6 +345,8 @@ describe("PieceList", () => {
         { initialEntries: ["/"] },
       );
       render(<RouterProvider router={router} />);
+      // Sort selector lives inside the expandable panel
+      await openFilters(user);
       expect(screen.getByLabelText("Sort order")).toBeInTheDocument();
     });
 
@@ -472,6 +370,8 @@ describe("PieceList", () => {
       );
       render(<RouterProvider router={router} />);
 
+      // Open filter panel so the sort selector is interactable
+      await openFilters(user);
       await user.click(screen.getByLabelText("Sort order"));
       await user.click(screen.getByRole("option", { name: "Name A → Z" }));
 

--- a/web/src/pages/LandingPage.tsx
+++ b/web/src/pages/LandingPage.tsx
@@ -1,13 +1,75 @@
 import { useLocation, useNavigate, Outlet } from "react-router-dom";
-import { Box, Tab, Tabs } from "@mui/material";
+import { Box, Tab, Tabs, useMediaQuery } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
+
+// Height of the fixed bottom tab bar on mobile
+export const BOTTOM_TAB_BAR_HEIGHT = 56;
 
 export default function LandingPage() {
   const location = useLocation();
   const navigate = useNavigate();
   const currentTab = location.pathname === "/analyze" ? "/analyze" : "/";
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+
+  if (isMobile) {
+    return (
+      <>
+        <Box sx={{ pt: 2, pb: `${BOTTOM_TAB_BAR_HEIGHT + 16}px` }}>
+          <Outlet />
+        </Box>
+
+        <Box
+          component="nav"
+          aria-label="Main navigation"
+          sx={{
+            position: "fixed",
+            bottom: 0,
+            left: 0,
+            right: 0,
+            zIndex: (t) => t.zIndex.appBar,
+            height: BOTTOM_TAB_BAR_HEIGHT,
+            bgcolor: "rgba(24, 18, 16, 0.92)",
+            backdropFilter: "blur(12px)",
+            borderTop: "1px solid",
+            borderColor: "divider",
+            pb: "env(safe-area-inset-bottom)",
+          }}
+        >
+          <Tabs
+            value={currentTab}
+            onChange={(_event, nextTab: string) => navigate(nextTab)}
+            aria-label="Landing page navigation"
+            variant="fullWidth"
+            sx={{
+              height: "100%",
+              "& .MuiTabs-flexContainer": { height: "100%" },
+              "& .MuiTab-root": {
+                height: "100%",
+                minHeight: "unset",
+                textTransform: "none",
+                fontSize: "0.75rem",
+                fontWeight: 600,
+                letterSpacing: "0.02em",
+                "&:not(.Mui-selected)": { color: "text.disabled" },
+              },
+              "& .MuiTabs-indicator": {
+                top: 0,
+                bottom: "unset",
+                height: 2,
+              },
+            }}
+          >
+            <Tab label="Pieces" value="/" />
+            <Tab label="Analyze" value="/analyze" />
+          </Tabs>
+        </Box>
+      </>
+    );
+  }
 
   return (
-    <Box sx={{ pb: 2 }}>
+    <Box sx={{ pt: 1.5, pb: 2 }}>
       <Tabs
         value={currentTab}
         onChange={(_event, nextTab: string) => navigate(nextTab)}

--- a/web/src/pages/PieceListPage.tsx
+++ b/web/src/pages/PieceListPage.tsx
@@ -19,7 +19,12 @@ import PieceList from "../components/PieceList";
 import type { PieceDetail, PieceSummary } from "../util/types";
 
 export default function PieceListPage() {
+  // `pieces` is the committed list shown in the masonry grid.
+  // `pendingPieces` holds newly fetched items that are buffered while
+  // loadingMore is true, then flushed in one DOM update when loading finishes
+  // to avoid mid-scroll masonry reflow.
   const [pieces, setPieces] = useState<PieceSummary[]>([]);
+  const pendingRef = useRef<PieceSummary[] | null>(null);
   const [count, setCount] = useState(0);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -31,11 +36,14 @@ export default function PieceListPage() {
 
   const offsetRef = useRef(0);
   const sortOrderRef = useRef(sortOrder);
+  // Synchronous guard — React state updates are batched and arrive too late
+  // to prevent double-firing from rapid scroll events.
+  const loadingMoreRef = useRef(false);
 
   const loadPage = useCallback(
     async (ordering: PieceSortOrder, offset: number, replace: boolean) => {
       if (replace) setLoading(true);
-      else setLoadingMore(true);
+      else { setLoadingMore(true); loadingMoreRef.current = true; }
       setError(null);
       try {
         const page = await fetchPieces({
@@ -45,13 +53,29 @@ export default function PieceListPage() {
         });
         if (sortOrderRef.current !== ordering) return;
         setCount(page.count);
-        setPieces((prev) => (replace ? page.results : [...prev, ...page.results]));
+        if (replace) {
+          pendingRef.current = null;
+          setPieces(page.results);
+        } else {
+          // Buffer the new items; flush them when we clear loadingMore so
+          // the masonry grid updates in one frame instead of reshuffling
+          // mid-scroll as items trickle in.
+          pendingRef.current = page.results;
+        }
         offsetRef.current = offset + page.results.length;
       } catch {
         setError("Failed to load pieces.");
       } finally {
-        if (replace) setLoading(false);
-        else setLoadingMore(false);
+        if (replace) {
+          setLoading(false);
+        } else {
+          // Flush buffered items and clear the loading flag atomically
+          const pending = pendingRef.current;
+          pendingRef.current = null;
+          if (pending) setPieces((prev) => [...prev, ...pending]);
+          setLoadingMore(false);
+          loadingMoreRef.current = false;
+        }
       }
     },
     [],
@@ -60,6 +84,8 @@ export default function PieceListPage() {
   useEffect(() => {
     sortOrderRef.current = sortOrder;
     offsetRef.current = 0;
+    loadingMoreRef.current = false;
+    pendingRef.current = null;
     setPieces([]);
     loadPage(sortOrder, 0, true);
   }, [sortOrder, loadPage]);
@@ -69,10 +95,10 @@ export default function PieceListPage() {
   }
 
   const handleLoadMore = useCallback(() => {
-    if (loadingMore || loading) return;
+    if (loadingMoreRef.current || loading) return;
     const currentOffset = offsetRef.current;
     loadPage(sortOrder, currentOffset, false);
-  }, [loadingMore, loading, sortOrder, loadPage]);
+  }, [loading, sortOrder, loadPage]);
 
   function handleCreated(piece: PieceDetail) {
     setPieces((prev) => [piece, ...prev]);
@@ -91,8 +117,16 @@ export default function PieceListPage() {
           sx={{
             position: "fixed",
             right: 16,
-            bottom: 16,
+            // Sit above the bottom tab bar (56px) with extra breathing room
+            bottom: "calc(56px + 18px)",
             zIndex: (muiTheme) => muiTheme.zIndex.speedDial,
+            boxShadow: (muiTheme) => `
+              0 1px 0 rgba(255,255,255,0.18) inset,
+              0 -2px 6px rgba(0,0,0,0.35) inset,
+              0 8px 14px ${muiTheme.palette.common.black}8c,
+              0 22px 40px ${muiTheme.palette.primary.dark}8c,
+              0 0 0 1px ${muiTheme.palette.primary.dark}b3
+            `,
           }}
         >
           <AddIcon />


### PR DESCRIPTION
## Summary

- **Masonry card layout**: replaces the table with a 2-column CSS masonry grid (3–4 columns on wider screens). Card thumbnail height varies by recency (180px ≤ 2d, 140px < 14d, 110px stale/terminal). A kiln-glow amber dot marks stale pieces; a filled state chip overlays the bottom-left of each thumbnail; last-activity caption appears in monospace below the piece name. Tags are shown as colored chips (max 2) with a dashed `+N` overflow chip.
- **Floating filter strip**: sticky at the top, rendered as a compact toggle button. Expanding it opens an absolutely-positioned overlay panel (so the masonry never scrolls or shifts when the strip opens). The panel contains status filter chips (Active / Completed / Recycled), tag filter chips + `+ tag` picker, sort selector, and a New Piece button on desktop.
- **Mobile bottom tab bar**: `LandingPage` shows a fixed bottom nav bar (Pieces / Analyze) on small screens with the indicator at the top edge; desktop keeps the existing top tabs.
- **FAB**: sits above the bottom tab bar on mobile with a layered inset + drop + halo shadow.
- **Pagination stability**: a synchronous `loadingMoreRef` guard prevents duplicate fetches on rapid scroll. While a next page is loading the masonry dims to 35% opacity and shows a centered spinner overlay, masking the CSS column redistribution reflow.
- **Dev fixtures**: `_seed_dev_pieces` now generates 8 tags and attaches 0–3 to each seeded piece.
- **Bug fixes**: React Router `Link` for card navigation (was full-page reload via `<a href>`); `App.tsx` `pl`/`pr` split for `safe-area-inset` support; `apps.get_model` for `PieceTag` to satisfy mypy.

## Test plan

- [ ] All 30 Bazel test targets pass (`bazel test //...`)
- [ ] All linters pass (`bazel build --config=lint //...`)
- [ ] Cards navigate to piece detail without full page reload
- [ ] Filter strip overlays masonry when expanded; page does not scroll
- [ ] Rapid scrolling shows spinner overlay without layout flicker
- [ ] Tags appear as colored chips on cards; overflow shows `+N`
- [ ] Mobile layout shows bottom tab bar; FAB sits above it
- [ ] Dev bootstrap creates tagged pieces visible in the list

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)
