### PR TITLE
[codex] Hide Back to Pieces for logged-out detail views

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -510,7 +510,7 @@ function UnauthenticatedApp({
               path="/pieces/:id"
               element={
                 <PublicPieceShell>
-                  <PieceDetailPage />
+                  <PieceDetailPage showBackToPieces={false} />
                 </PublicPieceShell>
               }
             />

--- a/web/src/pages/PieceDetailPage.tsx
+++ b/web/src/pages/PieceDetailPage.tsx
@@ -5,12 +5,19 @@ import { useAsync } from "../util/useAsync";
 import PieceDetailComponent from "../components/PieceDetail";
 import { type PieceDetail } from "../util/types";
 
-export default function PieceDetailPage() {
+interface PieceDetailPageProps {
+  showBackToPieces?: boolean;
+}
+
+export default function PieceDetailPage({
+  showBackToPieces = true,
+}: PieceDetailPageProps) {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const location = useLocation();
   const fromGallery =
     (location.state as { fromGallery?: boolean } | null)?.fromGallery === true;
+  const showBackButton = fromGallery || showBackToPieces;
   // id is always defined — this component is only rendered via the /pieces/:id route
   const {
     data: piece,
@@ -21,15 +28,17 @@ export default function PieceDetailPage() {
 
   return (
     <>
-      <Box sx={{ mb: 2, textAlign: "left" }}>
-        <Button
-          variant="text"
-          onClick={() => navigate(fromGallery ? "/analyze" : "/")}
-          sx={{ px: 0 }}
-        >
-          {fromGallery ? "← Back to Gallery" : "← Back to Pieces"}
-        </Button>
-      </Box>
+      {showBackButton && (
+        <Box sx={{ mb: 2, textAlign: "left" }}>
+          <Button
+            variant="text"
+            onClick={() => navigate(fromGallery ? "/analyze" : "/")}
+            sx={{ px: 0 }}
+          >
+            {fromGallery ? "← Back to Gallery" : "← Back to Pieces"}
+          </Button>
+        </Box>
+      )}
       {loading && (
         <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
           <CircularProgress />

--- a/web/src/pages/__tests__/PieceDetailPage.test.tsx
+++ b/web/src/pages/__tests__/PieceDetailPage.test.tsx
@@ -44,10 +44,18 @@ const MOCK_PIECE: PieceDetail = {
 function renderPage({
   fromGallery = false,
   id = "piece-1",
-}: { fromGallery?: boolean; id?: string } = {}) {
+  showBackToPieces,
+}: {
+  fromGallery?: boolean;
+  id?: string;
+  showBackToPieces?: boolean;
+} = {}) {
   const router = createMemoryRouter(
     [
-      { path: "/pieces/:id", element: <PieceDetailPage /> },
+      {
+        path: "/pieces/:id",
+        element: <PieceDetailPage showBackToPieces={showBackToPieces} />,
+      },
       { path: "/", element: <div data-testid="pieces-page" /> },
       { path: "/analyze", element: <div data-testid="analyze-page" /> },
     ],
@@ -75,6 +83,17 @@ describe("PieceDetailPage", () => {
         screen.getByRole("button", { name: /Back to Pieces/i }),
       ).toBeInTheDocument(),
     );
+  });
+
+  it("hides Back to Pieces when disabled for public views", async () => {
+    renderPage({ showBackToPieces: false });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("piece-detail-component")).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByRole("button", { name: /Back to Pieces/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("shows Back to Gallery button when navigated from gallery", async () => {


### PR DESCRIPTION
## Summary

Hides the `Back to Pieces` button on public/logged-out piece detail pages while keeping it visible for authenticated detail pages.

## Impact

Visitors opening a shared piece link no longer see a navigation action that points back to the authenticated pieces list. Authenticated users keep the existing back navigation, and gallery-origin navigation can still show `Back to Gallery`.

## Validation

- `rtk bazel test //web:web_piece_detail_page_test`
- `rtk bazel test //...`
- `rtk bazel build --config=lint //...`