### PR TITLE
[codex] Fix admin tile preview JSON values

### DIFF
--- a/api/BUILD.bazel
+++ b/api/BUILD.bazel
@@ -199,7 +199,9 @@ py_test(
         "api/tests/test_cloudinary_image_widget.py",
         "api/tests/test_cloudinary_upload_signature.py",
     ],
-    data = _TEST_DATA,
+    data = _TEST_DATA + [
+        "static/admin/js/cloudinary_image_widget.js",
+    ],
     env = _TEST_ENV,
     main = "//tools:pytest_main.py",
     deps = _TEST_DEPS,

--- a/api/admin.py
+++ b/api/admin.py
@@ -111,24 +111,42 @@ def _cloudinary_public_id(url: str) -> str | None:
     return match.group(1) if match else None
 
 
+def _json_image_payload(value: str) -> dict | None:
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
 def _image_url(value: dict | str | None) -> str:
     """Extract a plain URL string from an image field value.
 
     Accepts the new dict format ``{"url": "...", "cloudinary_public_id": "..."}``
-    as well as legacy plain URL strings (for robustness during any transition).
+    as well as its prepared JSON-string form and legacy plain URL strings.
     Returns an empty string for missing/None values.
     """
     if not value:
         return ""
+    if isinstance(value, str):
+        parsed = _json_image_payload(value)
+        if isinstance(parsed, dict):
+            return _image_url(parsed)
+        return value  # legacy string
     image_payload = image_to_dict(value)
     if image_payload:
         return image_payload.get("url", "")
     if isinstance(value, dict):
         return value.get("url", "")
-    return value  # legacy string
+    return ""
 
 
 def _image_cloud_name(value: dict | str | None) -> str:
+    if isinstance(value, str):
+        parsed = _json_image_payload(value)
+        if isinstance(parsed, dict):
+            return _image_cloud_name(parsed)
+        return os.environ.get("CLOUDINARY_CLOUD_NAME", "")
     image_payload = image_to_dict(value)
     if image_payload:
         return image_payload.get("cloud_name") or os.environ.get(
@@ -145,6 +163,10 @@ def _cloudinary_preview_url(value: dict | str | None) -> str:
     cloud_name = _image_cloud_name(value)
     if not url or not cloud_name:
         return url
+    if isinstance(value, str):
+        parsed = _json_image_payload(value)
+        if isinstance(parsed, dict):
+            value = parsed
     image_payload = image_to_dict(value)
     public_id = (
         (value.get("cloudinary_public_id") if isinstance(value, dict) else None)
@@ -165,6 +187,10 @@ def _cloudinary_lightbox_url(value: dict | str | None) -> str:
     cloud_name = _image_cloud_name(value)
     if not url or not cloud_name:
         return url
+    if isinstance(value, str):
+        parsed = _json_image_payload(value)
+        if isinstance(parsed, dict):
+            value = parsed
     image_payload = image_to_dict(value)
     if isinstance(value, dict) and "cloudinary_public_id" not in value:
         raise AssertionError("image values must include cloudinary_public_id")

--- a/api/static/admin/js/cloudinary_image_widget.js
+++ b/api/static/admin/js/cloudinary_image_widget.js
@@ -2,7 +2,7 @@
  * Cloudinary upload widget integration for Django admin image fields.
  *
  * Attaches a Cloudinary Upload Widget to every button rendered by
- * CloudinaryImageWidget.  On successful upload the secure_url is written
+ * CloudinaryImageWidget.  On successful upload an image JSON payload is written
  * into the associated text input and a live preview image is updated.
  *
  * Configuration (cloud_name, api_key, folder) is read from data-attributes set by
@@ -43,17 +43,12 @@
     return withTransform(rawUrl, 'f_jpg');
   }
 
-  /**
-   * Extract the plain URL from an image field value.
-   * Accepts a JSON string {"url":"...","cloudinary_public_id":"..."} or a bare URL.
-   */
-  function extractUrl(inputValue) {
-    if (!inputValue) { return ''; }
-    try {
-      var parsed = JSON.parse(inputValue);
-      if (parsed && typeof parsed === 'object') { return parsed.url || ''; }
-    } catch (e) { /* not JSON — treat as plain URL */ }
-    return inputValue;
+  function buildImagePayload(info, fallbackCloudName) {
+    return {
+      url: info.secure_url || info.url || '',
+      cloudinary_public_id: info.public_id || null,
+      cloud_name: info.cloud_name || fallbackCloudName || null,
+    };
   }
 
   /** Open a full-screen lightbox showing the given image URL. */
@@ -116,17 +111,15 @@
       widgetOptions,
       function (error, result) {
         if (!error && result && result.event === 'success') {
-          var rawUrl = result.info.secure_url;
-          var publicId = result.info.public_id || null;
-          inp.value = JSON.stringify({
-            url: rawUrl,
-            cloudinary_public_id: publicId,
-            cloud_name: inp.dataset.cloudinaryCloudName || null,
-          });
+          var imagePayload = buildImagePayload(
+            result.info,
+            inp.dataset.cloudinaryCloudName
+          );
+          inp.value = JSON.stringify(imagePayload);
           var preview = document.getElementById(previewId);
           if (preview) {
-            preview.src = getPreviewUrl(rawUrl);
-            preview.dataset.fullUrl = getLightboxUrl(rawUrl);
+            preview.src = getPreviewUrl(imagePayload.url);
+            preview.dataset.fullUrl = getLightboxUrl(imagePayload.url);
             preview.style.display = 'block';
           }
         }

--- a/api/tests/test_cloudinary_image_widget.py
+++ b/api/tests/test_cloudinary_image_widget.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 import pytest
 
@@ -10,6 +11,10 @@ from api.admin import (
     _image_url,
 )
 
+ADMIN_WIDGET_JS = (
+    Path(__file__).parents[1] / "static/admin/js/cloudinary_image_widget.js"
+)
+
 HEIC_URL = (
     "https://res.cloudinary.com/demo-cloud/image/upload"
     "/v1776304349/glaze_public/eyy9whpmb5wajybtfk3p.heic"
@@ -17,6 +22,13 @@ HEIC_URL = (
 HEIC_PUBLIC_ID = "glaze_public/eyy9whpmb5wajybtfk3p"
 
 HEIC_IMAGE_DICT = {"url": HEIC_URL, "cloudinary_public_id": HEIC_PUBLIC_ID}
+HEIC_IMAGE_JSON = json.dumps(
+    {
+        "url": HEIC_URL,
+        "cloudinary_public_id": HEIC_PUBLIC_ID,
+        "cloud_name": "demo-cloud",
+    }
+)
 
 
 class TestCloudinaryPublicId:
@@ -48,6 +60,9 @@ class TestImageUrl:
             _image_url("https://example.com/img.jpg") == "https://example.com/img.jpg"
         )
 
+    def test_extracts_url_from_prepared_json_string(self):
+        assert _image_url(HEIC_IMAGE_JSON) == HEIC_URL
+
     def test_returns_empty_string_for_none(self):
         assert _image_url(None) == ""
 
@@ -71,6 +86,14 @@ class TestCloudinaryPreviewUrl:
         assert result.endswith(".jpg")
         assert "w_200" in result
         # public_id used directly from dict — no URL parsing needed
+        assert HEIC_PUBLIC_ID.split("/")[-1] in result
+
+    def test_returns_jpg_thumbnail_url_from_prepared_json_string(self, monkeypatch):
+        monkeypatch.delenv("CLOUDINARY_CLOUD_NAME", raising=False)
+        result = _cloudinary_preview_url(HEIC_IMAGE_JSON)
+        assert result.startswith("https://res.cloudinary.com/demo-cloud/")
+        assert result.endswith(".jpg")
+        assert "w_200" in result
         assert HEIC_PUBLIC_ID.split("/")[-1] in result
 
     def test_uses_stored_cloud_name_from_dict(self, monkeypatch):
@@ -122,6 +145,12 @@ class TestCloudinaryLightboxUrl:
         result = _cloudinary_lightbox_url(HEIC_IMAGE_DICT)
         assert result.endswith(".jpg")
         assert result.startswith("https://")
+
+    def test_returns_jpg_url_from_prepared_json_string(self, monkeypatch):
+        monkeypatch.delenv("CLOUDINARY_CLOUD_NAME", raising=False)
+        result = _cloudinary_lightbox_url(HEIC_IMAGE_JSON)
+        assert result.startswith("https://res.cloudinary.com/demo-cloud/")
+        assert result.endswith(".jpg")
 
     def test_dict_value_must_include_public_id_key(self, monkeypatch):
         monkeypatch.setenv("CLOUDINARY_CLOUD_NAME", "demo-cloud")
@@ -229,6 +258,20 @@ class TestCloudinaryImageWidgetRender:
         assert "data-full-url" in html
         assert ".heic" not in html.split("src=")[1].split('"')[1]
 
+    def test_prepared_json_string_value_renders_jpg_preview(self, monkeypatch):
+        monkeypatch.setenv("CLOUDINARY_CLOUD_NAME", "configured-cloud")
+        monkeypatch.setenv("CLOUDINARY_API_KEY", "api-key")
+        monkeypatch.setenv("CLOUDINARY_PUBLIC_UPLOAD_FOLDER", "glaze-public")
+
+        html = CloudinaryImageWidget().render(
+            "test_tile_image", HEIC_IMAGE_JSON, attrs={"id": "id_test_tile_image"}
+        )
+
+        assert "cloudinary-preview" in html
+        assert "res.cloudinary.com/demo-cloud" in html
+        assert "w_200" in html
+        assert ".heic" not in html.split("src=")[1].split('"')[1]
+
     def test_dict_value_stored_as_json_in_input(self, monkeypatch):
         monkeypatch.setenv("CLOUDINARY_CLOUD_NAME", "demo-cloud")
         monkeypatch.setenv("CLOUDINARY_API_KEY", "api-key")
@@ -268,3 +311,14 @@ class TestCloudinaryImageWidgetRender:
         )
 
         assert "display:block" in html
+
+
+class TestCloudinaryImageWidgetJavascript:
+    def test_upload_success_writes_image_json_payload(self):
+        script = ADMIN_WIDGET_JS.read_text()
+
+        assert "function buildImagePayload(info, fallbackCloudName)" in script
+        assert "inp.value = JSON.stringify(imagePayload);" in script
+        assert "cloudinary_public_id: info.public_id || null" in script
+        assert "url: info.secure_url || info.url || ''" in script
+        assert "inp.value = rawUrl" not in script


### PR DESCRIPTION
## Summary

Fixes the Django admin Test tile image inline editor preview and makes the Upload Image popup flow explicitly write the structured image JSON payload into the admin form field.

## Root Cause

The admin changelist preview receives the model image value, but the change-form widget can receive the prepared JSON string for the same image payload. The preview helpers treated that JSON string as a literal URL, so the widget rendered a broken preview `src` even though the list-view thumbnail worked.

The browser upload callback also had the JSON write inline and assumed `secure_url`, which made the intended stored shape less explicit and less robust for Cloudinary popup result variants.

## Changes

- Parse prepared JSON-string image payloads before building admin preview and lightbox URLs.
- Preserve legacy bare URL handling.
- Route successful Cloudinary popup uploads through a named image-payload builder.
- Write `{ url, cloudinary_public_id, cloud_name }` JSON into the admin input after popup upload, using `secure_url` with `url` fallback.
- Add regression coverage for JSON-string values in URL extraction, preview generation, lightbox generation, widget rendering, and the admin JavaScript upload assignment.

## Validation

- `rtk bazel test //api:api_admin_test`
- `rtk bazel test //api:api_test`
- `rtk bazel test //api:api_mypy`