### PR TITLE
fix: handle UUID pk in CloudinaryImageFormField.prepare_value

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -265,6 +265,15 @@ class CloudinaryImageFormField(forms.Field):
     widget = CloudinaryImageWidget
 
     def prepare_value(self, value):
+        import uuid
+
+        if isinstance(value, uuid.UUID):
+            from api.models import Image
+
+            try:
+                value = Image.objects.get(pk=value)
+            except Image.DoesNotExist:
+                value = None
         image_payload = image_to_dict(value)
         if image_payload:
             return json.dumps(image_payload)

--- a/api/tests/test_glaze_combination_admin.py
+++ b/api/tests/test_glaze_combination_admin.py
@@ -240,6 +240,40 @@ class TestGlazeCombinationAdmin:
 
         assert list(field.queryset) == [public]
 
+    def test_change_page_renders_with_test_tile_image(self):
+        """Regression: prepare_value must handle a UUID pk, not just an Image instance.
+
+        Django admin passes the raw FK pk (UUID) to prepare_value when rendering
+        an existing object's change form, which previously caused an AttributeError.
+        """
+        from django.test import Client, override_settings
+
+        gt = GlazeType.objects.create(user=None, name="Shino")
+        combo, _ = GlazeCombination.get_or_create_with_components(
+            user=None, glaze_types=[gt]
+        )
+        from api.models import Image
+
+        image = Image.objects.create(
+            url="https://res.cloudinary.com/demo/image/upload/test/tile.jpg",
+            cloudinary_public_id="test/tile",
+            cloud_name="demo",
+        )
+        combo.test_tile_image = image
+        combo.save(update_fields=["test_tile_image"])
+
+        admin_user = User.objects.create_superuser(
+            username="admin@example.com",
+            email="admin@example.com",
+            password="password",
+        )
+        with override_settings(ALLOWED_HOSTS=["testserver"]):
+            c = Client()
+            c.force_login(admin_user)
+            response = c.get(f"/admin/api/glazecombination/{combo.pk}/change/")
+
+        assert response.status_code == 200
+
     def test_save_related_recomputes_name_from_layer_order(self):
         gt1 = GlazeType.objects.create(user=None, name="Base")
         gt2 = GlazeType.objects.create(user=None, name="Top")


### PR DESCRIPTION
## Summary

- `CloudinaryImageFormField.prepare_value` crashed with `AttributeError: 'UUID' object has no attribute 'url'` on any GlazeCombination or GlazeType change page that had a `test_tile_image` set
- Django admin passes the raw FK primary key (UUID) to `prepare_value` when rendering an existing object — not the resolved `Image` instance — but `image_to_dict` only handled instances
- Fix: resolve the UUID to an `Image` instance before calling `image_to_dict`
- Regression test added to `test_glaze_combination_admin.py` covering the change page with a `test_tile_image` set

The bug was introduced when `test_tile_image` was migrated from a JSONField to an `ImageForeignKey` in `0004_normalize_images`.

Closes #259

## Test plan

- [ ] `bazel test //api:api_admin_test` passes
- [ ] Deploy to prod and confirm `/admin/api/glazecombination/<pk>/change/` loads without 500
