### PR TITLE
feat: piece list filter persistence, shared filter, glaze_combination propagation

### DIFF
--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -18,7 +18,7 @@ import type { PieceSortOrder } from "../util/api";
 import { DEFAULT_PIECE_SORT, PIECE_SORT_OPTIONS } from "../util/api";
 import { Masonry } from "masonic";
 import type { RenderComponentProps } from "masonic";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import CloudinaryImage from "./CloudinaryImage";
 import TagAutocomplete from "./TagAutocomplete";
 import TagChip from "./TagChip";
@@ -27,7 +27,7 @@ import { DEFAULT_THUMBNAIL } from "./thumbnailConstants";
 // Kiln-glow amber used for stale indicator
 const KILN_COLOR = "oklch(0.72 0.13 55)";
 
-type FilterCategory = "wip" | "completed" | "discarded";
+type FilterCategory = "wip" | "completed" | "discarded" | "shared";
 
 interface FilterOption {
   value: FilterCategory;
@@ -38,6 +38,7 @@ const FILTER_OPTIONS: FilterOption[] = [
   { value: "wip", label: "Active" },
   { value: "completed", label: "Completed" },
   { value: "discarded", label: "Recycled" },
+  { value: "shared", label: "Shared" },
 ];
 
 function matchesFilter(piece: PieceSummary, filter: FilterCategory): boolean {
@@ -46,7 +47,29 @@ function matchesFilter(piece: PieceSummary, filter: FilterCategory): boolean {
   if (filter === "wip") return isNonTerminal;
   if (filter === "completed") return state === "completed";
   if (filter === "discarded") return state === "recycled";
+  if (filter === "shared") return piece.shared;
   return false;
+}
+
+const VALID_FILTER_CATEGORIES = new Set<FilterCategory>([
+  "wip",
+  "completed",
+  "discarded",
+  "shared",
+]);
+
+function parseFilterParam(param: string | null): FilterCategory[] {
+  if (!param) return [];
+  return param
+    .split(",")
+    .filter((v): v is FilterCategory =>
+      VALID_FILTER_CATEGORIES.has(v as FilterCategory),
+    );
+}
+
+function parseTagIdsParam(param: string | null): string[] {
+  if (!param) return [];
+  return param.split(",").filter(Boolean);
 }
 
 function daysSince(date: Date): number {
@@ -284,8 +307,15 @@ const PieceList = (props: PieceListProps) => {
   } = props;
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
-  const [activeFilters, setActiveFilters] = useState<FilterCategory[]>([]);
-  const [activeTags, setActiveTags] = useState<TagEntry[]>([]);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeFilters = useMemo(
+    () => parseFilterParam(searchParams.get("filter")),
+    [searchParams],
+  );
+  const activeTagIds = useMemo(
+    () => parseTagIdsParam(searchParams.get("tags")),
+    [searchParams],
+  );
   const [filterOpen, setFilterOpen] = useState(false);
   const [tagPickerOpen, setTagPickerOpen] = useState(false);
 
@@ -316,6 +346,11 @@ const PieceList = (props: PieceListProps) => {
     return [...deduped.values()].sort((a, b) => a.name.localeCompare(b.name));
   }, [pieces]);
 
+  const activeTags = useMemo(
+    () => availableTags.filter((tag) => activeTagIds.includes(tag.id)),
+    [availableTags, activeTagIds],
+  );
+
   const filteredPieces = useMemo(() => {
     return pieces.filter((piece) => {
       const matchesState =
@@ -323,17 +358,17 @@ const PieceList = (props: PieceListProps) => {
           ? true
           : activeFilters.some((filter) => matchesFilter(piece, filter));
       const matchesTags =
-        activeTags.length === 0
+        activeTagIds.length === 0
           ? true
-          : activeTags.every((tag) =>
-              (piece.tags ?? []).some((pieceTag) => pieceTag.id === tag.id),
+          : activeTagIds.every((id) =>
+              (piece.tags ?? []).some((pieceTag) => pieceTag.id === id),
             );
       return matchesState && matchesTags;
     });
-  }, [pieces, activeFilters, activeTags]);
+  }, [pieces, activeFilters, activeTagIds]);
 
   const activeFilterLabel = useMemo(() => {
-    if (activeFilters.length === 0 && activeTags.length === 0) return "All";
+    if (activeFilters.length === 0 && activeTagIds.length === 0) return "All";
     const parts: string[] = [];
     activeFilters.forEach((f) => {
       const opt = FILTER_OPTIONS.find((o) => o.value === f);
@@ -341,25 +376,36 @@ const PieceList = (props: PieceListProps) => {
     });
     activeTags.forEach((t) => parts.push(t.name));
     return parts.join(", ");
-  }, [activeFilters, activeTags]);
+  }, [activeFilters, activeTagIds, activeTags]);
 
-  const hasActiveFilters = activeFilters.length > 0 || activeTags.length > 0;
+  const hasActiveFilters = activeFilters.length > 0 || activeTagIds.length > 0;
   const filterKey = useMemo(() => {
     const filters = [...activeFilters].sort().join(",");
-    const tags = activeTags
-      .map((tag) => tag.id)
-      .sort()
-      .join(",");
+    const tags = [...activeTagIds].sort().join(",");
     return `${filters}|${tags}|${sortOrder}`;
-  }, [activeFilters, activeTags, sortOrder]);
+  }, [activeFilters, activeTagIds, sortOrder]);
 
-  const toggleFilter = useCallback((filter: FilterCategory) => {
-    setActiveFilters((prev) =>
-      prev.includes(filter)
-        ? prev.filter((f) => f !== filter)
-        : [...prev, filter],
-    );
-  }, []);
+  const toggleFilter = useCallback(
+    (filter: FilterCategory) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          const current = parseFilterParam(next.get("filter"));
+          const updated = current.includes(filter)
+            ? current.filter((f) => f !== filter)
+            : [...current, filter];
+          if (updated.length > 0) {
+            next.set("filter", updated.join(","));
+          } else {
+            next.delete("filter");
+          }
+          return next;
+        },
+        { replace: false },
+      );
+    },
+    [setSearchParams],
+  );
 
   const sortLabel = useMemo(() => {
     return (
@@ -535,7 +581,21 @@ const PieceList = (props: PieceListProps) => {
                   label={tag.name}
                   color={tag.color}
                   onDelete={() =>
-                    setActiveTags((prev) => prev.filter((t) => t.id !== tag.id))
+                    setSearchParams(
+                      (prev) => {
+                        const next = new URLSearchParams(prev);
+                        const ids = parseTagIdsParam(next.get("tags")).filter(
+                          (id) => id !== tag.id,
+                        );
+                        if (ids.length > 0) {
+                          next.set("tags", ids.join(","));
+                        } else {
+                          next.delete("tags");
+                        }
+                        return next;
+                      },
+                      { replace: false },
+                    )
                   }
                 />
               ))}
@@ -548,7 +608,18 @@ const PieceList = (props: PieceListProps) => {
                     options={availableTags}
                     value={activeTags}
                     onChange={(next) => {
-                      setActiveTags(next);
+                      setSearchParams(
+                        (prev) => {
+                          const params = new URLSearchParams(prev);
+                          if (next.length > 0) {
+                            params.set("tags", next.map((t) => t.id).join(","));
+                          } else {
+                            params.delete("tags");
+                          }
+                          return params;
+                        },
+                        { replace: false },
+                      );
                       setTagPickerOpen(false);
                     }}
                     sx={{ minWidth: 0 }}

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -49,6 +49,8 @@ function makePiece(overrides: Partial<PieceSummary> = {}): PieceSummary {
     current_location: null,
     current_state: { state: "designed" } as any,
     tags: [],
+    shared: false,
+    can_edit: true,
     ...overrides,
   };
 }

--- a/web/src/pages/PieceListPage.tsx
+++ b/web/src/pages/PieceListPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import AddIcon from "@mui/icons-material/Add";
 import {
   Box,
@@ -10,6 +11,7 @@ import {
 import { useTheme } from "@mui/material/styles";
 import {
   DEFAULT_PIECE_SORT,
+  PIECE_SORT_OPTIONS,
   PIECES_PAGE_SIZE,
   fetchPieces,
 } from "../util/api";
@@ -30,7 +32,13 @@ export default function PieceListPage() {
   const [refreshing, setRefreshing] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [sortOrder, setSortOrder] = useState<PieceSortOrder>(DEFAULT_PIECE_SORT);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const sortFromUrl = searchParams.get("sort") as PieceSortOrder | null;
+  const sortOrder: PieceSortOrder =
+    sortFromUrl &&
+    PIECE_SORT_OPTIONS.some((o) => o.value === sortFromUrl)
+      ? sortFromUrl
+      : DEFAULT_PIECE_SORT;
   const [dialogOpen, setDialogOpen] = useState(false);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
@@ -107,7 +115,18 @@ export default function PieceListPage() {
   }, [sortOrder, loadPage]);
 
   function handleSortChange(order: PieceSortOrder) {
-    setSortOrder(order);
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (order === DEFAULT_PIECE_SORT) {
+          next.delete("sort");
+        } else {
+          next.set("sort", order);
+        }
+        return next;
+      },
+      { replace: false },
+    );
   }
 
   const handleLoadMore = useCallback(() => {

--- a/web/src/pages/__tests__/PieceListPage.test.tsx
+++ b/web/src/pages/__tests__/PieceListPage.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
 
 import PieceListPage from "../PieceListPage";
 import type { PieceDetail, PieceSummary } from "../../util/types";
@@ -111,6 +112,8 @@ const EXISTING_PIECE: PieceSummary = {
   current_state: { state: "designed" } as PieceSummary["current_state"],
   current_location: null,
   tags: [],
+  shared: false,
+  can_edit: true,
 };
 
 describe("PieceListPage", () => {
@@ -121,13 +124,13 @@ describe("PieceListPage", () => {
 
   it("shows a loading spinner while pieces are loading", () => {
     mockFetchPieces.mockReturnValue(new Promise(() => {}));
-    render(<PieceListPage />);
+    render(<MemoryRouter><PieceListPage /></MemoryRouter>);
     expect(screen.getByRole("progressbar")).toBeInTheDocument();
   });
 
   it("shows an error message when loading pieces fails", async () => {
     mockFetchPieces.mockRejectedValue(new Error("boom"));
-    render(<PieceListPage />);
+    render(<MemoryRouter><PieceListPage /></MemoryRouter>);
     await waitFor(() => {
       expect(screen.getByText("Failed to load pieces.")).toBeInTheDocument();
     });
@@ -135,7 +138,7 @@ describe("PieceListPage", () => {
 
   it("renders pieces after successful load", async () => {
     mockFetchPieces.mockResolvedValue({ count: 1, results: [EXISTING_PIECE] });
-    render(<PieceListPage />);
+    render(<MemoryRouter><PieceListPage /></MemoryRouter>);
     await waitFor(() => {
       expect(screen.getByText("Existing Bowl")).toBeInTheDocument();
     });
@@ -143,7 +146,7 @@ describe("PieceListPage", () => {
 
   it("opens the dialog from the desktop button and prepends created pieces", async () => {
     mockFetchPieces.mockResolvedValue({ count: 1, results: [EXISTING_PIECE] });
-    render(<PieceListPage />);
+    render(<MemoryRouter><PieceListPage /></MemoryRouter>);
 
     await waitFor(() => screen.getByText("Existing Bowl"));
 
@@ -163,7 +166,7 @@ describe("PieceListPage", () => {
   it("shows the mobile fab on small screens", async () => {
     installMatchMedia(true);
     mockFetchPieces.mockResolvedValue({ count: 0, results: [] });
-    render(<PieceListPage />);
+    render(<MemoryRouter><PieceListPage /></MemoryRouter>);
 
     await waitFor(() => screen.getByTestId("piece-list"));
 
@@ -173,7 +176,7 @@ describe("PieceListPage", () => {
 
   it("re-fetches with new sort order when sort changes", async () => {
     mockFetchPieces.mockResolvedValue({ count: 1, results: [EXISTING_PIECE] });
-    render(<PieceListPage />);
+    render(<MemoryRouter><PieceListPage /></MemoryRouter>);
 
     await waitFor(() => screen.getByTestId("piece-list"));
 
@@ -200,7 +203,7 @@ describe("PieceListPage", () => {
           }),
       );
 
-    render(<PieceListPage />);
+    render(<MemoryRouter><PieceListPage /></MemoryRouter>);
 
     await waitFor(() => screen.getByText("Existing Bowl"));
     await userEvent.click(screen.getByRole("button", { name: "Sort by Name" }));
@@ -227,7 +230,7 @@ describe("PieceListPage", () => {
       name: `Piece ${i}`,
     }));
     mockFetchPieces.mockResolvedValueOnce({ count: 6, results: firstPage });
-    render(<PieceListPage />);
+    render(<MemoryRouter><PieceListPage /></MemoryRouter>);
 
     await waitFor(() => screen.getByTestId("piece-list"));
 

--- a/workflow.yml
+++ b/workflow.yml
@@ -412,6 +412,9 @@ states:
         $ref: "@location.name"
         description: Name of the kiln where this piece was submitted for glaze firing.
         can_create: true
+      glaze_combination:
+        $ref: "glazed.glaze_combination"
+        description: Glaze combination queued for firing.
 
   - id: glaze_fired
     visible: true
@@ -438,6 +441,10 @@ states:
     friendly_name: Sanding
     past_friendly_name: Sanded
     description: Almost there. Smoothing the last rough spots before calling it done.
+    fields:
+      glaze_combination:
+        $ref: "glazed.glaze_combination"
+        description: Glaze combination applied to this piece.
     successors:
       - recycled
       - completed


### PR DESCRIPTION
## Summary

- **#253 – Filter persistence**: Piece list filter/sort state is now stored in URL search params (`?filter=wip,completed&tags=abc&sort=name`). Navigating to a piece and pressing back restores the exact filter state. Sort order is also persisted.
- **#250 – Shared filter**: New "Shared" chip in the filter strip; filters to pieces where `shared: true`.
- **#254 – Glaze combination in post-glazing states**: Added `glaze_combination` state-ref to `submitted_to_glaze_fire` and `sanded` in `workflow.yml`. `glaze_fired` already had it; `completed` shows it in the terminal summary.

## Test plan

- [ ] Apply a filter on the piece list, open a piece, press back — filter is still active
- [ ] Bookmark/share a filtered URL — filters restore on load
- [ ] Share a piece (via piece detail), return to list, toggle "Shared" filter — shared piece appears
- [ ] Advance a piece to `submitted_to_glaze_fire`, `glaze_fired`, or `sanded` — glaze combination field is shown
- [ ] All 33 Bazel tests pass, all linters clean

Closes #250
Closes #253
Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)
