### PR TITLE
Fix piece list masonry append reshuffling

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -262,7 +262,7 @@
         "bzlTransitiveDigest": "HKMVj1TG4O7hW/qkMUGevNijK2IpfzhTvuIV3FOWIbo=",
         "usagesDigest": "jgXSyw2zB6hLAQDv/3Pr3kgPnN5jdzqcETRqehvo1aw=",
         "recordedFileInputs": {
-          "@@//web/package.json": "43c01fb695303b3e63fe9c5bc30df36e8892bdbf0bc4ee10a2676f6f514e78d7"
+          "@@//web/package.json": "1c2123d7e53c65b380bd36e97839b8a780e83a4aba938ff903fb5a0fe488b6e9"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -17,6 +17,7 @@
         "@opencvjs/web": "^4.13.0-release.1",
         "@react-oauth/google": "^0.13.4",
         "axios": "^1.15.2",
+        "masonic": "^4.1.0",
         "mui": "^0.0.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -919,6 +920,33 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@essentials/memoize-one": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@essentials/memoize-one/-/memoize-one-1.1.0.tgz",
+      "integrity": "sha512-HMkuIkKNe0EWSUpZhlaq9+5Yp47YhrMhxLMnXTRnEyE5N4xKLspAvMGjUFdi794VnEF1EcOZFS8rdROeujrgag==",
+      "license": "MIT"
+    },
+    "node_modules/@essentials/one-key-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@essentials/one-key-map/-/one-key-map-1.2.0.tgz",
+      "integrity": "sha512-C2H7zHVcsoipDv4VKY5uUcv5ilsK+uEgEj+WeOdN5oz/Qj1/OZIzCdle90gDzj0xnGQrmZ9qDujwD7AkBb5k9A==",
+      "license": "MIT"
+    },
+    "node_modules/@essentials/raf": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@essentials/raf/-/raf-1.2.0.tgz",
+      "integrity": "sha512-AWJvpprE2o7ATMb7HBYMVUVmPJBCt2wZp2rY7d+rAcNSMvzLbDepy9KFeqqrPZh+s9aIpbw1LgmuAW7kuRFgrQ==",
+      "license": "MIT"
+    },
+    "node_modules/@essentials/request-timeout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@essentials/request-timeout/-/request-timeout-1.3.0.tgz",
+      "integrity": "sha512-lKZPhKScNFnR1MBnk4+sxshk46fpvdN+Uh1LlKWFO5g1ocuz4EcknNIL7tm/rsCAs/+xMWiBTwbDUvm+pDNlXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@essentials/raf": "^1.2.0"
+      }
+    },
     "node_modules/@exodus/bytes": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
@@ -1327,6 +1355,84 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@react-hook/debounce": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-hook/debounce/-/debounce-3.0.0.tgz",
+      "integrity": "sha512-ir/kPrSfAzY12Gre0sOHkZ2rkEmM4fS5M5zFxCi4BnCeXh2nvx9Ujd+U4IGpKCuPA+EQD0pg1eK2NGLvfWejag==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-hook/latest": "^1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@react-hook/event": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@react-hook/event/-/event-1.2.6.tgz",
+      "integrity": "sha512-JUL5IluaOdn5w5Afpe/puPa1rj8X6udMlQ9dt4hvMuKmTrBS1Ya6sb4sVgvfe2eU4yDuOfAhik8xhbcCekbg9Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@react-hook/latest": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@react-hook/latest/-/latest-1.0.3.tgz",
+      "integrity": "sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@react-hook/passive-layout-effect": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@react-hook/passive-layout-effect/-/passive-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@react-hook/throttle": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-hook/throttle/-/throttle-2.2.0.tgz",
+      "integrity": "sha512-LJ5eg+yMV8lXtqK3lR+OtOZ2WH/EfWvuiEEu0M3bhR7dZRfTyEJKxH1oK9uyBxiXPtWXiQggWbZirMCXam51tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-hook/latest": "^1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@react-hook/window-scroll": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@react-hook/window-scroll/-/window-scroll-1.3.0.tgz",
+      "integrity": "sha512-LdYnCL22pFI+LTs85Fi2OQHSKWkzIuHFgv8lA+wwuaPxLOEhWR5bzJ21iygUH9X4meeLVRZKEbfpYi3OWWD4GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-hook/event": "^1.2.1",
+        "@react-hook/throttle": "^2.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@react-hook/window-size": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@react-hook/window-size/-/window-size-3.1.1.tgz",
+      "integrity": "sha512-yWnVS5LKnOUIrEsI44oz3bIIUYqflamPL27n+k/PC//PsX/YeWBky09oPeAoc9As6jSH16Wgo8plI+ECZaHk3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-hook/debounce": "^3.0.0",
+        "@react-hook/event": "^1.2.1",
+        "@react-hook/throttle": "^2.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
       }
     },
     "node_modules/@react-oauth/google": {
@@ -4564,6 +4670,28 @@
         "node": ">=10"
       }
     },
+    "node_modules/masonic": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/masonic/-/masonic-4.1.0.tgz",
+      "integrity": "sha512-3RNbAG5qLve7qNtGp1UM/u7vI39jO73ZFHDBAg3xl8AVh7A6Ikx7I7mBeC0NY0h1r1jJn2Wqeol1QMa09MQbyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@essentials/memoize-one": "^1.1.0",
+        "@essentials/one-key-map": "^1.2.0",
+        "@essentials/request-timeout": "^1.3.0",
+        "@react-hook/event": "^1.2.6",
+        "@react-hook/latest": "^1.0.3",
+        "@react-hook/passive-layout-effect": "^1.2.1",
+        "@react-hook/throttle": "^2.2.0",
+        "@react-hook/window-scroll": "^1.3.0",
+        "@react-hook/window-size": "^3.1.1",
+        "raf-schd": "^4.0.3",
+        "trie-memoize": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5155,6 +5283,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
@@ -5657,6 +5791,12 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/trie-memoize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/trie-memoize/-/trie-memoize-1.2.0.tgz",
+      "integrity": "sha512-hEDLVEP1FCgaRtt0oZDJdz2lK9uK7WlB7ASswt9U9cqruSNueVigtRGxI97hevKlViqhAcRgNgzuY/m8FCCMcg==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",

--- a/web/package.json
+++ b/web/package.json
@@ -22,6 +22,7 @@
     "@opencvjs/web": "^4.13.0-release.1",
     "@react-oauth/google": "^0.13.4",
     "axios": "^1.15.2",
+    "masonic": "^4.1.0",
     "mui": "^0.0.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       axios:
         specifier: ^1.15.2
         version: 1.15.2
+      masonic:
+        specifier: ^4.1.0
+        version: 4.1.0(react@19.2.4)
       mui:
         specifier: ^0.0.1
         version: 0.0.1
@@ -392,6 +395,18 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@essentials/memoize-one@1.1.0':
+    resolution: {integrity: sha512-HMkuIkKNe0EWSUpZhlaq9+5Yp47YhrMhxLMnXTRnEyE5N4xKLspAvMGjUFdi794VnEF1EcOZFS8rdROeujrgag==}
+
+  '@essentials/one-key-map@1.2.0':
+    resolution: {integrity: sha512-C2H7zHVcsoipDv4VKY5uUcv5ilsK+uEgEj+WeOdN5oz/Qj1/OZIzCdle90gDzj0xnGQrmZ9qDujwD7AkBb5k9A==}
+
+  '@essentials/raf@1.2.0':
+    resolution: {integrity: sha512-AWJvpprE2o7ATMb7HBYMVUVmPJBCt2wZp2rY7d+rAcNSMvzLbDepy9KFeqqrPZh+s9aIpbw1LgmuAW7kuRFgrQ==}
+
+  '@essentials/request-timeout@1.3.0':
+    resolution: {integrity: sha512-lKZPhKScNFnR1MBnk4+sxshk46fpvdN+Uh1LlKWFO5g1ocuz4EcknNIL7tm/rsCAs/+xMWiBTwbDUvm+pDNlXw==}
+
   '@exodus/bytes@1.15.0':
     resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -544,6 +559,41 @@ packages:
 
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
+
+  '@react-hook/debounce@3.0.0':
+    resolution: {integrity: sha512-ir/kPrSfAzY12Gre0sOHkZ2rkEmM4fS5M5zFxCi4BnCeXh2nvx9Ujd+U4IGpKCuPA+EQD0pg1eK2NGLvfWejag==}
+    peerDependencies:
+      react: '>=16.8'
+
+  '@react-hook/event@1.2.6':
+    resolution: {integrity: sha512-JUL5IluaOdn5w5Afpe/puPa1rj8X6udMlQ9dt4hvMuKmTrBS1Ya6sb4sVgvfe2eU4yDuOfAhik8xhbcCekbg9Q==}
+    peerDependencies:
+      react: '>=16.8'
+
+  '@react-hook/latest@1.0.3':
+    resolution: {integrity: sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg==}
+    peerDependencies:
+      react: '>=16.8'
+
+  '@react-hook/passive-layout-effect@1.2.1':
+    resolution: {integrity: sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==}
+    peerDependencies:
+      react: '>=16.8'
+
+  '@react-hook/throttle@2.2.0':
+    resolution: {integrity: sha512-LJ5eg+yMV8lXtqK3lR+OtOZ2WH/EfWvuiEEu0M3bhR7dZRfTyEJKxH1oK9uyBxiXPtWXiQggWbZirMCXam51tg==}
+    peerDependencies:
+      react: '>=16.8'
+
+  '@react-hook/window-scroll@1.3.0':
+    resolution: {integrity: sha512-LdYnCL22pFI+LTs85Fi2OQHSKWkzIuHFgv8lA+wwuaPxLOEhWR5bzJ21iygUH9X4meeLVRZKEbfpYi3OWWD4GQ==}
+    peerDependencies:
+      react: '>=16.8'
+
+  '@react-hook/window-size@3.1.1':
+    resolution: {integrity: sha512-yWnVS5LKnOUIrEsI44oz3bIIUYqflamPL27n+k/PC//PsX/YeWBky09oPeAoc9As6jSH16Wgo8plI+ECZaHk3g==}
+    peerDependencies:
+      react: '>=16.8'
 
   '@react-oauth/google@0.13.4':
     resolution: {integrity: sha512-hGKyNEH+/PK8M0sFEuo3MAEk0txtHpgs94tDQit+s2LXg7b6z53NtzHfqDvoB2X8O6lGB+FRg80hY//X6hfD+w==}
@@ -1601,6 +1651,11 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  masonic@4.1.0:
+    resolution: {integrity: sha512-3RNbAG5qLve7qNtGp1UM/u7vI39jO73ZFHDBAg3xl8AVh7A6Ikx7I7mBeC0NY0h1r1jJn2Wqeol1QMa09MQbyQ==}
+    peerDependencies:
+      react: '>=16.8'
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -1775,6 +1830,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  raf-schd@4.0.3:
+    resolution: {integrity: sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==}
 
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
@@ -1968,6 +2026,9 @@ packages:
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
+
+  trie-memoize@1.2.0:
+    resolution: {integrity: sha512-hEDLVEP1FCgaRtt0oZDJdz2lK9uK7WlB7ASswt9U9cqruSNueVigtRGxI97hevKlViqhAcRgNgzuY/m8FCCMcg==}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -2519,6 +2580,16 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@essentials/memoize-one@1.1.0': {}
+
+  '@essentials/one-key-map@1.2.0': {}
+
+  '@essentials/raf@1.2.0': {}
+
+  '@essentials/request-timeout@1.3.0':
+    dependencies:
+      '@essentials/raf': 1.2.0
+
   '@exodus/bytes@1.15.0': {}
 
   '@humanfs/core@0.19.1': {}
@@ -2656,6 +2727,41 @@ snapshots:
   '@polka/url@1.0.0-next.29': {}
 
   '@popperjs/core@2.11.8': {}
+
+  '@react-hook/debounce@3.0.0(react@19.2.4)':
+    dependencies:
+      '@react-hook/latest': 1.0.3(react@19.2.4)
+      react: 19.2.4
+
+  '@react-hook/event@1.2.6(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+
+  '@react-hook/latest@1.0.3(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+
+  '@react-hook/passive-layout-effect@1.2.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+
+  '@react-hook/throttle@2.2.0(react@19.2.4)':
+    dependencies:
+      '@react-hook/latest': 1.0.3(react@19.2.4)
+      react: 19.2.4
+
+  '@react-hook/window-scroll@1.3.0(react@19.2.4)':
+    dependencies:
+      '@react-hook/event': 1.2.6(react@19.2.4)
+      '@react-hook/throttle': 2.2.0(react@19.2.4)
+      react: 19.2.4
+
+  '@react-hook/window-size@3.1.1(react@19.2.4)':
+    dependencies:
+      '@react-hook/debounce': 3.0.0(react@19.2.4)
+      '@react-hook/event': 1.2.6(react@19.2.4)
+      '@react-hook/throttle': 2.2.0(react@19.2.4)
+      react: 19.2.4
 
   '@react-oauth/google@0.13.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -3696,6 +3802,21 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  masonic@4.1.0(react@19.2.4):
+    dependencies:
+      '@essentials/memoize-one': 1.1.0
+      '@essentials/one-key-map': 1.2.0
+      '@essentials/request-timeout': 1.3.0
+      '@react-hook/event': 1.2.6(react@19.2.4)
+      '@react-hook/latest': 1.0.3(react@19.2.4)
+      '@react-hook/passive-layout-effect': 1.2.1(react@19.2.4)
+      '@react-hook/throttle': 2.2.0(react@19.2.4)
+      '@react-hook/window-scroll': 1.3.0(react@19.2.4)
+      '@react-hook/window-size': 3.1.1(react@19.2.4)
+      raf-schd: 4.0.3
+      react: 19.2.4
+      trie-memoize: 1.2.0
+
   math-intrinsics@1.1.0: {}
 
   mdn-data@2.27.1: {}
@@ -3841,6 +3962,8 @@ snapshots:
   proxy-from-env@2.1.0: {}
 
   punycode@2.3.1: {}
+
+  raf-schd@4.0.3: {}
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:
@@ -4018,6 +4141,8 @@ snapshots:
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
+
+  trie-memoize@1.2.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -20,6 +20,8 @@ import {
 } from "../util/types";
 import type { PieceSortOrder } from "../util/api";
 import { DEFAULT_PIECE_SORT, PIECE_SORT_OPTIONS } from "../util/api";
+import { Masonry } from "masonic";
+import type { RenderComponentProps } from "masonic";
 import { Link } from "react-router-dom";
 import CloudinaryImage from "./CloudinaryImage";
 import TagAutocomplete from "./TagAutocomplete";
@@ -65,7 +67,6 @@ function thumbHeight(days: number, isTerminal: boolean): number {
 
 interface PieceCardProps {
   piece: PieceSummary;
-  activeTagIds: string[];
 }
 
 const PieceCard = ({ piece }: PieceCardProps) => {
@@ -93,8 +94,6 @@ const PieceCard = ({ piece }: PieceCardProps) => {
       to={detailPath}
       sx={{
         display: "block",
-        breakInside: "avoid",
-        mb: 1,
         borderRadius: 2,
         overflow: "hidden",
         bgcolor: "background.paper",
@@ -231,6 +230,10 @@ const PieceCard = ({ piece }: PieceCardProps) => {
   );
 };
 
+function MasonryPieceCard({ data }: RenderComponentProps<PieceSummary>) {
+  return <PieceCard piece={data} />;
+}
+
 type PieceListProps = {
   pieces: PieceSummary[];
   onNewPiece?: () => void;
@@ -311,6 +314,11 @@ const PieceList = (props: PieceListProps) => {
   }, [activeFilters, activeTags]);
 
   const hasActiveFilters = activeFilters.length > 0 || activeTags.length > 0;
+  const filterKey = useMemo(() => {
+    const filters = [...activeFilters].sort().join(",");
+    const tags = activeTags.map((tag) => tag.id).sort().join(",");
+    return `${filters}|${tags}|${sortOrder}`;
+  }, [activeFilters, activeTags, sortOrder]);
 
   const toggleFilter = useCallback((filter: FilterCategory) => {
     setActiveFilters((prev) =>
@@ -553,26 +561,28 @@ const PieceList = (props: PieceListProps) => {
         )}
       </Box>
 
-      {/* 2-column masonry grid on mobile, more columns on wider screens */}
+      {/* Masonry layout keeps append order stable without CSS column rebalancing. */}
       <Box sx={{ mt: 1.5 }} />
       {/* Wrapper enables the loadingMore overlay without affecting layout */}
       <Box sx={{ position: "relative" }}>
-        <Box sx={{
-          columnCount: isMobile ? 2 : { sm: 3, md: 4 },
-          columnGap: "8px",
-          // Dim the grid while loading more so the column redistribution
-          // that happens on append is masked behind the overlay.
-          opacity: loadingMore ? 0.35 : 1,
-          transition: "opacity 0.15s ease",
-          pointerEvents: loadingMore ? "none" : "auto",
-        }}>
-          {filteredPieces.map((piece) => (
-            <PieceCard
-              key={piece.id}
-              piece={piece}
-              activeTagIds={activeTags.map((t) => t.id)}
-            />
-          ))}
+        <Box
+          sx={{
+            opacity: loadingMore ? 0.35 : 1,
+            transition: "opacity 0.15s ease",
+            pointerEvents: loadingMore ? "none" : "auto",
+          }}
+        >
+          <Masonry
+            key={filterKey}
+            items={filteredPieces}
+            render={MasonryPieceCard}
+            itemKey={(piece) => piece.id}
+            itemHeightEstimate={260}
+            columnWidth={isMobile ? 160 : 220}
+            maxColumnCount={isMobile ? 2 : 4}
+            columnGutter={8}
+            rowGutter={8}
+          />
         </Box>
 
         {/* Centered spinner overlay while fetching the next page */}

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -8,6 +9,29 @@ import type { PieceSummary } from "../../util/types";
 vi.mock("../CloudinaryImage", () => ({
   default: ({ url, alt }: { url: string; alt?: string }) => (
     <img src={url} alt={alt ?? ""} />
+  ),
+}));
+
+vi.mock("masonic", () => ({
+  Masonry: ({
+    items,
+    render: RenderComponent,
+    itemKey,
+  }: {
+    items: PieceSummary[];
+    render: React.ComponentType<{ data: PieceSummary; index: number; width: number }>;
+    itemKey?: (item: PieceSummary, index: number) => string | number;
+  }) => (
+    <div data-testid="piece-grid">
+      {items.map((item, index) => (
+        <div
+          key={itemKey ? itemKey(item, index) : index}
+          data-key={itemKey ? itemKey(item, index) : index}
+        >
+          <RenderComponent data={item} index={index} width={240} />
+        </div>
+      ))}
+    </div>
   ),
 }));
 
@@ -121,6 +145,19 @@ describe("PieceList", () => {
       renderPieceList(pieces);
       expect(screen.getByText("Designing")).toBeInTheDocument();
       expect(screen.getByText("Glazing")).toBeInTheDocument();
+    });
+
+    it("passes stable piece ids to the masonry renderer as item keys", () => {
+      const pieces = [
+        makePiece({ id: "id-1", name: "Tagged Bowl", tags: [{ id: "tag-1", name: "Gift", color: "#2A9D8F", is_public: false }] }),
+        makePiece({ id: "id-2", name: "Plain Mug", tags: [] }),
+      ];
+
+      const { container } = renderPieceList(pieces);
+      const wrappers = container.querySelectorAll('[data-testid="piece-grid"] > div');
+
+      expect(wrappers[0]?.getAttribute("data-key")).toBe("id-1");
+      expect(wrappers[1]?.getAttribute("data-key")).toBe("id-2");
     });
   });
 


### PR DESCRIPTION
## Summary
- replace the CSS multi-column piece list layout with `masonic` so infinite-scroll appends keep existing cards visually stable
- preserve the existing filter and load-more behavior while remounting the masonry cache when the active filter set changes
- add a focused `PieceList` regression test and update the npm/pnpm lockfiles Bazel consumes

## Root Cause
The recent UI rework moved `PieceList` to a CSS multi-column masonry layout. When a new page of cards was appended, the browser rebalanced existing cards across columns. Shorter cards, especially pieces without tags, were the most likely to appear to disappear and re-enter later in the list.

## Validation
- `rtk bazel test //...`
- `rtk bazel build --config=lint //...`
- `source env.sh && gz_build`

Closes #221