### PR TITLE
[codex] Add streaming Cloudinary cleanup archive

### DIFF
--- a/api/cloudinary_cleanup.py
+++ b/api/cloudinary_cleanup.py
@@ -1,6 +1,12 @@
 import os
 import logging
+import posixpath
+from collections.abc import Iterator
 from dataclasses import dataclass
+from typing import Any, cast
+from urllib.parse import urlparse
+from urllib.request import urlopen
+from zipfile import ZIP_DEFLATED, ZipFile
 
 import cloudinary
 import cloudinary.api
@@ -19,6 +25,7 @@ class CloudinaryCleanupAsset:
     path_prefix: str | None
     url: str
     thumbnail_url: str
+    format: str | None
     bytes: int | None
     created_at: str | None
     referenced: bool
@@ -87,6 +94,11 @@ def list_cloudinary_assets(max_results: int = 500) -> list[CloudinaryCleanupAsse
                         format="jpg",
                         secure=True,
                     ),
+                    format=resource.get("format")
+                    if isinstance(resource.get("format"), str)
+                    else _extension_from_url(
+                        str(resource.get("secure_url") or resource.get("url") or "")
+                    ),
                     bytes=resource.get("bytes")
                     if isinstance(resource.get("bytes"), int)
                     else None,
@@ -102,6 +114,67 @@ def list_cloudinary_assets(max_results: int = 500) -> list[CloudinaryCleanupAsse
             break
 
     return assets
+
+
+def _extension_from_url(url: str) -> str | None:
+    suffix = posixpath.splitext(urlparse(url).path)[1].lstrip(".").lower()
+    return suffix or None
+
+
+def _archive_member_name(asset: CloudinaryCleanupAsset) -> str:
+    prefix = (asset.path_prefix or "").strip("/")
+    cloud_id = asset.public_id.strip("/")
+    if prefix and cloud_id == prefix:
+        cloud_id = posixpath.basename(cloud_id)
+    elif prefix and cloud_id.startswith(f"{prefix}/"):
+        cloud_id = cloud_id[len(prefix) + 1 :]
+
+    extension = (asset.format or _extension_from_url(asset.url) or "bin").lstrip(".")
+    return posixpath.join(asset.cloud_name, prefix, f"{cloud_id}.{extension}")
+
+
+class _StreamingZipBuffer:
+    def __init__(self) -> None:
+        self._chunks: list[bytes] = []
+
+    def write(self, data: bytes) -> int:
+        self._chunks.append(bytes(data))
+        return len(data)
+
+    def flush_chunks(self) -> Iterator[bytes]:
+        while self._chunks:
+            yield self._chunks.pop(0)
+
+    def flush(self) -> None:
+        return None
+
+
+def stream_cloudinary_cleanup_archive(
+    assets: list[CloudinaryCleanupAsset],
+) -> Iterator[bytes]:
+    buffer = _StreamingZipBuffer()
+    with ZipFile(cast(Any, buffer), "w", ZIP_DEFLATED) as archive:
+        used_names: set[str] = set()
+        for asset in assets:
+            if not asset.url:
+                continue
+            member_name = _archive_member_name(asset)
+            if member_name in used_names:
+                stem, extension = posixpath.splitext(member_name)
+                index = 2
+                while f"{stem}-{index}{extension}" in used_names:
+                    index += 1
+                member_name = f"{stem}-{index}{extension}"
+            used_names.add(member_name)
+
+            with urlopen(asset.url, timeout=30) as response:
+                with archive.open(member_name, "w") as member:
+                    while chunk := response.read(1024 * 1024):
+                        member.write(chunk)
+                        yield from buffer.flush_chunks()
+            yield from buffer.flush_chunks()
+
+    yield from buffer.flush_chunks()
 
 
 def delete_cloudinary_assets(public_ids: list[str]) -> dict[str, str]:

--- a/api/tests/test_cloudinary_cleanup.py
+++ b/api/tests/test_cloudinary_cleanup.py
@@ -1,10 +1,17 @@
 import pytest
 import cloudinary.exceptions
 from django.contrib.auth.models import User
+from io import BytesIO
+from zipfile import ZipFile
 
+from api.cloudinary_cleanup import (
+    CloudinaryCleanupAsset,
+    stream_cloudinary_cleanup_archive,
+)
 from api.models import Image
 
 URL = "/api/admin/cloudinary-cleanup/"
+ARCHIVE_URL = "/api/admin/cloudinary-cleanup/archive/"
 
 
 @pytest.mark.django_db
@@ -153,3 +160,143 @@ class TestCloudinaryCleanup:
 
         assert response.status_code == 503
         assert response.json() == {"detail": "Unable to delete Cloudinary assets."}
+
+    def test_archive_streams_all_unused_assets_with_cloudinary_paths(
+        self, client, user, monkeypatch
+    ):
+        admin = User.objects.create(
+            username="admin@example.com",
+            email="admin@example.com",
+            is_staff=True,
+        )
+        client.force_authenticate(user=admin)
+        Image.objects.create(
+            user=user,
+            url="https://res.cloudinary.com/demo/image/upload/glaze_dev/used.jpg",
+            cloud_name="demo",
+            cloudinary_public_id="glaze_dev/used",
+        )
+        monkeypatch.setenv("CLOUDINARY_CLOUD_NAME", "demo")
+        monkeypatch.setenv("CLOUDINARY_API_KEY", "api-key")
+        monkeypatch.setenv("CLOUDINARY_API_SECRET", "api-secret")
+        monkeypatch.setenv("CLOUDINARY_UPLOAD_FOLDER", "glaze_dev")
+
+        def fake_resources(**kwargs):
+            return {
+                "resources": [
+                    {
+                        "public_id": "glaze_dev/used",
+                        "secure_url": "https://example.com/used.jpg",
+                        "format": "jpg",
+                    },
+                    {
+                        "public_id": "glaze_dev/piece/orphan",
+                        "secure_url": "https://example.com/orphan.heic",
+                        "format": "heic",
+                    },
+                    {
+                        "public_id": "glaze_dev/piece/another",
+                        "secure_url": "https://example.com/another.webp",
+                        "format": "webp",
+                    },
+                ]
+            }
+
+        class FakeDownload:
+            def __init__(self, body: bytes):
+                self._body = body
+                self._offset = 0
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return None
+
+            def read(self, size=-1):
+                if size == -1:
+                    size = len(self._body) - self._offset
+                chunk = self._body[self._offset : self._offset + size]
+                self._offset += len(chunk)
+                return chunk
+
+        def fake_urlopen(url, timeout):
+            assert timeout == 30
+            bodies = {
+                "https://example.com/orphan.heic": b"orphan-bytes",
+                "https://example.com/another.webp": b"another-bytes",
+            }
+            return FakeDownload(bodies[url])
+
+        monkeypatch.setattr(
+            "api.cloudinary_cleanup.cloudinary.api.resources", fake_resources
+        )
+        monkeypatch.setattr("api.cloudinary_cleanup.urlopen", fake_urlopen)
+
+        response = client.get(ARCHIVE_URL)
+
+        assert response.status_code == 200
+        assert response["Content-Type"] == "application/zip"
+        archive_bytes = b"".join(response.streaming_content)
+        with ZipFile(BytesIO(archive_bytes)) as archive:
+            assert sorted(archive.namelist()) == [
+                "demo/glaze_dev/piece/another.webp",
+                "demo/glaze_dev/piece/orphan.heic",
+            ]
+            assert archive.read("demo/glaze_dev/piece/orphan.heic") == b"orphan-bytes"
+
+    def test_archive_iterator_fetches_assets_lazily(self, monkeypatch):
+        opened_urls = []
+
+        class FakeDownload:
+            def __init__(self, url: str):
+                self.url = url
+                self._sent = False
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return None
+
+            def read(self, size=-1):
+                if self._sent:
+                    return b""
+                self._sent = True
+                return f"bytes from {self.url}".encode()
+
+        def fake_urlopen(url, timeout):
+            opened_urls.append(url)
+            return FakeDownload(url)
+
+        assets = [
+            CloudinaryCleanupAsset(
+                public_id="glaze_dev/first",
+                cloud_name="demo",
+                path_prefix="glaze_dev",
+                url="https://example.com/first.jpg",
+                thumbnail_url="",
+                format="jpg",
+                bytes=None,
+                created_at=None,
+                referenced=False,
+            ),
+            CloudinaryCleanupAsset(
+                public_id="glaze_dev/second",
+                cloud_name="demo",
+                path_prefix="glaze_dev",
+                url="https://example.com/second.jpg",
+                thumbnail_url="",
+                format="jpg",
+                bytes=None,
+                created_at=None,
+                referenced=False,
+            ),
+        ]
+        monkeypatch.setattr("api.cloudinary_cleanup.urlopen", fake_urlopen)
+
+        stream = stream_cloudinary_cleanup_archive(assets)
+        first_chunk = next(stream)
+
+        assert first_chunk
+        assert opened_urls == ["https://example.com/first.jpg"]

--- a/api/urls.py
+++ b/api/urls.py
@@ -10,6 +10,11 @@ urlpatterns = [
         name="admin-cloudinary-cleanup",
     ),
     path(
+        "admin/cloudinary-cleanup/archive/",
+        views.admin_cloudinary_cleanup_archive,
+        name="admin-cloudinary-cleanup-archive",
+    ),
+    path(
         "analysis/glaze-combination-images/",
         views.glaze_combination_images,
         name="analysis-glaze-combination-images",

--- a/api/views.py
+++ b/api/views.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model, login, logout
 from django.db.models import DateTimeField, OuterRef, Q, Subquery
 from django.db.models.functions import Coalesce, Greatest
+from django.http import StreamingHttpResponse
 from django.shortcuts import get_object_or_404
 from django.views.decorators.csrf import ensure_csrf_cookie
 from drf_spectacular.utils import OpenApiParameter, extend_schema, inline_serializer
@@ -22,7 +23,11 @@ from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from .cloudinary_cleanup import delete_cloudinary_assets, list_cloudinary_assets
+from .cloudinary_cleanup import (
+    delete_cloudinary_assets,
+    list_cloudinary_assets,
+    stream_cloudinary_cleanup_archive,
+)
 from .manual_tile_imports import import_manual_tile_records
 from .models import (
     FavoriteGlazeCombination,
@@ -669,6 +674,7 @@ def cloudinary_widget_sign(request: Request) -> Response:
                             "cloud_name": {"type": "string"},
                             "path_prefix": {"type": ["string", "null"]},
                             "url": {"type": "string"},
+                            "thumbnail_url": {"type": "string"},
                             "bytes": {"type": ["integer", "null"]},
                             "created_at": {"type": ["string", "null"]},
                             "referenced": {"type": "boolean"},
@@ -754,6 +760,33 @@ def admin_cloudinary_cleanup(request: Request) -> Response:
         return Response({"detail": message}, status=response_status)
 
     return Response({"deleted": deleted})
+
+
+@extend_schema(
+    responses={
+        200: {"type": "string", "format": "binary"},
+        503: {"type": "object"},
+    },
+)
+@api_view(["GET"])
+@permission_classes([IsAdminUser])
+def admin_cloudinary_cleanup_archive(
+    request: Request,
+) -> StreamingHttpResponse | Response:
+    try:
+        assets = list_cloudinary_assets()
+        unused = [asset for asset in assets if not asset.referenced]
+    except ValueError as exc:
+        return Response({"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+
+    response = StreamingHttpResponse(
+        stream_cloudinary_cleanup_archive(unused),
+        content_type="application/zip",
+    )
+    response["Content-Disposition"] = (
+        'attachment; filename="cloudinary-cleanup-unused-images.zip"'
+    )
+    return response
 
 
 @extend_schema(request=None, responses={204: None})

--- a/web/src/pages/CloudinaryCleanupPage.tsx
+++ b/web/src/pages/CloudinaryCleanupPage.tsx
@@ -22,6 +22,7 @@ import {
   Typography,
 } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
+import DownloadIcon from "@mui/icons-material/Download";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import SearchIcon from "@mui/icons-material/Search";
 
@@ -215,14 +216,25 @@ export default function CloudinaryCleanupPage() {
       {scanResult && (
         <Stack spacing={1.5}>
           <Stack direction="row" justifyContent="space-between" spacing={1}>
-            <Button
-              variant="outlined"
-              startIcon={<RefreshIcon />}
-              onClick={handleScan}
-              disabled={loading || deleting}
-            >
-              Refresh
-            </Button>
+            <Stack direction="row" spacing={1}>
+              <Button
+                variant="outlined"
+                startIcon={<RefreshIcon />}
+                onClick={handleScan}
+                disabled={loading || deleting}
+              >
+                Refresh
+              </Button>
+              <Button
+                component="a"
+                href="/api/admin/cloudinary-cleanup/archive/"
+                variant="outlined"
+                startIcon={<DownloadIcon />}
+                disabled={!assets.length || loading || deleting}
+              >
+                Download Archive
+              </Button>
+            </Stack>
             <Button
               variant="contained"
               color="error"


### PR DESCRIPTION
## Summary

Adds a streaming ZIP archive download to the Cloudinary Cleanup tool so admins can download all unused Cloudinary images, not just assets visible on the current table page.

The archive endpoint streams each Cloudinary asset lazily into a ZIP response and preserves paths as `<cloud_name>/<prefix>/<cloud_id>.<native_extension>`. The cleanup UI now exposes a direct browser download link so the client does not buffer the archive through Axios before saving.

Fixes #278

## Validation

- `rtk bazel test //api:api_test`
- `rtk bazel test //api:api_mypy`
- `rtk bazel test //web:web_test`