### PR TITLE
[codex] Implement public sharing for terminal pieces

### DIFF
--- a/api/migrations/0002_piece_shared.py
+++ b/api/migrations/0002_piece_shared.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="piece",
+            name="shared",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/api/models.py
+++ b/api/models.py
@@ -114,6 +114,7 @@ class Piece(models.Model):
     # Use the `last_modified` property externally — it incorporates the current state's timestamp.
     fields_last_modified = models.DateTimeField(auto_now=True)
     thumbnail = models.JSONField(null=True, blank=True, default=None)
+    shared = models.BooleanField(default=False)
     current_location = models.ForeignKey(
         'Location',
         null=True,

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -60,6 +60,7 @@ from .utils import get_or_create_location
 from .workflow import (
     ENTRY_STATE,
     SUCCESSORS,
+    TERMINAL_STATES,
     VALID_STATES,
     get_global_config,
     get_global_ref_fields_for_state,
@@ -304,6 +305,7 @@ class ThumbnailSerializer(serializers.Serializer):
 class PieceSummarySerializer(serializers.ModelSerializer):
     current_state = serializers.SerializerMethodField()
     current_location = serializers.SerializerMethodField()
+    can_edit = serializers.SerializerMethodField()
     thumbnail = ThumbnailSerializer(allow_null=True, read_only=True)
     last_modified = serializers.DateTimeField(read_only=True)
 
@@ -315,6 +317,8 @@ class PieceSummarySerializer(serializers.ModelSerializer):
             "created",
             "last_modified",
             "thumbnail",
+            "shared",
+            "can_edit",
             "current_state",
             "current_location",
         ]
@@ -334,6 +338,15 @@ class PieceSummarySerializer(serializers.ModelSerializer):
     @extend_schema_field(serializers.CharField(allow_null=True, required=False))
     def get_current_location(self, obj: Piece) -> str | None:
         return obj.current_location.name if obj.current_location else None
+
+    @extend_schema_field(serializers.BooleanField())
+    def get_can_edit(self, obj: Piece) -> bool:
+        request = self.context.get("request")
+        return bool(
+            request
+            and request.user.is_authenticated
+            and obj.user_id == request.user.id
+        )
 
 
 class PieceDetailSerializer(PieceSummarySerializer):
@@ -623,7 +636,19 @@ class PieceUpdateSerializer(serializers.Serializer):
         required=False, allow_blank=True, allow_null=True
     )
     thumbnail = ThumbnailSerializer(required=False, allow_null=True)
+    shared = serializers.BooleanField(required=False)
     tags = serializers.ListField(child=serializers.CharField(), required=False)
+
+    def validate_shared(self, value: bool) -> bool:
+        if not value:
+            return value
+        instance: Piece | None = self.context.get("piece")
+        current = instance.current_state if instance is not None else None
+        if current is None or current.state not in TERMINAL_STATES:
+            raise serializers.ValidationError(
+                "Only terminal pieces can be shared."
+            )
+        return value
 
     def update(self, instance: Piece, validated_data: dict) -> Piece:
         if "name" in validated_data:
@@ -634,6 +659,8 @@ class PieceUpdateSerializer(serializers.Serializer):
             )
         if "thumbnail" in validated_data:
             instance.thumbnail = validated_data["thumbnail"]
+        if "shared" in validated_data:
+            instance.shared = validated_data["shared"]
         instance.save()
         if "tags" in validated_data:
             tag_ids = [str(tag_id) for tag_id in validated_data["tags"]]

--- a/api/tests/test_global_entries.py
+++ b/api/tests/test_global_entries.py
@@ -113,6 +113,8 @@ class TestGlobalEntries:
                     '+00:00', 'Z'
                 ),
                 'thumbnail': None,
+                'shared': False,
+                'can_edit': True,
                 'current_state': {'state': 'designed'},
                 'current_location': None,
                 'tags': [],

--- a/api/tests/test_patch_current_state.py
+++ b/api/tests/test_patch_current_state.py
@@ -116,6 +116,26 @@ class TestPatchCurrentState:
         )
         assert response.status_code == 404
 
+    def test_non_owner_cannot_patch_shared_piece_state(self, client, other_user):
+        foreign_piece = Piece.objects.create(
+            user=other_user,
+            name='Shared Foreign Piece',
+            shared=True,
+        )
+        PieceState.objects.create(
+            user=other_user,
+            piece=foreign_piece,
+            state=ENTRY_STATE,
+        )
+
+        response = client.patch(
+            f'/api/pieces/{foreign_piece.id}/state/',
+            {'notes': 'Nope'},
+            format='json',
+        )
+
+        assert response.status_code == 404
+
     def test_piece_with_no_states_returns_404(self, client, user):
         from api.models import Piece
 

--- a/api/tests/test_piece_detail.py
+++ b/api/tests/test_piece_detail.py
@@ -2,8 +2,9 @@ import uuid
 
 import pytest
 from rest_framework.exceptions import ValidationError
+from rest_framework.test import APIClient
 
-from api.models import Location, Tag
+from api.models import Location, PieceState, Tag
 from api.serializers import _replace_piece_tags
 
 # ---------------------------------------------------------------------------
@@ -17,6 +18,8 @@ class TestPieceDetail:
         assert response.status_code == 200
         data = response.json()
         assert data['name'] == 'Test Bowl'
+        assert data['shared'] is False
+        assert data['can_edit'] is True
         assert 'history' in data
         assert len(data['history']) == 1
 
@@ -119,6 +122,15 @@ class TestPieceDetail:
         assert response.status_code == 201
         assert response.json()['current_location'] is None
 
+    def test_new_piece_private_by_default(self, client):
+        response = client.post(
+            '/api/pieces/',
+            {'name': 'Private by Default'},
+            format='json',
+        )
+        assert response.status_code == 201
+        assert response.json()['shared'] is False
+
     def test_patch_updates_name(self, client, piece):
         response = client.patch(
             f'/api/pieces/{piece.id}/',
@@ -163,6 +175,67 @@ class TestPieceDetail:
         assert response.json()['thumbnail'] == thumbnail
         piece.refresh_from_db()
         assert piece.thumbnail == thumbnail
+
+    def test_owner_can_share_completed_piece(self, client, piece):
+        PieceState.objects.create(
+            user=piece.user,
+            piece=piece,
+            state='completed',
+        )
+
+        response = client.patch(
+            f'/api/pieces/{piece.id}/',
+            {'shared': True},
+            format='json',
+        )
+
+        assert response.status_code == 200
+        assert response.json()['shared'] is True
+        piece.refresh_from_db()
+        assert piece.shared is True
+
+    def test_owner_can_share_recycled_piece(self, client, piece):
+        PieceState.objects.create(
+            user=piece.user,
+            piece=piece,
+            state='recycled',
+        )
+
+        response = client.patch(
+            f'/api/pieces/{piece.id}/',
+            {'shared': True},
+            format='json',
+        )
+
+        assert response.status_code == 200
+        assert response.json()['shared'] is True
+
+    def test_owner_cannot_share_non_terminal_piece(self, client, piece):
+        response = client.patch(
+            f'/api/pieces/{piece.id}/',
+            {'shared': True},
+            format='json',
+        )
+
+        assert response.status_code == 400
+        assert response.json() == {'shared': ['Only terminal pieces can be shared.']}
+        piece.refresh_from_db()
+        assert piece.shared is False
+
+    def test_owner_can_unshare_non_terminal_piece(self, client, piece):
+        piece.shared = True
+        piece.save()
+
+        response = client.patch(
+            f'/api/pieces/{piece.id}/',
+            {'shared': False},
+            format='json',
+        )
+
+        assert response.status_code == 200
+        assert response.json()['shared'] is False
+        piece.refresh_from_db()
+        assert piece.shared is False
 
     def test_patch_updates_ordered_tags(self, client, piece, user):
         first = Tag.objects.create(user=user, name='Functional', color='#E76F51')
@@ -209,8 +282,71 @@ class TestPieceDetail:
         from api.models import ENTRY_STATE, Piece, PieceState
 
         foreign_piece = Piece.objects.create(user=other_user, name='Other User Piece')
-        PieceState.objects.create(piece=foreign_piece, state=ENTRY_STATE)
+        PieceState.objects.create(user=other_user, piece=foreign_piece, state=ENTRY_STATE)
         response = client.get(f'/api/pieces/{foreign_piece.id}/')
+        assert response.status_code == 404
+
+    def test_anonymous_can_read_shared_piece(self, piece):
+        PieceState.objects.create(user=piece.user, piece=piece, state='completed')
+        piece.shared = True
+        piece.save()
+        anon = APIClient()
+
+        response = anon.get(f'/api/pieces/{piece.id}/')
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data['name'] == 'Test Bowl'
+        assert data['shared'] is True
+        assert data['can_edit'] is False
+
+    def test_anonymous_cannot_read_private_piece(self, piece):
+        response = APIClient().get(f'/api/pieces/{piece.id}/')
+        assert response.status_code == 404
+
+    def test_anonymous_cannot_patch_shared_piece(self, piece):
+        PieceState.objects.create(user=piece.user, piece=piece, state='completed')
+        piece.shared = True
+        piece.save()
+        response = APIClient().patch(
+            f'/api/pieces/{piece.id}/',
+            {'name': 'Nope'},
+            format='json',
+        )
+
+        assert response.status_code == 403
+
+    def test_non_owner_can_read_shared_piece_read_only(self, client, other_user):
+        from api.models import ENTRY_STATE, Piece, PieceState
+
+        foreign_piece = Piece.objects.create(
+            user=other_user,
+            name='Other User Piece',
+            shared=True,
+        )
+        PieceState.objects.create(user=other_user, piece=foreign_piece, state=ENTRY_STATE)
+
+        response = client.get(f'/api/pieces/{foreign_piece.id}/')
+
+        assert response.status_code == 200
+        assert response.json()['can_edit'] is False
+
+    def test_non_owner_cannot_patch_shared_piece(self, client, other_user):
+        from api.models import ENTRY_STATE, Piece, PieceState
+
+        foreign_piece = Piece.objects.create(
+            user=other_user,
+            name='Other User Piece',
+            shared=True,
+        )
+        PieceState.objects.create(user=other_user, piece=foreign_piece, state=ENTRY_STATE)
+
+        response = client.patch(
+            f'/api/pieces/{foreign_piece.id}/',
+            {'name': 'Nope'},
+            format='json',
+        )
+
         assert response.status_code == 404
 
 

--- a/api/tests/test_piece_states.py
+++ b/api/tests/test_piece_states.py
@@ -245,6 +245,24 @@ class TestPieceStates:
         )
         assert response.status_code == 404
 
+    def test_non_owner_cannot_add_state_to_shared_piece(self, client, other_user):
+        foreign_piece = Piece.objects.create(
+            user=other_user,
+            name='Shared Foreign Piece',
+            shared=True,
+        )
+        from api.models import PieceState
+
+        PieceState.objects.create(user=other_user, piece=foreign_piece, state=ENTRY_STATE)
+
+        response = client.post(
+            f'/api/pieces/{foreign_piece.id}/states/',
+            {'state': SUCCESSORS[ENTRY_STATE][0]},
+            format='json',
+        )
+
+        assert response.status_code == 404
+
     def test_summary_serializer_asserts_piece_has_current_state(self, user):
         piece = Piece.objects.create(user=user, name='Broken Summary')
         serializer = PieceSummarySerializer()

--- a/api/tests/test_pieces_list.py
+++ b/api/tests/test_pieces_list.py
@@ -27,7 +27,18 @@ class TestPiecesList:
     def test_summary_shape(self, client, piece):
         data = client.get('/api/pieces/').json()
         keys = set(data['results'][0].keys())
-        assert keys == {'id', 'name', 'created', 'current_location', 'last_modified', 'thumbnail', 'current_state', 'tags'}
+        assert keys == {
+            'id',
+            'name',
+            'created',
+            'current_location',
+            'last_modified',
+            'thumbnail',
+            'shared',
+            'can_edit',
+            'current_state',
+            'tags',
+        }
 
     def test_does_not_include_other_users_pieces(self, client, other_user):
         hidden = Piece.objects.create(user=other_user, name='Hidden Piece')

--- a/api/views.py
+++ b/api/views.py
@@ -113,6 +113,21 @@ def _piece_queryset(request: Request):
     )  # type: ignore[misc]
 
 
+def _piece_read_queryset(request: Request):
+    qs = Piece.objects.prefetch_related("states", "tag_links__tag")
+    if request.user.is_authenticated:
+        return qs.filter(Q(user=request.user) | Q(shared=True))
+    return qs.filter(shared=True)
+
+
+def _serialize_piece_detail(piece: Piece, request: Request):
+    return PieceDetailSerializer(piece, context={"request": request}).data
+
+
+def _serialize_piece_summary(qs, request: Request):
+    return PieceSummarySerializer(qs, many=True, context={"request": request}).data
+
+
 def _apply_piece_ordering(qs, ordering_param: str):
     db_ordering = _PIECE_ORDERING_MAP.get(ordering_param, _PIECE_ORDERING_MAP[_DEFAULT_ORDERING])
     if "computed_last_modified" in db_ordering:
@@ -185,12 +200,12 @@ def pieces(request: Request) -> Response:
             offset = 0
         count = qs.count()
         page_qs = qs[offset : offset + limit]
-        return Response({"count": count, "results": PieceSummarySerializer(page_qs, many=True).data})
+        return Response({"count": count, "results": _serialize_piece_summary(page_qs, request)})
 
     serializer = PieceCreateSerializer(data=request.data, context={"request": request})
     serializer.is_valid(raise_exception=True)
     piece = serializer.save()
-    return Response(PieceDetailSerializer(piece).data, status=status.HTTP_201_CREATED)
+    return Response(_serialize_piece_detail(piece, request), status=status.HTTP_201_CREATED)
 
 
 @extend_schema(methods=["GET"], operation_id="pieces_retrieve", responses={200: PieceDetailSerializer})
@@ -200,17 +215,26 @@ def pieces(request: Request) -> Response:
     responses={200: PieceDetailSerializer},
 )
 @api_view(["GET", "PATCH"])
-@permission_classes([IsAuthenticated])
+@permission_classes([AllowAny])
 def piece_detail(request: Request, piece_id: str) -> Response:
+    if request.method == "GET":
+        piece = get_object_or_404(_piece_read_queryset(request), pk=piece_id)
+        return Response(_serialize_piece_detail(piece, request))
+
+    if not request.user.is_authenticated:
+        return Response(
+            {"detail": "Authentication credentials were not provided."},
+            status=status.HTTP_403_FORBIDDEN,
+        )
     piece = get_object_or_404(_piece_queryset(request), pk=piece_id)
     if request.method == "PATCH":
         serializer = PieceUpdateSerializer(
-            data=request.data, context={"request": request}
+            data=request.data, context={"request": request, "piece": piece}
         )
         serializer.is_valid(raise_exception=True)
         serializer.update(piece, serializer.validated_data)
         piece.refresh_from_db()
-    return Response(PieceDetailSerializer(piece).data)
+    return Response(_serialize_piece_detail(piece, request))
 
 
 @extend_schema(
@@ -226,7 +250,7 @@ def piece_states(request: Request, piece_id: str) -> Response:
     serializer.save()
     # Reload to pick up updated last_modified on current_state
     piece.refresh_from_db()
-    return Response(PieceDetailSerializer(piece).data, status=status.HTTP_201_CREATED)
+    return Response(_serialize_piece_detail(piece, request), status=status.HTTP_201_CREATED)
 
 
 @extend_schema(
@@ -263,7 +287,7 @@ def piece_current_state(request: Request, piece_id: str) -> Response:
     serializer.is_valid(raise_exception=True)
     serializer.update(current, serializer.validated_data)
     piece.refresh_from_db()
-    return Response(PieceDetailSerializer(piece).data)
+    return Response(_serialize_piece_detail(piece, request))
 
 
 _GLOBAL_ENTRY_SCHEMA = {

--- a/docs/agents/glaze-domain.md
+++ b/docs/agents/glaze-domain.md
@@ -395,6 +395,13 @@ All data-fetching components must render a loading spinner (`<CircularProgress /
 - Unauthenticated → login form with email/password and optional Google Sign-In button (`VITE_GOOGLE_CLIENT_ID`).
 - `Sign Up` is intentionally disabled (`SIGN_UP_ENABLED = false`); create accounts via Django admin.
 
+**Frontend routing for piece detail access:**
+
+- Unauthenticated users normally see the auth routes, but `/pieces/:id` is also registered in the unauthenticated router inside `PublicPieceShell`. That route calls the same `PieceDetailPage` as the authenticated app. The backend decides whether the piece is readable: shared pieces load read-only; private pieces return the normal load error.
+- Authenticated owners reach `/pieces/:id` through the app shell. The API returns `can_edit: true`, so `PieceDetail` renders owner controls for name, tags, location, workflow edits, image upload/photo editing, transitions, and terminal-piece sharing.
+- Authenticated non-owners can open `/pieces/:id` only when the piece is shared. The API returns `can_edit: false`, and the same `PieceDetail` component renders a read-only view with edit, upload, transition, tag, and share-management controls hidden or disabled.
+- Do not introduce a separate public piece detail page or route unless the product behavior changes. The canonical public URL is `/pieces/:id`; ownership and read-only behavior come from the API response.
+
 **Cloudinary image upload flow:**
 
 - Images are stored as a JSON array of `CaptionedImage` objects (url, caption, created, cloudinary_public_id).

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -405,6 +405,25 @@ js_library(
 )
 
 js_library(
+    name = "piece_share_controls_src",
+    srcs = ["src/components/PieceShareControls.tsx"],
+    deps = [
+        ":generated_types",
+        ":node_modules",
+        ":util_lib",
+    ],
+)
+
+js_library(
+    name = "public_piece_shell_src",
+    srcs = ["src/components/PublicPieceShell.tsx"],
+    deps = [
+        ":node_modules",
+        ":primitive_src",
+    ],
+)
+
+js_library(
     name = "piece_detail_src",
     srcs = [
         "src/components/NavigationBlocker.tsx",
@@ -417,6 +436,7 @@ js_library(
         ":node_modules",
         ":piece_history_src",
         ":piece_photo_gallery_src",
+        ":piece_share_controls_src",
         ":primitive_src",
         ":state_transition_src",
         ":tag_manager_src",
@@ -523,6 +543,7 @@ vitest_test(
     name = "web_picker_test",
     srcs = [
         "src/components/__tests__/GlobalEntryDialog.test.tsx",
+        "src/components/__tests__/GlobalEntryField.test.tsx",
     ],
     tags = ["ibazel_notify_changes"],
     deps = [
@@ -617,6 +638,28 @@ vitest_test(
     tags = ["ibazel_notify_changes"],
     deps = [
         ":piece_history_src",
+    ],
+)
+
+vitest_test(
+    name = "web_piece_share_controls_test",
+    srcs = [
+        "src/components/__tests__/PieceShareControls.test.tsx",
+    ],
+    tags = ["ibazel_notify_changes"],
+    deps = [
+        ":piece_share_controls_src",
+    ],
+)
+
+vitest_test(
+    name = "web_public_piece_shell_test",
+    srcs = [
+        "src/components/__tests__/PublicPieceShell.test.tsx",
+    ],
+    tags = ["ibazel_notify_changes"],
+    deps = [
+        ":public_piece_shell_src",
     ],
 )
 
@@ -738,7 +781,9 @@ test_suite(
         ":web_piece_history_test",
         ":web_piece_list_page_test",
         ":web_piece_list_test",
+        ":web_piece_share_controls_test",
         ":web_primitive_test",
+        ":web_public_piece_shell_test",
         ":web_state_transition_test",
         ":web_tag_manager_test",
         ":web_tag_test",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -48,6 +48,7 @@ import {
 } from "./util/api";
 import { useAsync } from "./util/useAsync";
 import ErrorBoundary from "./components/ErrorBoundary";
+import PublicPieceShell from "./components/PublicPieceShell";
 import type { AuthUser } from "./util/api";
 
 const LandingPage = lazy(() => import("./pages/LandingPage"));
@@ -503,6 +504,14 @@ function UnauthenticatedApp({
                     <PrivacyPolicyPage />
                   </Suspense>
                 </ErrorBoundary>
+              }
+            />
+            <Route
+              path="/pieces/:id"
+              element={
+                <PublicPieceShell>
+                  <PieceDetailPage />
+                </PublicPieceShell>
               }
             />
             <Route path="*" element={<Navigate to="/" replace />} />

--- a/web/src/components/GlobalEntryField.tsx
+++ b/web/src/components/GlobalEntryField.tsx
@@ -12,6 +12,7 @@ export interface GlobalEntryFieldProps {
   required?: boolean;
   canCreate?: boolean;
   hideLabel?: boolean;
+  disabled?: boolean;
   sx?: SxProps<Theme>;
 }
 
@@ -26,6 +27,7 @@ export default function GlobalEntryField({
   required = false,
   canCreate = false,
   hideLabel = false,
+  disabled = false,
   sx,
 }: GlobalEntryFieldProps) {
   const [open, setOpen] = useState(false);
@@ -50,11 +52,17 @@ export default function GlobalEntryField({
             {required && " *"}
           </Typography>
         )}
-        {value && <Chip label={value} onDelete={() => onSelect(null)} />}
+        {value && (
+          <Chip
+            label={value}
+            onDelete={disabled ? undefined : () => onSelect(null)}
+          />
+        )}
         <Button
           variant="outlined"
           size="small"
           onClick={() => setOpen(true)}
+          disabled={disabled}
           aria-label={value ? `Change ${label}` : `Browse ${label}`}
           sx={{ whiteSpace: "nowrap", flexShrink: 0 }}
         >

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -28,6 +28,7 @@ import PiecePhotoGallery, {
 } from "./PiecePhotoGallery";
 import { PieceDetailSaveStatusProvider } from "./PieceDetailSaveStatusContext";
 import { usePieceDetailSaveStatus } from "./usePieceDetailSaveStatus";
+import ShareControls from "./PieceShareControls";
 
 type PieceDetailProps = {
   piece: PieceDetailType;
@@ -137,6 +138,7 @@ function PieceDetailContent({
   const pieceDetailSaveStatus = usePieceDetailSaveStatus();
   const currentState = piece.current_state;
   const isTerminal = isTerminalState(currentState.state);
+  const canEdit = piece.can_edit;
   const pastHistory = piece.history.slice(0, -1);
   function formatDate(d: Date): string {
     const y = d.getFullYear();
@@ -153,7 +155,7 @@ function PieceDetailContent({
     return state.images.map((image, imageIndex) => ({
       ...image,
       stateLabel: formatState(state.state),
-      editableCurrentStateIndex: isCurrentState ? imageIndex : null,
+      editableCurrentStateIndex: canEdit && isCurrentState ? imageIndex : null,
     }));
   });
   const editButtonSx = {
@@ -166,7 +168,7 @@ function PieceDetailContent({
     backgroundColor: alpha(theme.palette.background.paper, 0.38),
   } as const;
 
-  const blocker = useBlocker(isDirty);
+  const blocker = useBlocker(canEdit && isDirty);
 
   async function handleTransition(nextState: string) {
     setTransitioning(true);
@@ -249,8 +251,8 @@ function PieceDetailContent({
     currentStateAdditionalFields: currentState.additional_fields ?? {},
     currentThumbnailUrl: piece.thumbnail?.url,
     onPieceUpdated,
-    updatePieceFn: updatePiece,
-    updateCurrentStateFn: updateCurrentState,
+    updatePieceFn: canEdit ? updatePiece : undefined,
+    updateCurrentStateFn: canEdit ? updateCurrentState : undefined,
   } satisfies ComponentProps<typeof PiecePhotoGallery>;
 
   return (
@@ -355,31 +357,42 @@ function PieceDetailContent({
                   >
                     {piece.name}
                   </Typography>
-                  <IconButton
-                    aria-label="Edit piece name"
-                    onClick={startEditingName}
-                    size="small"
-                    sx={{ ...editButtonSx, alignSelf: "center" }}
-                  >
-                    <EditIcon sx={{ fontSize: 14 }} />
-                  </IconButton>
+                  {canEdit && (
+                    <IconButton
+                      aria-label="Edit piece name"
+                      onClick={startEditingName}
+                      size="small"
+                      sx={{ ...editButtonSx, alignSelf: "center" }}
+                    >
+                      <EditIcon sx={{ fontSize: 14 }} />
+                    </IconButton>
+                  )}
                 </Box>
               )}
             </Box>
-            <TagManager
-              pieceId={piece.id}
-              initialTags={piece.tags ?? []}
-              onSaved={onPieceUpdated}
-            />
-            <Box sx={{ mt: 2, mb: 1.5 }}>
-              <StateTransition
-                currentStateName={currentState.state}
-                disabled={isDirty}
-                transitioning={transitioning}
-                transitionError={transitionError}
-                onTransition={handleTransition}
+            {canEdit ? (
+              <TagManager
+                pieceId={piece.id}
+                initialTags={piece.tags ?? []}
+                onSaved={onPieceUpdated}
               />
-            </Box>
+            ) : null}
+            {canEdit && (
+              <Box sx={{ mt: 2, mb: 1.5 }}>
+                <StateTransition
+                  currentStateName={currentState.state}
+                  disabled={isDirty}
+                  transitioning={transitioning}
+                  transitionError={transitionError}
+                  onTransition={handleTransition}
+                />
+              </Box>
+            )}
+            {canEdit && isTerminal && (
+              <Box sx={{ mb: 1.5 }}>
+                <ShareControls piece={piece} onPieceUpdated={onPieceUpdated} />
+              </Box>
+            )}
             <Box sx={{ mb: 1.5 }}>
               <SectionCard>
                 <GlobalEntryField
@@ -387,6 +400,7 @@ function PieceDetailContent({
                   label="Current location"
                   value={piece.current_location ?? ""}
                   onSelect={(entry) => void handleLocationSelect(entry)}
+                  disabled={!canEdit}
                   sx={{ opacity: locationSaving ? 0.7 : 1 }}
                 />
                 {locationError && (
@@ -468,6 +482,7 @@ function PieceDetailContent({
             pieceId={piece.id}
             onSaved={onPieceUpdated}
             onDirtyChange={setIsDirty}
+            readOnly={!canEdit}
           />
         </SectionCard>
 
@@ -489,11 +504,13 @@ function PieceDetailContent({
         </SectionCard>
       </Box>
 
-      <NavigationBlocker
-        open={blocker.state === "blocked"}
-        onStay={() => blocker.reset?.()}
-        onLeave={() => blocker.proceed?.()}
-      />
+      {canEdit && (
+        <NavigationBlocker
+          open={blocker.state === "blocked"}
+          onStay={() => blocker.reset?.()}
+          onLeave={() => blocker.proceed?.()}
+        />
+      )}
     </Box>
   );
 }

--- a/web/src/components/PieceShareControls.tsx
+++ b/web/src/components/PieceShareControls.tsx
@@ -1,0 +1,143 @@
+import { useState } from "react";
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
+import IosShareIcon from "@mui/icons-material/IosShare";
+import PublicIcon from "@mui/icons-material/Public";
+import PublicOffIcon from "@mui/icons-material/PublicOff";
+import { alpha, Box, Button, Stack, Typography } from "@mui/material";
+import type { PieceDetail } from "../util/types";
+import { updatePiece } from "../util/api";
+
+function publicPieceUrl(pieceId: string): string {
+  return `${window.location.origin}/pieces/${pieceId}`;
+}
+
+export default function ShareControls({
+  piece,
+  onPieceUpdated,
+}: {
+  piece: PieceDetail;
+  onPieceUpdated: (updated: PieceDetail) => void;
+}) {
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const publicUrl = publicPieceUrl(piece.id);
+  const canUseNativeShare = typeof navigator.share === "function";
+
+  async function toggleShared() {
+    setSaving(true);
+    setMessage(null);
+    try {
+      const updated = await updatePiece(piece.id, { shared: !piece.shared });
+      onPieceUpdated(updated);
+      setMessage(updated.shared ? "Public link created." : "Public link disabled.");
+    } catch {
+      setMessage("Failed to update sharing. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function copyLink() {
+    try {
+      await navigator.clipboard.writeText(publicUrl);
+      setMessage("Public link copied.");
+    } catch {
+      setMessage("Could not copy the public link.");
+    }
+  }
+
+  async function shareLink() {
+    if (!canUseNativeShare) return;
+    try {
+      await navigator.share({
+        title: piece.name,
+        text: piece.name,
+        url: publicUrl,
+      });
+    } catch {
+      // Browser share sheets reject when the user cancels; no UI error needed.
+    }
+  }
+
+  return (
+    <Box
+      sx={(theme) => ({
+        borderRadius: "6px",
+        border: "1px solid",
+        borderColor: "divider",
+        backgroundColor: alpha(theme.palette.background.paper, 0.66),
+        backdropFilter: "blur(14px)",
+        boxShadow: `0 14px 34px ${alpha(theme.palette.common.black, 0.14)}`,
+        overflow: "hidden",
+      })}
+    >
+      <Box sx={{ px: { xs: 1.5, sm: 2 }, pt: 1.25, pb: 0.75 }}>
+        <Typography variant="h6" component="h3">
+          Share
+        </Typography>
+      </Box>
+      <Box sx={{ px: { xs: 1.5, sm: 2 }, pb: 1.5 }}>
+        <Stack
+          direction={{ xs: "column", sm: "row" }}
+          spacing={1}
+          alignItems={{ xs: "stretch", sm: "center" }}
+        >
+          <Button
+            variant={piece.shared ? "outlined" : "contained"}
+            startIcon={piece.shared ? <PublicOffIcon /> : <PublicIcon />}
+            onClick={() => void toggleShared()}
+            disabled={saving}
+          >
+            {piece.shared ? "Unshare" : "Share"}
+          </Button>
+          {piece.shared && (
+            <>
+              <Button
+                variant="outlined"
+                startIcon={<ContentCopyIcon />}
+                onClick={() => void copyLink()}
+              >
+                Copy link
+              </Button>
+              {canUseNativeShare && (
+                <Button
+                  variant="outlined"
+                  startIcon={<IosShareIcon />}
+                  onClick={() => void shareLink()}
+                >
+                  Share
+                </Button>
+              )}
+            </>
+          )}
+        </Stack>
+        {piece.shared && (
+          <Typography
+            variant="caption"
+            sx={{
+              display: "block",
+              mt: 0.75,
+              color: "text.secondary",
+              overflowWrap: "anywhere",
+            }}
+          >
+            {publicUrl}
+          </Typography>
+        )}
+        {message && (
+          <Typography
+            variant="body2"
+            color={
+              message.startsWith("Failed") || message.startsWith("Could")
+                ? "error"
+                : "text.secondary"
+            }
+            sx={{ mt: 0.75 }}
+          >
+            {message}
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/web/src/components/PublicPieceShell.tsx
+++ b/web/src/components/PublicPieceShell.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from "react";
+import { Suspense } from "react";
+import { Box, CircularProgress, Container, Typography } from "@mui/material";
+import ErrorBoundary from "./ErrorBoundary";
+
+export default function PublicPieceShell({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <Container
+      maxWidth="lg"
+      sx={{
+        minHeight: "100dvh",
+        pt: {
+          xs: "max(12px, calc(env(safe-area-inset-top) + 8px))",
+          sm: 2,
+        },
+        pb: 2,
+        pl: {
+          xs: "max(16px, env(safe-area-inset-left))",
+          sm: 3,
+        },
+        pr: {
+          xs: "max(16px, env(safe-area-inset-right))",
+          sm: 3,
+        },
+      }}
+    >
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1.5 }}>
+        <Box
+          component="img"
+          src="/favicon.svg"
+          alt="PotterDoc app icon"
+          sx={{ width: 22, height: 22, flexShrink: 0, display: "block" }}
+        />
+        <Typography variant="h6" component="p" color="text.primary">
+          PotterDoc
+        </Typography>
+      </Box>
+      <ErrorBoundary>
+        <Suspense
+          fallback={
+            <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+              <CircularProgress />
+            </Box>
+          }
+        >
+          {children}
+        </Suspense>
+      </ErrorBoundary>
+    </Container>
+  );
+}

--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -38,6 +38,7 @@ type WorkflowStateProps = {
   onSaved: (updated: PieceDetail) => void;
   onDirtyChange?: (dirty: boolean) => void;
   autosaveDelayMs?: number;
+  readOnly?: boolean;
 };
 
 
@@ -144,6 +145,7 @@ export default function WorkflowState({
   onSaved,
   onDirtyChange,
   autosaveDelayMs,
+  readOnly = false,
 }: WorkflowStateProps) {
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [widgetLoading, setWidgetLoading] = useState(false);
@@ -189,8 +191,8 @@ export default function WorkflowState({
   const isDirty = notes !== baseState.notes || additionalFieldsDirty;
 
   useEffect(() => {
-    onDirtyChange?.(isDirty);
-  }, [isDirty, onDirtyChange]);
+    onDirtyChange?.(readOnly ? false : isDirty);
+  }, [isDirty, onDirtyChange, readOnly]);
 
   const saveWorkflowState = useCallback(async () => {
     const payload = {
@@ -220,7 +222,7 @@ export default function WorkflowState({
   );
 
   const autosave = useAutosave({
-    dirty: isDirty,
+    dirty: !readOnly && isDirty,
     saveKey: autosaveKey,
     save: saveWorkflowState,
     delayMs: autosaveDelayMs,
@@ -241,6 +243,9 @@ export default function WorkflowState({
   ]);
 
   async function handleUploadWidgetClick() {
+    if (readOnly) {
+      return;
+    }
     setUploadError(null);
     setWidgetLoading(true);
     let config;
@@ -365,6 +370,7 @@ export default function WorkflowState({
         value={notes}
         onChange={(e) => dispatch({ type: "set_notes", notes: e.target.value })}
         slotProps={{ htmlInput: { maxLength: 2000 } }}
+        disabled={readOnly}
         fullWidth
       />
       {additionalFieldDefs.length > 0 && (
@@ -405,6 +411,7 @@ export default function WorkflowState({
                     label={label}
                     value={value}
                     onSelect={(entry) => {
+                      if (readOnly) return;
                       handleFieldChange(field.name, entryNameOrEmpty(entry));
                       dispatch({
                         type: "set_global_ref_pks",
@@ -418,6 +425,7 @@ export default function WorkflowState({
                       });
                     }}
                     canCreate={Boolean(field.canCreate)}
+                    disabled={readOnly}
                     helperText={helperText}
                     required={field.required}
                   />
@@ -433,6 +441,7 @@ export default function WorkflowState({
                     onChange={(e) => handleFieldChange(field.name, e.target.value)}
                     helperText={helperText}
                     required={field.required}
+                    disabled={readOnly}
                     fullWidth
                   >
                     {field.enum.map((option) => (
@@ -460,6 +469,7 @@ export default function WorkflowState({
                     }}
                     helperText={helperText}
                     required={field.required}
+                    disabled={readOnly}
                     fullWidth
                   />
                 );
@@ -474,6 +484,7 @@ export default function WorkflowState({
                     onChange={(e) => handleFieldChange(field.name, e.target.value)}
                     helperText={helperText}
                     required={field.required}
+                    disabled={readOnly}
                     fullWidth
                   >
                     <MenuItem value="true">True</MenuItem>
@@ -489,6 +500,7 @@ export default function WorkflowState({
                   onChange={(e) => handleFieldChange(field.name, e.target.value)}
                   helperText={helperText}
                   required={field.required}
+                  disabled={readOnly}
                   fullWidth
                 />
               );
@@ -506,14 +518,16 @@ export default function WorkflowState({
         />
       )}
 
-      <ImageUploader
-        saving={savingImage}
-        widgetLoading={widgetLoading}
-        uploadError={uploadError}
-        imageError={imageError}
-        mobile={isMobileLayout}
-        onUploadClick={handleUploadWidgetClick}
-      />
+      {!readOnly && (
+        <ImageUploader
+          saving={savingImage}
+          widgetLoading={widgetLoading}
+          uploadError={uploadError}
+          imageError={imageError}
+          mobile={isMobileLayout}
+          onUploadClick={handleUploadWidgetClick}
+        />
+      )}
     </Box>
   );
 }

--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -50,6 +50,7 @@ type ImageUploaderProps = {
   uploadError: string | null;
   imageError: string | null;
   mobile: boolean;
+  hidden?: boolean;
   onUploadClick: () => void;
 };
 
@@ -59,13 +60,14 @@ function ImageUploader({
   uploadError,
   imageError,
   mobile,
+  hidden = false,
   onUploadClick,
 }: ImageUploaderProps) {
   const buttonDisabled = saving || widgetLoading;
   const statusMessage = saving ? "Saving…" : "Upload Image";
 
   return (
-    <Box>
+    <Box sx={hidden ? { display: "none" } : undefined}>
       {mobile ? (
         <Portal>
           <Fab
@@ -73,7 +75,9 @@ function ImageUploader({
             aria-label="Upload Image"
             onClick={onUploadClick}
             disabled={buttonDisabled}
+            hidden={hidden}
             sx={{
+              display: hidden ? "none" : undefined,
               position: "fixed",
               right: 24,
               bottom: 24,
@@ -111,10 +115,11 @@ function ImageUploader({
             size="small"
             onClick={onUploadClick}
             disabled={buttonDisabled}
+            hidden={hidden}
             startIcon={
               saving ? <CircularProgress size={14} color="inherit" /> : undefined
             }
-            sx={{ position: "relative" }}
+            sx={{ display: hidden ? "none" : undefined, position: "relative" }}
           >
             <Box sx={{ opacity: widgetLoading ? 0 : 1 }}>{statusMessage}</Box>
             {widgetLoading && (
@@ -518,16 +523,15 @@ export default function WorkflowState({
         />
       )}
 
-      {!readOnly && (
-        <ImageUploader
-          saving={savingImage}
-          widgetLoading={widgetLoading}
-          uploadError={uploadError}
-          imageError={imageError}
-          mobile={isMobileLayout}
-          onUploadClick={handleUploadWidgetClick}
-        />
-      )}
+      <ImageUploader
+        saving={savingImage}
+        widgetLoading={widgetLoading}
+        uploadError={uploadError}
+        imageError={imageError}
+        mobile={isMobileLayout}
+        hidden={readOnly}
+        onUploadClick={handleUploadWidgetClick}
+      />
     </Box>
   );
 }

--- a/web/src/components/__tests__/GlobalEntryField.test.tsx
+++ b/web/src/components/__tests__/GlobalEntryField.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import GlobalEntryField from "../GlobalEntryField";
+
+vi.mock("../GlobalEntryDialog", () => ({
+  default: () => null,
+}));
+
+describe("GlobalEntryField", () => {
+  it("clears the selected entry from the chip delete action", async () => {
+    const onSelect = vi.fn();
+
+    render(
+      <GlobalEntryField
+        globalName="location"
+        label="Current location"
+        value="Studio Shelf"
+        onSelect={onSelect}
+      />,
+    );
+
+    await userEvent.click(screen.getByTestId("CancelIcon"));
+
+    expect(onSelect).toHaveBeenCalledWith(null);
+  });
+
+  it("disables the chip delete action when disabled", () => {
+    render(
+      <GlobalEntryField
+        globalName="location"
+        label="Current location"
+        value="Studio Shelf"
+        onSelect={vi.fn()}
+        disabled
+      />,
+    );
+
+    expect(screen.queryByTestId("CancelIcon")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Change Current location" }),
+    ).toBeDisabled();
+  });
+});

--- a/web/src/components/__tests__/PieceDetail.test.tsx
+++ b/web/src/components/__tests__/PieceDetail.test.tsx
@@ -152,6 +152,8 @@ function makePiece(overrides: Partial<PieceDetailType> = {}): PieceDetailType {
     created: new Date("2024-01-15T10:00:00Z"),
     last_modified: new Date("2024-01-15T10:00:00Z"),
     thumbnail: { url: "/thumbnails/bowl.svg", cloudinary_public_id: null, cloud_name: null },
+    shared: false,
+    can_edit: true,
     current_state: state,
     current_location: "",
     tags: [],
@@ -382,6 +384,65 @@ describe("PieceDetail", () => {
     expect(screen.getByText(/terminal state/i)).toBeInTheDocument();
   });
 
+  it("shows share controls for editable terminal pieces", async () => {
+    await renderPieceDetail(
+      makePiece({
+        current_state: makeState({ state: "completed" }),
+        history: [makeState({ state: "completed" })],
+      }),
+    );
+
+    expect(screen.getByRole("button", { name: "Share" })).toBeInTheDocument();
+  });
+
+  it("copies the public link for a shared terminal piece", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    await renderPieceDetail(
+      makePiece({
+        shared: true,
+        current_state: makeState({ state: "completed" }),
+        history: [makeState({ state: "completed" })],
+      }),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Copy link" }));
+
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(
+        "http://localhost:3000/pieces/piece-id-1",
+      ),
+    );
+  });
+
+  it("uses native share when available for a shared terminal piece", async () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "share", {
+      value: share,
+      configurable: true,
+    });
+    await renderPieceDetail(
+      makePiece({
+        shared: true,
+        current_state: makeState({ state: "completed" }),
+        history: [makeState({ state: "completed" })],
+      }),
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Share" }));
+
+    await waitFor(() =>
+      expect(share).toHaveBeenCalledWith({
+        title: "Test Bowl",
+        text: "Test Bowl",
+        url: "http://localhost:3000/pieces/piece-id-1",
+      }),
+    );
+  });
+
   it("shows no transition buttons for terminal states", async () => {
     const piece = makePiece({
       current_state: makeState({ state: "completed" }),
@@ -391,6 +452,29 @@ describe("PieceDetail", () => {
     expect(
       screen.queryByRole("button", { name: "Throwing" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("hides editing controls in read-only mode", async () => {
+    await renderPieceDetail(
+      makePiece({
+        can_edit: false,
+        shared: true,
+        current_state: makeState({ state: "completed" }),
+        history: [makeState({ state: "completed" })],
+      }),
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Edit piece name" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Add or edit tags" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Upload Image" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Unshare" })).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Notes")).toBeDisabled();
   });
 
   it("transition buttons disabled when there are unsaved changes", async () => {

--- a/web/src/components/__tests__/PieceShareControls.test.tsx
+++ b/web/src/components/__tests__/PieceShareControls.test.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ShareControls from "../PieceShareControls";
+import type { PieceDetail } from "../../util/types";
+import * as api from "../../util/api";
+
+vi.mock("../../util/api", () => ({
+  updatePiece: vi.fn(),
+}));
+
+function makePiece(overrides: Partial<PieceDetail> = {}): PieceDetail {
+  return {
+    id: "piece-id-1",
+    name: "Test Bowl",
+    created: new Date("2024-01-15T10:00:00Z"),
+    last_modified: new Date("2024-01-15T10:00:00Z"),
+    thumbnail: null,
+    shared: false,
+    can_edit: true,
+    current_state: {
+      state: "completed",
+      notes: "",
+      created: new Date("2024-01-15T10:00:00Z"),
+      last_modified: new Date("2024-01-15T10:00:00Z"),
+      images: [],
+      additional_fields: {},
+      previous_state: null,
+      next_state: null,
+    },
+    current_location: "",
+    tags: [],
+    history: [],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(navigator, "share", {
+    value: undefined,
+    configurable: true,
+  });
+});
+
+describe("PieceShareControls", () => {
+  it("shares an unshared piece", async () => {
+    const updated = makePiece({ shared: true });
+    vi.mocked(api.updatePiece).mockResolvedValue(updated);
+    const onPieceUpdated = vi.fn();
+
+    render(<ShareControls piece={makePiece()} onPieceUpdated={onPieceUpdated} />);
+    await userEvent.click(screen.getByRole("button", { name: "Share" }));
+
+    await waitFor(() =>
+      expect(api.updatePiece).toHaveBeenCalledWith("piece-id-1", {
+        shared: true,
+      }),
+    );
+    expect(onPieceUpdated).toHaveBeenCalledWith(updated);
+    expect(screen.getByText("Public link created.")).toBeInTheDocument();
+  });
+
+  it("shows an error when toggling sharing fails", async () => {
+    vi.mocked(api.updatePiece).mockRejectedValue(new Error("Network error"));
+    const onPieceUpdated = vi.fn();
+
+    render(<ShareControls piece={makePiece()} onPieceUpdated={onPieceUpdated} />);
+    await userEvent.click(screen.getByRole("button", { name: "Share" }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Failed to update sharing. Please try again."),
+      ).toBeInTheDocument(),
+    );
+    expect(onPieceUpdated).not.toHaveBeenCalled();
+  });
+
+  it("copies the public URL for a shared piece", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    render(
+      <ShareControls
+        piece={makePiece({ shared: true })}
+        onPieceUpdated={vi.fn()}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Copy link" }));
+
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(
+        "http://localhost:3000/pieces/piece-id-1",
+      ),
+    );
+    expect(screen.getByText("Public link copied.")).toBeInTheDocument();
+  });
+
+  it("shows an error when copying the public URL fails", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("No clipboard"));
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    render(
+      <ShareControls
+        piece={makePiece({ shared: true })}
+        onPieceUpdated={vi.fn()}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Copy link" }));
+
+    await waitFor(() =>
+      expect(screen.getByText("Could not copy the public link.")).toBeInTheDocument(),
+    );
+  });
+
+  it("hides the native share action when Web Share is unavailable", () => {
+    render(
+      <ShareControls
+        piece={makePiece({ shared: true })}
+        onPieceUpdated={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Share" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Unshare" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copy link" })).toBeInTheDocument();
+  });
+
+  it("uses the native share sheet when available", async () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "share", {
+      value: share,
+      configurable: true,
+    });
+
+    render(
+      <ShareControls
+        piece={makePiece({ shared: true })}
+        onPieceUpdated={vi.fn()}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Share" }));
+
+    await waitFor(() =>
+      expect(share).toHaveBeenCalledWith({
+        title: "Test Bowl",
+        text: "Test Bowl",
+        url: "http://localhost:3000/pieces/piece-id-1",
+      }),
+    );
+  });
+});

--- a/web/src/components/__tests__/PublicPieceShell.test.tsx
+++ b/web/src/components/__tests__/PublicPieceShell.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import PublicPieceShell from "../PublicPieceShell";
+
+describe("PublicPieceShell", () => {
+  it("renders PotterDoc chrome around public content", () => {
+    render(
+      <PublicPieceShell>
+        <main>Shared piece detail</main>
+      </PublicPieceShell>,
+    );
+
+    expect(screen.getByText("PotterDoc")).toBeInTheDocument();
+    expect(
+      screen.getByAltText("PotterDoc app icon"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Shared piece detail")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/__tests__/WorkflowState.test.tsx
+++ b/web/src/components/__tests__/WorkflowState.test.tsx
@@ -822,6 +822,18 @@ describe("WorkflowState", () => {
     expect(api.fetchCloudinaryWidgetConfig).not.toHaveBeenCalled();
   });
 
+  it("returns before opening the upload widget when read-only", async () => {
+    await act(async () => {
+      render(<WorkflowState {...defaultProps} readOnly />);
+    });
+
+    const hiddenUploadButton = document.querySelector("button[hidden]");
+    expect(hiddenUploadButton).toBeInstanceOf(HTMLButtonElement);
+    fireEvent.click(hiddenUploadButton as HTMLButtonElement);
+
+    expect(api.fetchCloudinaryWidgetConfig).not.toHaveBeenCalled();
+  });
+
   it("shows a floating camera action on mobile layouts", async () => {
     setScreenWidth(390);
     await act(async () => {

--- a/web/src/components/__tests__/WorkflowState.test.tsx
+++ b/web/src/components/__tests__/WorkflowState.test.tsx
@@ -811,6 +811,17 @@ describe("WorkflowState", () => {
     ).toBeInTheDocument();
   });
 
+  it("does not expose the upload action when read-only", async () => {
+    await act(async () => {
+      render(<WorkflowState {...defaultProps} readOnly />);
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "Upload Image" }),
+    ).not.toBeInTheDocument();
+    expect(api.fetchCloudinaryWidgetConfig).not.toHaveBeenCalled();
+  });
+
   it("shows a floating camera action on mobile layouts", async () => {
     setScreenWidth(390);
     await act(async () => {

--- a/web/src/pages/__tests__/PieceDetailPage.test.tsx
+++ b/web/src/pages/__tests__/PieceDetailPage.test.tsx
@@ -26,6 +26,8 @@ const MOCK_PIECE: PieceDetail = {
   created: new Date("2024-01-01T00:00:00Z"),
   last_modified: new Date("2024-01-02T00:00:00Z"),
   thumbnail: "/thumbnails/question-mark.svg",
+  shared: false,
+  can_edit: true,
   current_state: {
     state: "designed",
     notes: "",

--- a/web/src/util/api.ts
+++ b/web/src/util/api.ts
@@ -123,6 +123,8 @@ function mapPieceSummary(raw: Wire<PieceSummary>): PieceSummary {
     created: new Date(raw.created ?? ""),
     last_modified: new Date(raw.last_modified ?? ""),
     thumbnail: raw.thumbnail as Thumbnail | null,
+    shared: raw.shared ?? false,
+    can_edit: raw.can_edit ?? true,
     current_state: mapStateSummary(raw.current_state),
     current_location: raw.current_location ?? "",
     tags: (raw.tags ?? []).map(mapTagEntry),
@@ -291,6 +293,7 @@ export type UpdatePiecePayload = {
   name?: string;
   current_location?: string;
   thumbnail?: Thumbnail | null;
+  shared?: boolean;
   tags?: string[];
 };
 

--- a/web/src/util/types.ts
+++ b/web/src/util/types.ts
@@ -64,6 +64,8 @@ export type PieceState = components["schemas"]["PieceState"] & {
 // Piece list entry. Intersection narrows current_state to use our typed StateSummary.
 export type PieceSummary = components["schemas"]["PieceSummary"] & {
   current_state: StateSummary;
+  shared: boolean;
+  can_edit: boolean;
   tags: TagEntry[];
 };
 


### PR DESCRIPTION
## Summary

- Add a `shared` flag to pieces and expose share/read-only metadata in piece API responses.
- Allow public anonymous reads for shared pieces while keeping private pieces and all mutations owner-only.
- Add terminal-piece share controls for owners with copy link and native Web Share support.
- Render shared pieces read-only for anonymous users and authenticated non-owners.

Fixes #231

## Validation

- `rtk bazel test //api:api_test`
- `rtk bazel test //web:web_piece_detail_test //web:web_piece_detail_page_test //web:web_workflow_state_test`
- `rtk bazel test //...`
- `rtk bazel build --config=lint //...`

## Notes

- Sandboxed `rtk gh auth status` reported an invalid token, but the same command with escalated permissions succeeded. The CLI auth is valid outside the sandbox.