### PR TITLE
feat: add --force flag to backpopulate_crops to fix release crops

### DIFF
--- a/api/management/commands/backpopulate_crops.py
+++ b/api/management/commands/backpopulate_crops.py
@@ -21,10 +21,16 @@ class Command(BaseCommand):
             action="store_true",
             help="Fetch crops and report counts without writing changes.",
         )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Overwrite existing crops (default skips images that already have a crop).",
+        )
 
     def handle(self, *args, **options):
         delay_seconds = max(options["delay_ms"], 0) / 1000
         dry_run = options["dry_run"]
+        force = options["force"]
         images = (
             Image.objects.filter(
                 cloud_name__isnull=False,
@@ -60,9 +66,15 @@ class Command(BaseCommand):
                 continue
 
             fetched += 1
-            link_qs = PieceStateImage.objects.filter(image=image, crop__isnull=True)
-            piece_qs = Piece.objects.filter(
-                thumbnail=image, thumbnail_crop__isnull=True
+            link_qs = (
+                PieceStateImage.objects.filter(image=image)
+                if force
+                else PieceStateImage.objects.filter(image=image, crop__isnull=True)
+            )
+            piece_qs = (
+                Piece.objects.filter(thumbnail=image)
+                if force
+                else Piece.objects.filter(thumbnail=image, thumbnail_crop__isnull=True)
             )
             link_count = link_qs.count()
             piece_count = piece_qs.count()

--- a/api/tests/test_utils.py
+++ b/api/tests/test_utils.py
@@ -1,6 +1,7 @@
 import pytest
+from django.core.management import call_command
 
-from api.models import GlazeCombination, GlazeType
+from api.models import GlazeCombination, GlazeType, Image, Piece
 from api.utils import (
     cloudinary_getinfo_url,
     crop_to_dict,
@@ -99,6 +100,86 @@ class TestCloudinaryCropParsing:
         assert fetch_cloudinary_auto_crop("", "pieces/mug") is None
         assert fetch_cloudinary_auto_crop("demo", "") is None
         assert calls == []
+
+
+@pytest.mark.django_db
+class TestBackpopulateCropsCommand:
+    def _make_cloudinary_image(self):
+        return Image.objects.create(
+            url="https://res.cloudinary.com/demo/image/upload/v1/pieces/mug.jpg",
+            cloud_name="demo",
+            cloudinary_public_id="pieces/mug",
+        )
+
+    def test_skips_images_with_existing_crop_by_default(self, monkeypatch):
+        image = self._make_cloudinary_image()
+        existing_crop = {"x": 0.1, "y": 0.2, "width": 0.5, "height": 0.6}
+        fetched = []
+
+        def fake_fetch(cloud_name, cloudinary_public_id, **kwargs):
+            fetched.append((cloud_name, cloudinary_public_id))
+            return {"x": 0.3, "y": 0.4, "width": 0.4, "height": 0.5}
+
+        monkeypatch.setattr(
+            "api.management.commands.backpopulate_crops.fetch_cloudinary_auto_crop",
+            fake_fetch,
+        )
+
+        from django.contrib.auth.models import User
+
+        user = User.objects.create(username="u@example.com", email="u@example.com")
+        piece = Piece.objects.create(
+            user=user, name="Mug", thumbnail=image, thumbnail_crop=existing_crop
+        )
+
+        call_command("backpopulate_crops", "--delay-ms=0")
+
+        piece.refresh_from_db()
+        assert piece.thumbnail_crop == existing_crop
+
+    def test_force_overwrites_existing_crops(self, monkeypatch):
+        image = self._make_cloudinary_image()
+        existing_crop = {"x": 0.1, "y": 0.2, "width": 0.5, "height": 0.6}
+        new_crop = {"x": 0.3, "y": 0.4, "width": 0.4, "height": 0.5}
+
+        monkeypatch.setattr(
+            "api.management.commands.backpopulate_crops.fetch_cloudinary_auto_crop",
+            lambda cloud_name, cloudinary_public_id, **kwargs: new_crop,
+        )
+
+        from django.contrib.auth.models import User
+
+        user = User.objects.create(username="u@example.com", email="u@example.com")
+        piece = Piece.objects.create(
+            user=user, name="Mug", thumbnail=image, thumbnail_crop=existing_crop
+        )
+
+        call_command("backpopulate_crops", "--delay-ms=0", "--force")
+
+        piece.refresh_from_db()
+        assert piece.thumbnail_crop == new_crop
+
+    def test_dry_run_does_not_write(self, monkeypatch):
+        image = self._make_cloudinary_image()
+        monkeypatch.setattr(
+            "api.management.commands.backpopulate_crops.fetch_cloudinary_auto_crop",
+            lambda cloud_name, cloudinary_public_id, **kwargs: {
+                "x": 0.1,
+                "y": 0.1,
+                "width": 0.5,
+                "height": 0.5,
+            },
+        )
+
+        from django.contrib.auth.models import User
+
+        user = User.objects.create(username="u@example.com", email="u@example.com")
+        piece = Piece.objects.create(user=user, name="Mug", thumbnail=image)
+
+        call_command("backpopulate_crops", "--delay-ms=0", "--dry-run")
+
+        piece.refresh_from_db()
+        assert piece.thumbnail_crop is None
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

- Adds a `--force` flag to the `backpopulate_crops` management command that overwrites existing crop values instead of skipping images that already have a crop stored.
- Without `--force` (default), the command is unchanged: it skips images where a crop is already present.
- With `--force`, it removes the `crop__isnull=True` / `thumbnail_crop__isnull=True` filters, allowing re-population for images whose crops were stored during the buggy double-crop release (commit `2e19529` fixed the rendering; this flag fixes the data).
- Added tests covering the default-skip, `--force` overwrite, and `--dry-run` no-write cases.

## Usage

```bash
# Preview how many records would be updated
python manage.py backpopulate_crops --force --dry-run

# Re-crop all Cloudinary images, overwriting existing crops
python manage.py backpopulate_crops --force
```

## Test plan

- [ ] `rtk bazel test //api:api_model_test` passes (covers the three new `TestBackpopulateCropsCommand` tests)
- [ ] Ran `backpopulate_crops --force --dry-run` against the production DB to verify count before writing
- [ ] Ran `backpopulate_crops --force` to fix crops stored during the buggy release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
