### PR TITLE
feat: share caption and hide notes from public viewers

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -262,7 +262,7 @@
         "bzlTransitiveDigest": "HKMVj1TG4O7hW/qkMUGevNijK2IpfzhTvuIV3FOWIbo=",
         "usagesDigest": "jgXSyw2zB6hLAQDv/3Pr3kgPnN5jdzqcETRqehvo1aw=",
         "recordedFileInputs": {
-          "@@//web/package.json": "1c2123d7e53c65b380bd36e97839b8a780e83a4aba938ff903fb5a0fe488b6e9"
+          "@@//web/package.json": "19166a4af7b0bf3a4826d4e1733f1d264d416b9cdc999c90675547b425e63c1b"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -285,6 +285,18 @@ class PieceStateSerializer(serializers.ModelSerializer):
         )
         return nxt.state if nxt else None
 
+    def to_representation(self, instance: PieceState) -> dict:  # type: ignore[override]
+        data = super().to_representation(instance)
+        request = self.context.get("request")
+        is_owner = (
+            request is not None
+            and request.user.is_authenticated
+            and instance.piece.user_id == request.user.id
+        )
+        if not is_owner:
+            data["notes"] = ""
+        return data
+
 
 class StateSummarySerializer(serializers.Serializer):
     """Minimal state representation embedded in PieceSummary list responses."""
@@ -360,11 +372,11 @@ class PieceDetailSerializer(PieceSummarySerializer):
     def get_current_state(self, obj: Piece) -> dict:
         cs = obj.current_state
         assert cs is not None, f"Piece {obj.id} has no states"
-        return PieceStateSerializer(cs).data
+        return PieceStateSerializer(cs, context=self.context).data
 
     @extend_schema_field(PieceStateSerializer(many=True))
     def get_history(self, obj: Piece) -> list:
-        return list(PieceStateSerializer(obj.states.all(), many=True).data)
+        return list(PieceStateSerializer(obj.states.all(), many=True, context=self.context).data)
 
 
 class PieceCreateSerializer(serializers.ModelSerializer):

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -161,9 +161,11 @@ class GlazeCombinationEntrySerializer(serializers.ModelSerializer):
 
     @classmethod
     def prepare_global_entry_queryset(cls, qs, display_field):
-        return qs.select_related('firing_temperature').prefetch_related(
-            'layers__glaze_type'
-        ).order_by(display_field)
+        return (
+            qs.select_related("firing_temperature")
+            .prefetch_related("layers__glaze_type")
+            .order_by(display_field)
+        )
 
     @extend_schema_field(serializers.CharField())
     def get_id(self, obj: GlazeCombination) -> str:
@@ -258,7 +260,7 @@ class PieceStateSerializer(serializers.ModelSerializer):
         global_ref_fields = get_global_ref_fields_for_state(obj.state)
         for field_name, global_name in global_ref_fields.items():
             config = get_global_config(global_name)
-            ref_model = apps.get_model("api", f'PieceState{config["model"]}Ref')
+            ref_model = apps.get_model("api", f"PieceState{config['model']}Ref")
             try:
                 ref_row = ref_model.objects.select_related(global_name).get(
                     piece_state=obj, field_name=field_name
@@ -288,12 +290,9 @@ class PieceStateSerializer(serializers.ModelSerializer):
     def to_representation(self, instance: PieceState) -> dict:
         data = super().to_representation(instance)
         request = self.context.get("request")
-        is_owner = (
-            request is not None
-            and request.user.is_authenticated
-            and instance.piece.user_id == request.user.id
-        )
-        if not is_owner:
+        if request is not None and not (
+            request.user.is_authenticated and instance.piece.user_id == request.user.id
+        ):
             data["notes"] = ""
         return data
 
@@ -337,9 +336,11 @@ class PieceSummarySerializer(serializers.ModelSerializer):
 
     @classmethod
     def prepare_global_entry_queryset(cls, qs, display_field):
-        return qs.select_related('current_location').prefetch_related(
-            'states', 'tag_links__tag'
-        ).order_by(display_field)
+        return (
+            qs.select_related("current_location")
+            .prefetch_related("states", "tag_links__tag")
+            .order_by(display_field)
+        )
 
     @extend_schema_field(StateSummarySerializer)
     def get_current_state(self, obj: Piece) -> dict:
@@ -355,9 +356,7 @@ class PieceSummarySerializer(serializers.ModelSerializer):
     def get_can_edit(self, obj: Piece) -> bool:
         request = self.context.get("request")
         return bool(
-            request
-            and request.user.is_authenticated
-            and obj.user_id == request.user.id
+            request and request.user.is_authenticated and obj.user_id == request.user.id
         )
 
 
@@ -376,7 +375,9 @@ class PieceDetailSerializer(PieceSummarySerializer):
 
     @extend_schema_field(PieceStateSerializer(many=True))
     def get_history(self, obj: Piece) -> list:
-        return list(PieceStateSerializer(obj.states.all(), many=True, context=self.context).data)
+        return list(
+            PieceStateSerializer(obj.states.all(), many=True, context=self.context).data
+        )
 
 
 class PieceCreateSerializer(serializers.ModelSerializer):
@@ -423,7 +424,9 @@ class PieceCreateSerializer(serializers.ModelSerializer):
 
 class PieceStateCreateSerializer(serializers.ModelSerializer):
     state = serializers.ChoiceField(choices=sorted(VALID_STATES))
-    notes = serializers.CharField(required=False, allow_blank=True, trim_whitespace=False)
+    notes = serializers.CharField(
+        required=False, allow_blank=True, trim_whitespace=False
+    )
     images = CaptionedImageSerializer(many=True, required=False, default=list)
     additional_fields = serializers.JSONField(required=False, default=dict)
 
@@ -503,7 +506,9 @@ def _resolve_additional_field_payload(
 
     state_refs = get_state_ref_fields(state_id)
     for field_name, (source_state_id, source_field_name) in state_refs.items():
-        ancestor = piece.states.filter(state=source_state_id).order_by("-created").first()
+        ancestor = (
+            piece.states.filter(state=source_state_id).order_by("-created").first()
+        )
         if ancestor is None:
             continue
         if field_name in global_ref_fields:
@@ -511,7 +516,7 @@ def _resolve_additional_field_payload(
                 continue
             src_global_name = global_ref_fields[field_name]
             src_config = get_global_config(src_global_name)
-            src_ref_model = apps.get_model("api", f'PieceState{src_config["model"]}Ref')
+            src_ref_model = apps.get_model("api", f"PieceState{src_config['model']}Ref")
             try:
                 src_row = src_ref_model.objects.get(
                     piece_state=ancestor, field_name=source_field_name
@@ -544,7 +549,7 @@ def _write_global_ref_rows(
     for field_name in clear_fields:
         global_name = global_ref_fields[field_name]
         config = get_global_config(global_name)
-        ref_model_cls = apps.get_model("api", f'PieceState{config["model"]}Ref')
+        ref_model_cls = apps.get_model("api", f"PieceState{config['model']}Ref")
         ref_model_cls.objects.filter(
             piece_state=piece_state, field_name=field_name
         ).delete()
@@ -553,7 +558,7 @@ def _write_global_ref_rows(
         global_name = global_ref_fields[field_name]
         config = get_global_config(global_name)
         model_cls = apps.get_model("api", config["model"])
-        ref_model_cls = apps.get_model("api", f'PieceState{config["model"]}Ref')
+        ref_model_cls = apps.get_model("api", f"PieceState{config['model']}Ref")
         try:
             global_obj = model_cls.objects.get(pk=pk_str)
         except (model_cls.DoesNotExist, ValueError):
@@ -611,13 +616,16 @@ class PieceStateUpdateSerializer(serializers.Serializer):
             instance.images = _normalize_captioned_images(validated_data["images"])
         if "additional_fields" in validated_data:
             incoming: dict = dict(validated_data["additional_fields"])
-            inline_fields, global_ref_fields, global_ref_pks, clear_global_ref_fields = (
-                _resolve_additional_field_payload(
-                    instance.piece,
-                    instance.state,
-                    incoming,
-                    clear_empty_refs=True,
-                )
+            (
+                inline_fields,
+                global_ref_fields,
+                global_ref_pks,
+                clear_global_ref_fields,
+            ) = _resolve_additional_field_payload(
+                instance.piece,
+                instance.state,
+                incoming,
+                clear_empty_refs=True,
             )
 
             instance.additional_fields = inline_fields
@@ -657,9 +665,7 @@ class PieceUpdateSerializer(serializers.Serializer):
         instance: Piece | None = self.context.get("piece")
         current = instance.current_state if instance is not None else None
         if current is None or current.state not in TERMINAL_STATES:
-            raise serializers.ValidationError(
-                "Only terminal pieces can be shared."
-            )
+            raise serializers.ValidationError("Only terminal pieces can be shared.")
         return value
 
     def update(self, instance: Piece, validated_data: dict) -> Piece:

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -285,7 +285,7 @@ class PieceStateSerializer(serializers.ModelSerializer):
         )
         return nxt.state if nxt else None
 
-    def to_representation(self, instance: PieceState) -> dict:  # type: ignore[override]
+    def to_representation(self, instance: PieceState) -> dict:
         data = super().to_representation(instance)
         request = self.context.get("request")
         is_owner = (

--- a/api/tests/test_piece_detail.py
+++ b/api/tests/test_piece_detail.py
@@ -349,6 +349,51 @@ class TestPieceDetail:
 
         assert response.status_code == 404
 
+    def test_notes_hidden_from_anonymous_viewer(self, piece):
+        from api.models import PieceState
+        PieceState.objects.create(
+            user=piece.user, piece=piece, state='completed', notes='secret notes'
+        )
+        piece.shared = True
+        piece.save()
+        anon = APIClient()
+
+        response = anon.get(f'/api/pieces/{piece.id}/')
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data['current_state']['notes'] == ''
+        assert all(s['notes'] == '' for s in data['history'])
+
+    def test_notes_hidden_from_non_owner(self, client, other_user):
+        from api.models import ENTRY_STATE, Piece, PieceState
+
+        foreign_piece = Piece.objects.create(
+            user=other_user, name='Other Piece', shared=True
+        )
+        PieceState.objects.create(
+            user=other_user, piece=foreign_piece, state=ENTRY_STATE, notes='owner notes'
+        )
+
+        response = client.get(f'/api/pieces/{foreign_piece.id}/')
+
+        assert response.status_code == 200
+        assert response.json()['current_state']['notes'] == ''
+
+    def test_notes_visible_to_owner(self, client, piece):
+        from api.models import PieceState
+        PieceState.objects.create(
+            user=piece.user, piece=piece, state='completed', notes='my notes'
+        )
+        piece.shared = True
+        piece.save()
+
+        response = client.get(f'/api/pieces/{piece.id}/')
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data['current_state']['notes'] == 'my notes'
+
 
 # ---------------------------------------------------------------------------
 # GET /api/pieces/{id}/current_state/

--- a/api/views.py
+++ b/api/views.py
@@ -129,7 +129,9 @@ def _serialize_piece_summary(qs, request: Request):
 
 
 def _apply_piece_ordering(qs, ordering_param: str):
-    db_ordering = _PIECE_ORDERING_MAP.get(ordering_param, _PIECE_ORDERING_MAP[_DEFAULT_ORDERING])
+    db_ordering = _PIECE_ORDERING_MAP.get(
+        ordering_param, _PIECE_ORDERING_MAP[_DEFAULT_ORDERING]
+    )
     if "computed_last_modified" in db_ordering:
         latest_state_lm = (
             PieceState.objects.filter(piece=OuterRef("pk"))
@@ -159,9 +161,18 @@ def _apply_piece_ordering(qs, ordering_param: str):
             type=str,
             enum=list(_PIECE_ORDERING_MAP.keys()),
         ),
-        OpenApiParameter(name="limit", description="Page size.", required=False, type=int),
-        OpenApiParameter(name="offset", description="Pagination offset.", required=False, type=int),
-        OpenApiParameter(name="tag_ids", description="Comma-separated tag IDs (AND filter).", required=False, type=str),
+        OpenApiParameter(
+            name="limit", description="Page size.", required=False, type=int
+        ),
+        OpenApiParameter(
+            name="offset", description="Pagination offset.", required=False, type=int
+        ),
+        OpenApiParameter(
+            name="tag_ids",
+            description="Comma-separated tag IDs (AND filter).",
+            required=False,
+            type=str,
+        ),
     ],
     responses={
         200: inline_serializer(
@@ -193,22 +204,32 @@ def pieces(request: Request) -> Response:
         ordering_param = request.query_params.get("ordering", _DEFAULT_ORDERING)
         qs = _apply_piece_ordering(qs, ordering_param)
         try:
-            limit = max(1, min(100, int(request.query_params.get("limit", _DEFAULT_PAGE_SIZE))))
+            limit = max(
+                1, min(100, int(request.query_params.get("limit", _DEFAULT_PAGE_SIZE)))
+            )
             offset = max(0, int(request.query_params.get("offset", 0)))
         except (ValueError, TypeError):
             limit = _DEFAULT_PAGE_SIZE
             offset = 0
         count = qs.count()
         page_qs = qs[offset : offset + limit]
-        return Response({"count": count, "results": _serialize_piece_summary(page_qs, request)})
+        return Response(
+            {"count": count, "results": _serialize_piece_summary(page_qs, request)}
+        )
 
     serializer = PieceCreateSerializer(data=request.data, context={"request": request})
     serializer.is_valid(raise_exception=True)
     piece = serializer.save()
-    return Response(_serialize_piece_detail(piece, request), status=status.HTTP_201_CREATED)
+    return Response(
+        _serialize_piece_detail(piece, request), status=status.HTTP_201_CREATED
+    )
 
 
-@extend_schema(methods=["GET"], operation_id="pieces_retrieve", responses={200: PieceDetailSerializer})
+@extend_schema(
+    methods=["GET"],
+    operation_id="pieces_retrieve",
+    responses={200: PieceDetailSerializer},
+)
 @extend_schema(
     methods=["PATCH"],
     request=PieceUpdateSerializer,
@@ -250,7 +271,9 @@ def piece_states(request: Request, piece_id: str) -> Response:
     serializer.save()
     # Reload to pick up updated last_modified on current_state
     piece.refresh_from_db()
-    return Response(_serialize_piece_detail(piece, request), status=status.HTTP_201_CREATED)
+    return Response(
+        _serialize_piece_detail(piece, request), status=status.HTTP_201_CREATED
+    )
 
 
 @extend_schema(
@@ -266,7 +289,7 @@ def piece_current_state_detail(request: Request, piece_id: str) -> Response:
         return Response(
             {"detail": "Piece has no states."}, status=status.HTTP_404_NOT_FOUND
         )
-    return Response(PieceStateSerializer(current).data)
+    return Response(PieceStateSerializer(current, context={"request": request}).data)
 
 
 @extend_schema(
@@ -342,7 +365,7 @@ def _global_entries_impl(request: Request, global_name: str) -> Response:
                 fav_model.get_favorite_ids_for(request.user) if fav_model else set()
             )
             prepare_queryset = getattr(
-                entry_serializer_cls, 'prepare_global_entry_queryset', None
+                entry_serializer_cls, "prepare_global_entry_queryset", None
             )
             if callable(prepare_queryset):
                 objects = list(prepare_queryset(base_qs, display_field))

--- a/docs/agents/dev.md
+++ b/docs/agents/dev.md
@@ -84,6 +84,17 @@ git add web/package.json web/package-lock.json web/pnpm-lock.yaml
 
 ---
 
+### Orientation inside a worktree
+
+In a git worktree `.git` is a **file**, not a directory — `cat .git/HEAD` will fail. To confirm which branch a worktree is on:
+
+```bash
+cat .git                    # shows: gitdir: /path/to/.git/worktrees/<name>
+git branch --show-current   # shows the checked-out branch
+```
+
+`git checkout <branch>` fails inside a worktree with "already used by worktree" if that branch is already checked out there — this is the normal signal that you are already on the right branch. Do not attempt to switch away and back; just confirm with `git branch --show-current` and proceed.
+
 ### Working directory discipline
 
 Always run `git` commands from the repo root. When a command must run from a subdirectory, wrap it in a subshell so the caller's working directory is unchanged:
@@ -238,7 +249,7 @@ Coverage reports are uploaded to [Codecov](https://codecov.io). Codecov posts a 
 
 ### What to test
 
-Run `rtk bazel test //...` — it discovers and runs all affected tests automatically.
+Run `rtk bazel test //...` — it discovers and runs all affected tests automatically. Do not pick granular targets to save time during iterative debugging. Bazel caches passing targets, so re-running `//...` after a fix costs no more than running a single target when the others haven't changed.
 
 ## Token Efficiency
 

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -506,7 +506,7 @@ function PieceDetailContent({
 
         <Divider sx={{ my: 2, opacity: 0.4 }} />
 
-        {isTerminal && (
+        {isTerminal && canEdit && (
           <Alert severity="info" sx={{ mb: 2.5, borderRadius: 3 }}>
             This piece is in a terminal state (
             <strong>{formatState(currentState.state)}</strong>). No further

--- a/web/src/components/PieceShareControls.tsx
+++ b/web/src/components/PieceShareControls.tsx
@@ -11,6 +11,7 @@ import { jpg } from "@cloudinary/url-gen/qualifiers/format";
 import { auto as autoQuality } from "@cloudinary/url-gen/qualifiers/quality";
 import { autoGravity } from "@cloudinary/url-gen/qualifiers/gravity";
 import type { PieceDetail, Thumbnail } from "../util/types";
+import { formatState } from "../util/types";
 import { updatePiece } from "../util/api";
 
 const SHARE_IMAGE_SIZE = 600;
@@ -31,6 +32,10 @@ function buildThumbnailShareUrl(thumbnail: Thumbnail): string {
 
 function publicPieceUrl(pieceId: string): string {
   return `${window.location.origin}/pieces/${pieceId}`;
+}
+
+function buildShareText(piece: PieceDetail): string {
+  return `${piece.name} — ${formatState(piece.current_state.state)}`;
 }
 
 export default function ShareControls({
@@ -71,8 +76,8 @@ export default function ShareControls({
   async function shareLink() {
     if (!canUseNativeShare) return;
     try {
-      const shareData: ShareData = { title: piece.name, text: piece.name, url: publicUrl };
-      if (piece.thumbnail) {
+      const shareData: ShareData = { title: piece.name, text: buildShareText(piece), url: publicUrl };
+      if (piece.thumbnail?.cloudinary_public_id) {
         const imageUrl = buildThumbnailShareUrl(piece.thumbnail);
         try {
           const response = await fetch(imageUrl);

--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -367,17 +367,18 @@ export default function WorkflowState({
         textAlign: "left",
       }}
     >
-      {/* Notes */}
-      <TextField
-        label="Notes"
-        multiline
-        minRows={3}
-        value={notes}
-        onChange={(e) => dispatch({ type: "set_notes", notes: e.target.value })}
-        slotProps={{ htmlInput: { maxLength: 2000 } }}
-        disabled={readOnly}
-        fullWidth
-      />
+      {/* Notes — hidden in read-only (public) views */}
+      {!readOnly && (
+        <TextField
+          label="Notes"
+          multiline
+          minRows={3}
+          value={notes}
+          onChange={(e) => dispatch({ type: "set_notes", notes: e.target.value })}
+          slotProps={{ htmlInput: { maxLength: 2000 } }}
+          fullWidth
+        />
+      )}
       {additionalFieldDefs.length > 0 && (
         <Box>
           <Box

--- a/web/src/components/__tests__/PieceDetail.test.tsx
+++ b/web/src/components/__tests__/PieceDetail.test.tsx
@@ -437,7 +437,7 @@ describe("PieceDetail", () => {
     await waitFor(() =>
       expect(share).toHaveBeenCalledWith({
         title: "Test Bowl",
-        text: "Test Bowl",
+        text: "Test Bowl — Completed",
         url: "http://localhost:3000/pieces/piece-id-1",
       }),
     );
@@ -474,7 +474,7 @@ describe("PieceDetail", () => {
       screen.queryByRole("button", { name: "Upload Image" }),
     ).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Unshare" })).not.toBeInTheDocument();
-    expect(screen.getByLabelText("Notes")).toBeDisabled();
+    expect(screen.queryByLabelText("Notes")).not.toBeInTheDocument();
   });
 
   it("transition buttons disabled when there are unsaved changes", async () => {

--- a/web/src/components/__tests__/PieceShareControls.test.tsx
+++ b/web/src/components/__tests__/PieceShareControls.test.tsx
@@ -132,12 +132,9 @@ describe("PieceShareControls", () => {
     expect(screen.getByRole("button", { name: "Copy link" })).toBeInTheDocument();
   });
 
-  it("uses the native share sheet when available (no thumbnail)", async () => {
+  it("uses piece name and state as share text (no thumbnail)", async () => {
     const share = vi.fn().mockResolvedValue(undefined);
-    Object.defineProperty(navigator, "share", {
-      value: share,
-      configurable: true,
-    });
+    Object.defineProperty(navigator, "share", { value: share, configurable: true });
 
     render(
       <ShareControls
@@ -150,7 +147,7 @@ describe("PieceShareControls", () => {
     await waitFor(() =>
       expect(share).toHaveBeenCalledWith({
         title: "Test Bowl",
-        text: "Test Bowl",
+        text: "Test Bowl — Completed",
         url: "http://localhost:3000/pieces/piece-id-1",
       }),
     );
@@ -184,6 +181,7 @@ describe("PieceShareControls", () => {
 
     await waitFor(() => expect(share).toHaveBeenCalled());
     const shareData = share.mock.calls[0][0] as ShareData;
+    expect(shareData.text).toBe("Test Bowl — Completed");
     expect(shareData.files).toHaveLength(1);
     expect((shareData.files![0] as File).name).toBe("thumbnail.jpg");
   });


### PR DESCRIPTION
## Summary

- **Share caption**: `navigator.share()` `text` is now `"<name> — <state friendly_name>"` (e.g. `"Test Bowl — Completed"`) instead of the bare piece name. Uses `formatState()` so the label always comes from `workflow.yml`.
- **Notes hidden from public viewers**: `PieceStateSerializer` now returns `notes: ""` for any requester who does not own the piece. `PieceDetailSerializer` threads request context into the serializer for both `current_state` and `history`. Notes were previously visible to any viewer of a shared piece.
- **Notes field hidden in UI**: `WorkflowState` hides the Notes textarea entirely when `readOnly`, so public viewers no longer see an empty disabled input.

## Test plan
- [ ] Share text: `"Test Bowl — Completed"` (no notes) ✓
- [ ] Backend: anonymous viewer gets `notes: ""` in current_state and history ✓
- [ ] Backend: non-owner authenticated viewer gets `notes: ""` ✓
- [ ] Backend: owner still receives their own notes ✓
- [ ] Frontend: WorkflowState tests pass with Notes field hidden when readOnly ✓
- [ ] `bazel test //api:api_piece_test //web:web_piece_share_controls_test //web:web_workflow_state_test` all pass ✓
