### PR TITLE
fix: center fill instead of g_auto to prevent face-detection zoom

### DIFF
--- a/api/management/commands/clear_crops.py
+++ b/api/management/commands/clear_crops.py
@@ -1,0 +1,35 @@
+from django.core.management.base import BaseCommand
+
+from api.models import Piece, PieceStateImage
+
+
+class Command(BaseCommand):
+    help = "Clear auto-seeded Cloudinary crops that were generated using g_auto (face-biased)."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report counts without writing changes.",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+
+        state_qs = PieceStateImage.objects.exclude(crop=None)
+        thumb_qs = Piece.objects.exclude(thumbnail_crop=None)
+
+        state_count = state_qs.count()
+        thumb_count = thumb_qs.count()
+
+        if not dry_run:
+            state_qs.update(crop=None)
+            thumb_qs.update(thumbnail_crop=None)
+
+        mode = "Would clear" if dry_run else "Cleared"
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"{mode} {state_count} state image crops and "
+                f"{thumb_count} thumbnail crops."
+            )
+        )

--- a/web/src/components/CloudinaryImage.tsx
+++ b/web/src/components/CloudinaryImage.tsx
@@ -18,7 +18,6 @@ import { crop as cropAction, fill, fit } from "@cloudinary/url-gen/actions/resiz
 import { format, quality } from "@cloudinary/url-gen/actions/delivery";
 import { auto as autoFormat, jpg } from "@cloudinary/url-gen/qualifiers/format";
 import { auto as autoQuality } from "@cloudinary/url-gen/qualifiers/quality";
-import { autoGravity } from "@cloudinary/url-gen/qualifiers/gravity";
 import { relative } from "@cloudinary/url-gen/qualifiers/flag";
 import { AdvancedImage } from "@cloudinary/react";
 import { Box, CircularProgress } from "@mui/material";
@@ -217,15 +216,11 @@ export default function CloudinaryImage({
         context === "gallery" ? (requestedWidth ?? 320) : THUMBNAIL_SIZE;
       const targetHeight =
         context === "gallery" ? (requestedHeight ?? 240) : THUMBNAIL_SIZE;
-      // When a stored crop is present the subject is already isolated — use
-      // center fill to avoid running auto gravity a second time on the cropped
-      // image, which would cause a second round of subject detection and
-      // hyper-zoom.  Without a stored crop, let auto gravity pick the subject.
-      img.resize(
-        crop
-          ? fill().width(targetWidth).height(targetHeight)
-          : fill().width(targetWidth).height(targetHeight).gravity(autoGravity()),
-      );
+      // Always use center fill — no auto gravity. g_auto prioritizes face
+      // detection and hyper-zooms into photographer reflections/backgrounds
+      // rather than the pottery subject. Center fill is more reliable for
+      // pottery photos where the subject is nearly always centered in the frame.
+      img.resize(fill().width(targetWidth).height(targetHeight));
     }
 
     // Thumbnail and preview contexts request JPG explicitly — consistent

--- a/web/src/components/__tests__/CloudinaryImage.test.tsx
+++ b/web/src/components/__tests__/CloudinaryImage.test.tsx
@@ -6,7 +6,7 @@ import CloudinaryImage from "../CloudinaryImage";
 const cloudinaryMocks = vi.hoisted(() => ({
   resize: vi.fn(),
   cropAddFlag: vi.fn(),
-  fillGravity: vi.fn(),
+  fillGravity: vi.fn(), // retained to confirm gravity is never called
 }));
 
 vi.mock("@cloudinary/react", () => ({
@@ -116,10 +116,6 @@ vi.mock("@cloudinary/url-gen/qualifiers/quality", () => ({
   auto: vi.fn(),
 }));
 
-vi.mock("@cloudinary/url-gen/qualifiers/gravity", () => ({
-  autoGravity: vi.fn(),
-}));
-
 vi.mock("@cloudinary/url-gen/qualifiers/flag", () => ({
   relative: () => "relative",
 }));
@@ -206,7 +202,8 @@ describe("CloudinaryImage", () => {
     expect(cloudinaryMocks.resize).toHaveBeenCalledTimes(2);
   });
 
-  it("does not call fill.gravity when a stored crop is present (prevents double-crop)", () => {
+  it("never calls fill.gravity — always uses center fill to avoid face-detection zoom", () => {
+    // With crop
     render(
       <CloudinaryImage
         url="https://res.cloudinary.com/demo/image/upload/v1/pottery/sample.jpg"
@@ -218,9 +215,8 @@ describe("CloudinaryImage", () => {
       />,
     );
     expect(cloudinaryMocks.fillGravity).not.toHaveBeenCalled();
-  });
 
-  it("calls fill.gravity with autoGravity when no stored crop is present", () => {
+    // Without crop
     render(
       <CloudinaryImage
         url="https://res.cloudinary.com/demo/image/upload/v1/pottery/sample.jpg"
@@ -230,7 +226,7 @@ describe("CloudinaryImage", () => {
         context="thumbnail"
       />,
     );
-    expect(cloudinaryMocks.fillGravity).toHaveBeenCalledTimes(1);
+    expect(cloudinaryMocks.fillGravity).not.toHaveBeenCalled();
   });
 
   it("resets loading state when only the crop changes", () => {


### PR DESCRIPTION
## Problem

Cloudinary's `g_auto` gravity prioritizes face detection. Pottery photos frequently have a photographer's reflection, background person, or face visible that `g_auto` selects as the "subject." This produced tiny zoomed crops of faces instead of pottery pieces — all 93 auto-seeded crops in prod had `area < 0.25`, and `g_auto` was pointing crops at face regions rather than the pottery.

## Changes

**`CloudinaryImage.tsx`** — always use plain center fill (no `autoGravity`) for thumbnail/gallery/preview contexts:

- **Without a stored crop:** avoids face-detection bias that hyper-zooms into photographer reflections instead of the pottery subject.
- **With a stored crop:** the first resize step (`c_crop,fl_relative`) already extracts the subject region using stored coordinates; the fill step just scales that region to the target dimensions — no further subject detection needed. This means the fix remains correct once the async local crop pipeline (issue #270) seeds accurate subject crops.

**`clear_crops` management command** — clears all auto-seeded crops generated using `g_auto`. Run on prod after deploying:

```bash
# Preview
python manage.py clear_crops --dry-run

# Apply
python manage.py clear_crops
```

## Test plan

- [ ] `rtk bazel test //web:web_cloudinary_image_test` — updated test asserts `fill.gravity` is never called (with or without stored crop)
- [ ] `rtk bazel build --config=lint //web/...` passes
- [ ] Deploy and run `python manage.py clear_crops` on prod
- [ ] Spot-check thumbnails in the piece list — should show centered pottery, not zoomed face regions

Closes the prod hyper-zoom issue diagnosed in PR #268 analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
