### PR TITLE
[codex] Fix public piece share metadata

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -262,7 +262,7 @@
         "bzlTransitiveDigest": "HKMVj1TG4O7hW/qkMUGevNijK2IpfzhTvuIV3FOWIbo=",
         "usagesDigest": "jgXSyw2zB6hLAQDv/3Pr3kgPnN5jdzqcETRqehvo1aw=",
         "recordedFileInputs": {
-          "@@//web/package.json": "776fc8afbb1df635090fc6a36d1e5aaecf60a5b675e3272950381cfe54883cb8"
+          "@@//web/package.json": "7758caadb18a07fe2b9e5a5f1c35ace106b3c5b4e766ecc4b487f2703990b261"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -941,7 +941,7 @@
           "@@rules_python~//tools/publish/requirements_linux.txt": "d576e0d8542df61396a9b38deeaa183c24135ed5e8e73bb9622f298f2671811e",
           "@@rules_fuzzing~//fuzzing/requirements.txt": "ab04664be026b632a0d2a2446c4f65982b7654f5b6851d2f9d399a19b7242a5b",
           "@@rules_python~//tools/publish/requirements_windows.txt": "d18538a3982beab378fd5687f4db33162ee1ece69801f9a451661b1b64286b76",
-          "@@//requirements.lock": "db82c616c10d523454e50ebba0a0baf4c3b645c18eb81e6c999be7dae6cd4cb4",
+          "@@//requirements.lock": "0c9f40969f3f9faa90a3aa27d562bd2f102fde69cefafc18066a933713ae9abb",
           "@@protobuf~//python/requirements.txt": "983be60d3cec4b319dcab6d48aeb3f5b2f7c3350f26b3a9e97486c37967c73c5",
           "@@rules_python~//tools/publish/requirements_darwin.txt": "095d4a4f3d639dce831cd493367631cd51b53665292ab20194bac2c0c6458fa8"
         },
@@ -1109,6 +1109,16 @@
               "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
               "repo": "pip_312",
               "requirement": "django-import-export==4.3.9 --hash=sha256:3d83b1c28f30935240ef9d914a1d4845c6fcaf5c7e5454889dda800eb5d374fb --hash=sha256:966e01c2cbd6acda710a0a0097cd99b28d4f9883abbfbbf712f34a2e8eea8809"
+            }
+          },
+          "pip_312_django_meta": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "pip_312",
+              "requirement": "django-meta==2.5.1 --hash=sha256:0699e585444d59286c25bc301b865e56814e2473a069cd1046840669204cec2a --hash=sha256:35941347c39fa69139cdede3fe39f408330eb586819c7a9c4610991479e1ae57"
             }
           },
           "pip_312_django_stubs": {
@@ -4225,6 +4235,7 @@
                 "django_admin_sortable2": "{\"pip_312_django_admin_sortable2\":[{\"version\":\"3.12\"}]}",
                 "django_cors_headers": "{\"pip_312_django_cors_headers\":[{\"version\":\"3.12\"}]}",
                 "django_import_export": "{\"pip_312_django_import_export\":[{\"version\":\"3.12\"}]}",
+                "django_meta": "{\"pip_312_django_meta\":[{\"version\":\"3.12\"}]}",
                 "django_stubs": "{\"pip_312_django_stubs\":[{\"version\":\"3.12\"}]}",
                 "django_stubs_ext": "{\"pip_312_django_stubs_ext\":[{\"version\":\"3.12\"}]}",
                 "djangorestframework": "{\"pip_312_djangorestframework\":[{\"version\":\"3.12\"}]}",
@@ -4292,6 +4303,7 @@
                 "django_admin_sortable2",
                 "django_cors_headers",
                 "django_import_export",
+                "django_meta",
                 "django_stubs",
                 "django_stubs_ext",
                 "djangorestframework",

--- a/api/tests/test_piece_detail.py
+++ b/api/tests/test_piece_detail.py
@@ -396,6 +396,68 @@ class TestPieceDetail:
 
 
 # ---------------------------------------------------------------------------
+# GET /pieces/{id}
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestPublicPieceMetadata:
+    def test_shared_piece_spa_response_includes_open_graph_metadata(
+        self, client, piece, tmp_path, monkeypatch
+    ):
+        import backend.urls
+
+        index_html = tmp_path / 'index.html'
+        index_html.write_text(
+            '<html><head><title>PotterDoc</title></head><body></body></html>',
+            encoding='utf-8',
+        )
+        monkeypatch.setattr(backend.urls, '_INDEX_HTML', index_html)
+        PieceState.objects.create(user=piece.user, piece=piece, state='completed')
+        piece.thumbnail = {
+            'url': 'https://res.cloudinary.com/demo/image/upload/sample.jpg',
+            'cloudinary_public_id': 'pieces/sample',
+            'cloud_name': 'demo',
+        }
+        piece.shared = True
+        piece.save()
+
+        response = client.get(f'/pieces/{piece.id}')
+
+        assert response.status_code == 200
+        html = response.content.decode()
+        assert '<title>Test Bowl - Completed</title>' in html
+        assert '<meta property="og:title" content="Test Bowl - Completed">' in html
+        assert (
+            '<meta property="og:url" content="http://testserver/pieces/'
+            f'{piece.id}">'
+        ) in html
+        assert (
+            'https://res.cloudinary.com/demo/image/upload/'
+            'c_fill,g_auto,h_600,q_auto,w_600,f_jpg/pieces/sample.jpg'
+        ) in html
+        assert '<meta name="twitter:card" content="summary_large_image">' in html
+
+    def test_private_piece_spa_response_uses_default_metadata(
+        self, client, piece, tmp_path, monkeypatch
+    ):
+        import backend.urls
+
+        index_html = tmp_path / 'index.html'
+        index_html.write_text(
+            '<html><head><title>PotterDoc</title></head><body></body></html>',
+            encoding='utf-8',
+        )
+        monkeypatch.setattr(backend.urls, '_INDEX_HTML', index_html)
+
+        response = client.get(f'/pieces/{piece.id}')
+
+        assert response.status_code == 200
+        html = response.content.decode()
+        assert '<title>PotterDoc</title>' in html
+        assert 'og:title' not in html
+
+
+# ---------------------------------------------------------------------------
 # GET /api/pieces/{id}/current_state/
 # ---------------------------------------------------------------------------
 

--- a/api/workflow.py
+++ b/api/workflow.py
@@ -41,6 +41,12 @@ def get_name_for_global(model: type[django_models.Model]) -> str | None:
             return global_name
     return None
 
+
+def get_state_friendly_name(state_id: str) -> str:
+    """Return the authored friendly name for a workflow state."""
+    return str(_STATE_MAP.get(state_id, {}).get('friendly_name', state_id))
+
+
 def get_state_ref_fields(state_id: str) -> dict[str, tuple[str, str]]:
     """Return {field_name: (source_state_id, source_field_name)} for all state ref fields.
 

--- a/backend/BUILD.bazel
+++ b/backend/BUILD.bazel
@@ -29,6 +29,7 @@ py_library(
         requirement("Pillow"),
         requirement("psycopg2-binary"),
         requirement("django-import-export"),
+        requirement("django-meta"),
     ],
     visibility = ["//visibility:public"],
 )

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -64,6 +64,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "adminsortable2",
     "import_export",
+    "meta",
     "rest_framework",
     "corsheaders",
     "drf_spectacular",

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -1,16 +1,101 @@
+from urllib.parse import quote
+
 from django.conf import settings
 from django.contrib import admin
 from django.http import HttpRequest, HttpResponse, HttpResponseNotFound
+from django.template.loader import render_to_string
 from django.urls import include, path, re_path
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
+from meta.views import Meta  # type: ignore[import-untyped]
 
 _INDEX_HTML = settings.BASE_DIR / 'web' / 'dist' / 'index.html'
+_SHARE_IMAGE_SIZE = 600
+
+
+class RequestMeta(Meta):
+    """django-meta object that derives canonical host details from the request."""
+
+    def get_domain(self):
+        return self.request.get_host()
+
+    def get_protocol(self):
+        return self.request.scheme
+
+
+def _index_html() -> str | None:
+    if not _INDEX_HTML.exists():
+        return None
+    return _INDEX_HTML.read_text(encoding='utf-8')
 
 
 def _spa(request: HttpRequest) -> HttpResponse | HttpResponseNotFound:
-    if _INDEX_HTML.exists():
-        return HttpResponse(_INDEX_HTML.read_bytes(), content_type='text/html')
+    index_html = _index_html()
+    if index_html is not None:
+        return HttpResponse(index_html, content_type='text/html')
     return HttpResponseNotFound('Frontend not built.')
+
+
+def _cloudinary_share_image_url(thumbnail: dict) -> str:
+    cloud_name = (thumbnail.get('cloud_name') or '').strip()
+    public_id = (thumbnail.get('cloudinary_public_id') or '').strip()
+    if cloud_name and public_id:
+        return (
+            f'https://res.cloudinary.com/{quote(cloud_name)}/image/upload/'
+            f'c_fill,g_auto,h_{_SHARE_IMAGE_SIZE},q_auto,w_{_SHARE_IMAGE_SIZE},f_jpg/'
+            f'{quote(public_id, safe="/")}.jpg'
+        )
+    return str(thumbnail.get('url') or '')
+
+
+def _inject_piece_metadata(index_html: str, request: HttpRequest, piece_id) -> str:
+    from api.models import Piece
+    from api.workflow import get_state_friendly_name
+
+    piece = (
+        Piece.objects.prefetch_related('states')
+        .filter(id=piece_id, shared=True)
+        .first()
+    )
+    if piece is None or piece.current_state is None:
+        return index_html
+
+    state_label = get_state_friendly_name(piece.current_state.state)
+    title = f'{piece.name} - {state_label}'
+    description = 'Powered by PotterDoc'
+    url = request.build_absolute_uri(request.path)
+    thumbnail = piece.thumbnail if isinstance(piece.thumbnail, dict) else None
+    image_url = _cloudinary_share_image_url(thumbnail) if thumbnail else ''
+    if image_url.startswith('/'):
+        image_url = request.build_absolute_uri(image_url)
+
+    meta = RequestMeta(
+        request=request,
+        title=title,
+        description=description,
+        url=url,
+        image=image_url,
+        image_width=_SHARE_IMAGE_SIZE if image_url else None,
+        image_height=_SHARE_IMAGE_SIZE if image_url else None,
+        object_type='article',
+        site_name='PotterDoc',
+        twitter_type='summary_large_image',
+        use_og=True,
+        use_twitter=True,
+        use_title_tag=True,
+    )
+    tags = render_to_string('meta/meta.html', {'meta': meta}).strip()
+    index_html = index_html.replace('<title>PotterDoc</title>', tags, 1)
+    return index_html
+
+
+def _piece_spa(request: HttpRequest, piece_id) -> HttpResponse | HttpResponseNotFound:
+    index_html = _index_html()
+    if index_html is None:
+        return HttpResponseNotFound('Frontend not built.')
+    return HttpResponse(
+        _inject_piece_metadata(index_html, request, piece_id),
+        content_type='text/html',
+    )
 
 
 urlpatterns = [
@@ -18,6 +103,7 @@ urlpatterns = [
     path('api/', include('api.urls')),
     path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
     path('api/schema/swagger/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger'),
+    path('pieces/<uuid:piece_id>', _piece_spa),
     # Catch-all: serve the React SPA for any non-API route so client-side
     # routing works on hard refresh or direct URL navigation.
     re_path(r'^(?!api/|admin/|static/).*$', _spa),

--- a/requirements.lock
+++ b/requirements.lock
@@ -552,6 +552,10 @@ django-import-export==4.3.9 \
     --hash=sha256:3d83b1c28f30935240ef9d914a1d4845c6fcaf5c7e5454889dda800eb5d374fb \
     --hash=sha256:966e01c2cbd6acda710a0a0097cd99b28d4f9883abbfbbf712f34a2e8eea8809
     # via -r requirements.txt
+django-meta==2.5.1 \
+    --hash=sha256:0699e585444d59286c25bc301b865e56814e2473a069cd1046840669204cec2a \
+    --hash=sha256:35941347c39fa69139cdede3fe39f408330eb586819c7a9c4610991479e1ae57
+    # via -r requirements.txt
 django-stubs[compatible-mypy]==6.0.2 \
     --hash=sha256:56d43b5e3741563af0063e5b6283f908c625b0439aa06314268673699d1bdccd \
     --hash=sha256:c3bc84d80421758f3b2ad9e1358e001d719388a8eb106e67c873e606216108d4

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ Django==6.0.4
 django-admin-sortable2==2.3.1
 django-cors-headers==4.9.0
 django-import-export==4.3.9
+django-meta==2.5.1
 django-stubs==6.0.2
 django-stubs-ext==6.0.2
 djangorestframework==3.17.1

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -18,17 +18,13 @@
         "@react-oauth/google": "^0.13.4",
         "axios": "^1.15.2",
         "helmet": "^8.1.0",
-        "invariant": "^2.2.4",
         "masonic": "^4.1.0",
         "mui": "^0.0.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "react-fast-compare": "^3.2.2",
-        "react-helmet-async": "^3.0.0",
         "react-router-dom": "^7.14.0",
         "react-sketch-canvas": "^6.2.0",
         "react-swipeable": "^7.0.2",
-        "shallowequal": "^1.1.0",
         "tesseract.js": "^7.0.0"
       },
       "devDependencies": {
@@ -4040,15 +4036,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
-      }
-    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -5334,26 +5321,6 @@
         "react": "^19.2.4"
       }
     },
-    "node_modules/react-fast-compare": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
-      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
-      "license": "MIT"
-    },
-    "node_modules/react-helmet-async": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-3.0.0.tgz",
-      "integrity": "sha512-nA3IEZfXiclgrz4KLxAhqJqIfFDuvzQwlKwpdmzZIuC1KNSghDEIXmyU0TKtbM+NafnkICcwx8CECFrZ/sL/1w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "invariant": "^2.2.4",
-        "react-fast-compare": "^3.2.2",
-        "shallowequal": "^1.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
@@ -5568,12 +5535,6 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
-    },
-    "node_modules/shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
       "license": "MIT"
     },
     "node_modules/shebang-command": {

--- a/web/package.json
+++ b/web/package.json
@@ -23,17 +23,13 @@
     "@react-oauth/google": "^0.13.4",
     "axios": "^1.15.2",
     "helmet": "^8.1.0",
-    "invariant": "^2.2.4",
     "masonic": "^4.1.0",
     "mui": "^0.0.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-fast-compare": "^3.2.2",
-    "react-helmet-async": "^3.0.0",
     "react-router-dom": "^7.14.0",
     "react-sketch-canvas": "^6.2.0",
     "react-swipeable": "^7.0.2",
-    "shallowequal": "^1.1.0",
     "tesseract.js": "^7.0.0"
   },
   "devDependencies": {

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -38,9 +38,6 @@ importers:
       helmet:
         specifier: ^8.1.0
         version: 8.1.0
-      invariant:
-        specifier: ^2.2.4
-        version: 2.2.4
       masonic:
         specifier: ^4.1.0
         version: 4.1.0(react@19.2.4)
@@ -53,12 +50,6 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
-      react-fast-compare:
-        specifier: ^3.2.2
-        version: 3.2.2
-      react-helmet-async:
-        specifier: ^3.0.0
-        version: 3.0.0(react@19.2.4)
       react-router-dom:
         specifier: ^7.14.0
         version: 7.14.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -68,9 +59,6 @@ importers:
       react-swipeable:
         specifier: ^7.0.2
         version: 7.0.2(react@19.2.4)
-      shallowequal:
-        specifier: ^1.1.0
-        version: 1.1.0
       tesseract.js:
         specifier: ^7.0.0
         version: 7.0.0
@@ -1467,9 +1455,6 @@ packages:
     resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
     engines: {node: '>=18'}
 
-  invariant@2.2.4:
-    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
-
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
@@ -1864,14 +1849,6 @@ packages:
     peerDependencies:
       react: ^19.2.4
 
-  react-fast-compare@3.2.2:
-    resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
-
-  react-helmet-async@3.0.0:
-    resolution: {integrity: sha512-nA3IEZfXiclgrz4KLxAhqJqIfFDuvzQwlKwpdmzZIuC1KNSghDEIXmyU0TKtbM+NafnkICcwx8CECFrZ/sL/1w==}
-    peerDependencies:
-      react: ^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -1963,9 +1940,6 @@ packages:
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
-  shallowequal@1.1.0:
-    resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
-
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -2033,10 +2007,6 @@ packages:
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
-
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
@@ -3096,7 +3066,7 @@ snapshots:
       debug: 4.4.3(supports-color@10.2.2)
       minimatch: 10.2.5
       semver: 7.7.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -3672,10 +3642,6 @@ snapshots:
 
   index-to-position@1.2.0: {}
 
-  invariant@2.2.4:
-    dependencies:
-      loose-envify: 1.4.0
-
   is-arrayish@0.2.1: {}
 
   is-core-module@2.16.1:
@@ -4021,15 +3987,6 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
-  react-fast-compare@3.2.2: {}
-
-  react-helmet-async@3.0.0(react@19.2.4):
-    dependencies:
-      invariant: 2.2.4
-      react: 19.2.4
-      react-fast-compare: 3.2.2
-      shallowequal: 1.1.0
-
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
@@ -4119,8 +4076,6 @@ snapshots:
 
   set-cookie-parser@2.7.2: {}
 
-  shallowequal@1.1.0: {}
-
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -4180,11 +4135,6 @@ snapshots:
   tinybench@2.9.0: {}
 
   tinyexec@1.1.1: {}
-
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
 
   tinyglobby@0.2.16:
     dependencies:
@@ -4288,7 +4238,7 @@ snapshots:
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.1.1
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 8.0.10(@types/node@24.12.2)
       why-is-node-running: 2.3.0

--- a/web/src/components/PieceShareControls.tsx
+++ b/web/src/components/PieceShareControls.tsx
@@ -13,7 +13,6 @@ import { autoGravity } from "@cloudinary/url-gen/qualifiers/gravity";
 import type { PieceDetail, Thumbnail } from "../util/types";
 import { formatState } from "../util/types";
 import { updatePiece } from "../util/api";
-import { Helmet } from "react-helmet-async";
 
 const SHARE_IMAGE_SIZE = 600;
 
@@ -122,23 +121,6 @@ export default function ShareControls({
         overflow: "hidden",
       })}
     >
-      <Helmet>
-        <title>{piece ? buildShareText(piece) : "Loading..."}</title>
-        <meta
-          property="og:title"
-          content={piece ? buildShareText(piece) : "Loading..."}
-        />
-        <meta property="og:description" content="Powered by PotterDoc" />
-        <meta property="og:url" content={publicUrl} />
-        {piece.thumbnail !== null && (
-          <meta
-            property="og:image"
-            content={buildThumbnailShareUrl(piece.thumbnail)}
-          />
-        )}
-        <meta property="og:type" content="article" />
-      </Helmet>
-
       <Box sx={{ px: { xs: 1.5, sm: 2 }, pt: 1.25, pb: 0.75 }}>
         <Typography variant="h6" component="h3">
           Share

--- a/web/src/components/__tests__/PieceDetail.test.tsx
+++ b/web/src/components/__tests__/PieceDetail.test.tsx
@@ -403,6 +403,33 @@ describe("PieceDetail", () => {
     expect(screen.getByRole("button", { name: "Share" })).toBeInTheDocument();
   });
 
+  it("shares an editable terminal piece through the PieceDetail API interaction", async () => {
+    const updated = makePiece({
+      shared: true,
+      current_state: makeState({ state: "completed" }),
+      history: [makeState({ state: "completed" })],
+    });
+    vi.mocked(api.updatePiece).mockResolvedValue(updated);
+    const onPieceUpdated = vi.fn();
+    await renderPieceDetail(
+      makePiece({
+        current_state: makeState({ state: "completed" }),
+        history: [makeState({ state: "completed" })],
+      }),
+      onPieceUpdated,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Share" }));
+
+    await waitFor(() =>
+      expect(api.updatePiece).toHaveBeenCalledWith("piece-id-1", {
+        shared: true,
+      }),
+    );
+    expect(onPieceUpdated).toHaveBeenCalledWith(updated);
+    expect(screen.getByText("Public link created.")).toBeInTheDocument();
+  });
+
   it("copies the public link for a shared terminal piece", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, "clipboard", {


### PR DESCRIPTION
## Summary

- Move public piece Open Graph and Twitter metadata into the initial Django HTML response for `/pieces/<id>` so link preview crawlers can read it without running React.
- Render share metadata through the `django-meta` package instead of hand-building backend meta tags.
- Remove the ineffective `react-helmet-async` usage from `PieceShareControls`.
- Drop the now-unused Helmet-related web dependencies and regenerate npm, pnpm, Python, and Bazel lock metadata.
- Add backend coverage for shared/private public piece metadata and PieceDetail-level share API coverage.

## Root Cause

The previous Helmet approach injected metadata after the React app loaded. Social/link preview crawlers generally inspect the initial HTML response, so `/pieces/<id>` still served the generic SPA shell metadata.

## Validation

- `python -m ruff check backend/urls.py backend/settings.py api/tests/test_piece_detail.py api/workflow.py`
- `rtk bazel test //api:api_piece_test`
- `rtk bazel test //api:api_mypy`
- `rtk bazel test //web:web_piece_detail_test //web:web_piece_share_controls_test`
- `rtk bazel build --config=lint //web/...`