### PR TITLE
feat: include Cloudinary thumbnail in native web share

### DIFF
--- a/web/src/components/PieceShareControls.tsx
+++ b/web/src/components/PieceShareControls.tsx
@@ -4,8 +4,30 @@ import IosShareIcon from "@mui/icons-material/IosShare";
 import PublicIcon from "@mui/icons-material/Public";
 import PublicOffIcon from "@mui/icons-material/PublicOff";
 import { alpha, Box, Button, Stack, Typography } from "@mui/material";
-import type { PieceDetail } from "../util/types";
+import { Cloudinary } from "@cloudinary/url-gen";
+import { fill } from "@cloudinary/url-gen/actions/resize";
+import { format, quality } from "@cloudinary/url-gen/actions/delivery";
+import { jpg } from "@cloudinary/url-gen/qualifiers/format";
+import { auto as autoQuality } from "@cloudinary/url-gen/qualifiers/quality";
+import { autoGravity } from "@cloudinary/url-gen/qualifiers/gravity";
+import type { PieceDetail, Thumbnail } from "../util/types";
 import { updatePiece } from "../util/api";
+
+const SHARE_IMAGE_SIZE = 600;
+
+function buildThumbnailShareUrl(thumbnail: Thumbnail): string {
+  const cloudName = thumbnail.cloud_name?.trim() ?? null;
+  const publicId = thumbnail.cloudinary_public_id?.trim() ?? null;
+  if (cloudName && publicId) {
+    const cld = new Cloudinary({ cloud: { cloudName } });
+    const img = cld.image(publicId);
+    img.resize(fill().width(SHARE_IMAGE_SIZE).height(SHARE_IMAGE_SIZE).gravity(autoGravity()));
+    img.delivery(format(jpg()));
+    img.delivery(quality(autoQuality()));
+    return img.toURL();
+  }
+  return thumbnail.url;
+}
 
 function publicPieceUrl(pieceId: string): string {
   return `${window.location.origin}/pieces/${pieceId}`;
@@ -49,11 +71,21 @@ export default function ShareControls({
   async function shareLink() {
     if (!canUseNativeShare) return;
     try {
-      await navigator.share({
-        title: piece.name,
-        text: piece.name,
-        url: publicUrl,
-      });
+      const shareData: ShareData = { title: piece.name, text: piece.name, url: publicUrl };
+      if (piece.thumbnail) {
+        const imageUrl = buildThumbnailShareUrl(piece.thumbnail);
+        try {
+          const response = await fetch(imageUrl);
+          const blob = await response.blob();
+          const file = new File([blob], "thumbnail.jpg", { type: blob.type || "image/jpeg" });
+          if (navigator.canShare?.({ files: [file] })) {
+            shareData.files = [file];
+          }
+        } catch {
+          // Thumbnail fetch failure is non-fatal — share without the image.
+        }
+      }
+      await navigator.share(shareData);
     } catch {
       // Browser share sheets reject when the user cancels; no UI error needed.
     }

--- a/web/src/components/__tests__/PieceShareControls.test.tsx
+++ b/web/src/components/__tests__/PieceShareControls.test.tsx
@@ -132,7 +132,7 @@ describe("PieceShareControls", () => {
     expect(screen.getByRole("button", { name: "Copy link" })).toBeInTheDocument();
   });
 
-  it("uses the native share sheet when available", async () => {
+  it("uses the native share sheet when available (no thumbnail)", async () => {
     const share = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, "share", {
       value: share,
@@ -153,6 +153,100 @@ describe("PieceShareControls", () => {
         text: "Test Bowl",
         url: "http://localhost:3000/pieces/piece-id-1",
       }),
+    );
+  });
+
+  it("includes thumbnail file in native share when Cloudinary image is available", async () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    const canShare = vi.fn().mockReturnValue(true);
+    Object.defineProperty(navigator, "share", { value: share, configurable: true });
+    Object.defineProperty(navigator, "canShare", { value: canShare, configurable: true });
+
+    const mockBlob = new Blob(["img"], { type: "image/jpeg" });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ blob: () => Promise.resolve(mockBlob) }),
+    );
+
+    const thumbnail = {
+      url: "https://res.cloudinary.com/demo/image/upload/sample.jpg",
+      cloudinary_public_id: "sample",
+      cloud_name: "demo",
+    };
+
+    render(
+      <ShareControls
+        piece={makePiece({ shared: true, thumbnail })}
+        onPieceUpdated={vi.fn()}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Share" }));
+
+    await waitFor(() => expect(share).toHaveBeenCalled());
+    const shareData = share.mock.calls[0][0] as ShareData;
+    expect(shareData.files).toHaveLength(1);
+    expect((shareData.files![0] as File).name).toBe("thumbnail.jpg");
+  });
+
+  it("shares without files when thumbnail fetch fails", async () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    const canShare = vi.fn().mockReturnValue(true);
+    Object.defineProperty(navigator, "share", { value: share, configurable: true });
+    Object.defineProperty(navigator, "canShare", { value: canShare, configurable: true });
+
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network")));
+
+    const thumbnail = {
+      url: "https://res.cloudinary.com/demo/image/upload/sample.jpg",
+      cloudinary_public_id: "sample",
+      cloud_name: "demo",
+    };
+
+    render(
+      <ShareControls
+        piece={makePiece({ shared: true, thumbnail })}
+        onPieceUpdated={vi.fn()}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Share" }));
+
+    await waitFor(() =>
+      expect(share).toHaveBeenCalledWith(
+        expect.not.objectContaining({ files: expect.anything() }),
+      ),
+    );
+  });
+
+  it("shares without files when canShare rejects file sharing", async () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    const canShare = vi.fn().mockReturnValue(false);
+    Object.defineProperty(navigator, "share", { value: share, configurable: true });
+    Object.defineProperty(navigator, "canShare", { value: canShare, configurable: true });
+
+    const mockBlob = new Blob(["img"], { type: "image/jpeg" });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ blob: () => Promise.resolve(mockBlob) }),
+    );
+
+    const thumbnail = {
+      url: "https://res.cloudinary.com/demo/image/upload/sample.jpg",
+      cloudinary_public_id: "sample",
+      cloud_name: "demo",
+    };
+
+    render(
+      <ShareControls
+        piece={makePiece({ shared: true, thumbnail })}
+        onPieceUpdated={vi.fn()}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Share" }));
+
+    await waitFor(() =>
+      expect(share).toHaveBeenCalledWith(
+        expect.not.objectContaining({ files: expect.anything() }),
+      ),
     );
   });
 });


### PR DESCRIPTION
## Summary

- Builds a 600×600 Cloudinary fill-crop URL for the piece thumbnail before invoking `navigator.share()`
- Fetches the image as a `File` and passes it in `shareData.files` when `navigator.canShare({ files })` approves
- Falls back silently to URL-only share if the thumbnail fetch fails or file sharing is unsupported by the browser

## Test plan
- [ ] New tests in `PieceShareControls.test.tsx`: Cloudinary file included, fetch failure falls back, `canShare` rejection falls back
- [ ] All existing share control tests still pass
- [ ] `bazel test //web:web_piece_share_controls_test` passes

Closes #231
