### PR TITLE
feat: lightbox carousel swipe + indicator dots + image preloading

### DIFF
--- a/docs/agents/dev.md
+++ b/docs/agents/dev.md
@@ -64,6 +64,26 @@ This keeps worktrees close to the repo-local bootstrap, makes cleanup easier, an
 
 When you do want a truly separate dependency environment inside the worktree, run `gz_setup --isolated` to replace any shared `.venv` or `web/node_modules` symlinks with local worktree-specific installs.
 
+### Updating pnpm-lock.yaml after npm installs
+
+Bazel resolves npm packages from `web/pnpm-lock.yaml`. After any `npm install` that adds or removes packages, regenerate the lockfile with `pnpm import` so Bazel picks up the change:
+
+```bash
+# Install the package normally (from the repo root or web/ — npm resolves via web/package.json)
+(cd web && npm install react-swipeable)
+
+# Regenerate the pnpm lockfile from the updated package-lock.json
+# pnpm must be run from web/ where package.json and pnpm-lock.yaml live
+(cd web && pnpm import)
+
+# Commit both the updated package files
+git add web/package.json web/package-lock.json web/pnpm-lock.yaml
+```
+
+`pnpm` is available at `~/.nvm/versions/node/*/bin/pnpm` when nvm is active. If `env-agent.sh` has sourced `.nvm/nvm.sh`, the `pnpm` binary is on `$PATH` and the `(cd web && pnpm import)` subshell inherits it.
+
+---
+
 ### Working directory discipline
 
 Always run `git` commands from the repo root. When a command must run from a subdirectory, wrap it in a subshell so the caller's working directory is unchanged:

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -23,6 +23,7 @@
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.14.0",
         "react-sketch-canvas": "^6.2.0",
+        "react-swipeable": "^7.0.2",
         "tesseract.js": "^7.0.0"
       },
       "devDependencies": {
@@ -5364,6 +5365,15 @@
       },
       "peerDependencies": {
         "react": ">=16.8"
+      }
+    },
+    "node_modules/react-swipeable": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-7.0.2.tgz",
+      "integrity": "sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/react-transition-group": {

--- a/web/package.json
+++ b/web/package.json
@@ -28,6 +28,7 @@
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.14.0",
     "react-sketch-canvas": "^6.2.0",
+    "react-swipeable": "^7.0.2",
     "tesseract.js": "^7.0.0"
   },
   "devDependencies": {

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       react-sketch-canvas:
         specifier: ^6.2.0
         version: 6.2.0(react@19.2.4)
+      react-swipeable:
+        specifier: ^7.0.2
+        version: 7.0.2(react@19.2.4)
       tesseract.js:
         specifier: ^7.0.0
         version: 7.0.0
@@ -1871,6 +1874,11 @@ packages:
     peerDependencies:
       react: '>=16.8'
 
+  react-swipeable@7.0.2:
+    resolution: {integrity: sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==}
+    peerDependencies:
+      react: ^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc
+
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
     peerDependencies:
@@ -1992,6 +2000,10 @@ packages:
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
@@ -3051,7 +3063,7 @@ snapshots:
       debug: 4.4.3(supports-color@10.2.2)
       minimatch: 10.2.5
       semver: 7.7.4
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.15
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -3994,6 +4006,10 @@ snapshots:
     dependencies:
       react: 19.2.4
 
+  react-swipeable@7.0.2(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
   react-transition-group@4.4.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@babel/runtime': 7.29.2
@@ -4115,6 +4131,11 @@ snapshots:
 
   tinyexec@1.1.1: {}
 
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -4217,7 +4238,7 @@ snapshots:
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.1.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
       vite: 8.0.10(@types/node@24.12.2)
       why-is-node-running: 2.3.0

--- a/web/src/components/ImageLightbox.tsx
+++ b/web/src/components/ImageLightbox.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useState } from "react";
 import {
   Box,
   Button,
@@ -7,8 +7,11 @@ import {
   Modal,
   Typography,
 } from "@mui/material";
+import { useSwipeable } from "react-swipeable";
 import type { CaptionedImage } from "../util/types";
 import CloudinaryImage from "./CloudinaryImage";
+
+const SWIPE_THRESHOLD = 50;
 
 type ImageLightboxProps = {
   images: CaptionedImage[];
@@ -28,10 +31,8 @@ export default function ImageLightbox({
   footerActions,
 }: ImageLightboxProps) {
   const [index, setIndex] = useState(initialIndex);
+  const [dragDeltaX, setDragDeltaX] = useState(0);
   const [settingThumbnail, setSettingThumbnail] = useState(false);
-  const isTouchDevice =
-    "ontouchstart" in window || navigator.maxTouchPoints > 0;
-  const touchStartX = useRef<number | null>(null);
 
   function prev() {
     setIndex((i) => (i > 0 ? i - 1 : i));
@@ -40,16 +41,31 @@ export default function ImageLightbox({
     setIndex((i) => (i < images.length - 1 ? i + 1 : i));
   }
 
-  function handleTouchStart(e: React.TouchEvent) {
-    touchStartX.current = e.touches[0].clientX;
-  }
-  function handleTouchEnd(e: React.TouchEvent) {
-    if (touchStartX.current === null) return;
-    const delta = e.changedTouches[0].clientX - touchStartX.current;
-    if (delta > 50) prev();
-    else if (delta < -50) next();
-    touchStartX.current = null;
-  }
+  const swipeHandlers = useSwipeable({
+    onSwiping: ({ deltaX, dir }) => {
+      // Resist at boundaries — dampen drag past the first/last image
+      if ((index === 0 && dir === "Right") || (index === images.length - 1 && dir === "Left")) {
+        setDragDeltaX(deltaX * 0.25);
+      } else {
+        setDragDeltaX(deltaX);
+      }
+    },
+    onSwipedLeft: ({ absX }) => {
+      setDragDeltaX(0);
+      if (absX >= SWIPE_THRESHOLD) next();
+    },
+    onSwipedRight: ({ absX }) => {
+      setDragDeltaX(0);
+      if (absX >= SWIPE_THRESHOLD) prev();
+    },
+    onTouchEndOrOnMouseUp: () => {
+      setDragDeltaX(0);
+    },
+    trackMouse: false,
+    trackTouch: true,
+    delta: 10,
+    preventScrollOnSwipe: true,
+  });
 
   const image = images[index];
   const isCurrentThumbnail =
@@ -73,9 +89,8 @@ export default function ImageLightbox({
       slotProps={{ backdrop: { sx: { backgroundColor: "rgba(0,0,0,0.92)" } } }}
     >
       <Box
+        data-testid="lightbox-backdrop"
         onClick={onClose}
-        onTouchStart={handleTouchStart}
-        onTouchEnd={handleTouchEnd}
         sx={{
           position: "fixed",
           inset: 0,
@@ -87,20 +102,37 @@ export default function ImageLightbox({
           outline: "none",
         }}
       >
-        <CloudinaryImage
-          url={image.url}
-          cloud_name={image.cloud_name}
-          cloudinary_public_id={image.cloudinary_public_id}
-          alt={image.caption || "Pottery image"}
-          context="lightbox"
-          style={{
-            maxWidth: "90vw",
-            maxHeight: "80vh",
-            objectFit: "contain",
-            borderRadius: 4,
-            userSelect: "none",
-          }}
-        />
+        {/* Swipeable image area */}
+        <Box
+          {...swipeHandlers}
+          data-testid="lightbox-swipe-area"
+          onClick={(e) => e.stopPropagation()}
+          sx={{ touchAction: "pan-y", cursor: images.length > 1 ? "grab" : undefined }}
+        >
+          <Box
+            sx={{
+              transform: `translateX(${dragDeltaX}px)`,
+              transition: dragDeltaX === 0 ? "transform 0.25s ease" : "none",
+            }}
+          >
+            <CloudinaryImage
+              url={image.url}
+              cloud_name={image.cloud_name}
+              cloudinary_public_id={image.cloudinary_public_id}
+              alt={image.caption || "Pottery image"}
+              context="lightbox"
+              style={{
+                maxWidth: "90vw",
+                maxHeight: "80vh",
+                objectFit: "contain",
+                borderRadius: 4,
+                userSelect: "none",
+                pointerEvents: "none",
+              }}
+            />
+          </Box>
+        </Box>
+
         {footerActions && (
           <Box onClick={(e) => e.stopPropagation()}>{footerActions(index)}</Box>
         )}
@@ -126,34 +158,77 @@ export default function ImageLightbox({
             </Button>
           </Box>
         )}
-        {!isTouchDevice && images.length > 1 && (
+
+        {/* Navigation — arrows on non-touch, dots always when multiple images */}
+        {images.length > 1 && (
           <Box
             onClick={(e) => e.stopPropagation()}
-            sx={{ display: "flex", gap: 2 }}
+            sx={{ display: "flex", alignItems: "center", gap: 1 }}
           >
             <IconButton
               onClick={prev}
               disabled={index === 0}
-              sx={{ color: "white", fontSize: "1.5rem" }}
+              sx={{
+                color: "white",
+                fontSize: "1.5rem",
+                display: { xs: "none", sm: "inline-flex" },
+              }}
               aria-label="previous image"
             >
               ←
             </IconButton>
-            <Typography
-              variant="body2"
-              sx={{ color: "rgba(255,255,255,0.6)", alignSelf: "center" }}
-            >
-              {index + 1} / {images.length}
-            </Typography>
+
+            {/* Indicator dots */}
+            <Box sx={{ display: "flex", gap: 0.75, alignItems: "center" }}>
+              {images.map((_, i) => (
+                <Box
+                  key={i}
+                  onClick={() => setIndex(i)}
+                  sx={{
+                    width: i === index ? 10 : 7,
+                    height: i === index ? 10 : 7,
+                    borderRadius: "50%",
+                    backgroundColor:
+                      i === index
+                        ? "white"
+                        : "rgba(255,255,255,0.35)",
+                    cursor: "pointer",
+                    transition: "all 0.2s ease",
+                    flexShrink: 0,
+                  }}
+                  role="button"
+                  aria-label={`Go to image ${i + 1}`}
+                />
+              ))}
+            </Box>
+
             <IconButton
               onClick={next}
               disabled={index === images.length - 1}
-              sx={{ color: "white", fontSize: "1.5rem" }}
+              sx={{
+                color: "white",
+                fontSize: "1.5rem",
+                display: { xs: "none", sm: "inline-flex" },
+              }}
               aria-label="next image"
             >
               →
             </IconButton>
           </Box>
+        )}
+
+        {/* Counter — non-touch only, alongside arrows */}
+        {images.length > 1 && (
+          <Typography
+            variant="body2"
+            sx={{
+              color: "rgba(255,255,255,0.5)",
+              mt: -1.5,
+              display: { xs: "none", sm: "block" },
+            }}
+          >
+            {index + 1} / {images.length}
+          </Typography>
         )}
       </Box>
     </Modal>

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -1,4 +1,4 @@
-import { type ComponentProps, type ReactNode, useRef, useState } from "react";
+import { type ComponentProps, type ReactNode, useEffect, useRef, useState } from "react";
 import {
   Alert,
   alpha,
@@ -169,6 +169,24 @@ function PieceDetailContent({
   } as const;
 
   const blocker = useBlocker(canEdit && isDirty);
+
+  // Preload all piece images aggressively: hero first, then the rest async.
+  useEffect(() => {
+    const heroUrl = piece.thumbnail?.url;
+    const galleryUrls = galleryImages.map((img) => img.url).filter(Boolean);
+    // Prioritize hero, then background-load the rest.
+    const ordered = heroUrl
+      ? [heroUrl, ...galleryUrls.filter((u) => u !== heroUrl)]
+      : galleryUrls;
+    ordered.forEach((url, i) => {
+      const img = new Image();
+      if (i === 0) img.fetchPriority = "high";
+      img.src = url;
+    });
+  // galleryImages is recomputed every render but its identity changes with piece,
+  // so depend only on piece to avoid re-running on every render.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [piece]);
 
   async function handleTransition(nextState: string) {
     setTransitioning(true);

--- a/web/src/components/__tests__/ImageLightbox.test.tsx
+++ b/web/src/components/__tests__/ImageLightbox.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ImageLightbox from "../ImageLightbox";
@@ -34,12 +34,6 @@ function renderLightbox(
   };
 }
 
-// jsdom has `ontouchstart` in window by default, making isTouchDevice always true.
-// Remove it before each test so the component sees a non-touch device unless explicitly changed.
-beforeEach(() => {
-  delete (window as Window & { ontouchstart?: unknown }).ontouchstart;
-});
-
 describe("ImageLightbox", () => {
   describe("image display", () => {
     it("renders the image at initialIndex", () => {
@@ -56,9 +50,7 @@ describe("ImageLightbox", () => {
 
     it("does not show a caption element when caption is empty", () => {
       const { container } = renderLightbox(THREE_IMAGES, 2);
-      // Image renders but no Typography caption should be present
       expect(screen.getByRole("img")).toHaveAttribute("src", "/img/c.jpg");
-      // The only <p> elements are from MUI structure, none containing caption text
       const paragraphs = container.querySelectorAll("p");
       paragraphs.forEach((p) => expect(p.textContent).not.toBe(""));
     });
@@ -70,7 +62,7 @@ describe("ImageLightbox", () => {
   });
 
   describe("navigation", () => {
-    it("shows prev/next buttons for multiple images on non-touch device", () => {
+    it("shows prev/next buttons for multiple images", () => {
       renderLightbox(THREE_IMAGES, 1);
       expect(
         screen.getByRole("button", { name: /previous image/i }),
@@ -130,7 +122,6 @@ describe("ImageLightbox", () => {
 
     it("shows image counter with current position and total", () => {
       renderLightbox(THREE_IMAGES, 1);
-      // Counter text may be split across text nodes; match by combined textContent
       const counter = screen.getByText((_, el) => el?.textContent === "2 / 3");
       expect(counter).toBeInTheDocument();
     });
@@ -149,11 +140,32 @@ describe("ImageLightbox", () => {
     });
   });
 
+  describe("indicator dots", () => {
+    it("shows one dot per image when there are multiple images", () => {
+      renderLightbox(THREE_IMAGES, 0);
+      expect(
+        screen.getAllByRole("button", { name: /go to image/i }),
+      ).toHaveLength(3);
+    });
+
+    it("does not show indicator dots for a single image", () => {
+      renderLightbox(ONE_IMAGE, 0);
+      expect(
+        screen.queryByRole("button", { name: /go to image/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("clicking a dot navigates to that image", () => {
+      renderLightbox(THREE_IMAGES, 0);
+      fireEvent.click(screen.getByRole("button", { name: "Go to image 3" }));
+      expect(screen.getByRole("img")).toHaveAttribute("src", "/img/c.jpg");
+    });
+  });
+
   describe("close behavior", () => {
     it("calls onClose when backdrop is clicked", () => {
       const { onClose } = renderLightbox(THREE_IMAGES, 0);
-      // The outer Box has onClick={onClose}; click parent of the <img>
-      fireEvent.click(screen.getByRole("img").parentElement!);
+      fireEvent.click(screen.getByTestId("lightbox-backdrop"));
       expect(onClose).toHaveBeenCalledOnce();
     });
 
@@ -178,69 +190,52 @@ describe("ImageLightbox", () => {
   });
 
   describe("touch swipe", () => {
-    beforeEach(() => {
-      Object.defineProperty(navigator, "maxTouchPoints", {
-        value: 1,
-        configurable: true,
-        writable: true,
-      });
-    });
-
-    afterEach(() => {
-      Object.defineProperty(navigator, "maxTouchPoints", {
-        value: 0,
-        configurable: true,
-        writable: true,
-      });
-    });
-
-    it("hides nav buttons on touch device", () => {
-      renderLightbox(THREE_IMAGES, 1);
-      expect(
-        screen.queryByRole("button", { name: /previous image/i }),
-      ).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole("button", { name: /next image/i }),
-      ).not.toBeInTheDocument();
-    });
+    function getSwipeArea() {
+      return screen.getByTestId("lightbox-swipe-area");
+    }
 
     it("swipe right (positive delta > 50px) navigates to previous image", () => {
       renderLightbox(THREE_IMAGES, 1);
-      const box = screen.getByRole("img").parentElement!;
-      fireEvent.touchStart(box, { touches: [{ clientX: 200 }] });
-      fireEvent.touchEnd(box, { changedTouches: [{ clientX: 260 }] });
+      const area = getSwipeArea();
+      fireEvent.touchStart(area, { touches: [{ clientX: 200, clientY: 0 }] });
+      fireEvent.touchMove(area, { touches: [{ clientX: 260, clientY: 0 }] });
+      fireEvent.touchEnd(area, { changedTouches: [{ clientX: 260, clientY: 0 }] });
       expect(screen.getByRole("img")).toHaveAttribute("src", "/img/a.jpg");
     });
 
     it("swipe left (negative delta > 50px) navigates to next image", () => {
       renderLightbox(THREE_IMAGES, 1);
-      const box = screen.getByRole("img").parentElement!;
-      fireEvent.touchStart(box, { touches: [{ clientX: 200 }] });
-      fireEvent.touchEnd(box, { changedTouches: [{ clientX: 140 }] });
+      const area = getSwipeArea();
+      fireEvent.touchStart(area, { touches: [{ clientX: 200, clientY: 0 }] });
+      fireEvent.touchMove(area, { touches: [{ clientX: 140, clientY: 0 }] });
+      fireEvent.touchEnd(area, { changedTouches: [{ clientX: 140, clientY: 0 }] });
       expect(screen.getByRole("img")).toHaveAttribute("src", "/img/c.jpg");
     });
 
     it("small swipe (< 50px) does not navigate", () => {
       renderLightbox(THREE_IMAGES, 1);
-      const box = screen.getByRole("img").parentElement!;
-      fireEvent.touchStart(box, { touches: [{ clientX: 200 }] });
-      fireEvent.touchEnd(box, { changedTouches: [{ clientX: 230 }] });
+      const area = getSwipeArea();
+      fireEvent.touchStart(area, { touches: [{ clientX: 200, clientY: 0 }] });
+      fireEvent.touchMove(area, { touches: [{ clientX: 230, clientY: 0 }] });
+      fireEvent.touchEnd(area, { changedTouches: [{ clientX: 230, clientY: 0 }] });
       expect(screen.getByRole("img")).toHaveAttribute("src", "/img/b.jpg");
     });
 
     it("swipe does not go past the first image", () => {
       renderLightbox(THREE_IMAGES, 0);
-      const box = screen.getByRole("img").parentElement!;
-      fireEvent.touchStart(box, { touches: [{ clientX: 200 }] });
-      fireEvent.touchEnd(box, { changedTouches: [{ clientX: 260 }] });
+      const area = getSwipeArea();
+      fireEvent.touchStart(area, { touches: [{ clientX: 200, clientY: 0 }] });
+      fireEvent.touchMove(area, { touches: [{ clientX: 260, clientY: 0 }] });
+      fireEvent.touchEnd(area, { changedTouches: [{ clientX: 260, clientY: 0 }] });
       expect(screen.getByRole("img")).toHaveAttribute("src", "/img/a.jpg");
     });
 
     it("swipe does not go past the last image", () => {
       renderLightbox(THREE_IMAGES, 2);
-      const box = screen.getByRole("img").parentElement!;
-      fireEvent.touchStart(box, { touches: [{ clientX: 200 }] });
-      fireEvent.touchEnd(box, { changedTouches: [{ clientX: 140 }] });
+      const area = getSwipeArea();
+      fireEvent.touchStart(area, { touches: [{ clientX: 200, clientY: 0 }] });
+      fireEvent.touchMove(area, { touches: [{ clientX: 140, clientY: 0 }] });
+      fireEvent.touchEnd(area, { changedTouches: [{ clientX: 140, clientY: 0 }] });
       expect(screen.getByRole("img")).toHaveAttribute("src", "/img/c.jpg");
     });
   });


### PR DESCRIPTION
## Summary

- **#238 — Lightbox carousel drag-with-snap**: replaces hand-rolled `onTouchStart`/`onTouchEnd` with `react-swipeable` (`useSwipeable`). Dragging the image translates it in real time; releasing past 50 px snaps to the adjacent image. A rubber-band resistance effect kicks in at the first/last image so the boundary is obvious without an abrupt stop. Arrow buttons remain for keyboard/mouse users but are hidden on xs (mobile) via CSS breakpoint.
- **#238 — Indicator dots**: always visible when there are multiple images (both touch and non-touch). Each dot is a tappable/clickable target. The active dot is larger and fully white; inactive dots are smaller and muted. This gives mobile users a clear position indicator without requiring additional text below the image.
- **#240 — Aggressive image preloading**: on mount, `PieceDetailContent` fires `new Image()` for every image URL across all history states. The hero/thumbnail is requested first with `fetchPriority = "high"`; the rest are enqueued immediately after. This warms the CDN cache before the user opens the lightbox, minimizing spinner time.

## Test plan

- [ ] Open a piece with 3+ images in the lightbox on desktop — arrow buttons and `N / M` counter work as before
- [ ] On mobile, swipe left/right — image snaps to next/previous; dragging past the boundary shows resistance
- [ ] Tap indicator dots to jump directly to an image
- [ ] Open a piece with many images — check network tab: all image URLs are fetched immediately on page load, hero first
- [ ] Single-image piece: no dots, no arrows; lightbox opens and closes normally
- [ ] `npm test` passes (pre-existing `uses native share` failure is unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
