### PR TITLE
fix(cloudinary-cleanup): scan full cloud, show only unused, add pagination

### DIFF
--- a/api/cloudinary_cleanup.py
+++ b/api/cloudinary_cleanup.py
@@ -46,15 +46,13 @@ def list_cloudinary_assets(max_results: int = 500) -> list[CloudinaryCleanupAsse
     next_cursor = None
 
     while True:
-        params = {
+        params: dict[str, object] = {
             "resource_type": "image",
             "type": "upload",
             "max_results": min(max_results, 500),
-            "prefix": os.environ.get("CLOUDINARY_UPLOAD_FOLDER", "").strip() or None,
         }
         if next_cursor:
             params["next_cursor"] = next_cursor
-        params = {key: value for key, value in params.items() if value is not None}
 
         result = cloudinary.api.resources(**params)
         resources = result.get("resources", [])

--- a/api/tests/test_cloudinary_cleanup.py
+++ b/api/tests/test_cloudinary_cleanup.py
@@ -13,9 +13,7 @@ class TestCloudinaryCleanup:
 
         assert response.status_code == 403
 
-    def test_scan_returns_cloudinary_assets_with_reference_status(
-        self, client, user, monkeypatch
-    ):
+    def test_scan_returns_unused_assets_only(self, client, user, monkeypatch):
         admin = User.objects.create(
             username="admin@example.com",
             email="admin@example.com",
@@ -66,18 +64,10 @@ class TestCloudinaryCleanup:
         assert response.json() == {
             "assets": [
                 {
-                    "public_id": "piece/used",
-                    "url": "https://example.com/used.jpg",
-                    "bytes": 1234,
-                    "created_at": "2026-05-06T12:00:00Z",
-                    "referenced": True,
-                },
-                {
                     "public_id": "piece/orphan",
                     "url": "https://example.com/orphan.jpg",
                     "bytes": 5678,
                     "created_at": "2026-05-06T12:05:00Z",
-                    "referenced": False,
                 },
             ],
             "summary": {"total": 2, "referenced": 1, "unused": 1},

--- a/api/views.py
+++ b/api/views.py
@@ -715,9 +715,8 @@ def admin_cloudinary_cleanup(request: Request) -> Response:
                         "url": asset.url,
                         "bytes": asset.bytes,
                         "created_at": asset.created_at,
-                        "referenced": asset.referenced,
                     }
-                    for asset in assets
+                    for asset in unused
                 ],
                 "summary": {
                     "total": len(assets),

--- a/web/src/pages/CloudinaryCleanupPage.tsx
+++ b/web/src/pages/CloudinaryCleanupPage.tsx
@@ -64,7 +64,10 @@ export default function CloudinaryCleanupPage() {
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(PAGE_SIZE_OPTIONS[0]);
 
-  const assets = scanResult?.assets ?? [];
+  const assets = useMemo(
+    () => scanResult?.assets ?? [],
+    [scanResult],
+  );
   const pageAssets = useMemo(
     () => assets.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage),
     [assets, page, rowsPerPage],

--- a/web/src/pages/CloudinaryCleanupPage.tsx
+++ b/web/src/pages/CloudinaryCleanupPage.tsx
@@ -17,6 +17,7 @@ import {
   TableCell,
   TableContainer,
   TableHead,
+  TablePagination,
   TableRow,
   Typography,
 } from "@mui/material";
@@ -30,6 +31,8 @@ import {
   type CloudinaryCleanupAsset,
   type CloudinaryCleanupScanResponse,
 } from "../util/api";
+
+const PAGE_SIZE_OPTIONS = [25, 50, 100];
 
 function formatBytes(bytes: number | null) {
   if (bytes === null) return "Unknown";
@@ -58,17 +61,21 @@ export default function CloudinaryCleanupPage() {
   const [error, setError] = useState<string | null>(null);
   const [deletedCount, setDeletedCount] = useState<number | null>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(PAGE_SIZE_OPTIONS[0]);
 
-  const unusedAssets = useMemo(
-    () => scanResult?.assets.filter((asset) => !asset.referenced) ?? [],
-    [scanResult],
+  const assets = scanResult?.assets ?? [];
+  const pageAssets = useMemo(
+    () => assets.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage),
+    [assets, page, rowsPerPage],
   );
+  const allPageSelected =
+    pageAssets.length > 0 && pageAssets.every((a) => selected.has(a.public_id));
+  const somePageSelected = pageAssets.some((a) => selected.has(a.public_id));
   const selectedAssets = useMemo(
-    () => unusedAssets.filter((asset) => selected.has(asset.public_id)),
-    [selected, unusedAssets],
+    () => assets.filter((asset) => selected.has(asset.public_id)),
+    [selected, assets],
   );
-  const allUnusedSelected =
-    unusedAssets.length > 0 && selected.size === unusedAssets.length;
 
   async function handleScan() {
     setLoading(true);
@@ -77,11 +84,8 @@ export default function CloudinaryCleanupPage() {
     try {
       const result = await scanCloudinaryCleanupAssets();
       setScanResult(result);
-      setSelected(
-        new Set(
-          result.assets.filter((a) => !a.referenced).map((a) => a.public_id),
-        ),
-      );
+      setSelected(new Set(result.assets.map((a) => a.public_id)));
+      setPage(0);
     } catch {
       setError("Unable to scan Cloudinary assets.");
     } finally {
@@ -102,19 +106,19 @@ export default function CloudinaryCleanupPage() {
       setScanResult((current) => {
         if (!current) return current;
         const deleted = new Set(publicIds);
-        const assets = current.assets.filter(
+        const remaining = current.assets.filter(
           (asset) => !deleted.has(asset.public_id),
         );
-        const unused = assets.filter((asset) => !asset.referenced).length;
         return {
-          assets,
+          assets: remaining,
           summary: {
-            total: assets.length,
-            referenced: assets.length - unused,
-            unused,
+            total: current.summary.total - publicIds.length,
+            referenced: current.summary.referenced,
+            unused: remaining.length,
           },
         };
       });
+      setPage(0);
     } catch {
       setError("Unable to delete the selected assets.");
     } finally {
@@ -123,7 +127,6 @@ export default function CloudinaryCleanupPage() {
   }
 
   function toggleAsset(asset: CloudinaryCleanupAsset) {
-    if (asset.referenced) return;
     setSelected((current) => {
       const next = new Set(current);
       if (next.has(asset.public_id)) {
@@ -135,12 +138,16 @@ export default function CloudinaryCleanupPage() {
     });
   }
 
-  function toggleAllUnused() {
-    setSelected(
-      allUnusedSelected
-        ? new Set()
-        : new Set(unusedAssets.map((asset) => asset.public_id)),
-    );
+  function togglePageSelection() {
+    setSelected((current) => {
+      const next = new Set(current);
+      if (allPageSelected) {
+        pageAssets.forEach((a) => next.delete(a.public_id));
+      } else {
+        pageAssets.forEach((a) => next.add(a.public_id));
+      }
+      return next;
+    });
   }
 
   return (
@@ -178,7 +185,7 @@ export default function CloudinaryCleanupPage() {
         <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
           <Paper sx={{ px: 2, py: 1.5, flex: 1 }}>
             <Typography variant="caption" color="text.secondary">
-              Total
+              Total in Cloud
             </Typography>
             <Typography variant="h5">{scanResult.summary.total}</Typography>
           </Paper>
@@ -217,7 +224,7 @@ export default function CloudinaryCleanupPage() {
               onClick={() => setConfirmOpen(true)}
               disabled={!selectedAssets.length || deleting}
             >
-              Delete Selected
+              Delete Selected ({selectedAssets.length})
             </Button>
           </Stack>
 
@@ -227,29 +234,26 @@ export default function CloudinaryCleanupPage() {
                 <TableRow>
                   <TableCell padding="checkbox">
                     <Checkbox
-                      checked={allUnusedSelected}
-                      indeterminate={
-                        selected.size > 0 && selected.size < unusedAssets.length
-                      }
-                      onChange={toggleAllUnused}
-                      disabled={!unusedAssets.length || deleting}
-                      inputProps={{ "aria-label": "Select all unused assets" }}
+                      checked={allPageSelected}
+                      indeterminate={somePageSelected && !allPageSelected}
+                      onChange={togglePageSelection}
+                      disabled={!pageAssets.length || deleting}
+                      inputProps={{ "aria-label": "Select all on this page" }}
                     />
                   </TableCell>
                   <TableCell>Asset</TableCell>
-                  <TableCell>Status</TableCell>
                   <TableCell>Size</TableCell>
                   <TableCell>Created</TableCell>
                 </TableRow>
               </TableHead>
               <TableBody>
-                {scanResult.assets.map((asset) => (
+                {pageAssets.map((asset) => (
                   <TableRow key={asset.public_id} hover>
                     <TableCell padding="checkbox">
                       <Checkbox
                         checked={selected.has(asset.public_id)}
                         onChange={() => toggleAsset(asset)}
-                        disabled={asset.referenced || deleting}
+                        disabled={deleting}
                         inputProps={{
                           "aria-label": `Select ${asset.public_id}`,
                         }}
@@ -276,24 +280,33 @@ export default function CloudinaryCleanupPage() {
                         </Typography>
                       </Stack>
                     </TableCell>
-                    <TableCell>
-                      {asset.referenced ? "Referenced" : "Unused"}
-                    </TableCell>
                     <TableCell>{formatBytes(asset.bytes)}</TableCell>
                     <TableCell>{formatCreatedAt(asset.created_at)}</TableCell>
                   </TableRow>
                 ))}
-                {!scanResult.assets.length && (
+                {!assets.length && (
                   <TableRow>
-                    <TableCell colSpan={5}>
+                    <TableCell colSpan={4}>
                       <Typography color="text.secondary" textAlign="center">
-                        No Cloudinary assets found.
+                        No unused Cloudinary assets found.
                       </Typography>
                     </TableCell>
                   </TableRow>
                 )}
               </TableBody>
             </Table>
+            <TablePagination
+              component="div"
+              count={assets.length}
+              page={page}
+              onPageChange={(_e, newPage) => setPage(newPage)}
+              rowsPerPage={rowsPerPage}
+              rowsPerPageOptions={PAGE_SIZE_OPTIONS}
+              onRowsPerPageChange={(e) => {
+                setRowsPerPage(parseInt(e.target.value, 10));
+                setPage(0);
+              }}
+            />
           </TableContainer>
         </Stack>
       )}

--- a/web/src/util/__tests__/api.test.ts
+++ b/web/src/util/__tests__/api.test.ts
@@ -637,7 +637,7 @@ describe("upload endpoints", () => {
           url: "https://example.com/orphan.jpg",
           bytes: 2048,
           created_at: "2026-05-06T12:00:00Z",
-          referenced: false,
+
         },
       ],
       summary: { total: 1, referenced: 0, unused: 1 },

--- a/web/src/util/api.ts
+++ b/web/src/util/api.ts
@@ -528,7 +528,6 @@ export type CloudinaryCleanupAsset = {
   url: string;
   bytes: number | null;
   created_at: string | null;
-  referenced: boolean;
 };
 
 export type CloudinaryCleanupScanResponse = {


### PR DESCRIPTION
## Summary

- **Root cause fix**: The Cloudinary cleanup scan was passing `CLOUDINARY_UPLOAD_FOLDER` as a `prefix` filter, scoping the listing to only that subfolder. Glaze type and combination test tiles uploaded without that prefix were completely invisible. The prefix filter is now removed — the scan covers the full cloud account.
- **Unused-only response**: The GET endpoint now returns only unreferenced assets in `assets`. The summary still reports `total`/`referenced`/`unused` counts for context. (Referenced assets are already blocked at the delete endpoint.)
- **Pagination**: The cleanup table now has `TablePagination` with 25/50/100 rows per page. Select-all operates on the current page.
- **Removed `referenced` field** from the `CloudinaryCleanupAsset` type and the Status table column — no longer meaningful now that only unused assets are listed.

## Test plan

- [ ] Scan Cloudinary assets in prod — verify glaze type and combination test tiles now appear
- [ ] Confirm referenced piece images are absent from the list (counted in summary only)
- [ ] Verify pagination controls appear and work with > 25 results
- [ ] Delete a batch of selected unused assets and confirm success
- [ ] `bazel test //api:api_glaze_test //web:web_api_test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
