### PR TITLE
[codex] Remove readonly location browse action

### DIFF
--- a/web/src/components/GlobalEntryField.tsx
+++ b/web/src/components/GlobalEntryField.tsx
@@ -13,6 +13,7 @@ export interface GlobalEntryFieldProps {
   canCreate?: boolean;
   hideLabel?: boolean;
   disabled?: boolean;
+  hideActionWhenDisabled?: boolean;
   sx?: SxProps<Theme>;
 }
 
@@ -28,9 +29,11 @@ export default function GlobalEntryField({
   canCreate = false,
   hideLabel = false,
   disabled = false,
+  hideActionWhenDisabled = false,
   sx,
 }: GlobalEntryFieldProps) {
   const [open, setOpen] = useState(false);
+  const showAction = !disabled || !hideActionWhenDisabled;
 
   return (
     <Box sx={sx}>
@@ -58,16 +61,18 @@ export default function GlobalEntryField({
             onDelete={disabled ? undefined : () => onSelect(null)}
           />
         )}
-        <Button
-          variant="outlined"
-          size="small"
-          onClick={() => setOpen(true)}
-          disabled={disabled}
-          aria-label={value ? `Change ${label}` : `Browse ${label}`}
-          sx={{ whiteSpace: "nowrap", flexShrink: 0 }}
-        >
-          {value ? "Change…" : "Browse…"}
-        </Button>
+        {showAction && (
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={() => setOpen(true)}
+            disabled={disabled}
+            aria-label={value ? `Change ${label}` : `Browse ${label}`}
+            sx={{ whiteSpace: "nowrap", flexShrink: 0 }}
+          >
+            {value ? "Change…" : "Browse…"}
+          </Button>
+        )}
       </Box>
       {helperText && (
         <Typography

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -419,6 +419,7 @@ function PieceDetailContent({
                   value={piece.current_location ?? ""}
                   onSelect={(entry) => void handleLocationSelect(entry)}
                   disabled={!canEdit}
+                  hideActionWhenDisabled
                   sx={{ opacity: locationSaving ? 0.7 : 1 }}
                 />
                 {locationError && (

--- a/web/src/components/__tests__/PieceDetail.test.tsx
+++ b/web/src/components/__tests__/PieceDetail.test.tsx
@@ -511,6 +511,9 @@ describe("PieceDetail", () => {
     expect(
       screen.queryByRole("button", { name: "Unshare" }),
     ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Browse Current location" }),
+    ).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Notes")).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary

Removes the disabled current-location Browse button from the read-only `PieceDetail` view while keeping editable location browsing unchanged.

## Impact

Read-only piece details no longer show an unavailable action. Shared or otherwise non-editable pieces still display the current location value when present.

## Validation

- `rtk bazel test //web:web_piece_detail_test`
- `rtk bazel test //...`
- `rtk bazel build --config=lint //...`