### PR TITLE
Fix auth and piece list loading states

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -3,32 +3,41 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 // Mock the module before importing App
-vi.mock("./util/api", () => ({
-  fetchCurrentUser: vi.fn().mockResolvedValue(null),
-  loginWithGoogle: vi.fn(),
-  loginWithEmail: vi.fn(),
-  logoutUser: vi.fn().mockResolvedValue(undefined),
-  registerWithEmail: vi.fn(),
-  fetchPieces: vi.fn().mockResolvedValue([]),
-  fetchPiece: vi.fn(),
-  ensureCsrfCookie: vi.fn().mockResolvedValue(undefined),
-  createPiece: vi.fn(),
-  addPieceState: vi.fn(),
-  updateCurrentState: vi.fn(),
-  updatePiece: vi.fn(),
-  fetchGlobalEntries: vi.fn().mockResolvedValue([]),
-  createGlobalEntry: vi.fn(),
-  hasCloudinaryUploadConfig: vi.fn().mockReturnValue(false),
-  uploadImageToCloudinary: vi.fn(),
-  fetchGlazeCombinationImages: vi.fn().mockResolvedValue([]),
-}));
+vi.mock("./util/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./util/api")>();
+  return {
+    ...actual,
+    fetchCurrentUser: vi.fn().mockResolvedValue(null),
+    loginWithGoogle: vi.fn(),
+    loginWithEmail: vi.fn(),
+    logoutUser: vi.fn().mockResolvedValue(undefined),
+    registerWithEmail: vi.fn(),
+    fetchPieces: vi.fn().mockResolvedValue({ count: 0, results: [] }),
+    fetchPiece: vi.fn(),
+    ensureCsrfCookie: vi.fn().mockResolvedValue(undefined),
+    createPiece: vi.fn(),
+    addPieceState: vi.fn(),
+    updateCurrentState: vi.fn(),
+    updatePiece: vi.fn(),
+    fetchGlobalEntries: vi.fn().mockResolvedValue([]),
+    createGlobalEntry: vi.fn(),
+    hasCloudinaryUploadConfig: vi.fn().mockReturnValue(false),
+    uploadImageToCloudinary: vi.fn(),
+    fetchGlazeCombinationImages: vi.fn().mockResolvedValue([]),
+  };
+});
 
 vi.mock("./components/NewPieceDialog", () => ({
   default: () => null,
 }));
 
 vi.mock("./components/PieceList", () => ({
-  default: () => <div>Piece List Content</div>,
+  default: ({ onNewPiece }: { onNewPiece?: () => void }) => (
+    <div>
+      {onNewPiece && <button onClick={onNewPiece}>New Piece</button>}
+      <div>Piece List Content</div>
+    </div>
+  ),
 }));
 
 vi.mock("./components/PieceDetail", () => ({
@@ -197,6 +206,41 @@ describe("App auth flow", () => {
       "aria-selected",
       "false",
     );
+  });
+
+  it("shows a spinner while login is submitting", async () => {
+    vi.mocked(loginWithEmail).mockImplementation(
+      () => new Promise(() => {}) as ReturnType<typeof loginWithEmail>,
+    );
+
+    const { container } = render(<App />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Track every pottery piece through your workflow."),
+      ).toBeInTheDocument();
+    });
+
+    const inputs = container.querySelectorAll(
+      'input[type="email"], input[type="password"]',
+    );
+    const emailInput = inputs[0] as HTMLInputElement;
+    const passwordInput = inputs[1] as HTMLInputElement;
+
+    fireEvent.change(emailInput, { target: { value: "potter@example.com" } });
+    fireEvent.change(passwordInput, { target: { value: "password123" } });
+
+    const submitButton = screen
+      .getAllByRole("button")
+      .find((btn) => btn.textContent === "Log In" && btn.closest("form"));
+    expect(submitButton).toBeDefined();
+
+    await userEvent.click(submitButton!);
+
+    expect(screen.getByText("Signing you in...")).toBeInTheDocument();
+    expect(
+      submitButton?.querySelector('[role="progressbar"]'),
+    ).toBeInTheDocument();
   });
 
   it("switches between landing tabs and keeps the URL in sync", async () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -343,9 +343,21 @@ function AuthLanding({
                 type="submit"
                 variant="contained"
                 disabled={submitting || !email.trim() || !password}
+                startIcon={
+                  submitting ? (
+                    <CircularProgress size={16} color="inherit" />
+                  ) : undefined
+                }
               >
                 {mode === "login" ? "Log In" : "Create Account"}
               </Button>
+              {submitting && (
+                <Typography variant="body2" color="text.secondary">
+                  {mode === "login"
+                    ? "Signing you in..."
+                    : "Creating your account..."}
+                </Typography>
+              )}
             </Stack>
           </Box>
 
@@ -355,6 +367,9 @@ function AuthLanding({
               <Box
                 sx={{
                   display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  gap: 1,
                   justifyContent: "center",
                   overflowX: "auto",
                 }}
@@ -378,6 +393,13 @@ function AuthLanding({
                     setError("Google sign-in failed. Please try again.")
                   }
                 />
+                {submitting && (
+                  <CircularProgress
+                    size={20}
+                    color="inherit"
+                    aria-label="Authenticating"
+                  />
+                )}
               </Box>
             </>
           )}

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -267,6 +267,7 @@ type PieceListProps = {
   onSortChange?: (order: PieceSortOrder) => void;
   onLoadMore?: () => void;
   hasMore?: boolean;
+  loading?: boolean;
   loadingMore?: boolean;
 };
 
@@ -278,6 +279,7 @@ const PieceList = (props: PieceListProps) => {
     onSortChange,
     onLoadMore,
     hasMore = false,
+    loading = false,
     loadingMore = false,
   } = props;
   const theme = useTheme();
@@ -364,6 +366,9 @@ const PieceList = (props: PieceListProps) => {
       PIECE_SORT_OPTIONS.find((o) => o.value === sortOrder)?.label ?? sortOrder
     );
   }, [sortOrder]);
+
+  const showOverlay = loading || loadingMore;
+  const isReplacing = loading;
 
   return (
     <>
@@ -645,8 +650,13 @@ const PieceList = (props: PieceListProps) => {
       {/* Wrapper enables the loadingMore overlay without affecting layout */}
       <Box sx={{ position: "relative" }}>
         <Box
+          data-testid="piece-list-content"
+          style={{
+            opacity: isReplacing ? 0.42 : 1,
+            transition: "opacity 0.18s ease",
+          }}
           sx={{
-            pointerEvents: loadingMore ? "none" : "auto",
+            pointerEvents: showOverlay ? "none" : "auto",
           }}
         >
           <Masonry
@@ -663,8 +673,14 @@ const PieceList = (props: PieceListProps) => {
         </Box>
 
         {/* Centered spinner overlay while fetching the next page */}
-        {loadingMore && (
+        {showOverlay && (
           <Box
+            data-testid="piece-list-overlay"
+            style={{
+              backgroundColor: isReplacing
+                ? alpha(theme.palette.background.default, 0.5)
+                : "transparent",
+            }}
             sx={{
               position: "absolute",
               inset: 0,
@@ -682,7 +698,7 @@ const PieceList = (props: PieceListProps) => {
       {/* Scroll sentinel — placed after the grid so it triggers near the bottom */}
       <div ref={sentinelRef} style={{ height: 1 }} aria-hidden="true" />
 
-      {!hasMore && !loadingMore && pieces.length > 0 && (
+      {!hasMore && !showOverlay && pieces.length > 0 && (
         <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
           <Typography variant="caption" color="text.disabled">
             End of pieces

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -367,6 +367,8 @@ const PieceList = (props: PieceListProps) => {
     );
   }, [sortOrder]);
 
+  // Replace-style refreshes like re-sorting should visibly dim the current
+  // list, while append pagination keeps the list feeling seamless.
   const showOverlay = loading || loadingMore;
   const isReplacing = loading;
 

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -417,4 +417,48 @@ describe("PieceList", () => {
       });
     });
   });
+
+  describe("loading states", () => {
+    it("dims the existing list during replace-style refreshes", () => {
+      const router = createMemoryRouter(
+        [
+          {
+            path: "/",
+            element: <PieceList pieces={[makePiece()]} loading />,
+          },
+        ],
+        { initialEntries: ["/"] },
+      );
+
+      render(<RouterProvider router={router} />);
+
+      expect(screen.getByTestId("piece-list-content").getAttribute("style")).toContain(
+        "opacity: 0.42",
+      );
+      expect(screen.getByTestId("piece-list-overlay").getAttribute("style")).not.toContain(
+        "background-color: transparent",
+      );
+    });
+
+    it("keeps append pagination undimmed while showing the overlay spinner", () => {
+      const router = createMemoryRouter(
+        [
+          {
+            path: "/",
+            element: <PieceList pieces={[makePiece()]} loadingMore />,
+          },
+        ],
+        { initialEntries: ["/"] },
+      );
+
+      render(<RouterProvider router={router} />);
+
+      expect(screen.getByTestId("piece-list-content").getAttribute("style")).toContain(
+        "opacity: 1",
+      );
+      expect(screen.getByTestId("piece-list-overlay").getAttribute("style")).toContain(
+        "background-color: transparent",
+      );
+    });
+  });
 });

--- a/web/src/pages/PieceListPage.tsx
+++ b/web/src/pages/PieceListPage.tsx
@@ -27,6 +27,7 @@ export default function PieceListPage() {
   const pendingRef = useRef<PieceSummary[] | null>(null);
   const [count, setCount] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [sortOrder, setSortOrder] = useState<PieceSortOrder>(DEFAULT_PIECE_SORT);
@@ -35,6 +36,7 @@ export default function PieceListPage() {
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
   const offsetRef = useRef(0);
+  const piecesRef = useRef<PieceSummary[]>([]);
   const sortOrderRef = useRef(sortOrder);
   // Synchronous guard — React state updates are batched and arrive too late
   // to prevent double-firing from rapid scroll events.
@@ -42,8 +44,16 @@ export default function PieceListPage() {
 
   const loadPage = useCallback(
     async (ordering: PieceSortOrder, offset: number, replace: boolean) => {
-      if (replace) setLoading(true);
-      else { setLoadingMore(true); loadingMoreRef.current = true; }
+      if (replace) {
+        if (piecesRef.current.length === 0) {
+          setLoading(true);
+        } else {
+          setRefreshing(true);
+        }
+      } else {
+        setLoadingMore(true);
+        loadingMoreRef.current = true;
+      }
       setError(null);
       try {
         const page = await fetchPieces({
@@ -68,6 +78,7 @@ export default function PieceListPage() {
       } finally {
         if (replace) {
           setLoading(false);
+          setRefreshing(false);
         } else {
           // Flush buffered items and clear the loading flag atomically
           const pending = pendingRef.current;
@@ -82,11 +93,14 @@ export default function PieceListPage() {
   );
 
   useEffect(() => {
+    piecesRef.current = pieces;
+  }, [pieces]);
+
+  useEffect(() => {
     sortOrderRef.current = sortOrder;
     offsetRef.current = 0;
     loadingMoreRef.current = false;
     pendingRef.current = null;
-    setPieces([]);
     loadPage(sortOrder, 0, true);
   }, [sortOrder, loadPage]);
 
@@ -95,10 +109,10 @@ export default function PieceListPage() {
   }
 
   const handleLoadMore = useCallback(() => {
-    if (loadingMoreRef.current || loading) return;
+    if (loadingMoreRef.current || loading || refreshing) return;
     const currentOffset = offsetRef.current;
     loadPage(sortOrder, currentOffset, false);
-  }, [loading, sortOrder, loadPage]);
+  }, [loading, refreshing, sortOrder, loadPage]);
 
   function handleCreated(piece: PieceDetail) {
     setPieces((prev) => [piece, ...prev]);
@@ -146,6 +160,7 @@ export default function PieceListPage() {
           onSortChange={handleSortChange}
           onLoadMore={handleLoadMore}
           hasMore={hasMore}
+          loading={refreshing}
           loadingMore={loadingMore}
         />
       )}

--- a/web/src/pages/PieceListPage.tsx
+++ b/web/src/pages/PieceListPage.tsx
@@ -92,6 +92,8 @@ export default function PieceListPage() {
     [],
   );
 
+  // Keep the latest rendered list available so replace fetches can
+  // distinguish first-load empty state from re-sorting an existing list.
   useEffect(() => {
     piecesRef.current = pieces;
   }, [pieces]);

--- a/web/src/pages/__tests__/PieceListPage.test.tsx
+++ b/web/src/pages/__tests__/PieceListPage.test.tsx
@@ -22,11 +22,13 @@ vi.mock("../../components/PieceList", () => ({
     onNewPiece,
     onSortChange,
     onLoadMore,
+    loading = false,
   }: {
     pieces: PieceSummary[];
     onNewPiece?: () => void;
     onSortChange?: (order: PieceSortOrder) => void;
     onLoadMore?: () => void;
+    loading?: boolean;
   }) => (
     <div data-testid="piece-list">
       {onNewPiece && <button onClick={onNewPiece}>New Piece</button>}
@@ -34,6 +36,7 @@ vi.mock("../../components/PieceList", () => ({
         <button onClick={() => onSortChange("name")}>Sort by Name</button>
       )}
       {onLoadMore && <button onClick={onLoadMore}>Load More</button>}
+      {loading && <div>Refreshing Pieces</div>}
       {pieces.map((piece) => piece.name).join(", ")}
     </div>
   ),
@@ -181,6 +184,39 @@ describe("PieceListPage", () => {
       expect(mockFetchPieces).toHaveBeenCalledWith(
         expect.objectContaining({ ordering: "name" }),
       );
+    });
+  });
+
+  it("keeps the current list mounted while refreshing a new sort order", async () => {
+    let resolveSortedPage: ((value: { count: number; results: PieceSummary[] }) => void) | null =
+      null;
+
+    mockFetchPieces
+      .mockResolvedValueOnce({ count: 1, results: [EXISTING_PIECE] })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSortedPage = resolve;
+          }),
+      );
+
+    render(<PieceListPage />);
+
+    await waitFor(() => screen.getByText("Existing Bowl"));
+    await userEvent.click(screen.getByRole("button", { name: "Sort by Name" }));
+
+    expect(screen.getByTestId("piece-list")).toBeInTheDocument();
+    expect(screen.getByText("Existing Bowl")).toBeInTheDocument();
+    expect(screen.getByText("Refreshing Pieces")).toBeInTheDocument();
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+
+    resolveSortedPage?.({
+      count: 1,
+      results: [{ ...EXISTING_PIECE, name: "Alphabetized Bowl" }],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Alphabetized Bowl")).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary
- show a visible spinner and status copy while email or Google auth is submitting
- keep `PieceList` mounted during replace-style refetches like sort changes
- reintroduce list dimming only for replace fetches while leaving append pagination undimmed
- add regression tests for auth submission feedback and piece-list loading states

## Why
- [#223](https://github.com/shaoster/glaze/issues/223) asks for explicit feedback during slower login flows so users know the click registered
- [#220](https://github.com/shaoster/glaze/issues/220) asks for sort changes to feel like an in-place list refresh instead of a full page refresh
- [#224](https://github.com/shaoster/glaze/issues/224) turned off opacity changes during append pagination; this keeps that fix while restoring dimming for replace fetches only

## Validation
- `cd web && npm test -- src/App.test.tsx src/pages/__tests__/PieceListPage.test.tsx src/components/__tests__/PieceList.test.tsx`
- `rtk bazel test //...`
- `rtk bazel build --config=lint //...`
- `source env.sh && gz_build`

Closes #223
Closes #220
