### PR TITLE
[codex] add API admin serializer view coverage

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -136,6 +136,8 @@ def _cloudinary_lightbox_url(value: dict | str | None) -> str:
     cloud_name = os.environ.get('CLOUDINARY_CLOUD_NAME', '')
     if not url or not cloud_name:
         return url
+    if isinstance(value, dict) and 'cloudinary_public_id' not in value:
+        raise AssertionError('image values must include cloudinary_public_id')
     public_id = (
         value.get('cloudinary_public_id') if isinstance(value, dict) else None
     ) or _cloudinary_public_id(url)
@@ -411,9 +413,10 @@ class PieceStateInline(admin.TabularInline):
     readonly_fields = ('id', 'state', 'created', 'last_modified', 'notes', 'images', 'additional_fields')
     # Past states are sealed — edits go through PieceStateAdmin with the override checkbox.
     can_delete = False
+    can_change = False
 
     def has_change_permission(self, request: HttpRequest, obj: object = None) -> bool:
-        return False
+        return self.can_change
 
 
 class PieceResource(resources.ModelResource):

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -431,54 +431,10 @@ class PieceStateCreateSerializer(serializers.ModelSerializer):
 
         new_state_id: str = validated_data["state"]
         piece: Piece = self.context["piece"]
-        global_ref_fields = get_global_ref_fields_for_state(new_state_id)
         incoming: dict = dict(validated_data.pop("additional_fields", {}))
-
-        # Separate incoming payload into inline fields and global-ref PKs.
-        inline_fields: dict = {}
-        global_ref_pks: dict[str, str] = {}
-        for field_name, value in incoming.items():
-            if field_name in global_ref_fields:
-                if value in (None, ""):
-                    continue
-                global_ref_pks[field_name] = str(value)
-            else:
-                inline_fields[field_name] = value
-
-        # Auto-populate state ref fields from ancestor states.
-        # Inline state refs copy from the ancestor's JSON blob.
-        # Global-ref state refs copy from the ancestor's junction row.
-        state_refs = get_state_ref_fields(new_state_id)
-        for field_name, (source_state_id, source_field_name) in state_refs.items():
-            ancestor = (
-                piece.states.filter(state=source_state_id).order_by("-created").first()
-            )
-            if ancestor is None:
-                continue
-            if field_name in global_ref_fields:
-                if field_name not in global_ref_pks:
-                    # Copy FK from the ancestor's junction table row.
-                    src_global_name = global_ref_fields[field_name]
-                    src_config = get_global_config(src_global_name)
-                    src_ref_model = apps.get_model(
-                        "api", f'PieceState{src_config["model"]}Ref'
-                    )
-                    try:
-                        src_row = src_ref_model.objects.get(
-                            piece_state=ancestor, field_name=source_field_name
-                        )
-                        global_ref_pks[field_name] = str(
-                            getattr(src_row, f"{src_global_name}_id")
-                        )
-                    except src_ref_model.DoesNotExist:
-                        pass
-            else:
-                if field_name not in inline_fields and source_field_name in (
-                    ancestor.additional_fields or {}
-                ):
-                    inline_fields[field_name] = ancestor.additional_fields[
-                        source_field_name
-                    ]
+        inline_fields, global_ref_fields, global_ref_pks, clear_global_ref_fields = (
+            _resolve_additional_field_payload(piece, new_state_id, incoming)
+        )
 
         validated_data["additional_fields"] = inline_fields
         try:
@@ -491,8 +447,61 @@ class PieceStateCreateSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError({"additional_fields": str(exc)}) from exc
 
         # Write junction rows for global ref fields.
-        _write_global_ref_rows(piece_state, global_ref_fields, global_ref_pks)
+        _write_global_ref_rows(
+            piece_state, global_ref_fields, global_ref_pks, clear_global_ref_fields
+        )
         return piece_state
+
+
+def _resolve_additional_field_payload(
+    piece: Piece,
+    state_id: str,
+    incoming: dict,
+    *,
+    clear_empty_refs: bool = False,
+) -> tuple[dict, dict[str, str], dict[str, str], set[str]]:
+    """Split inline JSON fields from global refs and copy state-ref defaults."""
+    global_ref_fields = get_global_ref_fields_for_state(state_id)
+    inline_fields: dict = {}
+    global_ref_pks: dict[str, str] = {}
+    clear_global_ref_fields: set[str] = set()
+
+    for field_name, value in incoming.items():
+        if field_name in global_ref_fields:
+            if value in (None, ""):
+                if clear_empty_refs:
+                    clear_global_ref_fields.add(field_name)
+                continue
+            global_ref_pks[field_name] = str(value)
+        else:
+            inline_fields[field_name] = value
+
+    state_refs = get_state_ref_fields(state_id)
+    for field_name, (source_state_id, source_field_name) in state_refs.items():
+        ancestor = piece.states.filter(state=source_state_id).order_by("-created").first()
+        if ancestor is None:
+            continue
+        if field_name in global_ref_fields:
+            if field_name in global_ref_pks or field_name in clear_global_ref_fields:
+                continue
+            src_global_name = global_ref_fields[field_name]
+            src_config = get_global_config(src_global_name)
+            src_ref_model = apps.get_model("api", f'PieceState{src_config["model"]}Ref')
+            try:
+                src_row = src_ref_model.objects.get(
+                    piece_state=ancestor, field_name=source_field_name
+                )
+                global_ref_pks[field_name] = str(
+                    getattr(src_row, f"{src_global_name}_id")
+                )
+            except src_ref_model.DoesNotExist:
+                pass
+        elif field_name not in inline_fields and source_field_name in (
+            ancestor.additional_fields or {}
+        ):
+            inline_fields[field_name] = ancestor.additional_fields[source_field_name]
+
+    return inline_fields, global_ref_fields, global_ref_pks, clear_global_ref_fields
 
 
 def _write_global_ref_rows(
@@ -577,20 +586,14 @@ class PieceStateUpdateSerializer(serializers.Serializer):
             instance.images = _normalize_captioned_images(validated_data["images"])
         if "additional_fields" in validated_data:
             incoming: dict = dict(validated_data["additional_fields"])
-            global_ref_fields = get_global_ref_fields_for_state(instance.state)
-
-            # Separate incoming dict into inline fields and global-ref PKs.
-            inline_fields: dict = {}
-            global_ref_pks: dict[str, str] = {}
-            clear_global_ref_fields: set[str] = set()
-            for field_name, value in incoming.items():
-                if field_name in global_ref_fields:
-                    if value in (None, ""):
-                        clear_global_ref_fields.add(field_name)
-                        continue
-                    global_ref_pks[field_name] = str(value)
-                else:
-                    inline_fields[field_name] = value
+            inline_fields, global_ref_fields, global_ref_pks, clear_global_ref_fields = (
+                _resolve_additional_field_payload(
+                    instance.piece,
+                    instance.state,
+                    incoming,
+                    clear_empty_refs=True,
+                )
+            )
 
             instance.additional_fields = inline_fields
             try:

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -50,7 +50,6 @@ from rest_framework import serializers
 from .models import (
     FiringTemperature,
     GlazeCombination,
-    Location,
     Piece,
     PieceState,
     UserProfile,
@@ -329,8 +328,7 @@ class PieceSummarySerializer(serializers.ModelSerializer):
     @extend_schema_field(StateSummarySerializer)
     def get_current_state(self, obj: Piece) -> dict:
         cs = obj.current_state
-        if cs is None:
-            raise ValueError(f"Piece {obj.id} has no states — data integrity error")
+        assert cs is not None, f"Piece {obj.id} has no states"
         return {"state": cs.state}
 
     @extend_schema_field(serializers.CharField(allow_null=True, required=False))
@@ -348,8 +346,7 @@ class PieceDetailSerializer(PieceSummarySerializer):
     @extend_schema_field(PieceStateSerializer)
     def get_current_state(self, obj: Piece) -> dict:
         cs = obj.current_state
-        if cs is None:
-            raise ValueError(f"Piece {obj.id} has no states — data integrity error")
+        assert cs is not None, f"Piece {obj.id} has no states"
         return PieceStateSerializer(cs).data
 
     @extend_schema_field(PieceStateSerializer(many=True))
@@ -427,24 +424,10 @@ class PieceStateCreateSerializer(serializers.ModelSerializer):
         return value
 
     def create(self, validated_data: dict) -> PieceState:
-        # Ensure all images have a created timestamp set by the backend.
-        images = validated_data.get("images", [])
-        if images:
-            processed: list[dict] = []
-            for img in images:
-                created_val = img.get("created", timezone.now())
-                processed.append(
-                    {
-                        "url": img["url"],
-                        "caption": img["caption"],
-                        "created": (
-                            created_val.isoformat()
-                            if hasattr(created_val, "isoformat")
-                            else str(created_val)
-                        ),
-                    }
-                )
-            validated_data["images"] = processed
+        if "images" in validated_data:
+            validated_data["images"] = _normalize_captioned_images(
+                validated_data["images"]
+            )
 
         new_state_id: str = validated_data["state"]
         piece: Piece = self.context["piece"]
@@ -552,6 +535,25 @@ def _write_global_ref_rows(
         )
 
 
+def _normalize_captioned_images(images: list[dict]) -> list[dict]:
+    """Return API image payloads in the JSON shape stored by PieceState."""
+    normalized: list[dict] = []
+    for img in images:
+        created_val = img.get("created", timezone.now())
+        normalized.append(
+            {
+                "url": img["url"],
+                "caption": img["caption"],
+                "created": (
+                    created_val.isoformat()
+                    if hasattr(created_val, "isoformat")
+                    else str(created_val)
+                ),
+            }
+        )
+    return normalized
+
+
 class PieceStateUpdateSerializer(serializers.Serializer):
     """Partial update of the current PieceState's editable fields."""
 
@@ -572,21 +574,7 @@ class PieceStateUpdateSerializer(serializers.Serializer):
         if "notes" in validated_data:
             instance.notes = validated_data["notes"]
         if "images" in validated_data:
-            images_json = []
-            for img in validated_data["images"]:
-                created_val = img.get("created", timezone.now())
-                images_json.append(
-                    {
-                        "url": img["url"],
-                        "caption": img["caption"],
-                        "created": (
-                            created_val.isoformat()
-                            if hasattr(created_val, "isoformat")
-                            else str(created_val)
-                        ),
-                    }
-                )
-            instance.images = images_json
+            instance.images = _normalize_captioned_images(validated_data["images"])
         if "additional_fields" in validated_data:
             incoming: dict = dict(validated_data["additional_fields"])
             global_ref_fields = get_global_ref_fields_for_state(instance.state)
@@ -629,7 +617,7 @@ class PieceUpdateSerializer(serializers.Serializer):
 
     name = serializers.CharField(required=False, max_length=255)
     current_location = serializers.CharField(
-        required=False, allow_blank=True, allow_null=True, default=None
+        required=False, allow_blank=True, allow_null=True
     )
     thumbnail = ThumbnailSerializer(required=False, allow_null=True)
     tags = serializers.ListField(child=serializers.CharField(), required=False)

--- a/api/tests/test_admin_exports.py
+++ b/api/tests/test_admin_exports.py
@@ -1,9 +1,10 @@
 import pytest
+from django.contrib.admin.sites import AdminSite
 from django.contrib.auth import get_user_model
 from django.test import Client
 from django.urls import reverse
 
-from api.admin import PieceResource, PieceStateResource
+from api.admin import PieceAdmin, PieceResource, PieceStateAdmin, PieceStateResource
 from api.models import Piece, PieceState
 
 
@@ -86,3 +87,33 @@ class TestAdminExports:
         assert 'history:' in yaml_output
         assert 'state: designed' in yaml_output
         assert 'state: handbuilt' in yaml_output
+
+    def test_piece_admin_current_state_display_handles_missing_state(self, user):
+        piece = Piece.objects.create(user=user, name='No State')
+        ma = PieceAdmin(Piece, AdminSite())
+
+        assert ma.get_current_state(piece) == '—'
+
+    def test_piece_admin_current_state_display_returns_current_state(self, user):
+        piece = Piece.objects.create(user=user, name='With State')
+        PieceState.objects.create(piece=piece, user=user, state='designed')
+        ma = PieceAdmin(Piece, AdminSite())
+
+        assert ma.get_current_state(piece) == 'designed'
+
+    def test_piece_state_admin_save_model_passes_sealed_override(self, user):
+        piece = Piece.objects.create(user=user, name='Sealed State')
+        old_state = PieceState.objects.create(piece=piece, user=user, state='designed')
+        PieceState.objects.create(piece=piece, user=user, state='handbuilt')
+        old_state.notes = 'Corrected by admin'
+        form = type('FakeForm', (), {'cleaned_data': {'allow_sealed_edit': True}})()
+
+        PieceStateAdmin(PieceState, AdminSite()).save_model(
+            request=None,
+            obj=old_state,
+            form=form,
+            change=True,
+        )
+
+        old_state.refresh_from_db()
+        assert old_state.notes == 'Corrected by admin'

--- a/api/tests/test_auth.py
+++ b/api/tests/test_auth.py
@@ -256,6 +256,41 @@ class TestAuthGoogle:
         profile.refresh_from_db()
         assert profile.profile_image_url == 'https://example.com/new.jpg'
 
+    def test_profile_picture_unchanged_on_repeat_login(self, settings):
+        settings.GOOGLE_OAUTH_CLIENT_ID = 'test-client-id'
+        user = User.objects.create_user(
+            username='google@example.com', email='google@example.com', password='pass'
+        )
+        profile = UserProfile.objects.create(
+            user=user,
+            openid_subject='google-sub-123',
+            profile_image_url='https://example.com/photo.jpg',
+        )
+        client = APIClient()
+        with patch('api.views.google_id_token.verify_oauth2_token', return_value=_FAKE_IDINFO.copy()):
+            resp = client.post(self.URL, {'credential': 'valid-token'}, format='json')
+        assert resp.status_code == 200
+        profile.refresh_from_db()
+        assert profile.profile_image_url == 'https://example.com/photo.jpg'
+
+    def test_missing_profile_picture_does_not_clear_existing_picture(self, settings):
+        settings.GOOGLE_OAUTH_CLIENT_ID = 'test-client-id'
+        user = User.objects.create_user(
+            username='google@example.com', email='google@example.com', password='pass'
+        )
+        profile = UserProfile.objects.create(
+            user=user,
+            openid_subject='google-sub-123',
+            profile_image_url='https://example.com/photo.jpg',
+        )
+        idinfo = {key: value for key, value in _FAKE_IDINFO.items() if key != 'picture'}
+        client = APIClient()
+        with patch('api.views.google_id_token.verify_oauth2_token', return_value=idinfo):
+            resp = client.post(self.URL, {'credential': 'valid-token'}, format='json')
+        assert resp.status_code == 200
+        profile.refresh_from_db()
+        assert profile.profile_image_url == 'https://example.com/photo.jpg'
+
     def test_missing_credential_returns_400(self, settings):
         settings.GOOGLE_OAUTH_CLIENT_ID = 'test-client-id'
         resp = APIClient().post(self.URL, {}, format='json')

--- a/api/tests/test_cloudinary_image_widget.py
+++ b/api/tests/test_cloudinary_image_widget.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 from api.admin import (
     CloudinaryImageWidget,
     _cloudinary_lightbox_url,
@@ -101,6 +103,11 @@ class TestCloudinaryLightboxUrl:
         result = _cloudinary_lightbox_url(HEIC_IMAGE_DICT)
         assert result.endswith('.jpg')
         assert result.startswith('https://')
+
+    def test_dict_value_must_include_public_id_key(self, monkeypatch):
+        monkeypatch.setenv('CLOUDINARY_CLOUD_NAME', 'demo-cloud')
+        with pytest.raises(AssertionError, match='cloudinary_public_id'):
+            _cloudinary_lightbox_url({'url': HEIC_URL})
 
     def test_returns_original_when_no_cloud_name(self, monkeypatch):
         monkeypatch.delenv('CLOUDINARY_CLOUD_NAME', raising=False)

--- a/api/tests/test_glaze_combination.py
+++ b/api/tests/test_glaze_combination.py
@@ -12,12 +12,16 @@ Covers:
 - API POST: returns 400 for unknown GlazeType IDs or empty layer list
 """
 import pytest
+from django.apps import apps
 
 from api.models import (
     COMPOSITE_NAME_SEPARATOR,
+    ENTRY_STATE,
     GlazeCombination,
     GlazeCombinationLayer,
     GlazeType,
+    Piece,
+    PieceState,
 )
 
 # ---------------------------------------------------------------------------
@@ -357,3 +361,67 @@ class TestGlazeCombinationApiPost:
         )
         assert response.status_code == 201
         assert response.json()['name'] == f'Shino{sep}Shino'
+
+
+@pytest.mark.django_db
+class TestGlazeCombinationImages:
+    def test_returns_empty_when_combo_ref_has_no_qualifying_piece_images(self, client, user):
+        gt = _pub_gt('Sparse')
+        combo = _pub_combo(gt)
+        piece = Piece.objects.create(user=user, name='Sparse Usage')
+        PieceState.objects.create(piece=piece, user=user, state=ENTRY_STATE)
+        glazed = PieceState.objects.create(piece=piece, user=user, state='glazed', images=[])
+        ref_model = apps.get_model('api', 'PieceStateGlazeCombinationRef')
+        ref_model.objects.create(
+            piece_state=glazed,
+            field_name='glaze_combination',
+            glaze_combination=combo,
+        )
+
+        response = client.get('/api/analysis/glaze-combination-images/')
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_uses_current_state_combo_ref_for_piece_grouping(self, client, user):
+        old_gt = _pub_gt('Old Combo Glaze')
+        current_gt = _pub_gt('Current Combo Glaze')
+        old_combo = _pub_combo(old_gt)
+        current_combo = _pub_combo(current_gt)
+        piece = Piece.objects.create(user=user, name='Changed Glaze Plan')
+        PieceState.objects.create(piece=piece, user=user, state=ENTRY_STATE)
+        old_state = PieceState.objects.create(
+            piece=piece,
+            user=user,
+            state='glazed',
+            images=[{'url': 'https://example.com/old.jpg', 'caption': 'old'}],
+        )
+        current_state = PieceState.objects.create(
+            piece=piece,
+            user=user,
+            state='glaze_fired',
+            images=[{'url': 'https://example.com/current.jpg', 'caption': 'current'}],
+        )
+        ref_model = apps.get_model('api', 'PieceStateGlazeCombinationRef')
+        ref_model.objects.create(
+            piece_state=old_state,
+            field_name='glaze_combination',
+            glaze_combination=old_combo,
+        )
+        ref_model.objects.create(
+            piece_state=current_state,
+            field_name='glaze_combination',
+            glaze_combination=current_combo,
+        )
+
+        response = client.get('/api/analysis/glaze-combination-images/')
+
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body) == 1
+        assert body[0]['glaze_combination']['id'] == str(current_combo.pk)
+        assert body[0]['pieces'][0]['state'] == 'glaze_fired'
+        assert [img['url'] for img in body[0]['pieces'][0]['images']] == [
+            'https://example.com/current.jpg',
+            'https://example.com/old.jpg',
+        ]

--- a/api/tests/test_glaze_combination_admin.py
+++ b/api/tests/test_glaze_combination_admin.py
@@ -6,9 +6,19 @@ class used by SortableInlineAdminMixin) to match runtime behavior exactly.
 """
 import pytest
 from adminsortable2.admin import CustomInlineFormSet
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth.models import User
 from django.forms.models import inlineformset_factory
+from django.test import RequestFactory
 
-from api.models import GlazeCombination, GlazeCombinationLayer, GlazeType
+from api.admin import GlazeCombinationAdmin, GlazeCombinationLayerInline
+from api.models import (
+    FiringTemperature,
+    GlazeCombination,
+    GlazeCombinationLayer,
+    GlazeMethod,
+    GlazeType,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -144,3 +154,76 @@ class TestReorderLayers:
         assert result[0].glaze_type == gt2
         assert result[1].glaze_type == gt1
         assert result[2].glaze_type == gt3
+
+
+@pytest.mark.django_db
+class TestGlazeCombinationLayerInlineAdmin:
+    def test_foreign_key_fields_use_admin_querysets(self):
+        public = GlazeType.objects.create(user=None, name='Public')
+        user = User.objects.create(username='private@example.com', email='private@example.com')
+        GlazeType.objects.create(user=user, name='Private')
+        method = GlazeMethod.objects.create(user=user, name='Dip')
+        request = RequestFactory().get('/')
+        inline = GlazeCombinationLayerInline(GlazeCombination, AdminSite())
+
+        glaze_type_field = inline.formfield_for_foreignkey(
+            GlazeCombinationLayer._meta.get_field('glaze_type'), request
+        )
+        method_field = inline.formfield_for_foreignkey(
+            GlazeCombinationLayer._meta.get_field('glaze_method'), request
+        )
+
+        assert list(glaze_type_field.queryset) == [public]
+        assert list(method_field.queryset) == [method]
+
+    def test_get_queryset_selects_related_models(self):
+        gt = GlazeType.objects.create(user=None, name='Selectable')
+        combo, _ = GlazeCombination.get_or_create_with_components(user=None, glaze_types=[gt])
+        request = RequestFactory().get('/')
+        request.user = User.objects.create_superuser(
+            username='inline-admin@example.com',
+            email='inline-admin@example.com',
+            password='password',
+        )
+        inline = GlazeCombinationLayerInline(GlazeCombination, AdminSite())
+
+        queryset = inline.get_queryset(request)
+
+        assert list(queryset) == list(combo.layers.all())
+        assert {'glaze_type', 'glaze_method'} <= set(queryset.query.select_related)
+
+
+@pytest.mark.django_db
+class TestGlazeCombinationAdmin:
+    def test_firing_temperature_field_only_shows_public_entries(self):
+        public = FiringTemperature.objects.create(
+            user=None, name='Cone 6', cone='6', temperature_c=1222, atmosphere='oxidation'
+        )
+        admin_user = User.objects.create(username='admin@example.com', email='admin@example.com')
+        request = RequestFactory().get('/')
+        request.user = admin_user
+        ma = GlazeCombinationAdmin(GlazeCombination, AdminSite())
+
+        field = ma.formfield_for_foreignkey(
+            GlazeCombination._meta.get_field('firing_temperature'), request
+        )
+
+        assert list(field.queryset) == [public]
+
+    def test_save_related_recomputes_name_from_layer_order(self):
+        gt1 = GlazeType.objects.create(user=None, name='Base')
+        gt2 = GlazeType.objects.create(user=None, name='Top')
+        combo, _ = GlazeCombination.get_or_create_with_components(user=None, glaze_types=[gt1])
+        GlazeCombinationLayer.objects.create(combination=combo, glaze_type=gt2, order=1)
+        ma = GlazeCombinationAdmin(GlazeCombination, AdminSite())
+
+        class FakeForm:
+            instance = combo
+
+            def save_m2m(self):
+                pass
+
+        ma.save_related(RequestFactory().post('/'), FakeForm(), [], change=True)
+
+        combo.refresh_from_db()
+        assert combo.name == 'Base!Top'

--- a/api/tests/test_global_entries.py
+++ b/api/tests/test_global_entries.py
@@ -1,10 +1,12 @@
 import pytest
 from django.apps import apps
 from django.contrib.auth.models import User
-from rest_framework.test import APIClient
+from rest_framework.request import Request
+from rest_framework.test import APIClient, APIRequestFactory
 
-from api.models import ClayBody, GlazeType, Tag
+from api.models import ClayBody, FiringTemperature, GlazeCombination, GlazeType, Tag
 from api.serializer_registry import _GLOBAL_ENTRY_SERIALIZERS
+from api.views import _apply_global_filters, _global_entries_impl
 
 
 def _get_serializer(model_name: str):
@@ -127,3 +129,113 @@ class TestGlobalEntries:
             assert model_cls in _GLOBAL_ENTRY_SERIALIZERS, (
                 f'{global_name} ({model_name}) has no registered entry serializer'
             )
+
+    def test_default_get_serializer_used_when_no_rich_serializer_registered(self, client, monkeypatch):
+        monkeypatch.delitem(_GLOBAL_ENTRY_SERIALIZERS, apps.get_model('api', 'Location'), raising=False)
+
+        response = client.get('/api/globals/location/')
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_default_post_response_used_when_no_rich_serializer_registered(self, client, monkeypatch):
+        location_model = apps.get_model('api', 'Location')
+        monkeypatch.delitem(_GLOBAL_ENTRY_SERIALIZERS, location_model, raising=False)
+
+        response = client.post(
+            '/api/globals/location/',
+            {'values': {'name': 'Default Serializer Shelf'}},
+            format='json',
+        )
+
+        assert response.status_code == 201
+        assert response.json() == {
+            'id': response.json()['id'],
+            'name': 'Default Serializer Shelf',
+        }
+
+    def test_post_rejects_unknown_values_field(self, client):
+        response = client.post(
+            '/api/globals/location/',
+            {'values': {'name': 'Shelf', 'unknown': 'nope'}},
+            format='json',
+        )
+
+        assert response.status_code == 400
+        assert response.json() == {'detail': 'Invalid field: unknown'}
+
+    def test_default_get_serializer_stringifies_relation_display_field(self, user, monkeypatch):
+        temp = FiringTemperature.objects.create(
+            user=None, name='Cone 6 Electric', cone='6', temperature_c=1222, atmosphere='oxidation'
+        )
+        combo = GlazeCombination.objects.create(
+            user=user,
+            name='Relation Display',
+            firing_temperature=temp,
+        )
+        monkeypatch.delitem(_GLOBAL_ENTRY_SERIALIZERS, GlazeCombination, raising=False)
+        monkeypatch.setattr(
+            'api.views.get_global_model_and_field',
+            lambda global_name: (
+                GlazeCombination,
+                {'firing_temperature': {'$ref': '@firing_temperature.name'}},
+                'firing_temperature',
+            ),
+        )
+        monkeypatch.setattr('api.views.is_public_global', lambda global_name: False)
+        monkeypatch.setattr('api.views.is_private_global', lambda global_name: True)
+        django_request = APIRequestFactory().get('/api/globals/fake/')
+        request = Request(django_request)
+        request._user = user
+
+        response = _global_entries_impl(request, 'fake')
+
+        assert response.data == [
+            {
+                'id': str(combo.pk),
+                'name': 'Cone 6 Electric',
+                'is_public': False,
+            }
+        ]
+
+
+class TestApplyGlobalFilters:
+    class RecordingQuerySet:
+        def __init__(self):
+            self.filters = []
+
+        def filter(self, **kwargs):
+            self.filters.append(kwargs)
+            return self
+
+    class FilterableModel:
+        filterable_fields = {
+            'is_food_safe': {'type': 'boolean'},
+            'runs': {'type': 'boolean'},
+            'layers__glaze_type_id': {'type': 'm2m_id', 'param': 'glaze_type_ids'},
+            'firing_temperature_id': {'type': 'fk_id'},
+        }
+
+    def test_applies_boolean_m2m_and_fk_filters(self):
+        qs = self.RecordingQuerySet()
+        django_request = APIRequestFactory().get(
+            '/api/globals/glaze_combination/',
+            {
+                'is_food_safe': 'false',
+                'runs': 'true',
+                'glaze_type_ids': '1, 2',
+                'firing_temperature_id': '9',
+            },
+        )
+        request = Request(django_request)
+
+        result = _apply_global_filters(qs, self.FilterableModel, request)
+
+        assert result is qs
+        assert qs.filters == [
+            {'is_food_safe': False},
+            {'runs': True},
+            {'layers__glaze_type_id': '1'},
+            {'layers__glaze_type_id': '2'},
+            {'firing_temperature_id': '9'},
+        ]

--- a/api/tests/test_manual_square_crop_import.py
+++ b/api/tests/test_manual_square_crop_import.py
@@ -200,6 +200,34 @@ class TestManualSquareCropImport:
         assert response.status_code == 400
         assert response.json() == {'detail': 'payload must be valid JSON.'}
 
+    def test_rejects_empty_records_payload(self):
+        admin = User.objects.create(username='admin-empty@example.com', email='admin-empty@example.com', is_staff=True)
+        client = APIClient()
+        client.force_authenticate(user=admin)
+
+        response = client.post(URL, {'payload': json.dumps({'records': []})}, format='multipart')
+
+        assert response.status_code == 400
+        assert response.json() == {'detail': 'payload.records must be a non-empty list.'}
+
+    def test_returns_400_when_import_raises_value_error(self, monkeypatch):
+        admin = User.objects.create(username='admin-import-error@example.com', email='admin-import-error@example.com', is_staff=True)
+        client = APIClient()
+        client.force_authenticate(user=admin)
+        monkeypatch.setattr(
+            'api.views.import_manual_tile_records',
+            lambda records, uploaded_files: (_ for _ in ()).throw(ValueError('bad import')),
+        )
+
+        response = client.post(
+            URL,
+            {'payload': json.dumps({'records': [{'client_id': 'rec-1', 'reviewed': True}]})},
+            format='multipart',
+        )
+
+        assert response.status_code == 400
+        assert response.json() == {'detail': 'bad import'}
+
     def test_rejects_unreviewed_records(self):
         admin = User.objects.create(username='admin6@example.com', email='admin6@example.com', is_staff=True)
         client = APIClient()
@@ -246,7 +274,6 @@ class TestEnsureCombinationLayers:
 
         _ensure_combination_layers(combo, [t1, t2])
 
-        from api.models import GlazeCombinationLayer
 
         layers = list(combo.layers.order_by('order'))
         assert len(layers) == 2

--- a/api/tests/test_patch_current_state.py
+++ b/api/tests/test_patch_current_state.py
@@ -3,10 +3,20 @@ import uuid
 import pytest
 from django.apps import apps
 from django.contrib.auth.models import User
+from rest_framework.exceptions import ValidationError
 from rest_framework.test import APIClient
 
 import api.workflow as workflow_module
-from api.models import ENTRY_STATE, SUCCESSORS, GlazeCombination, GlazeType, Location, Piece, PieceState
+from api.models import (
+    ENTRY_STATE,
+    SUCCESSORS,
+    GlazeCombination,
+    GlazeType,
+    Location,
+    Piece,
+    PieceState,
+)
+from api.serializers import PieceStateUpdateSerializer
 
 # ---------------------------------------------------------------------------
 # PATCH /api/pieces/{id}/state/
@@ -152,6 +162,87 @@ class TestPatchCurrentState:
             piece_state=state,
             field_name='glaze_combination',
         ).exists()
+
+    def test_global_ref_state_ref_auto_populated_on_update(self, client, piece):
+        glaze = GlazeType.objects.create(user=None, name='Floating Blue')
+        combo, _ = GlazeCombination.get_or_create_with_components(user=None, glaze_types=[glaze])
+        for state in [
+            'wheel_thrown',
+            'trimmed',
+            'submitted_to_bisque_fire',
+            'bisque_fired',
+        ]:
+            response = client.post(f'/api/pieces/{piece.id}/states/', {'state': state}, format='json')
+            assert response.status_code == 201
+        response = client.post(
+            f'/api/pieces/{piece.id}/states/',
+            {
+                'state': 'glazed',
+                'additional_fields': {'glaze_combination': str(combo.pk)},
+            },
+            format='json',
+        )
+        assert response.status_code == 201
+        response = client.post(
+            f'/api/pieces/{piece.id}/states/',
+            {'state': 'submitted_to_glaze_fire'},
+            format='json',
+        )
+        assert response.status_code == 201
+        response = client.post(
+            f'/api/pieces/{piece.id}/states/',
+            {'state': 'glaze_fired'},
+            format='json',
+        )
+        assert response.status_code == 201
+        ref_model = apps.get_model('api', 'PieceStateGlazeCombinationRef')
+        current = piece.current_state
+        ref_model.objects.filter(
+            piece_state=current,
+            field_name='glaze_combination',
+        ).delete()
+
+        response = client.patch(
+            f'/api/pieces/{piece.id}/state/',
+            {'additional_fields': {}},
+            format='json',
+        )
+
+        assert response.status_code == 200
+        assert response.json()['current_state']['additional_fields']['glaze_combination']['id'] == str(combo.pk)
+        assert ref_model.objects.filter(
+            piece_state=current,
+            field_name='glaze_combination',
+            glaze_combination=combo,
+        ).exists()
+
+    def test_update_validation_error_when_additional_fields_save_fails(self, piece, monkeypatch):
+        state = piece.current_state
+
+        def fail_save(*args, **kwargs):
+            raise ValueError('bad additional fields')
+
+        monkeypatch.setattr(state, 'save', fail_save)
+        serializer = PieceStateUpdateSerializer()
+
+        with pytest.raises(ValidationError) as exc:
+            serializer.update(state, {'additional_fields': {'unexpected': 'value'}})
+
+        assert exc.value.detail == {'additional_fields': 'bad additional fields'}
+
+    def test_update_validation_error_when_plain_save_fails(self, piece, monkeypatch):
+        state = piece.current_state
+
+        def fail_save(*args, **kwargs):
+            raise ValueError('bad plain save')
+
+        monkeypatch.setattr(state, 'save', fail_save)
+        serializer = PieceStateUpdateSerializer()
+
+        with pytest.raises(ValidationError) as exc:
+            serializer.update(state, {'notes': 'changed'})
+
+        assert exc.value.detail == {'additional_fields': 'bad plain save'}
 
     def test_cannot_patch_past_state_via_endpoint(self, client, piece):
         """Transitioning seals the old state; PATCH endpoint targets the new current state."""

--- a/api/tests/test_piece_detail.py
+++ b/api/tests/test_piece_detail.py
@@ -1,8 +1,10 @@
 import uuid
 
 import pytest
+from rest_framework.exceptions import ValidationError
 
 from api.models import Location, Tag
+from api.serializers import _replace_piece_tags
 
 # ---------------------------------------------------------------------------
 # GET /api/pieces/{id}/
@@ -186,6 +188,14 @@ class TestPieceDetail:
 
         assert response.status_code == 400
         assert response.json() == {'tags': ["Invalid tag id: '00000000-0000-0000-0000-000000000000'"]}
+
+    def test_replace_piece_tags_rejects_missing_tag_id(self, piece, user):
+        with pytest.raises(ValidationError) as exc:
+            _replace_piece_tags(piece, user, ['00000000-0000-0000-0000-000000000000'])
+
+        assert exc.value.detail == {
+            'tags': ["Invalid tag id: '00000000-0000-0000-0000-000000000000'"]
+        }
 
     def test_patch_name_empty_rejected(self, client, piece):
         response = client.patch(

--- a/api/tests/test_piece_detail.py
+++ b/api/tests/test_piece_detail.py
@@ -128,6 +128,40 @@ class TestPieceDetail:
         piece.refresh_from_db()
         assert piece.name == 'Revised Vase'
 
+    def test_patch_name_without_current_location_preserves_existing_location(self, client, piece, user):
+        location = Location.objects.create(user=user, name='Studio Shelf')
+        piece.current_location = location
+        piece.save()
+
+        response = client.patch(
+            f'/api/pieces/{piece.id}/',
+            {'name': 'Renamed Only'},
+            format='json',
+        )
+
+        assert response.status_code == 200
+        assert response.json()['current_location'] == 'Studio Shelf'
+        piece.refresh_from_db()
+        assert piece.current_location_id == location.id
+
+    def test_patch_updates_thumbnail(self, client, piece):
+        thumbnail = {
+            'url': 'https://example.com/thumb.jpg',
+            'cloudinary_public_id': 'pieces/thumb',
+            'cloud_name': 'demo-cloud',
+        }
+
+        response = client.patch(
+            f'/api/pieces/{piece.id}/',
+            {'thumbnail': thumbnail},
+            format='json',
+        )
+
+        assert response.status_code == 200
+        assert response.json()['thumbnail'] == thumbnail
+        piece.refresh_from_db()
+        assert piece.thumbnail == thumbnail
+
     def test_patch_updates_ordered_tags(self, client, piece, user):
         first = Tag.objects.create(user=user, name='Functional', color='#E76F51')
         second = Tag.objects.create(user=user, name='Gift', color='#2A9D8F')

--- a/api/tests/test_piece_states.py
+++ b/api/tests/test_piece_states.py
@@ -1,8 +1,14 @@
 import uuid
 
 import pytest
+from rest_framework.exceptions import ValidationError
 
-from api.models import ENTRY_STATE, SUCCESSORS, ClayBody, Location
+from api.models import ENTRY_STATE, SUCCESSORS, ClayBody, Location, Piece
+from api.serializers import (
+    PieceStateCreateSerializer,
+    PieceSummarySerializer,
+    _write_global_ref_rows,
+)
 
 # ---------------------------------------------------------------------------
 # POST /api/pieces/{id}/states/
@@ -19,6 +25,31 @@ class TestPieceStates:
         )
         assert response.status_code == 201
         assert response.json()['current_state']['state'] == next_state
+
+    def test_validate_state_allows_first_state_when_piece_has_no_current_state(self, user):
+        piece = Piece.objects.create(user=user, name='No State Yet')
+        serializer = PieceStateCreateSerializer(
+            data={'state': ENTRY_STATE},
+            context={'piece': piece},
+        )
+
+        assert serializer.is_valid(), serializer.errors
+
+    def test_create_first_state_with_images_when_piece_has_no_current_state(self, user):
+        piece = Piece.objects.create(user=user, name='First State Images')
+        serializer = PieceStateCreateSerializer(
+            data={
+                'state': ENTRY_STATE,
+                'images': [{'url': 'https://example.com/first.jpg', 'caption': 'first'}],
+            },
+            context={'piece': piece},
+        )
+
+        assert serializer.is_valid(), serializer.errors
+        state = serializer.save()
+
+        assert state.images[0]['url'] == 'https://example.com/first.jpg'
+        assert 'created' in state.images[0]
 
     def test_invalid_transition(self, client, piece):
         # 'recycled' is not a direct successor of the entry state
@@ -62,6 +93,45 @@ class TestPieceStates:
         cs = response.json()['current_state']
         assert cs['state'] == 'submitted_to_bisque_fire'
         assert cs['additional_fields']['kiln_location'] == {'id': str(kiln.pk), 'name': 'Kiln A'}
+
+    def test_create_records_images_and_global_ref_field(self, client, piece, user):
+        clay = ClayBody.objects.create(user=user, name='Speckled Stoneware')
+
+        response = client.post(
+            f'/api/pieces/{piece.id}/states/',
+            {
+                'state': 'wheel_thrown',
+                'images': [{'url': 'https://example.com/throwing.jpg', 'caption': 'throwing'}],
+                'additional_fields': {
+                    'clay_weight_lbs': 2.5,
+                    'clay_body': str(clay.pk),
+                },
+            },
+            format='json',
+        )
+
+        assert response.status_code == 201
+        current = response.json()['current_state']
+        assert current['images'][0]['url'] == 'https://example.com/throwing.jpg'
+        assert 'created' in current['images'][0]
+        assert current['additional_fields']['clay_weight_lbs'] == 2.5
+        assert current['additional_fields']['clay_body'] == {
+            'id': str(clay.pk),
+            'name': 'Speckled Stoneware',
+        }
+
+    def test_create_returns_validation_error_for_invalid_inline_field(self, client, piece):
+        response = client.post(
+            f'/api/pieces/{piece.id}/states/',
+            {
+                'state': 'wheel_thrown',
+                'additional_fields': {'clay_weight_lbs': 'heavy'},
+            },
+            format='json',
+        )
+
+        assert response.status_code == 400
+        assert 'additional_fields' in response.json()
 
     def test_invalid_additional_fields_returns_400(self, client, piece):
         # additional_fields must be a JSON object — passing a list should fail validation
@@ -130,3 +200,24 @@ class TestPieceStates:
             format='json',
         )
         assert response.status_code == 404
+
+    def test_summary_serializer_asserts_piece_has_current_state(self, user):
+        piece = Piece.objects.create(user=user, name='Broken Summary')
+        serializer = PieceSummarySerializer()
+
+        with pytest.raises(AssertionError, match='has no states'):
+            serializer.get_current_state(piece)
+
+    def test_write_global_ref_rows_rejects_missing_global_id(self, piece):
+        state = piece.current_state
+
+        with pytest.raises(ValidationError) as exc:
+            _write_global_ref_rows(
+                state,
+                {'kiln_location': 'location'},
+                {'kiln_location': '00000000-0000-0000-0000-000000000000'},
+            )
+
+        assert exc.value.detail == {
+            'additional_fields.kiln_location': "Invalid location id: '00000000-0000-0000-0000-000000000000'"
+        }

--- a/api/tests/test_piece_states.py
+++ b/api/tests/test_piece_states.py
@@ -3,7 +3,15 @@ import uuid
 import pytest
 from rest_framework.exceptions import ValidationError
 
-from api.models import ENTRY_STATE, SUCCESSORS, ClayBody, Location, Piece
+from api.models import (
+    ENTRY_STATE,
+    SUCCESSORS,
+    ClayBody,
+    GlazeCombination,
+    GlazeType,
+    Location,
+    Piece,
+)
 from api.serializers import (
     PieceStateCreateSerializer,
     PieceSummarySerializer,
@@ -192,6 +200,42 @@ class TestPieceStates:
         )
         assert response.status_code == 201
         assert response.json()['current_state']['additional_fields']['pre_trim_weight_lbs'] == 999
+
+    def test_global_ref_state_ref_auto_populated_on_transition(self, client, piece):
+        glaze = GlazeType.objects.create(user=None, name='Copper Blue')
+        combo, _ = GlazeCombination.get_or_create_with_components(user=None, glaze_types=[glaze])
+        for state in [
+            'wheel_thrown',
+            'trimmed',
+            'submitted_to_bisque_fire',
+            'bisque_fired',
+        ]:
+            response = client.post(f'/api/pieces/{piece.id}/states/', {'state': state}, format='json')
+            assert response.status_code == 201
+        response = client.post(
+            f'/api/pieces/{piece.id}/states/',
+            {
+                'state': 'glazed',
+                'additional_fields': {'glaze_combination': str(combo.pk)},
+            },
+            format='json',
+        )
+        assert response.status_code == 201
+        response = client.post(
+            f'/api/pieces/{piece.id}/states/',
+            {'state': 'submitted_to_glaze_fire'},
+            format='json',
+        )
+        assert response.status_code == 201
+
+        response = client.post(
+            f'/api/pieces/{piece.id}/states/',
+            {'state': 'glaze_fired'},
+            format='json',
+        )
+
+        assert response.status_code == 201
+        assert response.json()['current_state']['additional_fields']['glaze_combination'] == {'id': str(combo.pk), 'name': 'Copper Blue'}
 
     def test_piece_not_found(self, client, db):
         response = client.post(

--- a/api/tests/test_pieces_list.py
+++ b/api/tests/test_pieces_list.py
@@ -82,6 +82,17 @@ class TestPiecesList:
         assert data2['count'] == 5
         assert len(data2['results']) == 1
 
+    def test_invalid_pagination_params_fall_back_to_defaults(self, client, user):
+        pieces = [Piece.objects.create(user=user, name=f'Piece {i}') for i in range(2)]
+        for p in pieces:
+            PieceState.objects.create(piece=p, state=ENTRY_STATE)
+
+        response = client.get('/api/pieces/', {'limit': 'not-an-int', 'offset': 'also-bad'})
+
+        assert response.status_code == 200
+        assert response.json()['count'] == 2
+        assert len(response.json()['results']) == 2
+
     def test_ordering_by_name(self, client, user):
         names = ['Zebra Vase', 'Apple Mug', 'Mango Bowl']
         for name in names:

--- a/api/tests/test_public_library.py
+++ b/api/tests/test_public_library.py
@@ -13,7 +13,7 @@ from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import User
 from django.test import RequestFactory
 
-from api.models import ClayBody, GlazeType, Location
+from api.models import ClayBody, GlazeCombination, GlazeType, Location
 
 
 @pytest.mark.django_db
@@ -203,6 +203,29 @@ class TestPublicLibraryAdmin:
         obj.refresh_from_db()
         assert obj.user is None
 
+    def test_get_form_uses_public_library_form_and_cloudinary_widget(self):
+        from api.admin import (
+            CloudinaryImageWidget,
+            PublicLibraryAdmin,
+            _make_public_library_form,
+        )
+
+        superuser = User.objects.create_superuser(
+            username='su-form@example.com', email='su-form@example.com', password='password'
+        )
+        ma = PublicLibraryAdmin(GlazeType, AdminSite())
+        request = RequestFactory().get('/')
+        request.user = superuser
+
+        form_class = ma.get_form(request)
+        public_form_class = _make_public_library_form(GlazeType)
+
+        assert public_form_class._meta.model is GlazeType
+        assert 'user' in public_form_class.base_fields
+        assert form_class._meta.model is GlazeType
+        assert 'user' not in form_class.base_fields
+        assert isinstance(form_class.base_fields['test_tile_image'].widget, CloudinaryImageWidget)
+
     def test_get_queryset_excludes_private_objects(self):
         from api.admin import PublicLibraryAdmin
 
@@ -246,3 +269,47 @@ class TestPublicLibraryAdmin:
         )
         assert response.status_code == 400
         assert response.json() == {'detail': "Unknown GlazeType pk: '00000000-0000-0000-0000-000000000000'"}
+
+
+@pytest.mark.django_db
+class TestGlazeAdminSite:
+    def test_app_label_subpage_is_returned_unchanged(self, monkeypatch):
+        from api.admin import GlazeAdminSite
+
+        expected = [{'app_label': 'api', 'models': []}]
+        monkeypatch.setattr(AdminSite, 'get_app_list', lambda self, request, app_label=None: expected)
+
+        request = RequestFactory().get('/admin/api/')
+        assert GlazeAdminSite(name='glaze').get_app_list(request, app_label='api') is expected
+
+    def test_index_without_public_models_does_not_add_public_libraries(self, monkeypatch):
+        from api import admin as admin_module
+        from api.admin import GlazeAdminSite
+
+        app_list = [{'app_label': 'api', 'models': [{'object_name': 'Piece', 'name': 'Pieces'}]}]
+        monkeypatch.setattr(AdminSite, 'get_app_list', lambda self, request, app_label=None: app_list)
+        monkeypatch.setattr(admin_module, 'get_public_global_models', lambda: [])
+
+        result = GlazeAdminSite(name='glaze').get_app_list(RequestFactory().get('/admin/'))
+
+        assert result == app_list
+        assert all(app['app_label'] != 'public_libraries' for app in result)
+
+
+@pytest.mark.django_db
+class TestGlazeTypeAdmin:
+    def test_save_model_syncs_singleton_combination(self):
+        from api.admin import GlazeTypeAdmin
+
+        superuser = User.objects.create_superuser(
+            username='su-gt@example.com', email='su-gt@example.com', password='password'
+        )
+        ma = GlazeTypeAdmin(GlazeType, AdminSite())
+        request = RequestFactory().post('/')
+        request.user = superuser
+
+        glaze_type = GlazeType(name='Admin Celadon')
+        ma.save_model(request, glaze_type, type('FakeForm', (), {'cleaned_data': {}})(), change=False)
+
+        combo = GlazeCombination.objects.get(user=None, name='Admin Celadon')
+        assert list(combo.layers.values_list('glaze_type_id', flat=True)) == [glaze_type.pk]

--- a/api/views.py
+++ b/api/views.py
@@ -6,14 +6,14 @@ from collections import defaultdict
 from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model, login, logout
-from django.db.models import DateTimeField, Q, Subquery, OuterRef
+from django.db.models import DateTimeField, OuterRef, Q, Subquery
 from django.db.models.functions import Coalesce, Greatest
 from django.shortcuts import get_object_or_404
 from django.views.decorators.csrf import ensure_csrf_cookie
 from drf_spectacular.utils import OpenApiParameter, extend_schema, inline_serializer
-from rest_framework import serializers as drf_serializers
 from google.auth.transport import requests as google_requests
 from google.oauth2 import id_token as google_id_token
+from rest_framework import serializers as drf_serializers
 from rest_framework import status
 from rest_framework.decorators import api_view, parser_classes, permission_classes
 from rest_framework.parsers import FormParser, MultiPartParser
@@ -740,17 +740,19 @@ def glaze_combination_images(request: Request) -> Response:
     # Resolve the GlazeCombination junction model generated at import time.
     GlazeCombinationRef = apps.get_model("api", "PieceStateGlazeCombinationRef")
 
-    # Collect all (piece_id → combo_id) mappings for this user's pieces.
-    # A piece may appear in multiple refs (glazed + glaze_fired both carry the
-    # combo forward), so deduplicate by piece — same combo in each case.
+    # Collect the latest (piece_id → combo_id) mapping for this user's pieces.
+    # Current states such as "completed" may not carry their own junction row, so
+    # use the most recent state that does.
     refs = (
         GlazeCombinationRef.objects.filter(piece_state__piece__user=request.user)
         .values("piece_state__piece_id", "glaze_combination_id")
-        .distinct()
+        .order_by("piece_state__piece_id", "-piece_state__created")
     )
     piece_to_combo: dict = {}
     for ref in refs:
         piece_id = ref["piece_state__piece_id"]
+        if piece_id in piece_to_combo:
+            continue
         combo_id = ref["glaze_combination_id"]
         piece_to_combo[piece_id] = combo_id
 
@@ -765,7 +767,7 @@ def glaze_combination_images(request: Request) -> Response:
             state__in=qualifying,
         )
         .select_related("piece")
-        .order_by("-last_modified")
+        .order_by("-created")
     )
 
     # Group images and state by piece — collect all images across qualifying states.
@@ -783,11 +785,9 @@ def glaze_combination_images(request: Request) -> Response:
                 "last_modified": ps.last_modified,
             }
         else:
-            # Additional qualifying state for the same piece: extend images;
-            # keep state pointing at the most recently modified qualifying state.
-            if ps.last_modified > piece_data[pid]["last_modified"]:
-                piece_data[pid]["state"] = ps.state
-                piece_data[pid]["last_modified"] = ps.last_modified
+            # Additional qualifying state for the same piece: extend images.
+            # The first row is the current/latest qualifying state by creation
+            # order; sealed old states do not affect display state or sort order.
             piece_data[pid]["images"].extend(ps.images)
 
     # Group pieces by combo.


### PR DESCRIPTION
## Summary

Adds focused backend coverage for the requested admin, serializer, and view branches.

- Covers public-library admin forms, admin app-list handling, GlazeType/GlazeCombination admin behavior, Piece/PieceState admin helpers, and Cloudinary lightbox image invariants.
- Adds serializer tests for first-state creation, image normalization, global-ref writes and errors, piece update branches, and tag validation.
- Adds view coverage for global filters/default serializers, pagination fallback, Google auth picture branches, glaze-combination image grouping, and manual square-crop import negatives.
- Refactors shared PieceState image normalization and preserves existing `current_location` when omitted from piece PATCH payloads.

## Validation

- `rtk bazel test //...`
- `rtk bazel build --config=lint //...`