### PR TITLE
[codex] Add completed workflow summary DSL

### DIFF
--- a/api/tests/test_workflow_helpers.py
+++ b/api/tests/test_workflow_helpers.py
@@ -77,6 +77,16 @@ _MOCK_STATE_MAP = {
         'id': 'completed',
         'visible': True,
         'terminal': True,
+        'summary': {
+            'sections': [
+                {
+                    'title': 'Making',
+                    'fields': [
+                        {'label': 'Starting weight', 'value': 'wheel_thrown.clay_weight_lbs'},
+                    ],
+                },
+            ],
+        },
     },
     'recycled': {
         'id': 'recycled',
@@ -185,6 +195,18 @@ def test_get_state_ref_fields_unknown_state_returns_empty(monkeypatch):
     monkeypatch.setattr(workflow_module, '_GLOBALS_MAP', _MOCK_GLOBALS_MAP)
 
     assert workflow_module.get_state_ref_fields('unknown_state') == {}
+
+
+def test_get_state_summary_returns_declared_summary(monkeypatch):
+    monkeypatch.setattr(workflow_module, '_STATE_MAP', _MOCK_STATE_MAP)
+
+    assert workflow_module.get_state_summary('completed') == _MOCK_STATE_MAP['completed']['summary']
+
+
+def test_get_state_summary_unknown_state_returns_empty(monkeypatch):
+    monkeypatch.setattr(workflow_module, '_STATE_MAP', _MOCK_STATE_MAP)
+
+    assert workflow_module.get_state_summary('unknown_state') == {}
 
 
 def test_get_global_model_and_field_prefers_name(monkeypatch):

--- a/api/workflow.py
+++ b/api/workflow.py
@@ -47,6 +47,17 @@ def get_state_friendly_name(state_id: str) -> str:
     return str(_STATE_MAP.get(state_id, {}).get('friendly_name', state_id))
 
 
+def get_state_summary(state_id: str) -> dict:
+    """Return read-only summary metadata declared for a workflow state.
+
+    The returned structure is copied from workflow.yml so callers can inspect
+    summary sections, direct value refs, display text, simple numeric
+    computations, and conditional visibility without mutating the cached
+    workflow definition.
+    """
+    return dict(_STATE_MAP.get(state_id, {}).get('summary', {}))
+
+
 def get_state_ref_fields(state_id: str) -> dict[str, tuple[str, str]]:
     """Return {field_name: (source_state_id, source_field_name)} for all state ref fields.
 

--- a/docs/agents/glaze-domain.md
+++ b/docs/agents/glaze-domain.md
@@ -100,6 +100,47 @@ Referential rules enforced by `TestAdditionalFieldsDSL`:
 - **State refs** (`state_id.field_name`): state must exist, field must be declared on it, state must be a reachable ancestor (path through the successor graph from that state to this one).
 - **Global refs** (`@global_name.field_name`): global must be declared in `globals`, field must be declared in that global's `fields`.
 
+**Terminal state summaries:** Terminal states may declare a read-only `summary`
+section that promotes useful data from prior states without creating new
+persisted fields on the terminal state. Summary items are display metadata for
+existing workflow data, so they belong in `workflow.yml` when the selected
+information is part of the domain contract for a finished piece.
+
+```yaml
+summary:
+  sections:
+    - title: Making
+      fields:
+        - label: Starting weight
+          value: wheel_thrown.clay_weight_lbs
+          when:
+            state_exists: wheel_thrown
+        - label: Trimming loss
+          compute:
+            op: difference # product | difference | sum | ratio
+            left: wheel_thrown.clay_weight_lbs
+            right: trimmed.trimmed_weight_lbs
+            unit: lb
+            decimals: 2
+          when:
+            state_exists: trimmed
+        - label: Wax resist
+          text: Not recorded
+          when:
+            state_missing: waxed
+```
+
+Summary items support exactly one of:
+
+- `value: state_id.field_name` — display a field from a reachable ancestor state.
+- `compute` — display a numeric result using `product`, `difference`, `sum`, or `ratio`.
+- `text` — display static workflow-authored text.
+
+Optional `when` clauses currently support `state_exists` and `state_missing`.
+This is intentionally conditional visibility, not a general expression language:
+use separate summary items for path-specific display instead of ternary-style
+logic. Summary computations are display-only; they are not persisted.
+
 **States** (in rough lifecycle order):
 
 Each state in [`workflow.yml`](../../workflow.yml) must declare a `friendly_name` and a `description`. Clients use the authored label directly and do not derive a fallback from the snake_case state ID.

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -89,6 +89,23 @@ def _all_refs(workflow):
                 yield state["id"], field_name, field_def["$ref"]
 
 
+def _summary_refs(summary_item):
+    if "value" in summary_item:
+        yield summary_item["value"]
+    compute = summary_item.get("compute", {})
+    for key in ("left", "right", "numerator", "denominator"):
+        if key in compute:
+            yield compute[key]
+    yield from compute.get("operands", [])
+
+
+def _all_summary_items(workflow):
+    for state in workflow["states"]:
+        for section in state.get("summary", {}).get("sections", []):
+            for item in section.get("fields", []):
+                yield state["id"], section["title"], item
+
+
 def _all_inline_fields(workflow):
     """Yield (context, field_name, field_def) for every inline field in states and globals."""
     for state in workflow["states"]:
@@ -112,6 +129,33 @@ def _state(state_id, **overrides):
     }
     state.update(overrides)
     return state
+
+
+def _field_def(workflow, state_id, field_name):
+    state = next((s for s in workflow["states"] if s["id"] == state_id), None)
+    if state is None:
+        return None
+    return state.get("fields", {}).get(field_name)
+
+
+def _resolved_field_def(workflow, state_id, field_name, seen=None):
+    if seen is None:
+        seen = set()
+    key = (state_id, field_name)
+    if key in seen:
+        return None
+    seen.add(key)
+    field_def = _field_def(workflow, state_id, field_name)
+    if not field_def:
+        return None
+    if "type" in field_def:
+        return field_def
+    ref = field_def["$ref"]
+    if ref.startswith("@"):
+        global_name, global_field_name = ref[1:].split(".", 1)
+        return workflow.get("globals", {}).get(global_name, {}).get("fields", {}).get(global_field_name)
+    source_state_id, source_field_name = ref.split(".", 1)
+    return _resolved_field_def(workflow, source_state_id, source_field_name, seen)
 
 
 # ---------------------------------------------------------------------------
@@ -366,6 +410,83 @@ class TestSchemaValidation:
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(instance=bad, schema=schema)
 
+    def test_summary_accepted_on_terminal_state(self, schema):
+        valid = {
+            "version": "1.0.0",
+            "states": [
+                _state("a", successors=["b"], fields={"x": {"type": "number"}}),
+                _state(
+                    "b",
+                    terminal=True,
+                    summary={
+                        "sections": [
+                            {
+                                "title": "Result",
+                                "fields": [
+                                    {"label": "Source", "value": "a.x"},
+                                    {
+                                        "label": "Double",
+                                        "compute": {
+                                            "op": "sum",
+                                            "operands": ["a.x", "a.x"],
+                                            "unit": "lb",
+                                            "decimals": 1,
+                                        },
+                                        "when": {"state_exists": "a"},
+                                    },
+                                    {"label": "Path", "text": "No wax", "when": {"state_missing": "waxed"}},
+                                ],
+                            }
+                        ]
+                    },
+                ),
+                _state("waxed", terminal=True),
+            ],
+        }
+        jsonschema.validate(instance=valid, schema=schema)
+
+    def test_summary_item_requires_one_value_text_or_compute(self, schema):
+        bad = {
+            "version": "1.0.0",
+            "states": [
+                _state("a", successors=["b"], fields={"x": {"type": "number"}}),
+                _state(
+                    "b",
+                    terminal=True,
+                    summary={"sections": [{"title": "Result", "fields": [{"label": "Missing"}]}]},
+                ),
+            ],
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=bad, schema=schema)
+
+    def test_summary_compute_rejects_unknown_op(self, schema):
+        bad = {
+            "version": "1.0.0",
+            "states": [
+                _state("a", successors=["b"], fields={"x": {"type": "number"}}),
+                _state(
+                    "b",
+                    terminal=True,
+                    summary={
+                        "sections": [
+                            {
+                                "title": "Result",
+                                "fields": [
+                                    {
+                                        "label": "Bad",
+                                        "compute": {"op": "median", "operands": ["a.x", "a.x"]},
+                                    }
+                                ],
+                            }
+                        ]
+                    },
+                ),
+            ],
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=bad, schema=schema)
+
     def test_invalid_ref_pattern_fails(self, schema):
         """A $ref that matches neither form must be rejected by the schema."""
         bad = {
@@ -577,6 +698,55 @@ class TestReferentialIntegrity:
                 f"State '{state['id']}' lists itself as a successor"
             )
 
+    def test_summary_only_on_terminal_states(self, workflow):
+        """State summaries are currently terminal-state display metadata."""
+        for state in workflow["states"]:
+            if "summary" in state:
+                assert state.get("terminal"), (
+                    f"State '{state['id']}' declares summary but is not terminal"
+                )
+
+    def test_summary_conditions_reference_known_states(self, workflow, state_ids):
+        for host_state_id, section_title, item in _all_summary_items(workflow):
+            when = item.get("when", {})
+            for key in ("state_exists", "state_missing"):
+                if key in when:
+                    assert when[key] in state_ids, (
+                        f"Summary item in state '{host_state_id}' section "
+                        f"'{section_title}' has unknown {key} state '{when[key]}'"
+                    )
+
+    def test_summary_refs_point_to_reachable_ancestor_fields(self, workflow, state_ids):
+        successors_map = _successors_map(workflow)
+        for host_state_id, section_title, item in _all_summary_items(workflow):
+            ancestors = _ancestors(host_state_id, successors_map)
+            for ref in _summary_refs(item):
+                source_state_id, field_name = ref.split(".", 1)
+                assert source_state_id in state_ids, (
+                    f"Summary item in state '{host_state_id}' section "
+                    f"'{section_title}' references unknown state '{source_state_id}'"
+                )
+                assert source_state_id in ancestors, (
+                    f"Summary item in state '{host_state_id}' section "
+                    f"'{section_title}' references non-ancestor state '{source_state_id}'"
+                )
+                assert _field_def(workflow, source_state_id, field_name) is not None, (
+                    f"Summary item in state '{host_state_id}' section "
+                    f"'{section_title}' references unknown field '{ref}'"
+                )
+
+    def test_summary_compute_refs_are_numeric(self, workflow):
+        for host_state_id, section_title, item in _all_summary_items(workflow):
+            if "compute" not in item:
+                continue
+            for ref in _summary_refs(item):
+                source_state_id, field_name = ref.split(".", 1)
+                field_def = _resolved_field_def(workflow, source_state_id, field_name)
+                assert field_def and field_def.get("type") in {"number", "integer"}, (
+                    f"Summary compute in state '{host_state_id}' section "
+                    f"'{section_title}' references non-numeric field '{ref}'"
+                )
+
 
 # ---------------------------------------------------------------------------
 # Additional fields DSL — referential integrity
@@ -648,4 +818,3 @@ class TestAdditionalFieldsDSL:
                     f"State '{host_state}' field '{field_name}': $ref '{ref_str}' "
                     f"references field '{ref_field}' which is not declared in global '@{global_name}'"
                 )
-

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -428,6 +428,7 @@ js_library(
     srcs = [
         "src/components/NavigationBlocker.tsx",
         "src/components/PieceDetail.tsx",
+        "src/components/WorkflowSummary.tsx",
     ],
     deps = [
         ":autosave_src",
@@ -653,6 +654,17 @@ vitest_test(
 )
 
 vitest_test(
+    name = "web_workflow_summary_test",
+    srcs = [
+        "src/components/__tests__/WorkflowSummary.test.tsx",
+    ],
+    tags = ["ibazel_notify_changes"],
+    deps = [
+        ":piece_detail_src",
+    ],
+)
+
+vitest_test(
     name = "web_public_piece_shell_test",
     srcs = [
         "src/components/__tests__/PublicPieceShell.test.tsx",
@@ -788,6 +800,7 @@ test_suite(
         ":web_tag_manager_test",
         ":web_tag_test",
         ":web_workflow_state_test",
+        ":web_workflow_summary_test",
         ":workflow_test",
     ],
 )

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -15,6 +15,7 @@ import CloseIcon from "@mui/icons-material/Close";
 import { useBlocker } from "react-router-dom";
 import type { PieceDetail as PieceDetailType } from "../util/types";
 import { formatState, isTerminalState } from "../util/types";
+import { getStateSummaryDefinition } from "../util/workflow";
 import { addPieceState, updateCurrentState, updatePiece } from "../util/api";
 import CloudinaryImage from "./CloudinaryImage";
 import NavigationBlocker from "./NavigationBlocker";
@@ -22,6 +23,7 @@ import WorkflowState from "./WorkflowState";
 import TagManager from "./TagManager";
 import StateTransition from "./StateTransition";
 import PieceHistory from "./PieceHistory";
+import WorkflowSummary from "./WorkflowSummary";
 import GlobalEntryField from "./GlobalEntryField";
 import PiecePhotoGallery, {
   type PiecePhotoGalleryImage,
@@ -138,6 +140,7 @@ function PieceDetailContent({
   const pieceDetailSaveStatus = usePieceDetailSaveStatus();
   const currentState = piece.current_state;
   const isTerminal = isTerminalState(currentState.state);
+  const hasStateSummary = getStateSummaryDefinition(currentState.state).length > 0;
   const canEdit = piece.can_edit;
   const pastHistory = piece.history.slice(0, -1);
   function formatDate(d: Date): string {
@@ -513,6 +516,14 @@ function PieceDetailContent({
             <strong>{formatState(currentState.state)}</strong>). No further
             transitions are possible.
           </Alert>
+        )}
+
+        {isTerminal && hasStateSummary && (
+          <Box sx={{ mb: 2.5 }}>
+            <SectionCard title="Summary">
+              <WorkflowSummary stateId={currentState.state} history={piece.history} />
+            </SectionCard>
+          </Box>
         )}
 
         <SectionCard

--- a/web/src/components/WorkflowSummary.tsx
+++ b/web/src/components/WorkflowSummary.tsx
@@ -1,0 +1,212 @@
+import { Box, Typography } from "@mui/material";
+import type { PieceState } from "../util/types";
+import {
+  getStateSummaryDefinition,
+  type WorkflowSummaryComputeDefinition,
+  type WorkflowSummaryCondition,
+  type WorkflowSummaryItem,
+} from "../util/workflow";
+
+type WorkflowSummaryProps = {
+  stateId: string;
+  history: PieceState[];
+};
+
+type RenderedSummaryItem = {
+  label: string;
+  value: string;
+  description?: string;
+};
+
+export default function WorkflowSummary({
+  stateId,
+  history,
+}: WorkflowSummaryProps) {
+  const sections = getStateSummaryDefinition(stateId)
+    .map((section) => ({
+      title: section.title,
+      fields: section.fields
+        .map((item) => renderSummaryItem(item, history))
+        .filter((item): item is RenderedSummaryItem => item !== null),
+    }))
+    .filter((section) => section.fields.length > 0);
+
+  if (sections.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box sx={{ display: "grid", gap: 2 }}>
+      {sections.map((section) => (
+        <Box key={section.title}>
+          <Typography
+            variant="subtitle2"
+            sx={{ mb: 1, color: "text.secondary", fontWeight: 700 }}
+          >
+            {section.title}
+          </Typography>
+          <Box
+            sx={{
+              display: "grid",
+              gap: 1,
+              gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+            }}
+          >
+            {section.fields.map((field) => (
+              <Box
+                key={`${section.title}-${field.label}-${field.value}`}
+                sx={{
+                  minWidth: 0,
+                  borderTop: "1px solid",
+                  borderColor: "divider",
+                  pt: 0.75,
+                }}
+              >
+                <Typography variant="caption" sx={{ color: "text.secondary" }}>
+                  {field.label}
+                </Typography>
+                <Typography variant="body1" sx={{ overflowWrap: "anywhere" }}>
+                  {field.value}
+                </Typography>
+                {field.description ? (
+                  <Typography variant="caption" sx={{ color: "text.secondary" }}>
+                    {field.description}
+                  </Typography>
+                ) : null}
+              </Box>
+            ))}
+          </Box>
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
+function renderSummaryItem(
+  item: WorkflowSummaryItem,
+  history: PieceState[],
+): RenderedSummaryItem | null {
+  if (!conditionMatches(item.when, history)) {
+    return null;
+  }
+  if (item.kind === "text") {
+    return item.text
+      ? { label: item.label, value: item.text, description: item.description }
+      : null;
+  }
+  if (item.kind === "value") {
+    const value = getFieldValue(history, item.stateId, item.fieldName);
+    const formatted = formatValue(value);
+    return formatted
+      ? { label: item.label, value: formatted, description: item.description }
+      : null;
+  }
+  const value = computeValue(item.compute, history);
+  return value === null
+    ? null
+    : {
+        label: item.label,
+        value: formatComputedValue(value, item.compute),
+        description: item.description,
+      };
+}
+
+function conditionMatches(
+  condition: WorkflowSummaryCondition | undefined,
+  history: PieceState[],
+): boolean {
+  if (!condition) {
+    return true;
+  }
+  if (condition.state_exists) {
+    return history.some((state) => state.state === condition.state_exists);
+  }
+  if (condition.state_missing) {
+    return !history.some((state) => state.state === condition.state_missing);
+  }
+  return true;
+}
+
+function getFieldValue(
+  history: PieceState[],
+  stateId: string,
+  fieldName: string,
+): unknown {
+  const state = [...history].reverse().find((entry) => entry.state === stateId);
+  return state?.additional_fields?.[fieldName];
+}
+
+function getNumericValue(
+  history: PieceState[],
+  ref: string | undefined,
+): number | null {
+  if (!ref) {
+    return null;
+  }
+  const [stateId, fieldName] = ref.split(".", 2);
+  const value = getFieldValue(history, stateId, fieldName);
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function computeValue(
+  compute: WorkflowSummaryComputeDefinition,
+  history: PieceState[],
+): number | null {
+  if (compute.op === "sum" || compute.op === "product") {
+    const operands = compute.operands?.map((ref) => getNumericValue(history, ref));
+    if (!operands || operands.some((value) => value === null)) {
+      return null;
+    }
+    const numericOperands = operands as number[];
+    return compute.op === "sum"
+      ? numericOperands.reduce((total, value) => total + value, 0)
+      : numericOperands.reduce((total, value) => total * value, 1);
+  }
+  if (compute.op === "difference") {
+    const left = getNumericValue(history, compute.left);
+    const right = getNumericValue(history, compute.right);
+    return left === null || right === null ? null : left - right;
+  }
+  const numerator = getNumericValue(history, compute.numerator);
+  const denominator = getNumericValue(history, compute.denominator);
+  if (numerator === null || denominator === null || denominator === 0) {
+    return null;
+  }
+  return numerator / denominator;
+}
+
+function formatComputedValue(
+  value: number,
+  compute: WorkflowSummaryComputeDefinition,
+): string {
+  const decimals = compute.decimals ?? 2;
+  const formatted = value.toLocaleString(undefined, {
+    maximumFractionDigits: decimals,
+    minimumFractionDigits: Number.isInteger(value) ? 0 : Math.min(decimals, 2),
+  });
+  return compute.unit ? `${formatted} ${compute.unit}` : formatted;
+}
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined || value === "") {
+    return "";
+  }
+  if (typeof value === "string" || typeof value === "number") {
+    return String(value);
+  }
+  if (typeof value === "boolean") {
+    return value ? "Yes" : "No";
+  }
+  if (typeof value === "object" && "name" in value) {
+    const name = (value as { name?: unknown }).name;
+    return typeof name === "string" ? name : "";
+  }
+  return "";
+}

--- a/web/src/components/__tests__/WorkflowSummary.test.tsx
+++ b/web/src/components/__tests__/WorkflowSummary.test.tsx
@@ -1,78 +1,7 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import WorkflowSummary from "../WorkflowSummary";
 import type { PieceState } from "../../util/types";
-
-vi.mock("../../../workflow.yml", () => ({
-  default: {
-    version: "0.0.2",
-    states: [
-      {
-        id: "wheel_thrown",
-        visible: true,
-        friendly_name: "Throwing",
-        past_friendly_name: "Thrown",
-        description: "Thrown.",
-        successors: ["trimmed"],
-        fields: {
-          clay_weight_lbs: { type: "number", label: "Clay weight" },
-        },
-      },
-      {
-        id: "trimmed",
-        visible: true,
-        friendly_name: "Trimming",
-        past_friendly_name: "Trimmed",
-        description: "Trimmed.",
-        successors: ["completed"],
-        fields: {
-          trimmed_weight_lbs: { type: "number", label: "Trimmed weight" },
-        },
-      },
-      {
-        id: "waxed",
-        visible: true,
-        friendly_name: "Waxing",
-        past_friendly_name: "Waxed",
-        description: "Waxed.",
-        successors: ["completed"],
-      },
-      {
-        id: "completed",
-        visible: true,
-        friendly_name: "Completed",
-        past_friendly_name: "Completed",
-        description: "Done.",
-        terminal: true,
-        summary: {
-          sections: [
-            {
-              title: "Making",
-              fields: [
-                { label: "Starting weight", value: "wheel_thrown.clay_weight_lbs" },
-                {
-                  label: "Trimming loss",
-                  compute: {
-                    op: "difference",
-                    left: "wheel_thrown.clay_weight_lbs",
-                    right: "trimmed.trimmed_weight_lbs",
-                    unit: "lb",
-                    decimals: 2,
-                  },
-                },
-                {
-                  label: "Wax resist",
-                  text: "Not recorded",
-                  when: { state_missing: "waxed" },
-                },
-              ],
-            },
-          ],
-        },
-      },
-    ],
-  },
-}));
 
 function makeState(
   state: string,
@@ -94,8 +23,18 @@ describe("WorkflowSummary", () => {
       <WorkflowSummary
         stateId="completed"
         history={[
-          makeState("wheel_thrown", { clay_weight_lbs: 4 }),
-          makeState("trimmed", { trimmed_weight_lbs: 3.25 }),
+          makeState("wheel_thrown", {
+            clay_weight_lbs: 4,
+            clay_body: { id: "clay-1", name: "Speckled Buff" },
+          }),
+          makeState("trimmed", {
+            trimmed_weight_lbs: 3.25,
+          }),
+          makeState("submitted_to_bisque_fire", {
+            length_in: 6,
+            width_in: 3,
+            height_in: 2,
+          }),
           makeState("completed"),
         ]}
       />,
@@ -104,10 +43,18 @@ describe("WorkflowSummary", () => {
     expect(screen.getByText("Making")).toBeInTheDocument();
     expect(screen.getByText("Starting weight")).toBeInTheDocument();
     expect(screen.getByText("4")).toBeInTheDocument();
+    expect(screen.getByText("Clay body")).toBeInTheDocument();
+    expect(screen.getByText("Speckled Buff")).toBeInTheDocument();
     expect(screen.getByText("Trimming loss")).toBeInTheDocument();
     expect(screen.getByText("0.75 lb")).toBeInTheDocument();
     expect(screen.getByText("Wax resist")).toBeInTheDocument();
     expect(screen.getByText("Not recorded")).toBeInTheDocument();
+    expect(screen.getByText("Dimensions total")).toBeInTheDocument();
+    expect(screen.getByText("11 in")).toBeInTheDocument();
+    expect(screen.getByText("Approximate volume")).toBeInTheDocument();
+    expect(screen.getByText("36 cu in")).toBeInTheDocument();
+    expect(screen.getByText("Length to width ratio")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
   });
 
   it("honors state_exists and state_missing visibility", () => {
@@ -124,5 +71,31 @@ describe("WorkflowSummary", () => {
     );
 
     expect(screen.queryByText("Not recorded")).not.toBeInTheDocument();
+    expect(screen.getByText("Applied")).toBeInTheDocument();
+  });
+
+  it("uses the latest matching state value and hides empty sections", () => {
+    const { container } = render(
+      <WorkflowSummary
+        stateId="completed"
+        history={[
+          makeState("wheel_thrown", { clay_weight_lbs: 4 }),
+          makeState("wheel_thrown", { clay_weight_lbs: "5.5" }),
+          makeState("completed"),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("5.5")).toBeInTheDocument();
+    expect(screen.queryByText("Trimming loss")).not.toBeInTheDocument();
+    expect(container).not.toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when a state has no summary", () => {
+    const { container } = render(
+      <WorkflowSummary stateId="recycled" history={[makeState("recycled")]} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/web/src/components/__tests__/WorkflowSummary.test.tsx
+++ b/web/src/components/__tests__/WorkflowSummary.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import WorkflowSummary from "../WorkflowSummary";
+import type { PieceState } from "../../util/types";
+
+vi.mock("../../../workflow.yml", () => ({
+  default: {
+    version: "0.0.2",
+    states: [
+      {
+        id: "wheel_thrown",
+        visible: true,
+        friendly_name: "Throwing",
+        past_friendly_name: "Thrown",
+        description: "Thrown.",
+        successors: ["trimmed"],
+        fields: {
+          clay_weight_lbs: { type: "number", label: "Clay weight" },
+        },
+      },
+      {
+        id: "trimmed",
+        visible: true,
+        friendly_name: "Trimming",
+        past_friendly_name: "Trimmed",
+        description: "Trimmed.",
+        successors: ["completed"],
+        fields: {
+          trimmed_weight_lbs: { type: "number", label: "Trimmed weight" },
+        },
+      },
+      {
+        id: "waxed",
+        visible: true,
+        friendly_name: "Waxing",
+        past_friendly_name: "Waxed",
+        description: "Waxed.",
+        successors: ["completed"],
+      },
+      {
+        id: "completed",
+        visible: true,
+        friendly_name: "Completed",
+        past_friendly_name: "Completed",
+        description: "Done.",
+        terminal: true,
+        summary: {
+          sections: [
+            {
+              title: "Making",
+              fields: [
+                { label: "Starting weight", value: "wheel_thrown.clay_weight_lbs" },
+                {
+                  label: "Trimming loss",
+                  compute: {
+                    op: "difference",
+                    left: "wheel_thrown.clay_weight_lbs",
+                    right: "trimmed.trimmed_weight_lbs",
+                    unit: "lb",
+                    decimals: 2,
+                  },
+                },
+                {
+                  label: "Wax resist",
+                  text: "Not recorded",
+                  when: { state_missing: "waxed" },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+  },
+}));
+
+function makeState(
+  state: string,
+  additionalFields: Record<string, unknown> = {},
+): PieceState {
+  return {
+    state,
+    notes: "",
+    images: [],
+    additional_fields: additionalFields,
+    created: new Date("2026-01-01T00:00:00Z"),
+    last_modified: new Date("2026-01-01T00:00:00Z"),
+  } as PieceState;
+}
+
+describe("WorkflowSummary", () => {
+  it("renders direct values, computed values, and conditional text", () => {
+    render(
+      <WorkflowSummary
+        stateId="completed"
+        history={[
+          makeState("wheel_thrown", { clay_weight_lbs: 4 }),
+          makeState("trimmed", { trimmed_weight_lbs: 3.25 }),
+          makeState("completed"),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Making")).toBeInTheDocument();
+    expect(screen.getByText("Starting weight")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+    expect(screen.getByText("Trimming loss")).toBeInTheDocument();
+    expect(screen.getByText("0.75 lb")).toBeInTheDocument();
+    expect(screen.getByText("Wax resist")).toBeInTheDocument();
+    expect(screen.getByText("Not recorded")).toBeInTheDocument();
+  });
+
+  it("honors state_exists and state_missing visibility", () => {
+    render(
+      <WorkflowSummary
+        stateId="completed"
+        history={[
+          makeState("wheel_thrown", { clay_weight_lbs: 4 }),
+          makeState("trimmed", { trimmed_weight_lbs: 3.25 }),
+          makeState("waxed"),
+          makeState("completed"),
+        ]}
+      />,
+    );
+
+    expect(screen.queryByText("Not recorded")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/util/workflow.test.ts
+++ b/web/src/util/workflow.test.ts
@@ -260,6 +260,36 @@ vi.mock("../../../workflow.yml", () => ({
         },
       },
       {
+        id: "summary_edge_cases",
+        visible: true,
+        friendly_name: "Summary Edge Cases",
+        past_friendly_name: "Summary Edge Cased",
+        description: "Coverage-only summary state.",
+        terminal: true,
+        summary: {
+          sections: [
+            {
+              title: "Edges",
+              fields: [
+                { value: "wheel_thrown.clay_body" },
+                { value: "not_a_ref" },
+                { value: "unknown_state.some_field" },
+                { text: "Fallback label text" },
+                {
+                  compute: {
+                    op: "sum",
+                    operands: [
+                      "wheel_thrown.clay_weight_lbs",
+                      "trimmed.trimmed_weight_lbs",
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+      {
         id: "recycled",
         visible: true,
         friendly_name: "Recycled",
@@ -648,6 +678,32 @@ describe("getStateSummaryDefinition", () => {
 
   it("returns an empty array for states without a summary", () => {
     expect(getStateSummaryDefinition("recycled")).toEqual([]);
+  });
+
+  it("returns an empty array for unknown states", () => {
+    expect(getStateSummaryDefinition("unknown_state")).toEqual([]);
+  });
+
+  it("handles omitted labels and skips unresolved value refs", () => {
+    const summary = getStateSummaryDefinition("summary_edge_cases");
+
+    expect(summary).toHaveLength(1);
+    expect(summary[0].fields).toHaveLength(3);
+    expect(summary[0].fields[0]).toMatchObject({
+      kind: "value",
+      label: "Clay Body",
+      ref: "wheel_thrown.clay_body",
+    });
+    expect(summary[0].fields[1]).toMatchObject({
+      kind: "text",
+      label: "",
+      text: "Fallback label text",
+    });
+    expect(summary[0].fields[2]).toMatchObject({
+      kind: "compute",
+      label: "Sum",
+      compute: expect.objectContaining({ op: "sum" }),
+    });
   });
 });
 

--- a/web/src/util/workflow.test.ts
+++ b/web/src/util/workflow.test.ts
@@ -226,6 +226,40 @@ vi.mock("../../../workflow.yml", () => ({
         },
       },
       {
+        id: "completed",
+        visible: true,
+        friendly_name: "Completed",
+        past_friendly_name: "Completed",
+        description: "All done.",
+        terminal: true,
+        summary: {
+          sections: [
+            {
+              title: "Making",
+              fields: [
+                { label: "Starting weight", value: "wheel_thrown.clay_weight_lbs" },
+                {
+                  label: "Trimming loss",
+                  compute: {
+                    op: "difference",
+                    left: "wheel_thrown.clay_weight_lbs",
+                    right: "trimmed.trimmed_weight_lbs",
+                    unit: "lb",
+                    decimals: 1,
+                  },
+                  when: { state_exists: "trimmed" },
+                },
+                {
+                  label: "Wax resist",
+                  text: "Not recorded",
+                  when: { state_missing: "waxed" },
+                },
+              ],
+            },
+          ],
+        },
+      },
+      {
         id: "recycled",
         visible: true,
         friendly_name: "Recycled",
@@ -249,6 +283,7 @@ import {
   getGlobalPickerFilters,
   getGlobalThumbnailField,
   getStateMetadata,
+  getStateSummaryDefinition,
   isFavoritableGlobal,
   isTerminalState,
   isTaggableGlobal,
@@ -576,6 +611,43 @@ describe("getAdditionalFieldDefinitions", () => {
     expect(fields.find((f) => f.name === "firing_fee_usd")!.label).toBe(
       "Firing Fee (USD)",
     );
+  });
+});
+
+describe("getStateSummaryDefinition", () => {
+  it("returns resolved direct, computed, and text summary items", () => {
+    const summary = getStateSummaryDefinition("completed");
+
+    expect(summary).toHaveLength(1);
+    expect(summary[0].title).toBe("Making");
+    expect(summary[0].fields[0]).toMatchObject({
+      kind: "value",
+      label: "Starting weight",
+      ref: "wheel_thrown.clay_weight_lbs",
+      stateId: "wheel_thrown",
+      fieldName: "clay_weight_lbs",
+      field: expect.objectContaining({ type: "number" }),
+    });
+    expect(summary[0].fields[1]).toMatchObject({
+      kind: "compute",
+      label: "Trimming loss",
+      compute: expect.objectContaining({
+        op: "difference",
+        left: "wheel_thrown.clay_weight_lbs",
+        right: "trimmed.trimmed_weight_lbs",
+      }),
+      when: { state_exists: "trimmed" },
+    });
+    expect(summary[0].fields[2]).toMatchObject({
+      kind: "text",
+      label: "Wax resist",
+      text: "Not recorded",
+      when: { state_missing: "waxed" },
+    });
+  });
+
+  it("returns an empty array for states without a summary", () => {
+    expect(getStateSummaryDefinition("recycled")).toEqual([]);
   });
 });
 

--- a/web/src/util/workflow.ts
+++ b/web/src/util/workflow.ts
@@ -56,6 +56,7 @@ interface WorkflowStateDefinition {
   terminal?: boolean;
   successors?: string[];
   fields?: Record<string, FieldDefinition>;
+  summary?: WorkflowStateSummaryDefinition;
 }
 
 export interface ComposeFromEntry {
@@ -114,6 +115,77 @@ export interface WorkflowStateMetadata {
   pastFriendlyName: string;
   description: string;
   isTerminal: boolean;
+}
+
+export type SummaryComputeOp = "product" | "difference" | "sum" | "ratio";
+
+export interface WorkflowSummaryCondition {
+  state_exists?: string;
+  state_missing?: string;
+}
+
+export interface WorkflowSummaryComputeDefinition {
+  op: SummaryComputeOp;
+  operands?: string[];
+  left?: string;
+  right?: string;
+  numerator?: string;
+  denominator?: string;
+  unit?: string;
+  decimals?: number;
+}
+
+interface WorkflowSummaryItemDefinition {
+  label?: string;
+  description?: string;
+  value?: string;
+  text?: string;
+  compute?: WorkflowSummaryComputeDefinition;
+  when?: WorkflowSummaryCondition;
+}
+
+interface WorkflowStateSummaryDefinition {
+  sections: Array<{
+    title: string;
+    fields: WorkflowSummaryItemDefinition[];
+  }>;
+}
+
+export interface WorkflowSummaryValueItem {
+  kind: "value";
+  label: string;
+  description?: string;
+  ref: string;
+  stateId: string;
+  fieldName: string;
+  field: ResolvedAdditionalField;
+  when?: WorkflowSummaryCondition;
+}
+
+export interface WorkflowSummaryTextItem {
+  kind: "text";
+  label: string;
+  description?: string;
+  text: string;
+  when?: WorkflowSummaryCondition;
+}
+
+export interface WorkflowSummaryComputeItem {
+  kind: "compute";
+  label: string;
+  description?: string;
+  compute: WorkflowSummaryComputeDefinition;
+  when?: WorkflowSummaryCondition;
+}
+
+export type WorkflowSummaryItem =
+  | WorkflowSummaryValueItem
+  | WorkflowSummaryTextItem
+  | WorkflowSummaryComputeItem;
+
+export interface WorkflowSummarySection {
+  title: string;
+  fields: WorkflowSummaryItem[];
 }
 
 /**
@@ -340,6 +412,21 @@ export function getStateMetadata(
   };
 }
 
+export function getStateSummaryDefinition(
+  stateId: string,
+): WorkflowSummarySection[] {
+  const summary = STATE_MAP.get(stateId)?.summary;
+  if (!summary) {
+    return [];
+  }
+  return summary.sections.map((section) => ({
+    title: section.title,
+    fields: section.fields
+      .map((item) => buildSummaryItem(item))
+      .filter((item): item is WorkflowSummaryItem => item !== null),
+  }));
+}
+
 function isStateRefField(def: FieldDefinition): boolean {
   return "$ref" in def && !def.$ref.startsWith("@");
 }
@@ -424,4 +511,63 @@ function parseGlobalRef(
     return [undefined, undefined];
   }
   return [globalName, fieldName];
+}
+
+function buildSummaryItem(
+  item: WorkflowSummaryItemDefinition,
+): WorkflowSummaryItem | null {
+  if (item.value) {
+    const resolved = resolveStateFieldRef(item.value);
+    if (!resolved) {
+      return null;
+    }
+    return {
+      kind: "value",
+      label: item.label ?? resolved.field.label,
+      description: item.description ?? resolved.field.description,
+      ref: item.value,
+      stateId: resolved.stateId,
+      fieldName: resolved.fieldName,
+      field: resolved.field,
+      when: item.when,
+    };
+  }
+  if (item.text !== undefined) {
+    return {
+      kind: "text",
+      label: item.label ?? "",
+      description: item.description,
+      text: item.text,
+      when: item.when,
+    };
+  }
+  if (item.compute) {
+    return {
+      kind: "compute",
+      label: item.label ?? formatWorkflowFieldLabel(item.compute.op),
+      description: item.description,
+      compute: item.compute,
+      when: item.when,
+    };
+  }
+  return null;
+}
+
+function resolveStateFieldRef(
+  ref: string,
+): { stateId: string; fieldName: string; field: ResolvedAdditionalField } | null {
+  const [stateId, fieldName] = ref.split(".", 2);
+  if (!stateId || !fieldName) {
+    return null;
+  }
+  const state = STATE_MAP.get(stateId);
+  const fieldDef = state?.fields?.[fieldName];
+  if (!fieldDef) {
+    return null;
+  }
+  return {
+    stateId,
+    fieldName,
+    field: buildResolvedField(fieldName, fieldDef),
+  };
 }

--- a/workflow.schema.yml
+++ b/workflow.schema.yml
@@ -227,6 +227,8 @@ $defs:
           pattern: '^[a-z][a-z0-9_]*$'
         additionalProperties:
           $ref: "#/$defs/field_def"
+      summary:
+        $ref: "#/$defs/state_summary"
 
   # ---------------------------------------------------------------------------
   # Field DSL
@@ -246,6 +248,126 @@ $defs:
     oneOf:
       - $ref: "#/$defs/inline_field"
       - $ref: "#/$defs/global_ref_field"
+
+  state_summary:
+    type: object
+    required: [sections]
+    additionalProperties: false
+    description: |
+      Read-only summary fields to display when this state is current. Summary
+      items read or compute values from previous workflow states; they do not
+      declare persisted fields on the host state.
+    properties:
+      sections:
+        type: array
+        minItems: 1
+        items:
+          type: object
+          required: [title, fields]
+          additionalProperties: false
+          properties:
+            title:
+              type: string
+            fields:
+              type: array
+              minItems: 1
+              items:
+                $ref: "#/$defs/summary_item"
+
+  summary_item:
+    type: object
+    additionalProperties: false
+    properties:
+      label:
+        type: string
+      description:
+        type: string
+      value:
+        $ref: "#/$defs/state_field_ref"
+      text:
+        type: string
+      compute:
+        $ref: "#/$defs/summary_compute"
+      when:
+        $ref: "#/$defs/summary_when"
+    oneOf:
+      - required: [value]
+      - required: [text]
+      - required: [compute]
+
+  summary_when:
+    type: object
+    additionalProperties: false
+    oneOf:
+      - required: [state_exists]
+      - required: [state_missing]
+    properties:
+      state_exists:
+        type: string
+        pattern: '^[a-z][a-z0-9_]*$'
+      state_missing:
+        type: string
+        pattern: '^[a-z][a-z0-9_]*$'
+
+  summary_compute:
+    type: object
+    additionalProperties: false
+    properties:
+      op:
+        type: string
+        enum: [product, difference, sum, ratio]
+      operands:
+        type: array
+        minItems: 2
+        items:
+          $ref: "#/$defs/state_field_ref"
+      left:
+        $ref: "#/$defs/state_field_ref"
+      right:
+        $ref: "#/$defs/state_field_ref"
+      numerator:
+        $ref: "#/$defs/state_field_ref"
+      denominator:
+        $ref: "#/$defs/state_field_ref"
+      unit:
+        type: string
+      decimals:
+        type: integer
+        minimum: 0
+        maximum: 6
+    oneOf:
+      - required: [op, operands]
+        properties:
+          op:
+            enum: [product, sum]
+        not:
+          anyOf:
+            - required: [left]
+            - required: [right]
+            - required: [numerator]
+            - required: [denominator]
+      - required: [op, left, right]
+        properties:
+          op:
+            const: difference
+        not:
+          anyOf:
+            - required: [operands]
+            - required: [numerator]
+            - required: [denominator]
+      - required: [op, numerator, denominator]
+        properties:
+          op:
+            const: ratio
+        not:
+          anyOf:
+            - required: [operands]
+            - required: [left]
+            - required: [right]
+
+  state_field_ref:
+    type: string
+    pattern: '^[a-z][a-z0-9_]*\.[a-z][a-z0-9_]*$'
 
   inline_field:
     type: object

--- a/workflow.yml
+++ b/workflow.yml
@@ -447,6 +447,95 @@ states:
     past_friendly_name: Completed
     description: All done and ready to admire.
     terminal: true
+    summary:
+      sections:
+        - title: Making
+          fields:
+            - label: Build method
+              text: Wheel thrown
+              when:
+                state_exists: wheel_thrown
+            - label: Build method
+              text: Handbuilt
+              when:
+                state_exists: handbuilt
+            - label: Clay body
+              value: wheel_thrown.clay_body
+              when:
+                state_exists: wheel_thrown
+            - label: Clay body
+              value: handbuilt.clay_body
+              when:
+                state_exists: handbuilt
+            - label: Starting weight
+              value: wheel_thrown.clay_weight_lbs
+              when:
+                state_exists: wheel_thrown
+            - label: Trimmed weight
+              value: trimmed.trimmed_weight_lbs
+              when:
+                state_exists: trimmed
+            - label: Trimming loss
+              compute:
+                op: difference
+                left: wheel_thrown.clay_weight_lbs
+                right: trimmed.trimmed_weight_lbs
+                unit: lb
+                decimals: 2
+              when:
+                state_exists: trimmed
+        - title: Firing
+          fields:
+            - label: Bisque kiln
+              value: submitted_to_bisque_fire.kiln_location
+            - label: Bisque cone
+              value: bisque_fired.cone
+            - label: Glaze kiln
+              value: submitted_to_glaze_fire.kiln_location
+            - label: Glaze cone
+              value: glaze_fired.cone
+        - title: Glaze and Finish
+          fields:
+            - label: Wax resist
+              text: Applied
+              when:
+                state_exists: waxed
+            - label: Wax resist
+              text: Not recorded
+              when:
+                state_missing: waxed
+            - label: Glaze combination
+              value: glazed.glaze_combination
+            - label: Finishing
+              text: Sanded
+              when:
+                state_exists: sanded
+        - title: Measurements
+          fields:
+            - label: Dimensions total
+              compute:
+                op: sum
+                operands:
+                  - submitted_to_bisque_fire.length_in
+                  - submitted_to_bisque_fire.width_in
+                  - submitted_to_bisque_fire.height_in
+                unit: in
+                decimals: 2
+            - label: Approximate volume
+              compute:
+                op: product
+                operands:
+                  - submitted_to_bisque_fire.length_in
+                  - submitted_to_bisque_fire.width_in
+                  - submitted_to_bisque_fire.height_in
+                unit: cu in
+                decimals: 2
+            - label: Length to width ratio
+              compute:
+                op: ratio
+                numerator: submitted_to_bisque_fire.length_in
+                denominator: submitted_to_bisque_fire.width_in
+                decimals: 2
 
   - id: recycled
     visible: true


### PR DESCRIPTION
## Summary

Adds a workflow-authored summary DSL for terminal states and renders the completed-state summary in piece detail.

## What changed

- Added `summary` schema support with sectioned summary items.
- Added direct values, static text, conditional visibility, and numeric computations using `product`, `difference`, `sum`, and `ratio`.
- Added backend workflow helper access via `get_state_summary()`.
- Added frontend workflow parsing and a `WorkflowSummary` renderer.
- Populated the `completed` state with useful Making, Firing, Glaze and Finish, and Measurements summary sections.
- Documented the DSL in the Glaze domain agent guide.

## Validation

- `rtk bazel test //tests:common_test`
- `rtk bazel test //api:api_workflow_test`
- `rtk bazel test //web:workflow_test //web:web_workflow_summary_test //web:web_piece_detail_test`
- `rtk bazel build --config=lint //web/...`
- `rtk bazel test //...`
- `rtk bazel build --config=lint //...`

Note: the documented `rtk bazel test //tests:...` target does not exist in this checkout, so I used the concrete `//tests:common_test` target from `tests/BUILD.bazel`.