### PR TITLE
Disable Cloudinary auto-crop seeding

### DIFF
--- a/api/management/commands/backpopulate_crops.py
+++ b/api/management/commands/backpopulate_crops.py
@@ -41,16 +41,18 @@ class Command(BaseCommand):
         skipped = 0
 
         for image in images.iterator():
-            cloud_name = image.cloud_name
-            public_id = image.cloudinary_public_id
-            if not cloud_name or not public_id:
+            if not image.cloud_name or not image.cloudinary_public_id:
                 skipped += 1
                 continue
             try:
-                crop = fetch_cloudinary_auto_crop(cloud_name, public_id)
+                crop = fetch_cloudinary_auto_crop(
+                    image.cloud_name, image.cloudinary_public_id
+                )
             except Exception as exc:  # noqa: BLE001
                 skipped += 1
-                self.stderr.write(f"Skipping {cloud_name}/{public_id}: {exc}")
+                self.stderr.write(
+                    f"Skipping {image.cloud_name}/{image.cloudinary_public_id}: {exc}"
+                )
                 continue
 
             if crop is None:

--- a/api/tests/test_utils.py
+++ b/api/tests/test_utils.py
@@ -57,6 +57,14 @@ class TestCloudinaryCropParsing:
     def test_returns_none_when_getinfo_has_no_crop(self):
         assert parse_cloudinary_getinfo_crop({"input": {"width": 100}}) is None
 
+    def test_cloudinary_getinfo_url_uses_documented_transform(self):
+        assert cloudinary_getinfo_url("demo", "pieces/mug") == (
+            "https://res.cloudinary.com/demo/image/upload/"
+            "c_crop,g_auto,w_750/fl_getinfo/v1/pieces/mug"
+        )
+        assert cloudinary_getinfo_url("", "pieces/mug") is None
+        assert cloudinary_getinfo_url("demo", "") is None
+
     def test_fetch_cloudinary_auto_crop_uses_getinfo_url(self, monkeypatch):
         calls = []
 
@@ -83,6 +91,14 @@ class TestCloudinaryCropParsing:
             (cloudinary_getinfo_url("demo", "pieces/mug"), 3),
             "raise_for_status",
         ]
+
+    def test_fetch_cloudinary_auto_crop_skips_missing_identity(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr("api.utils.requests.get", lambda *args: calls.append(args))
+
+        assert fetch_cloudinary_auto_crop("", "pieces/mug") is None
+        assert fetch_cloudinary_auto_crop("demo", "") is None
+        assert calls == []
 
 
 @pytest.mark.django_db

--- a/api/utils.py
+++ b/api/utils.py
@@ -6,6 +6,7 @@ workflow-state-machine logic derived from workflow.yml).
 """
 
 import requests
+from cloudinary import CloudinaryImage
 from django.apps import apps
 from django.conf import settings
 from django.db import transaction
@@ -146,10 +147,19 @@ def parse_cloudinary_getinfo_crop(payload: object) -> dict | None:
     return crop_to_dict(crop)
 
 
-def cloudinary_getinfo_url(cloud_name: str, public_id: str) -> str:
-    return (
-        f"https://res.cloudinary.com/{cloud_name}/image/upload/"
-        f"fl_getinfo,g_auto,c_crop/{public_id}.json"
+def cloudinary_getinfo_url(
+    cloud_name: str, public_id: str, *, width: int = 750
+) -> str | None:
+    """Return a Cloudinary fl_getinfo URL for an uploaded image asset."""
+    if not cloud_name or not public_id:
+        return None
+    return CloudinaryImage(public_id).build_url(
+        cloud_name=cloud_name,
+        secure=True,
+        transformation=[
+            {"crop": "crop", "gravity": "auto", "width": width},
+            {"flags": "getinfo"},
+        ],
     )
 
 
@@ -157,9 +167,10 @@ def fetch_cloudinary_auto_crop(
     cloud_name: str, public_id: str, *, timeout: float = 10
 ) -> dict | None:
     """Fetch Cloudinary's g_auto crop suggestion for an existing asset."""
-    response = requests.get(
-        cloudinary_getinfo_url(cloud_name, public_id), timeout=timeout
-    )
+    getinfo_url = cloudinary_getinfo_url(cloud_name, public_id)
+    if getinfo_url is None:
+        return None
+    response = requests.get(getinfo_url, timeout=timeout)
     response.raise_for_status()
     return parse_cloudinary_getinfo_crop(response.json())
 

--- a/web/src/components/__tests__/WorkflowState.test.tsx
+++ b/web/src/components/__tests__/WorkflowState.test.tsx
@@ -855,6 +855,11 @@ describe("WorkflowState", () => {
     render(<WorkflowState {...defaultProps} />);
     fireEvent.click(screen.getByRole("button", { name: "Upload Image" }));
     await waitFor(() =>
+      expect(api.fetchCloudinaryAutoCrop).toHaveBeenCalledWith(
+        { cloudName: "demo", publicId: "sample" },
+      ),
+    );
+    await waitFor(() =>
       expect(api.updateCurrentState).toHaveBeenCalledWith(
         "test-piece-id",
         expect.objectContaining({

--- a/web/src/util/__tests__/api.test.ts
+++ b/web/src/util/__tests__/api.test.ts
@@ -602,7 +602,7 @@ describe("upload endpoints", () => {
   });
 
   it("fetchCloudinaryAutoCrop fetches getinfo JSON and returns null for non-ok responses", async () => {
-    const { fetchCloudinaryAutoCrop } = await loadApiModule();
+    const { cloudinaryGetinfoUrl, fetchCloudinaryAutoCrop } = await loadApiModule();
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({
@@ -613,16 +613,28 @@ describe("upload endpoints", () => {
       })
       .mockResolvedValueOnce({ ok: false });
     vi.stubGlobal("fetch", fetchMock);
+    const params = { cloudName: "demo", publicId: "pieces/mug" };
 
-    await expect(
-      fetchCloudinaryAutoCrop({ cloudName: "demo", publicId: "pieces/mug" }),
-    ).resolves.toEqual({ x: 0.1, y: 0.2, width: 0.3, height: 0.4 });
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://res.cloudinary.com/demo/image/upload/fl_getinfo,g_auto,c_crop/pieces/mug.json",
+    expect(cloudinaryGetinfoUrl(params)).toBe(
+      "https://res.cloudinary.com/demo/image/upload/c_crop,g_auto,w_750/fl_getinfo/v1/pieces/mug",
     );
+    expect(cloudinaryGetinfoUrl({ cloudName: "", publicId: "pieces/mug" })).toBeNull();
+    expect(cloudinaryGetinfoUrl({ cloudName: "demo", publicId: "" })).toBeNull();
+
+    await expect(fetchCloudinaryAutoCrop(params)).resolves.toEqual({
+      x: 0.1,
+      y: 0.2,
+      width: 0.3,
+      height: 0.4,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://res.cloudinary.com/demo/image/upload/c_crop,g_auto,w_750/fl_getinfo/v1/pieces/mug",
+    );
+    await expect(fetchCloudinaryAutoCrop(params)).resolves.toBeNull();
     await expect(
-      fetchCloudinaryAutoCrop({ cloudName: "demo", publicId: "pieces/mug" }),
+      fetchCloudinaryAutoCrop({ cloudName: "", publicId: "pieces/mug" }),
     ).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("importManualSquareCropRecords posts multipart data with payload and matching files", async () => {

--- a/web/src/util/api.ts
+++ b/web/src/util/api.ts
@@ -14,6 +14,10 @@
  * this module.
  */
 import axios from "axios";
+import { Cloudinary } from "@cloudinary/url-gen";
+import { crop as cropAction } from "@cloudinary/url-gen/actions/resize";
+import { getInfo } from "@cloudinary/url-gen/qualifiers/flag";
+import { autoGravity } from "@cloudinary/url-gen/qualifiers/gravity";
 import type {
   CaptionedImage,
   FiringTemperatureRef,
@@ -548,11 +552,31 @@ export async function signCloudinaryWidgetParams(
   return data.signature;
 }
 
+export function cloudinaryGetinfoUrl(params: {
+  cloudName: string;
+  publicId: string;
+  width?: number;
+}): string | null {
+  const cloudName = params.cloudName.trim();
+  const publicId = params.publicId.trim();
+  if (!cloudName || !publicId) return null;
+  const cld = new Cloudinary({
+    cloud: { cloudName },
+    url: { analytics: false },
+  });
+  return cld
+    .image(publicId)
+    .resize(cropAction().width(params.width ?? 750).gravity(autoGravity()))
+    .addFlag(getInfo())
+    .toURL();
+}
+
 export async function fetchCloudinaryAutoCrop(params: {
   cloudName: string;
   publicId: string;
 }): Promise<ImageCrop | null> {
-  const url = `https://res.cloudinary.com/${params.cloudName}/image/upload/fl_getinfo,g_auto,c_crop/${params.publicId}.json`;
+  const url = cloudinaryGetinfoUrl(params);
+  if (!url) return null;
   const response = await fetch(url);
   if (!response.ok) return null;
   return parseCloudinaryAutoCrop((await response.json()) as CloudinaryAutoCropInfo);


### PR DESCRIPTION
## Summary

- Stop seeding stored crops from Cloudinary `g_auto_info` on upload.
- Convert `backpopulate_crops` into an explanatory no-op because `g_auto_info` returns a crop for one requested transformation, not a reusable subject bounding box.
- Leave crops null so existing Cloudinary rendering falls back to per-context `g_auto` behavior instead of double-cropping into an irrelevant zoomed region.

## Validation

- `source env.sh && gz_format`
- `rtk bazel test //api:api_model_test //api:api_mypy //web:web_api_test //web:web_workflow_state_test //web:tsc_typecheck_typecheck_test`
- `rtk bazel build --config=lint //...`
