### PR TITLE
Cloudinary-seeded image crops

### DIFF
--- a/api/management/commands/backpopulate_crops.py
+++ b/api/management/commands/backpopulate_crops.py
@@ -1,0 +1,83 @@
+import time
+
+from django.core.management.base import BaseCommand
+
+from api.models import Image, Piece, PieceStateImage
+from api.utils import fetch_cloudinary_auto_crop
+
+
+class Command(BaseCommand):
+    help = "Backpopulate Cloudinary auto crops for existing piece images."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--delay-ms",
+            type=int,
+            default=100,
+            help="Delay between Cloudinary delivery requests.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Fetch crops and report counts without writing changes.",
+        )
+
+    def handle(self, *args, **options):
+        delay_seconds = max(options["delay_ms"], 0) / 1000
+        dry_run = options["dry_run"]
+        images = (
+            Image.objects.filter(
+                cloud_name__isnull=False,
+                cloudinary_public_id__isnull=False,
+            )
+            .exclude(cloud_name="")
+            .exclude(cloudinary_public_id="")
+            .order_by("cloud_name", "cloudinary_public_id")
+        )
+
+        fetched = 0
+        updated_links = 0
+        updated_pieces = 0
+        skipped = 0
+
+        for image in images.iterator():
+            cloud_name = image.cloud_name
+            public_id = image.cloudinary_public_id
+            if not cloud_name or not public_id:
+                skipped += 1
+                continue
+            try:
+                crop = fetch_cloudinary_auto_crop(cloud_name, public_id)
+            except Exception as exc:  # noqa: BLE001
+                skipped += 1
+                self.stderr.write(f"Skipping {cloud_name}/{public_id}: {exc}")
+                continue
+
+            if crop is None:
+                skipped += 1
+                continue
+
+            fetched += 1
+            link_qs = PieceStateImage.objects.filter(image=image, crop__isnull=True)
+            piece_qs = Piece.objects.filter(
+                thumbnail=image, thumbnail_crop__isnull=True
+            )
+            link_count = link_qs.count()
+            piece_count = piece_qs.count()
+            if not dry_run:
+                updated_links += link_qs.update(crop=crop)
+                updated_pieces += piece_qs.update(thumbnail_crop=crop)
+            else:
+                updated_links += link_count
+                updated_pieces += piece_count
+
+            if delay_seconds:
+                time.sleep(delay_seconds)
+
+        mode = "Would update" if dry_run else "Updated"
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{mode} {updated_links} piece-state images and "
+                f"{updated_pieces} thumbnails from {fetched} crops; skipped {skipped}."
+            )
+        )

--- a/api/migrations/0005_image_crops.py
+++ b/api/migrations/0005_image_crops.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0004_normalize_images"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="piece",
+            name="thumbnail_crop",
+            field=models.JSONField(blank=True, default=None, null=True),
+        ),
+        migrations.AddField(
+            model_name="piecestateimage",
+            name="crop",
+            field=models.JSONField(blank=True, default=None, null=True),
+        ),
+    ]

--- a/api/models.py
+++ b/api/models.py
@@ -188,6 +188,7 @@ class Piece(models.Model):
         to="api.Image",
         related_name="thumbnail_for_pieces",
     )
+    thumbnail_crop = models.JSONField(null=True, blank=True, default=None)
     shared = models.BooleanField(default=False)
     current_location = models.ForeignKey(
         "Location",
@@ -315,6 +316,7 @@ class PieceStateImage(models.Model):
         related_name="piece_state_links",
     )
     caption = models.CharField(max_length=1024, blank=True, default="")
+    crop = models.JSONField(null=True, blank=True, default=None)
     created = models.DateTimeField(default=timezone.now)
     order = models.PositiveSmallIntegerField()
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -57,6 +57,7 @@ from .models import (
 from .serializer_registry import _GLOBAL_ENTRY_SERIALIZERS, global_entry_serializer
 from .utils import (
     captioned_image_to_dict,
+    crop_to_dict,
     get_or_create_location,
     image_to_dict,
     normalize_image_payload,
@@ -230,6 +231,7 @@ class CaptionedImageSerializer(serializers.Serializer):
         allow_blank=True, required=False, default=None, allow_null=True
     )
     cloud_name = serializers.CharField(allow_null=True, required=False, default=None)
+    crop = serializers.JSONField(required=False, allow_null=True, default=None)
 
 
 class PieceStateSerializer(serializers.ModelSerializer):
@@ -321,6 +323,7 @@ class ThumbnailSerializer(serializers.Serializer):
         allow_blank=True, allow_null=True, default=None
     )
     cloud_name = serializers.CharField(allow_null=True, required=False, default=None)
+    crop = serializers.JSONField(required=False, allow_null=True, default=None)
 
 
 @add_tags(Piece)
@@ -373,7 +376,10 @@ class PieceSummarySerializer(serializers.ModelSerializer):
 
     @extend_schema_field(ThumbnailSerializer(allow_null=True))
     def get_thumbnail(self, obj: Piece) -> dict | None:
-        return image_to_dict(obj.thumbnail)
+        thumbnail = image_to_dict(obj.thumbnail)
+        if thumbnail is None:
+            return None
+        return {**thumbnail, "crop": obj.thumbnail_crop}
 
 
 class PieceDetailSerializer(PieceSummarySerializer):
@@ -663,8 +669,14 @@ class PieceUpdateSerializer(serializers.Serializer):
                 self.context["request"].user, validated_data["current_location"]
             )
         if "thumbnail" in validated_data:
+            thumbnail_payload = validated_data["thumbnail"]
             instance.thumbnail = normalize_image_payload(
-                validated_data["thumbnail"], user=instance.user
+                thumbnail_payload, user=instance.user
+            )
+            instance.thumbnail_crop = (
+                crop_to_dict(thumbnail_payload.get("crop"))
+                if thumbnail_payload is not None
+                else None
             )
         if "shared" in validated_data:
             instance.shared = validated_data["shared"]

--- a/api/tests/test_patch_current_state.py
+++ b/api/tests/test_patch_current_state.py
@@ -44,10 +44,12 @@ class TestPatchCurrentState:
         assert response.json()["current_state"]["notes"] == "Updated notes  "
 
     def test_update_images(self, client, piece):
+        crop = {"x": 0.1, "y": 0.2, "width": 0.7, "height": 0.6}
         images = [
             {
                 "url": "http://example.com/img.jpg",
                 "caption": "Test",
+                "crop": crop,
                 "created": "2024-01-01T00:00:00Z",
             }
         ]
@@ -60,6 +62,7 @@ class TestPatchCurrentState:
         result_images = response.json()["current_state"]["images"]
         assert len(result_images) == 1
         assert result_images[0]["url"] == "http://example.com/img.jpg"
+        assert result_images[0]["crop"] == crop
 
     def test_update_images_empty_caption(self, client, piece):
         images = [{"url": "http://example.com/img.jpg", "caption": ""}]

--- a/api/tests/test_piece_detail.py
+++ b/api/tests/test_piece_detail.py
@@ -174,6 +174,7 @@ class TestPieceDetail:
             "url": "https://example.com/thumb.jpg",
             "cloudinary_public_id": "pieces/thumb",
             "cloud_name": "demo-cloud",
+            "crop": {"x": 0.15, "y": 0.1, "width": 0.6, "height": 0.75},
         }
 
         response = client.patch(
@@ -185,7 +186,12 @@ class TestPieceDetail:
         assert response.status_code == 200
         assert response.json()["thumbnail"] == thumbnail
         piece.refresh_from_db()
-        assert piece.thumbnail == thumbnail
+        assert piece.thumbnail == {
+            "url": thumbnail["url"],
+            "cloudinary_public_id": thumbnail["cloudinary_public_id"],
+            "cloud_name": thumbnail["cloud_name"],
+        }
+        assert piece.thumbnail_crop == thumbnail["crop"]
 
     def test_owner_can_share_completed_piece(self, client, piece):
         PieceState.objects.create(

--- a/api/tests/test_utils.py
+++ b/api/tests/test_utils.py
@@ -2,12 +2,28 @@ import pytest
 
 from api.models import GlazeCombination, GlazeType
 from api.utils import (
+    cloudinary_getinfo_url,
+    crop_to_dict,
+    fetch_cloudinary_auto_crop,
     parse_cloudinary_getinfo_crop,
     sync_glaze_type_singleton_combination,
 )
 
 
 class TestCloudinaryCropParsing:
+    def test_crop_to_dict_rejects_missing_and_invalid_values(self):
+        assert crop_to_dict(None) is None
+        assert crop_to_dict({"x": 0, "y": 0, "width": 0, "height": 1}) is None
+        assert crop_to_dict({"x": "bad", "y": 0, "width": 1, "height": 1}) is None
+
+    def test_crop_to_dict_clamps_relative_values(self):
+        assert crop_to_dict({"x": -0.2, "y": 1.2, "width": 1.5, "height": 0.5}) == {
+            "x": 0.0,
+            "y": 1.0,
+            "width": 1.0,
+            "height": 0.5,
+        }
+
     def test_normalizes_pixel_coordinates_from_getinfo(self):
         payload = {
             "input": {"width": 1000, "height": 800},
@@ -20,6 +36,53 @@ class TestCloudinaryCropParsing:
             "width": 0.5,
             "height": 0.5,
         }
+
+    def test_accepts_nested_w_h_crop_coordinates(self):
+        payload = {
+            "info": {
+                "coordinates": [
+                    {"ignored": True},
+                    {"x": 0.2, "y": 0.3, "w": 0.4, "h": 0.5},
+                ]
+            }
+        }
+
+        assert parse_cloudinary_getinfo_crop(payload) == {
+            "x": 0.2,
+            "y": 0.3,
+            "width": 0.4,
+            "height": 0.5,
+        }
+
+    def test_returns_none_when_getinfo_has_no_crop(self):
+        assert parse_cloudinary_getinfo_crop({"input": {"width": 100}}) is None
+
+    def test_fetch_cloudinary_auto_crop_uses_getinfo_url(self, monkeypatch):
+        calls = []
+
+        class Response:
+            def raise_for_status(self):
+                calls.append("raise_for_status")
+
+            def json(self):
+                return {"crop": {"x": 0.1, "y": 0.2, "width": 0.3, "height": 0.4}}
+
+        def fake_get(url, timeout):
+            calls.append((url, timeout))
+            return Response()
+
+        monkeypatch.setattr("api.utils.requests.get", fake_get)
+
+        assert fetch_cloudinary_auto_crop("demo", "pieces/mug", timeout=3) == {
+            "x": 0.1,
+            "y": 0.2,
+            "width": 0.3,
+            "height": 0.4,
+        }
+        assert calls == [
+            (cloudinary_getinfo_url("demo", "pieces/mug"), 3),
+            "raise_for_status",
+        ]
 
 
 @pytest.mark.django_db

--- a/api/tests/test_utils.py
+++ b/api/tests/test_utils.py
@@ -1,7 +1,25 @@
 import pytest
 
 from api.models import GlazeCombination, GlazeType
-from api.utils import sync_glaze_type_singleton_combination
+from api.utils import (
+    parse_cloudinary_getinfo_crop,
+    sync_glaze_type_singleton_combination,
+)
+
+
+class TestCloudinaryCropParsing:
+    def test_normalizes_pixel_coordinates_from_getinfo(self):
+        payload = {
+            "input": {"width": 1000, "height": 800},
+            "g_auto_info": {"x": 100, "y": 80, "width": 500, "height": 400},
+        }
+
+        assert parse_cloudinary_getinfo_crop(payload) == {
+            "x": 0.1,
+            "y": 0.1,
+            "width": 0.5,
+            "height": 0.5,
+        }
 
 
 @pytest.mark.django_db

--- a/api/utils.py
+++ b/api/utils.py
@@ -5,6 +5,7 @@ of the api app but do not belong in workflow.py (which is reserved for
 workflow-state-machine logic derived from workflow.yml).
 """
 
+import requests
 from django.apps import apps
 from django.conf import settings
 from django.db import transaction
@@ -69,6 +70,100 @@ def image_to_dict(image) -> dict | None:
     }
 
 
+def crop_to_dict(crop: object) -> dict | None:
+    """Normalize crop payloads to relative {x, y, width, height} coordinates."""
+    if not isinstance(crop, dict):
+        return None
+    try:
+        normalized = {
+            "x": float(crop["x"]),
+            "y": float(crop["y"]),
+            "width": float(crop["width"]),
+            "height": float(crop["height"]),
+        }
+    except (KeyError, TypeError, ValueError):
+        return None
+    if normalized["width"] <= 0 or normalized["height"] <= 0:
+        return None
+    return {key: min(max(value, 0.0), 1.0) for key, value in normalized.items()}
+
+
+def _first_crop_candidate(value: object) -> dict | None:
+    if isinstance(value, dict):
+        if {"x", "y", "width", "height"}.issubset(value):
+            try:
+                return {
+                    "x": float(value["x"]),
+                    "y": float(value["y"]),
+                    "width": float(value["width"]),
+                    "height": float(value["height"]),
+                }
+            except (TypeError, ValueError):
+                return None
+        if {"x", "y", "w", "h"}.issubset(value):
+            try:
+                return {
+                    "x": float(value["x"]),
+                    "y": float(value["y"]),
+                    "width": float(value["w"]),
+                    "height": float(value["h"]),
+                }
+            except (TypeError, ValueError):
+                return None
+        for nested in value.values():
+            crop = _first_crop_candidate(nested)
+            if crop is not None:
+                return crop
+    if isinstance(value, list):
+        for nested in value:
+            crop = _first_crop_candidate(nested)
+            if crop is not None:
+                return crop
+    return None
+
+
+def parse_cloudinary_getinfo_crop(payload: object) -> dict | None:
+    """Extract Cloudinary fl_getinfo g_auto crop coordinates as relative values."""
+    crop = _first_crop_candidate(payload)
+    if crop is None:
+        return None
+    input_info = payload.get("input") if isinstance(payload, dict) else None
+    input_width = input_info.get("width") if isinstance(input_info, dict) else None
+    input_height = input_info.get("height") if isinstance(input_info, dict) else None
+    if (
+        isinstance(input_width, int | float)
+        and isinstance(input_height, int | float)
+        and input_width > 1
+        and input_height > 1
+        and (crop["x"] > 1 or crop["y"] > 1 or crop["width"] > 1 or crop["height"] > 1)
+    ):
+        crop = {
+            "x": crop["x"] / input_width,
+            "y": crop["y"] / input_height,
+            "width": crop["width"] / input_width,
+            "height": crop["height"] / input_height,
+        }
+    return crop_to_dict(crop)
+
+
+def cloudinary_getinfo_url(cloud_name: str, public_id: str) -> str:
+    return (
+        f"https://res.cloudinary.com/{cloud_name}/image/upload/"
+        f"fl_getinfo,g_auto,c_crop/{public_id}.json"
+    )
+
+
+def fetch_cloudinary_auto_crop(
+    cloud_name: str, public_id: str, *, timeout: float = 10
+) -> dict | None:
+    """Fetch Cloudinary's g_auto crop suggestion for an existing asset."""
+    response = requests.get(
+        cloudinary_getinfo_url(cloud_name, public_id), timeout=timeout
+    )
+    response.raise_for_status()
+    return parse_cloudinary_getinfo_crop(response.json())
+
+
 def normalize_image_payload(payload: object, user=None):
     """Return an Image row for an API/admin image payload.
 
@@ -119,6 +214,7 @@ def captioned_image_to_dict(link) -> dict:
     return {
         **image_payload,
         "caption": link.caption,
+        "crop": link.crop,
         "created": link.created,
     }
 
@@ -138,6 +234,7 @@ def replace_piece_state_images(piece_state, images: list[dict], user=None) -> No
             piece_state=piece_state,
             image=image,
             caption=payload.get("caption") or "",
+            crop=crop_to_dict(payload.get("crop")),
             created=created_val,
             order=order,
         )

--- a/web/src/components/CloudinaryImage.tsx
+++ b/web/src/components/CloudinaryImage.tsx
@@ -14,14 +14,16 @@
  *   preview   — 64×64 fill, used for the upload preview before saving
  */
 import { Cloudinary } from "@cloudinary/url-gen";
-import { fill, fit } from "@cloudinary/url-gen/actions/resize";
+import { crop as cropAction, fill, fit } from "@cloudinary/url-gen/actions/resize";
 import { format, quality } from "@cloudinary/url-gen/actions/delivery";
 import { auto as autoFormat, jpg } from "@cloudinary/url-gen/qualifiers/format";
 import { auto as autoQuality } from "@cloudinary/url-gen/qualifiers/quality";
 import { autoGravity } from "@cloudinary/url-gen/qualifiers/gravity";
+import { relative } from "@cloudinary/url-gen/qualifiers/flag";
 import { AdvancedImage } from "@cloudinary/react";
 import { Box, CircularProgress } from "@mui/material";
 import { useEffect, useRef, useState } from "react";
+import type { ImageCrop } from "../util/types";
 
 const THUMBNAIL_SIZE = 64;
 const LIGHTBOX_MAX_WIDTH = "90vw";
@@ -65,6 +67,7 @@ export type CloudinaryImageProps = {
   alt?: string;
   /** Rendering context determines the requested dimensions. */
   context: CloudinaryImageContext;
+  crop?: ImageCrop | null;
   requestedWidth?: number;
   requestedHeight?: number;
   style?: React.CSSProperties;
@@ -80,6 +83,7 @@ export default function CloudinaryImage({
   cloudinary_public_id,
   alt = "",
   context,
+  crop,
   requestedWidth,
   requestedHeight,
   style,
@@ -95,7 +99,10 @@ export default function CloudinaryImage({
   // in state (not a ref) is the React-documented pattern for deriving state from
   // props during render — refs must not be read during render.
   // https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
-  const currentKey = `${url}__${cloudinary_public_id}__${context}`;
+  const cropKey = crop
+    ? `${crop.x}:${crop.y}:${crop.width}:${crop.height}`
+    : "";
+  const currentKey = `${url}__${cloudinary_public_id}__${context}__${cropKey}`;
   const [prevKey, setPrevKey] = useState(currentKey);
   if (prevKey !== currentKey) {
     setPrevKey(currentKey);
@@ -118,7 +125,7 @@ export default function CloudinaryImage({
       window.removeEventListener("pageshow", syncLoadedStateFromDom);
       document.removeEventListener("visibilitychange", syncLoadedStateFromDom);
     };
-  }, [url, cloudinary_public_id, context]);
+  }, [url, cloudinary_public_id, context, cropKey]);
 
   function handleLoad(event: React.SyntheticEvent<HTMLImageElement>) {
     setIsLoading(false);
@@ -185,6 +192,17 @@ export default function CloudinaryImage({
   if (cloudName && publicId) {
     const cld = new Cloudinary({ cloud: { cloudName } });
     const img = cld.image(publicId);
+
+    if (crop) {
+      img.resize(
+        cropAction()
+          .width(crop.width)
+          .height(crop.height)
+          .x(crop.x)
+          .y(crop.y)
+          .addFlag(relative()),
+      );
+    }
 
     if (context === "lightbox") {
       const vw = Math.round(viewport.width * viewport.pixelRatio * 0.9);

--- a/web/src/components/ImageLightbox.tsx
+++ b/web/src/components/ImageLightbox.tsx
@@ -119,6 +119,7 @@ export default function ImageLightbox({
               url={image.url}
               cloud_name={image.cloud_name}
               cloudinary_public_id={image.cloudinary_public_id}
+              crop={image.crop}
               alt={image.caption || "Pottery image"}
               context="lightbox"
               style={{

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -455,6 +455,7 @@ function PieceDetailContent({
                     url={piece.thumbnail.url}
                     cloud_name={piece.thumbnail.cloud_name}
                     cloudinary_public_id={piece.thumbnail.cloudinary_public_id}
+                    crop={piece.thumbnail.crop}
                     alt={piece.name}
                     context="detail"
                     style={{

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -76,24 +76,23 @@ function daysSince(date: Date): number {
   return Math.floor((Date.now() - date.getTime()) / (1000 * 60 * 60 * 24));
 }
 
-// Variable card thumbnail height based on recency
-function thumbHeight(days: number, isTerminal: boolean): number {
-  if (isTerminal) return 110;
-  if (days <= 2) return 180;
-  if (days < 14) return 140;
-  return 110;
+function thumbHeight(piece: PieceSummary, cardWidth: number): number {
+  const crop = piece.thumbnail?.crop;
+  if (!crop || crop.width <= 0 || crop.height <= 0) return 150;
+  return Math.min(Math.max(cardWidth * (crop.height / crop.width), 100), 220);
 }
 
 interface PieceCardProps {
   piece: PieceSummary;
+  width: number;
 }
 
-const PieceCard = ({ piece }: PieceCardProps) => {
+const PieceCard = ({ piece, width }: PieceCardProps) => {
   const theme = useTheme();
   const isTerminal = isTerminalState(piece.current_state.state);
   const days = daysSince(new Date(piece.last_modified));
   const isStale = days >= 14 && !isTerminal;
-  const h = thumbHeight(days, isTerminal);
+  const h = thumbHeight(piece, width);
   const label = formatState(piece.current_state.state);
   const detailPath = `/pieces/${piece.id}`;
 
@@ -134,9 +133,10 @@ const PieceCard = ({ piece }: PieceCardProps) => {
           url={piece.thumbnail?.url ?? DEFAULT_THUMBNAIL}
           cloud_name={piece.thumbnail?.cloud_name}
           cloudinary_public_id={piece.thumbnail?.cloudinary_public_id}
+          crop={piece.thumbnail?.crop}
           context="gallery"
-          requestedWidth={300}
-          requestedHeight={200}
+          requestedWidth={Math.round(width)}
+          requestedHeight={h}
           style={{
             width: "100%",
             height: "100%",
@@ -279,8 +279,8 @@ const PieceCard = ({ piece }: PieceCardProps) => {
   );
 };
 
-function MasonryPieceCard({ data }: RenderComponentProps<PieceSummary>) {
-  return <PieceCard piece={data} />;
+function MasonryPieceCard({ data, width }: RenderComponentProps<PieceSummary>) {
+  return <PieceCard piece={data} width={width} />;
 }
 
 type PieceListProps = {

--- a/web/src/components/PiecePhotoGallery.tsx
+++ b/web/src/components/PiecePhotoGallery.tsx
@@ -28,7 +28,7 @@ export type PiecePhotoGalleryImage = CaptionedImage & {
 
 export type EditablePiecePhoto = Pick<
   CaptionedImage,
-  "url" | "caption" | "cloudinary_public_id" | "cloud_name"
+  "url" | "caption" | "cloudinary_public_id" | "cloud_name" | "crop"
 >;
 
 type PiecePhotoGalleryProps = {
@@ -112,11 +112,12 @@ export default function PiecePhotoGallery({
   const editableCurrentStateImages = images
     .filter(isEditableImage)
     .sort((left, right) => left.editableCurrentStateIndex - right.editableCurrentStateIndex)
-    .map(({ url, caption, cloudinary_public_id, cloud_name }) => ({
+    .map(({ url, caption, cloudinary_public_id, cloud_name, crop }) => ({
       url,
       caption,
       cloudinary_public_id: cloudinary_public_id ?? null,
       cloud_name: cloud_name ?? null,
+      crop: crop ?? null,
     }));
 
   function stopEditingCaption() {
@@ -141,6 +142,7 @@ export default function PiecePhotoGallery({
         caption: image.caption,
         cloudinary_public_id: image.cloudinary_public_id ?? null,
         cloud_name: image.cloud_name ?? null,
+        crop: image.crop ?? null,
       })),
       custom_fields: normalizeFields(currentStateAdditionalFields ?? {}),
     });
@@ -156,6 +158,7 @@ export default function PiecePhotoGallery({
         url: image.url,
         cloudinary_public_id: image.cloudinary_public_id ?? null,
         cloud_name: image.cloud_name ?? null,
+        crop: image.crop ?? null,
       },
     });
     onPieceUpdated(updated);

--- a/web/src/components/PiecePhotoGalleryGrid.tsx
+++ b/web/src/components/PiecePhotoGalleryGrid.tsx
@@ -1,5 +1,6 @@
 import CloseIcon from "@mui/icons-material/Close";
 import { Box, IconButton, Typography } from "@mui/material";
+import type { ImageCrop } from "../util/types";
 import CloudinaryImage from "./CloudinaryImage";
 
 type PiecePhotoGalleryGridImage = {
@@ -7,6 +8,7 @@ type PiecePhotoGalleryGridImage = {
   caption: string;
   cloudinary_public_id?: string | null;
   cloud_name?: string | null;
+  crop?: ImageCrop | null;
   stateLabel: string;
   editableCurrentStateIndex: number | null;
 };
@@ -78,6 +80,7 @@ export default function PiecePhotoGalleryGrid({
                 url={image.url}
                 cloud_name={image.cloud_name}
                 cloudinary_public_id={image.cloudinary_public_id}
+                crop={image.crop}
                 alt={image.caption || "Piece photo"}
                 context="gallery"
                 requestedWidth={requestedWidth}

--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -14,6 +14,7 @@ import {
 } from "@mui/material";
 import type { PieceDetail, PieceState } from "../util/types";
 import {
+  fetchCloudinaryAutoCrop,
   fetchCloudinaryWidgetConfig,
   signCloudinaryWidgetParams,
   updateCurrentState,
@@ -337,11 +338,18 @@ export default function WorkflowState({
           };
           setSavingImage(true);
           setImageError(null);
-          updateCurrentState(pieceId, {
-            notes,
-            images: [...images, newImage],
-            custom_fields: normalizedAdditionalFields,
+          fetchCloudinaryAutoCrop({
+            cloudName: config.cloud_name,
+            publicId: result.info.public_id,
           })
+            .catch(() => null)
+            .then((crop) =>
+              updateCurrentState(pieceId, {
+                notes,
+                images: [...images, { ...newImage, crop }],
+                custom_fields: normalizedAdditionalFields,
+              }),
+            )
             .then((result) => {
               dispatch({
                 type: "replace_base_state",

--- a/web/src/components/__tests__/CloudinaryImage.test.tsx
+++ b/web/src/components/__tests__/CloudinaryImage.test.tsx
@@ -204,6 +204,35 @@ describe("CloudinaryImage", () => {
     expect(cloudinaryMocks.resize).toHaveBeenCalledTimes(2);
   });
 
+  it("resets loading state when only the crop changes", () => {
+    const { rerender } = render(
+      <CloudinaryImage
+        url="https://res.cloudinary.com/demo/image/upload/v1/pottery/sample.jpg"
+        cloud_name="demo"
+        cloudinary_public_id="pottery/sample"
+        crop={{ x: 0.1, y: 0.2, width: 0.6, height: 0.7 }}
+        alt="Cloudinary pot"
+        context="gallery"
+      />,
+    );
+
+    fireEvent.load(screen.getByAltText("Cloudinary pot"));
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+
+    rerender(
+      <CloudinaryImage
+        url="https://res.cloudinary.com/demo/image/upload/v1/pottery/sample.jpg"
+        cloud_name="demo"
+        cloudinary_public_id="pottery/sample"
+        crop={{ x: 0.2, y: 0.2, width: 0.6, height: 0.7 }}
+        alt="Cloudinary pot"
+        context="gallery"
+      />,
+    );
+
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+  });
+
 
   it("renders and clears loading state for lightbox-context images", () => {
     render(

--- a/web/src/components/__tests__/CloudinaryImage.test.tsx
+++ b/web/src/components/__tests__/CloudinaryImage.test.tsx
@@ -1,7 +1,12 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { forwardRef, useImperativeHandle, useRef } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import CloudinaryImage from "../CloudinaryImage";
+
+const cloudinaryMocks = vi.hoisted(() => ({
+  resize: vi.fn(),
+  cropAddFlag: vi.fn(),
+}));
 
 vi.mock("@cloudinary/react", () => ({
   AdvancedImage: forwardRef(function MockAdvancedImage(
@@ -46,9 +51,9 @@ vi.mock("@cloudinary/url-gen", () => ({
     image(publicId: string) {
       return {
         publicId,
-        resize() {
+        resize: cloudinaryMocks.resize.mockImplementation(function resize() {
           return this;
-        },
+        }),
         delivery() {
           return this;
         },
@@ -58,6 +63,23 @@ vi.mock("@cloudinary/url-gen", () => ({
 }));
 
 vi.mock("@cloudinary/url-gen/actions/resize", () => ({
+  crop: () => ({
+    width() {
+      return this;
+    },
+    height() {
+      return this;
+    },
+    x() {
+      return this;
+    },
+    y() {
+      return this;
+    },
+    addFlag: cloudinaryMocks.cropAddFlag.mockImplementation(function addFlag() {
+      return this;
+    }),
+  }),
   fill: () => ({
     width() {
       return this;
@@ -97,7 +119,16 @@ vi.mock("@cloudinary/url-gen/qualifiers/gravity", () => ({
   autoGravity: vi.fn(),
 }));
 
+vi.mock("@cloudinary/url-gen/qualifiers/flag", () => ({
+  relative: () => "relative",
+}));
+
 describe("CloudinaryImage", () => {
+  beforeEach(() => {
+    cloudinaryMocks.resize.mockClear();
+    cloudinaryMocks.cropAddFlag.mockClear();
+  });
+
   it("shows a spinner until a fallback image loads", () => {
     render(
       <CloudinaryImage
@@ -156,6 +187,23 @@ describe("CloudinaryImage", () => {
 
     expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
   });
+
+  it("applies a relative crop before context sizing when crop is present", () => {
+    render(
+      <CloudinaryImage
+        url="https://res.cloudinary.com/demo/image/upload/v1/pottery/sample.jpg"
+        cloud_name="demo"
+        cloudinary_public_id="pottery/sample"
+        crop={{ x: 0.1, y: 0.2, width: 0.6, height: 0.7 }}
+        alt="Cloudinary pot"
+        context="gallery"
+      />,
+    );
+
+    expect(cloudinaryMocks.cropAddFlag).toHaveBeenCalledWith("relative");
+    expect(cloudinaryMocks.resize).toHaveBeenCalledTimes(2);
+  });
+
 
   it("renders and clears loading state for lightbox-context images", () => {
     render(

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -7,8 +7,26 @@ import PieceList from "../PieceList";
 import type { PieceSummary } from "../../util/types";
 
 vi.mock("../CloudinaryImage", () => ({
-  default: ({ url, alt }: { url: string; alt?: string }) => (
-    <img src={url} alt={alt ?? ""} />
+  default: ({
+    crop,
+    requestedHeight,
+    requestedWidth,
+    url,
+    alt,
+  }: {
+    crop?: unknown;
+    requestedHeight?: number;
+    requestedWidth?: number;
+    url: string;
+    alt?: string;
+  }) => (
+    <img
+      src={url}
+      alt={alt ?? ""}
+      data-crop={crop ? "yes" : "no"}
+      data-requested-height={requestedHeight}
+      data-requested-width={requestedWidth}
+    />
   ),
 }));
 
@@ -97,6 +115,24 @@ describe("PieceList", () => {
           (img) => img.getAttribute("src") === "https://example.com/bowl.jpg",
         ),
       ).toBe(true);
+    });
+
+    it("sizes Cloudinary thumbnail requests from the crop aspect ratio", () => {
+      const { container } = renderPieceList([
+        makePiece({
+          thumbnail: {
+            url: "https://example.com/tall.jpg",
+            cloudinary_public_id: "pieces/tall",
+            cloud_name: "demo",
+            crop: { x: 0, y: 0, width: 0.5, height: 1 },
+          },
+        }),
+      ]);
+
+      const image = container.querySelector("img")!;
+      expect(image.getAttribute("data-crop")).toBe("yes");
+      expect(image.getAttribute("data-requested-width")).toBe("240");
+      expect(image.getAttribute("data-requested-height")).toBe("220");
     });
 
     it("card links to piece detail page", () => {

--- a/web/src/components/__tests__/PiecePhotoGallery.test.tsx
+++ b/web/src/components/__tests__/PiecePhotoGallery.test.tsx
@@ -174,6 +174,7 @@ describe("PiecePhotoGallery", () => {
             caption: "Updated caption",
             cloudinary_public_id: "piece/a",
             cloud_name: null,
+            crop: null,
           },
         ] satisfies EditablePiecePhoto[],
       }),
@@ -245,6 +246,7 @@ describe("PiecePhotoGallery", () => {
             caption: "Wheel detail",
             cloudinary_public_id: "piece/a",
             cloud_name: null,
+            crop: null,
           },
         ] satisfies EditablePiecePhoto[],
       }),
@@ -435,6 +437,7 @@ describe("PiecePhotoGallery", () => {
           url: "https://example.com/a.jpg",
           cloudinary_public_id: "piece/a",
           cloud_name: null,
+          crop: null,
         },
       }),
     );

--- a/web/src/components/__tests__/WorkflowState.test.tsx
+++ b/web/src/components/__tests__/WorkflowState.test.tsx
@@ -175,6 +175,9 @@ vi.mock("../../util/api", () => ({
   fetchCloudinaryWidgetConfig: vi
     .fn()
     .mockResolvedValue({ cloud_name: "demo", api_key: "123456" }),
+  fetchCloudinaryAutoCrop: vi
+    .fn()
+    .mockResolvedValue({ x: 0.1, y: 0.2, width: 0.7, height: 0.6 }),
   signCloudinaryWidgetParams: vi.fn().mockResolvedValue("mock-signature"),
 }));
 
@@ -859,6 +862,7 @@ describe("WorkflowState", () => {
             expect.objectContaining({
               url: "https://res.cloudinary.com/demo/image/upload/sample.jpg",
               cloudinary_public_id: "sample",
+              crop: { x: 0.1, y: 0.2, width: 0.7, height: 0.6 },
             }),
           ]),
         }),

--- a/web/src/components/__tests__/WorkflowState.test.tsx
+++ b/web/src/components/__tests__/WorkflowState.test.tsx
@@ -870,6 +870,36 @@ describe("WorkflowState", () => {
     );
   });
 
+  it("still saves uploaded images when Cloudinary crop detection fails", async () => {
+    const updated = makePieceDetail();
+    vi.mocked(api.updateCurrentState).mockResolvedValue(updated);
+    vi.mocked(api.fetchCloudinaryAutoCrop).mockRejectedValueOnce(
+      new Error("getinfo failed"),
+    );
+    setupUploadWidget({
+      secure_url: "https://res.cloudinary.com/demo/image/upload/sample.jpg",
+      public_id: "sample",
+    });
+
+    render(<WorkflowState {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: "Upload Image" }));
+
+    await waitFor(() =>
+      expect(api.updateCurrentState).toHaveBeenCalledWith(
+        "test-piece-id",
+        expect.objectContaining({
+          images: expect.arrayContaining([
+            expect.objectContaining({
+              url: "https://res.cloudinary.com/demo/image/upload/sample.jpg",
+              cloudinary_public_id: "sample",
+              crop: null,
+            }),
+          ]),
+        }),
+      ),
+    );
+  });
+
   it("widget upload error shows error message", async () => {
     const { triggerError } = setupControllableWidget();
     render(<WorkflowState {...defaultProps} />);

--- a/web/src/components/workflowStateDraft.ts
+++ b/web/src/components/workflowStateDraft.ts
@@ -1,4 +1,4 @@
-import type { PieceState } from "../util/types";
+import type { ImageCrop, PieceState } from "../util/types";
 import {
   type ResolvedAdditionalField,
   getAdditionalFieldDefinitions,
@@ -9,6 +9,7 @@ export type ImageEntry = {
   caption: string;
   cloudinary_public_id?: string | null;
   cloud_name?: string | null;
+  crop?: ImageCrop | null;
 };
 
 type AdditionalFieldInputMap = Record<string, string>;
@@ -137,6 +138,7 @@ function stateImages(pieceState: PieceState): ImageEntry[] {
     caption: img.caption,
     cloudinary_public_id: img.cloudinary_public_id ?? null,
     cloud_name: img.cloud_name ?? null,
+    crop: img.crop ?? null,
   }));
 }
 

--- a/web/src/util/__tests__/api.test.ts
+++ b/web/src/util/__tests__/api.test.ts
@@ -79,10 +79,12 @@ beforeEach(() => {
   mockClient.delete.mockReset();
   mockClient.defaults = {};
   delete process.env.EXPO_PUBLIC_API_BASE_URL;
+  vi.unstubAllGlobals();
 });
 
 afterEach(() => {
   delete process.env.EXPO_PUBLIC_API_BASE_URL;
+  vi.unstubAllGlobals();
 });
 
 describe("client setup", () => {
@@ -581,6 +583,46 @@ describe("upload endpoints", () => {
         g_auto_info: { x: 100, y: 80, width: 500, height: 400 },
       }),
     ).toEqual({ x: 0.1, y: 0.1, width: 0.5, height: 0.5 });
+  });
+
+  it("parseCloudinaryAutoCrop handles nested w/h crops and invalid payloads", async () => {
+    const { parseCloudinaryAutoCrop } = await loadApiModule();
+
+    expect(
+      parseCloudinaryAutoCrop({
+        nested: [{ ignored: true }, { x: 0.2, y: 0.3, w: 0.4, h: 0.5 }],
+      }),
+    ).toEqual({ x: 0.2, y: 0.3, width: 0.4, height: 0.5 });
+    expect(parseCloudinaryAutoCrop({ input: { width: 100, height: 100 } })).toBeNull();
+    expect(
+      parseCloudinaryAutoCrop({
+        crop: { x: "bad", y: 0, width: 1, height: 1 },
+      }),
+    ).toBeNull();
+  });
+
+  it("fetchCloudinaryAutoCrop fetches getinfo JSON and returns null for non-ok responses", async () => {
+    const { fetchCloudinaryAutoCrop } = await loadApiModule();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          crop: { x: 0.1, y: 0.2, width: 0.3, height: 0.4 },
+        }),
+      })
+      .mockResolvedValueOnce({ ok: false });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchCloudinaryAutoCrop({ cloudName: "demo", publicId: "pieces/mug" }),
+    ).resolves.toEqual({ x: 0.1, y: 0.2, width: 0.3, height: 0.4 });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://res.cloudinary.com/demo/image/upload/fl_getinfo,g_auto,c_crop/pieces/mug.json",
+    );
+    await expect(
+      fetchCloudinaryAutoCrop({ cloudName: "demo", publicId: "pieces/mug" }),
+    ).resolves.toBeNull();
   });
 
   it("importManualSquareCropRecords posts multipart data with payload and matching files", async () => {

--- a/web/src/util/__tests__/api.test.ts
+++ b/web/src/util/__tests__/api.test.ts
@@ -572,6 +572,17 @@ describe("upload endpoints", () => {
     expect(signature).toBe("signed-value");
   });
 
+  it("parseCloudinaryAutoCrop normalizes pixel getinfo coordinates", async () => {
+    const { parseCloudinaryAutoCrop } = await loadApiModule();
+
+    expect(
+      parseCloudinaryAutoCrop({
+        input: { width: 1000, height: 800 },
+        g_auto_info: { x: 100, y: 80, width: 500, height: 400 },
+      }),
+    ).toEqual({ x: 0.1, y: 0.1, width: 0.5, height: 0.5 });
+  });
+
   it("importManualSquareCropRecords posts multipart data with payload and matching files", async () => {
     const { importManualSquareCropRecords } = await loadApiModule();
     mockClient.post.mockResolvedValue({

--- a/web/src/util/api.ts
+++ b/web/src/util/api.ts
@@ -27,6 +27,7 @@ import type {
   StateSummary,
   TagEntry,
   Thumbnail,
+  ImageCrop,
 } from "./types";
 
 export type AuthUser = {
@@ -55,6 +56,11 @@ export type CloudinaryWidgetConfig = {
   api_key: string;
   folder?: string;
   upload_preset?: string;
+};
+
+export type CloudinaryAutoCropInfo = {
+  input?: { width?: number; height?: number };
+  [key: string]: unknown;
 };
 
 // ---------------------------------------------------------------------------
@@ -87,7 +93,77 @@ function mapImage(raw: Wire<CaptionedImage>): CaptionedImage {
     created: new Date(raw.created ?? ""),
     cloudinary_public_id: raw.cloudinary_public_id ?? null,
     cloud_name: raw.cloud_name ?? null,
+    crop: normalizeCrop(raw.crop),
   };
+}
+
+function normalizeCrop(value: unknown): ImageCrop | null {
+  if (!value || typeof value !== "object") return null;
+  const crop = value as Partial<Record<keyof ImageCrop, unknown>>;
+  const x = Number(crop.x);
+  const y = Number(crop.y);
+  const width = Number(crop.width);
+  const height = Number(crop.height);
+  if (![x, y, width, height].every(Number.isFinite)) return null;
+  if (width <= 0 || height <= 0) return null;
+  return {
+    x: Math.min(Math.max(x, 0), 1),
+    y: Math.min(Math.max(y, 0), 1),
+    width: Math.min(Math.max(width, 0), 1),
+    height: Math.min(Math.max(height, 0), 1),
+  };
+}
+
+function readCropCandidate(value: unknown): Record<string, unknown> | null {
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const crop = readCropCandidate(entry);
+      if (crop) return crop;
+    }
+    return null;
+  }
+  if (!value || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  if (
+    ("x" in record && "y" in record && "width" in record && "height" in record) ||
+    ("x" in record && "y" in record && "w" in record && "h" in record)
+  ) {
+    return record;
+  }
+  for (const nested of Object.values(record)) {
+    const crop = readCropCandidate(nested);
+    if (crop) return crop;
+  }
+  return null;
+}
+
+export function parseCloudinaryAutoCrop(info: CloudinaryAutoCropInfo): ImageCrop | null {
+  const candidate = readCropCandidate(info);
+  if (!candidate) return null;
+  const inputWidth = Number(info.input?.width);
+  const inputHeight = Number(info.input?.height);
+  const raw = {
+    x: Number(candidate.x),
+    y: Number(candidate.y),
+    width: Number(candidate.width ?? candidate.w),
+    height: Number(candidate.height ?? candidate.h),
+  };
+  if (![raw.x, raw.y, raw.width, raw.height].every(Number.isFinite)) {
+    return null;
+  }
+  if (
+    inputWidth > 1 &&
+    inputHeight > 1 &&
+    (raw.x > 1 || raw.y > 1 || raw.width > 1 || raw.height > 1)
+  ) {
+    return normalizeCrop({
+      x: raw.x / inputWidth,
+      y: raw.y / inputHeight,
+      width: raw.width / inputWidth,
+      height: raw.height / inputHeight,
+    });
+  }
+  return normalizeCrop(raw);
 }
 
 function mapStateSummary(raw: Wire<StateSummary>): StateSummary {
@@ -275,6 +351,7 @@ export type UpdateStatePayload = {
     caption: string;
     cloudinary_public_id?: string | null;
     cloud_name?: string | null;
+    crop?: ImageCrop | null;
   }>;
   custom_fields?: Record<string, string | number | boolean | null>;
 };
@@ -469,6 +546,16 @@ export async function signCloudinaryWidgetParams(
     },
   );
   return data.signature;
+}
+
+export async function fetchCloudinaryAutoCrop(params: {
+  cloudName: string;
+  publicId: string;
+}): Promise<ImageCrop | null> {
+  const url = `https://res.cloudinary.com/${params.cloudName}/image/upload/fl_getinfo,g_auto,c_crop/${params.publicId}.json`;
+  const response = await fetch(url);
+  if (!response.ok) return null;
+  return parseCloudinaryAutoCrop((await response.json()) as CloudinaryAutoCropInfo);
 }
 
 export type ManualSquareCropImportRecordPayload = {

--- a/web/src/util/types.ts
+++ b/web/src/util/types.ts
@@ -32,6 +32,13 @@ export const SUCCESSORS: Record<string, string[]> = Object.fromEntries(
 // State type from the generated schema — stays in sync with backend validation.
 export type State = components["schemas"]["StateEnum"];
 
+export type ImageCrop = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
 // ---------------------------------------------------------------------------
 // Domain types
 //
@@ -41,11 +48,18 @@ export type State = components["schemas"]["StateEnum"];
 // No Omit<> is required anywhere in this file.
 // ---------------------------------------------------------------------------
 
-// CaptionedImage is correct as-is — direct re-export.
-export type CaptionedImage = components["schemas"]["CaptionedImage"];
+// CaptionedImage narrows JSONField-backed crop to the normalized crop shape.
+export type CaptionedImage = Omit<
+  components["schemas"]["CaptionedImage"],
+  "crop"
+> & {
+  crop?: ImageCrop | null;
+};
 
 // Thumbnail stored on a Piece. Distinct from CaptionedImage — no caption field.
-export type Thumbnail = components["schemas"]["Thumbnail"];
+export type Thumbnail = Omit<components["schemas"]["Thumbnail"], "crop"> & {
+  crop?: ImageCrop | null;
+};
 
 // Minimal state shape returned in list responses.
 // Intersection narrows state: string → state: State.
@@ -56,14 +70,19 @@ export type StateSummary = components["schemas"]["StateSummary"] & {
 
 // Full state record returned in detail responses.
 // Intersection narrows state: string → state: State.
-export type PieceState = components["schemas"]["PieceState"] & {
+export type PieceState = Omit<components["schemas"]["PieceState"], "images"> & {
   state: State;
+  images: CaptionedImage[];
   custom_fields: Record<string, unknown>;
 };
 
 // Piece list entry. Intersection narrows current_state to use our typed StateSummary.
-export type PieceSummary = components["schemas"]["PieceSummary"] & {
+export type PieceSummary = Omit<
+  components["schemas"]["PieceSummary"],
+  "current_state" | "thumbnail"
+> & {
   current_state: StateSummary;
+  thumbnail: Thumbnail | null;
   shared: boolean;
   can_edit: boolean;
   tags: TagEntry[];


### PR DESCRIPTION
## Summary

- Store normalized crop rectangles for piece-state images and piece thumbnails.
- Seed new Cloudinary uploads with `fl_getinfo,g_auto,c_crop` crop suggestions and apply stored crops before context-specific Cloudinary rendering.
- Replace recency-based PieceList thumbnail heights with crop aspect ratio based heights.
- Add `manage.py backpopulate_crops` for existing Cloudinary-backed images.

Closes #209

## Validation

- `source env.sh && gz_format`
- `rtk bazel test //...`
- `rtk bazel build --config=lint //...`
- `source env.sh && gz_build`