### PR TITLE
fix(#256,#257,#258): PWA safe-area, glaze picker state-ref, back button

### DIFF
--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -261,7 +261,12 @@ export default function WorkflowState({
       return;
     }
     const hideStyle = document.createElement("style");
-    hideStyle.textContent = 'iframe[title="Upload Widget"] { opacity: 0; }';
+    hideStyle.textContent = [
+      'iframe[title="Upload Widget"] { opacity: 0; }',
+      // On iOS PWA with viewport-fit=cover the status bar overlays the page.
+      // Push the widget iframe below it so its header controls are reachable.
+      'iframe[title="Upload Widget"] { top: env(safe-area-inset-top) !important; height: calc(100dvh - env(safe-area-inset-top)) !important; }',
+    ].join("\n");
     document.head.appendChild(hideStyle);
 
     const uploadWidget = window.cloudinary?.createUploadWidget(

--- a/web/src/pages/PieceDetailPage.tsx
+++ b/web/src/pages/PieceDetailPage.tsx
@@ -17,6 +17,9 @@ export default function PieceDetailPage({
   const location = useLocation();
   const fromGallery =
     (location.state as { fromGallery?: boolean } | null)?.fromGallery === true;
+  // location.key is 'default' only when the user landed directly on this URL
+  // without navigating from elsewhere in the app.
+  const hasAppHistory = location.key !== "default";
   const showBackButton = fromGallery || showBackToPieces;
   // id is always defined — this component is only rendered via the /pieces/:id route
   const {
@@ -32,7 +35,11 @@ export default function PieceDetailPage({
         <Box sx={{ mb: 2, textAlign: "left" }}>
           <Button
             variant="text"
-            onClick={() => navigate(fromGallery ? "/analyze" : "/")}
+            onClick={() => {
+          if (fromGallery) navigate("/analyze");
+          else if (hasAppHistory) navigate(-1);
+          else navigate("/");
+        }}
             sx={{ px: 0 }}
           >
             {fromGallery ? "← Back to Gallery" : "← Back to Pieces"}

--- a/web/src/util/workflow.test.ts
+++ b/web/src/util/workflow.test.ts
@@ -207,6 +207,10 @@ vi.mock("../../../workflow.yml", () => ({
             type: "string",
             enum: ["04", "03", "02", "01"],
           },
+          kiln_location: {
+            $ref: "@location.name",
+            can_create: true,
+          },
         },
       },
       {
@@ -222,6 +226,11 @@ vi.mock("../../../workflow.yml", () => ({
           },
           cone: {
             $ref: "bisque_fired.cone",
+          },
+          // State ref that chains to a global ref — should behave as a global ref.
+          kiln_location: {
+            $ref: "bisque_fired.kiln_location",
+            description: "Carried-forward kiln location",
           },
         },
       },
@@ -599,6 +608,26 @@ describe("getAdditionalFieldDefinitions", () => {
       expect(fields.find((field) => field.name === "optional_copy")!.required).toBe(
         false,
       );
+    });
+
+    it("state ref chaining to a global ref is treated as a global ref, not a plain state ref", () => {
+      const fields = getAdditionalFieldDefinitions("glaze_fired");
+      const f = fields.find((f) => f.name === "kiln_location")!;
+      expect(f.isGlobalRef).toBe(true);
+      expect(f.isStateRef).toBe(false);
+      expect(f.globalName).toBe("location");
+      expect(f.globalField).toBe("name");
+    });
+
+    it("state ref chaining to a global ref uses the overriding description", () => {
+      const fields = getAdditionalFieldDefinitions("glaze_fired");
+      const f = fields.find((f) => f.name === "kiln_location")!;
+      expect(f.description).toBe("Carried-forward kiln location");
+    });
+
+    it("state ref chaining to a global ref defaults canCreate to false (no can_create on the ref)", () => {
+      const fields = getAdditionalFieldDefinitions("glaze_fired");
+      expect(fields.find((f) => f.name === "kiln_location")!.canCreate).toBe(false);
     });
 
     it("falls back to string metadata for malformed, missing, or cyclic state refs", () => {

--- a/web/src/util/workflow.ts
+++ b/web/src/util/workflow.ts
@@ -436,10 +436,18 @@ function buildResolvedField(
   fieldDef: FieldDefinition,
 ): ResolvedAdditionalField {
   const inline = resolveInlineField(fieldDef);
-  const globalRef = isGlobalRefField(fieldDef);
+  const isDirectGlobalRef = isGlobalRefField(fieldDef);
   const stateRef = isStateRefField(fieldDef);
+  // A state ref that ultimately chains to a global ref should render as an
+  // editable global-entry picker rather than a disabled plain text field.
+  const resolvedGlobal = isDirectGlobalRef
+    ? fieldDef
+    : stateRef
+      ? resolveStateRefToGlobalRef(fieldDef, new Set())
+      : null;
+  const globalRef = resolvedGlobal !== null;
   const [globalName, globalField] = globalRef
-    ? parseGlobalRef(fieldDef)
+    ? parseGlobalRef(resolvedGlobal!)
     : [undefined, undefined];
   return {
     name,
@@ -449,11 +457,26 @@ function buildResolvedField(
     required: fieldDef.required ?? inline.required ?? false,
     enum: inline.enum,
     isGlobalRef: globalRef,
-    isStateRef: stateRef,
-    canCreate: globalRef ? (fieldDef.can_create ?? false) : undefined,
+    isStateRef: stateRef && !globalRef,
+    canCreate: globalRef ? ((fieldDef as GlobalRefFieldDef).can_create ?? false) : undefined,
     globalName,
     globalField,
   };
+}
+
+function resolveStateRefToGlobalRef(
+  fieldDef: FieldDefinition,
+  seen: Set<string>,
+): GlobalRefFieldDef | null {
+  if (!isStateRefField(fieldDef)) return null;
+  const ref = (fieldDef as StateRefFieldDef).$ref;
+  if (seen.has(ref)) return null;
+  const [stateId, fieldName] = ref.split(".", 2);
+  if (!stateId || !fieldName) return null;
+  const target = STATE_MAP.get(stateId)?.fields?.[fieldName];
+  if (!target) return null;
+  if (isGlobalRefField(target)) return target;
+  return resolveStateRefToGlobalRef(target, new Set([...seen, ref]));
 }
 
 function resolveInlineField(


### PR DESCRIPTION
Closes #256
Closes #257
Closes #258

## #256 — PWA Cloudinary widget occluded by iOS status bar

`apple-mobile-web-app-status-bar-style: black-translucent` lets the app extend under the iOS status bar, but the Cloudinary Upload Widget iframe renders at `top: 0`, putting its header controls (close toggle, My Files tab) behind the status bar. The existing CSS injection on widget creation now also adds:

```css
iframe[title="Upload Widget"] {
  top: env(safe-area-inset-top) !important;
  height: calc(100dvh - env(safe-area-inset-top)) !important;
}
```

This shifts the iframe below the safe-area inset without affecting non-PWA browsers (where the inset is `0`).

## #257 — Glaze Combination picker unreachable in Queued → Glaze state

`submitted_to_glaze_fire.glaze_combination` is declared as `$ref: "glazed.glaze_combination"`, which is itself `$ref: "@glaze_combination.name"`. The old `buildResolvedField` only checked the immediate field definition for a global ref (`@`-prefix), so state refs that ultimately chain to a global ref were rendered as disabled plain TextFields.

`buildResolvedField` now calls `resolveStateRefToGlobalRef`, which follows the chain and returns the terminal `GlobalRefFieldDef` if one exists. When found: `isGlobalRef=true`, `isStateRef=false`, `globalName`/`globalField` populated — so `WorkflowState` renders it as an editable `GlobalEntryField`. Pure state refs (numeric, string, enum) are unchanged.

Tests: added `kiln_location` global ref to `bisque_fired` in the fixture, plus a chained `kiln_location` state ref in `glaze_fired`; three new assertions cover `isGlobalRef`, `isStateRef`, description override, and `canCreate` default.

## #258 — Back button drops PieceList filter/sort state

`navigate("/")` always returned to the unfiltered list root. Now uses `navigate(-1)` when `location.key !== "default"` (React Router sets this to `"default"` only on direct URL access), so the browser history entry for the filtered PieceList is restored. Falls back to `navigate("/")` for direct-URL access and continues to use `navigate("/analyze")` for gallery back-navigation.

## Test plan

- [ ] Upload an image from an iOS PWA — close/My Files should be fully visible below the status bar
- [ ] On a piece in Queued → Glaze state as owner: tap Glaze Combination → Browse… dialog should open
- [ ] Navigate to a piece from a filtered PieceList — Back to Pieces should return to the same filtered view
- [ ] Navigate directly to `/pieces/:id` — Back to Pieces should go to the unfiltered root
- [ ] `bazel test //...` passes
- [ ] `bazel build --config=lint //...` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
