### PR TITLE
[codex] Fix Cloudinary cleanup thumbnails and deletion

### DIFF
--- a/api/cloudinary_cleanup.py
+++ b/api/cloudinary_cleanup.py
@@ -1,4 +1,5 @@
 import os
+import logging
 from dataclasses import dataclass
 
 import cloudinary
@@ -7,6 +8,8 @@ import cloudinary.exceptions
 from cloudinary import CloudinaryImage
 
 from .models import Image
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -110,6 +113,10 @@ def delete_cloudinary_assets(public_ids: list[str]) -> dict[str, str]:
     try:
         result = cloudinary.api.delete_resources(public_ids, resource_type="image")
     except cloudinary.exceptions.Error as exc:
+        logger.exception(
+            "Cloudinary delete_resources failed for %d cleanup assets.",
+            len(public_ids),
+        )
         raise ValueError("Unable to delete Cloudinary assets.") from exc
     deleted = result.get("deleted", {})
     if not isinstance(deleted, dict):

--- a/api/cloudinary_cleanup.py
+++ b/api/cloudinary_cleanup.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 
 import cloudinary
 import cloudinary.api
+import cloudinary.exceptions
+from cloudinary import CloudinaryImage
 
 from .models import Image
 
@@ -11,6 +13,7 @@ from .models import Image
 class CloudinaryCleanupAsset:
     public_id: str
     url: str
+    thumbnail_url: str
     bytes: int | None
     created_at: str | None
     referenced: bool
@@ -69,6 +72,13 @@ def list_cloudinary_assets(max_results: int = 500) -> list[CloudinaryCleanupAsse
                 CloudinaryCleanupAsset(
                     public_id=public_id,
                     url=str(resource.get("secure_url") or resource.get("url") or ""),
+                    thumbnail_url=CloudinaryImage(public_id).build_url(
+                        width=96,
+                        height=96,
+                        crop="fill",
+                        format="jpg",
+                        secure=True,
+                    ),
                     bytes=resource.get("bytes")
                     if isinstance(resource.get("bytes"), int)
                     else None,
@@ -97,7 +107,10 @@ def delete_cloudinary_assets(public_ids: list[str]) -> dict[str, str]:
     if not public_ids:
         return {}
 
-    result = cloudinary.api.delete_resources(public_ids, resource_type="image")
+    try:
+        result = cloudinary.api.delete_resources(public_ids, resource_type="image")
+    except cloudinary.exceptions.Error as exc:
+        raise ValueError("Unable to delete Cloudinary assets.") from exc
     deleted = result.get("deleted", {})
     if not isinstance(deleted, dict):
         raise ValueError("Cloudinary returned an unexpected delete payload.")

--- a/api/tests/test_cloudinary_cleanup.py
+++ b/api/tests/test_cloudinary_cleanup.py
@@ -1,4 +1,5 @@
 import pytest
+import cloudinary.exceptions
 from django.contrib.auth.models import User
 
 from api.models import Image
@@ -66,6 +67,10 @@ class TestCloudinaryCleanup:
                 {
                     "public_id": "piece/orphan",
                     "url": "https://example.com/orphan.jpg",
+                    "thumbnail_url": (
+                        "https://res.cloudinary.com/demo/image/upload/"
+                        "c_fill,h_96,w_96/v1/piece/orphan.jpg"
+                    ),
                     "bytes": 5678,
                     "created_at": "2026-05-06T12:05:00Z",
                 },
@@ -122,3 +127,27 @@ class TestCloudinaryCleanup:
 
         assert response.status_code == 200
         assert response.json() == {"deleted": {"piece/orphan": "deleted"}}
+
+    def test_delete_cloudinary_error_returns_503(self, client, monkeypatch):
+        admin = User.objects.create(
+            username="admin@example.com",
+            email="admin@example.com",
+            is_staff=True,
+        )
+        client.force_authenticate(user=admin)
+        monkeypatch.setenv("CLOUDINARY_CLOUD_NAME", "demo")
+        monkeypatch.setenv("CLOUDINARY_API_KEY", "api-key")
+        monkeypatch.setenv("CLOUDINARY_API_SECRET", "api-secret")
+
+        def fake_delete_resources(public_ids, **kwargs):
+            raise cloudinary.exceptions.Error("boom")
+
+        monkeypatch.setattr(
+            "api.cloudinary_cleanup.cloudinary.api.delete_resources",
+            fake_delete_resources,
+        )
+
+        response = client.delete(URL, {"public_ids": ["piece/orphan"]}, format="json")
+
+        assert response.status_code == 503
+        assert response.json() == {"detail": "Unable to delete Cloudinary assets."}

--- a/api/views.py
+++ b/api/views.py
@@ -713,6 +713,7 @@ def admin_cloudinary_cleanup(request: Request) -> Response:
                     {
                         "public_id": asset.public_id,
                         "url": asset.url,
+                        "thumbnail_url": asset.thumbnail_url,
                         "bytes": asset.bytes,
                         "created_at": asset.created_at,
                     }
@@ -739,11 +740,13 @@ def admin_cloudinary_cleanup(request: Request) -> Response:
         deleted = delete_cloudinary_assets(public_ids)
     except ValueError as exc:
         message = str(exc)
-        response_status = (
-            status.HTTP_503_SERVICE_UNAVAILABLE
-            if message == "Cloudinary is not configured on the server."
-            else status.HTTP_400_BAD_REQUEST
-        )
+        service_unavailable_messages = {
+            "Cloudinary is not configured on the server.",
+            "Unable to delete Cloudinary assets.",
+        }
+        response_status: int = status.HTTP_400_BAD_REQUEST
+        if message in service_unavailable_messages:
+            response_status = status.HTTP_503_SERVICE_UNAVAILABLE
         return Response({"detail": message}, status=response_status)
 
     return Response({"deleted": deleted})

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -218,6 +218,34 @@ GOOGLE_OAUTH_CLIENT_ID = os.environ.get("GOOGLE_OAUTH_CLIENT_ID", "")
 # disabled in production.
 DEV_BOOTSTRAP_ENABLED = DEBUG and os.environ.get("GLAZE_DEV_BOOTSTRAP", "1") == "1"
 
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "console": {
+            "format": "%(levelname)s %(asctime)s %(name)s %(message)s",
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "console",
+        },
+    },
+    "loggers": {
+        "django.request": {
+            "handlers": ["console"],
+            "level": "ERROR",
+            "propagate": False,
+        },
+        "api": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+    },
+}
+
 # Security settings
 SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
 SECURE_CROSS_ORIGIN_OPENER_POLICY = "same-origin-allow-popups"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,4 +8,7 @@ python manage.py load_public_library --skip-if-missing
 exec python -m gunicorn backend.wsgi:application \
     --bind 0.0.0.0:8000 \
     --workers 1 \
-    --timeout 120
+    --timeout 120 \
+    --access-logfile - \
+    --error-logfile - \
+    --capture-output

--- a/web/src/pages/CloudinaryCleanupPage.tsx
+++ b/web/src/pages/CloudinaryCleanupPage.tsx
@@ -75,11 +75,10 @@ export default function CloudinaryCleanupPage() {
   const allPageSelected =
     pageAssets.length > 0 && pageAssets.every((a) => selected.has(a.public_id));
   const somePageSelected = pageAssets.some((a) => selected.has(a.public_id));
-  const selectedAssets = useMemo(
-    () => assets.filter((asset) => selected.has(asset.public_id)),
-    [selected, assets],
+  const selectedPageAssets = useMemo(
+    () => pageAssets.filter((asset) => selected.has(asset.public_id)),
+    [selected, pageAssets],
   );
-
   async function handleScan() {
     setLoading(true);
     setError(null);
@@ -97,7 +96,7 @@ export default function CloudinaryCleanupPage() {
   }
 
   async function handleDelete() {
-    const publicIds = selectedAssets.map((asset) => asset.public_id);
+    const publicIds = selectedPageAssets.map((asset) => asset.public_id);
     if (!publicIds.length) return;
     setDeleting(true);
     setError(null);
@@ -225,9 +224,9 @@ export default function CloudinaryCleanupPage() {
               color="error"
               startIcon={<DeleteIcon />}
               onClick={() => setConfirmOpen(true)}
-              disabled={!selectedAssets.length || deleting}
+              disabled={!selectedPageAssets.length || deleting}
             >
-              Delete Selected ({selectedAssets.length})
+              Delete Selected ({selectedPageAssets.length})
             </Button>
           </Stack>
 
@@ -264,10 +263,10 @@ export default function CloudinaryCleanupPage() {
                     </TableCell>
                     <TableCell>
                       <Stack direction="row" alignItems="center" spacing={1.5}>
-                        {asset.url ? (
+                        {asset.thumbnail_url ? (
                           <Box
                             component="img"
-                            src={asset.url}
+                            src={asset.thumbnail_url}
                             alt=""
                             sx={{
                               width: 48,
@@ -318,8 +317,9 @@ export default function CloudinaryCleanupPage() {
         <DialogTitle>Delete selected assets?</DialogTitle>
         <DialogContent>
           <DialogContentText>
-            This will permanently delete {selectedAssets.length} unused
-            Cloudinary assets. Referenced assets are blocked by the backend.
+            This will permanently delete {selectedPageAssets.length} unused
+            Cloudinary assets from the current page. Referenced assets are
+            blocked by the backend.
           </DialogContentText>
         </DialogContent>
         <DialogActions>

--- a/web/src/util/__tests__/api.test.ts
+++ b/web/src/util/__tests__/api.test.ts
@@ -700,9 +700,9 @@ describe("upload endpoints", () => {
         {
           public_id: "piece/orphan",
           url: "https://example.com/orphan.jpg",
+          thumbnail_url: "https://example.com/orphan-thumb.jpg",
           bytes: 2048,
           created_at: "2026-05-06T12:00:00Z",
-
         },
       ],
       summary: { total: 1, referenced: 0, unused: 1 },

--- a/web/src/util/api.ts
+++ b/web/src/util/api.ts
@@ -637,6 +637,7 @@ export async function importManualSquareCropRecords(
 export type CloudinaryCleanupAsset = {
   public_id: string;
   url: string;
+  thumbnail_url: string;
   bytes: number | null;
   created_at: string | null;
 };


### PR DESCRIPTION
## What changed

- Requests JPG Cloudinary cleanup thumbnails instead of showing native asset URLs that may be HEIC.
- Makes the cleanup Delete action operate only on selected assets from the current table page.
- Converts Cloudinary delete API failures into a controlled 503 response instead of an unhandled server error.
- Sends Gunicorn request/error logs and Django request exceptions to container logs so production 500s are visible with `docker compose logs web`.

## Validation

- `rtk bazel test //...`
- `rtk bazel build --config=lint //...`
- `rtk bazel test //api:api_admin_test //api:api_mypy`
- `rtk bazel build --config=lint //api:api_mypy`
