### PR TITLE
fix: prevent double-crop hyper-zoom from stored auto-gravity crops

### DIFF
--- a/web/src/components/CloudinaryImage.tsx
+++ b/web/src/components/CloudinaryImage.tsx
@@ -217,12 +217,14 @@ export default function CloudinaryImage({
         context === "gallery" ? (requestedWidth ?? 320) : THUMBNAIL_SIZE;
       const targetHeight =
         context === "gallery" ? (requestedHeight ?? 240) : THUMBNAIL_SIZE;
-      // thumbnail, gallery, or preview — cropped fill with auto gravity
+      // When a stored crop is present the subject is already isolated — use
+      // center fill to avoid running auto gravity a second time on the cropped
+      // image, which would cause a second round of subject detection and
+      // hyper-zoom.  Without a stored crop, let auto gravity pick the subject.
       img.resize(
-        fill()
-          .width(targetWidth)
-          .height(targetHeight)
-          .gravity(autoGravity()),
+        crop
+          ? fill().width(targetWidth).height(targetHeight)
+          : fill().width(targetWidth).height(targetHeight).gravity(autoGravity()),
       );
     }
 

--- a/web/src/components/__tests__/CloudinaryImage.test.tsx
+++ b/web/src/components/__tests__/CloudinaryImage.test.tsx
@@ -6,6 +6,7 @@ import CloudinaryImage from "../CloudinaryImage";
 const cloudinaryMocks = vi.hoisted(() => ({
   resize: vi.fn(),
   cropAddFlag: vi.fn(),
+  fillGravity: vi.fn(),
 }));
 
 vi.mock("@cloudinary/react", () => ({
@@ -87,9 +88,9 @@ vi.mock("@cloudinary/url-gen/actions/resize", () => ({
     height() {
       return this;
     },
-    gravity() {
+    gravity: cloudinaryMocks.fillGravity.mockImplementation(function gravity() {
       return this;
-    },
+    }),
   }),
   fit: () => ({
     width() {
@@ -127,6 +128,7 @@ describe("CloudinaryImage", () => {
   beforeEach(() => {
     cloudinaryMocks.resize.mockClear();
     cloudinaryMocks.cropAddFlag.mockClear();
+    cloudinaryMocks.fillGravity.mockClear();
   });
 
   it("shows a spinner until a fallback image loads", () => {
@@ -202,6 +204,33 @@ describe("CloudinaryImage", () => {
 
     expect(cloudinaryMocks.cropAddFlag).toHaveBeenCalledWith("relative");
     expect(cloudinaryMocks.resize).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not call fill.gravity when a stored crop is present (prevents double-crop)", () => {
+    render(
+      <CloudinaryImage
+        url="https://res.cloudinary.com/demo/image/upload/v1/pottery/sample.jpg"
+        cloud_name="demo"
+        cloudinary_public_id="pottery/sample"
+        crop={{ x: 0.1, y: 0.2, width: 0.6, height: 0.7 }}
+        alt="Cloudinary pot"
+        context="thumbnail"
+      />,
+    );
+    expect(cloudinaryMocks.fillGravity).not.toHaveBeenCalled();
+  });
+
+  it("calls fill.gravity with autoGravity when no stored crop is present", () => {
+    render(
+      <CloudinaryImage
+        url="https://res.cloudinary.com/demo/image/upload/v1/pottery/sample.jpg"
+        cloud_name="demo"
+        cloudinary_public_id="pottery/sample"
+        alt="Cloudinary pot"
+        context="thumbnail"
+      />,
+    );
+    expect(cloudinaryMocks.fillGravity).toHaveBeenCalledTimes(1);
   });
 
   it("resets loading state when only the crop changes", () => {


### PR DESCRIPTION
## Summary

- **Root cause**: `CloudinaryImage` applied `c_crop,fl_relative` to extract the auto-gravity subject, then immediately applied `c_fill,g_auto` on the already-cropped image. The second `g_auto` re-ran subject detection on a region that was already just the subject, causing a second round of cropping and hyper-zoom in thumbnail/gallery contexts.
- **Fix**: when a stored crop is present, use center fill (`c_fill` without gravity) — the subject is already isolated, so the fill just resizes to the target dimensions without re-detecting.
- **SDK migration**: `fetchCloudinaryAutoCrop` now builds the `fl_getinfo` URL using the Cloudinary SDK (`crop().gravity(autoGravity()).addFlag(getInfo())`) instead of a manually-constructed string, consistent with how the rest of the codebase uses the SDK.

## Before / After (thumbnail context with stored crop)

**Before** — subject detected twice:
```
c_crop,fl_relative,h_0.6,w_0.5,x_0.1,y_0.2 / c_fill,g_auto,h_64,w_64
```

**After** — subject detected once, then center-filled:
```
c_crop,fl_relative,h_0.6,w_0.5,x_0.1,y_0.2 / c_fill,h_64,w_64
```

Without a stored crop, `g_auto` is still used in the fill step (unchanged behavior).

## Test plan

- [ ] New unit tests verify `fill.gravity` is NOT called when a stored crop is present
- [ ] New unit test verifies `fill.gravity` IS called (with autoGravity) when no crop is present
- [ ] Updated `fetchCloudinaryAutoCrop` URL assertion matches SDK-generated URL (`c_crop,fl_getinfo,g_auto` qualifier order)
- [ ] `bazel test //web:web_cloudinary_image_test //web:web_api_test //web:web_workflow_state_test` all pass

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)
