### PR TITLE
Add Cloudinary cleanup reference breakdown

### DIFF
--- a/api/cloudinary_cleanup.py
+++ b/api/cloudinary_cleanup.py
@@ -1,6 +1,7 @@
-import os
 import logging
+import os
 import posixpath
+from collections import Counter
 from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any, cast
@@ -13,9 +14,16 @@ import cloudinary.api
 import cloudinary.exceptions
 from cloudinary import CloudinaryImage
 
-from .models import Image
+from .models import GlazeCombination, GlazeType, Image, Piece, PieceStateImage
 
 logger = logging.getLogger(__name__)
+
+REFERENCED_BREAKDOWN_WORKFLOW_IMAGE_PATHS = frozenset(
+    {
+        "globals.glaze_type.test_tile_image",
+        "globals.glaze_combination.test_tile_image",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -29,6 +37,19 @@ class CloudinaryCleanupAsset:
     bytes: int | None
     created_at: str | None
     referenced: bool
+
+
+@dataclass(frozen=True)
+class CloudinaryCleanupReferenceBreakdownItem:
+    key: str
+    label: str
+    count: int
+
+
+@dataclass(frozen=True)
+class CloudinaryCleanupReferenceBreakdown:
+    sources: list[CloudinaryCleanupReferenceBreakdownItem]
+    warnings: list[str]
 
 
 def configure_cloudinary_admin() -> tuple[str, str | None]:
@@ -53,6 +74,141 @@ def list_referenced_public_ids() -> set[str]:
         .values_list("cloudinary_public_id", flat=True)
     )
     return {public_id for public_id in public_ids if public_id is not None}
+
+
+def summarize_referenced_public_ids(
+    scanned_public_ids: set[str] | None = None,
+) -> CloudinaryCleanupReferenceBreakdown:
+    source_counts: Counter[str] = Counter()
+    warnings: list[str] = []
+
+    piece_thumbnail_refs = (
+        Piece.objects.exclude(thumbnail__isnull=True)
+        .exclude(thumbnail__cloudinary_public_id__isnull=True)
+        .exclude(thumbnail__cloudinary_public_id="")
+    )
+    piece_state_image_refs = PieceStateImage.objects.exclude(
+        image__cloudinary_public_id__isnull=True
+    ).exclude(image__cloudinary_public_id="")
+    glaze_tile_image_refs = (
+        GlazeType.objects.exclude(test_tile_image__isnull=True)
+        .exclude(test_tile_image__cloudinary_public_id__isnull=True)
+        .exclude(test_tile_image__cloudinary_public_id="")
+    )
+    glaze_combination_image_refs = (
+        GlazeCombination.objects.exclude(test_tile_image__isnull=True)
+        .exclude(test_tile_image__cloudinary_public_id__isnull=True)
+        .exclude(test_tile_image__cloudinary_public_id="")
+    )
+
+    if scanned_public_ids is not None:
+        piece_thumbnail_refs = piece_thumbnail_refs.filter(
+            thumbnail__cloudinary_public_id__in=scanned_public_ids
+        )
+        piece_state_image_refs = piece_state_image_refs.filter(
+            image__cloudinary_public_id__in=scanned_public_ids
+        )
+        glaze_tile_image_refs = glaze_tile_image_refs.filter(
+            test_tile_image__cloudinary_public_id__in=scanned_public_ids
+        )
+        glaze_combination_image_refs = glaze_combination_image_refs.filter(
+            test_tile_image__cloudinary_public_id__in=scanned_public_ids
+        )
+
+    glaze_tile_count = GlazeType.objects.count()
+    glaze_tile_image_count = (
+        GlazeType.objects.exclude(test_tile_image__isnull=True)
+        .exclude(test_tile_image__cloudinary_public_id__isnull=True)
+        .exclude(test_tile_image__cloudinary_public_id="")
+        .count()
+    )
+    glaze_combination_count = GlazeCombination.objects.count()
+    glaze_combination_image_count = (
+        GlazeCombination.objects.exclude(test_tile_image__isnull=True)
+        .exclude(test_tile_image__cloudinary_public_id__isnull=True)
+        .exclude(test_tile_image__cloudinary_public_id="")
+        .count()
+    )
+
+    source_counts["piece_list"] = piece_thumbnail_refs.count()
+    source_counts["piece_state_images"] = piece_state_image_refs.count()
+    source_counts["glaze_tiles"] = glaze_tile_image_refs.count()
+    source_counts["glaze_combinations"] = glaze_combination_image_refs.count()
+
+    covered_public_ids = (
+        set(
+            piece_thumbnail_refs.values_list(
+                "thumbnail__cloudinary_public_id", flat=True
+            )
+        )
+        | set(
+            piece_state_image_refs.values_list("image__cloudinary_public_id", flat=True)
+        )
+        | set(
+            glaze_tile_image_refs.values_list(
+                "test_tile_image__cloudinary_public_id", flat=True
+            )
+        )
+        | set(
+            glaze_combination_image_refs.values_list(
+                "test_tile_image__cloudinary_public_id", flat=True
+            )
+        )
+    )
+    if scanned_public_ids is None:
+        unknown_referenced_public_ids: set[str] = set()
+    else:
+        unknown_referenced_public_ids = (
+            scanned_public_ids & list_referenced_public_ids()
+        ) - covered_public_ids
+    source_counts["unknown_referenced_assets"] = len(unknown_referenced_public_ids)
+
+    if glaze_tile_image_count < glaze_tile_count:
+        warnings.append(
+            f"Found fewer references than glaze tiles "
+            f"({glaze_tile_image_count} of {glaze_tile_count})."
+        )
+    if glaze_combination_image_count < glaze_combination_count:
+        warnings.append(
+            f"Found fewer references than glaze combinations "
+            f"({glaze_combination_image_count} of {glaze_combination_count})."
+        )
+    if unknown_referenced_public_ids:
+        warnings.append(
+            f"Found {len(unknown_referenced_public_ids)} referenced assets "
+            f"not explained by known source paths."
+        )
+
+    return CloudinaryCleanupReferenceBreakdown(
+        sources=[
+            CloudinaryCleanupReferenceBreakdownItem(
+                key="piece_list",
+                label="PieceList",
+                count=source_counts["piece_list"],
+            ),
+            CloudinaryCleanupReferenceBreakdownItem(
+                key="piece_state_images",
+                label="Piece State Images",
+                count=source_counts["piece_state_images"],
+            ),
+            CloudinaryCleanupReferenceBreakdownItem(
+                key="glaze_tiles",
+                label="Glaze Tiles",
+                count=source_counts["glaze_tiles"],
+            ),
+            CloudinaryCleanupReferenceBreakdownItem(
+                key="glaze_combinations",
+                label="Glaze Combinations",
+                count=source_counts["glaze_combinations"],
+            ),
+            CloudinaryCleanupReferenceBreakdownItem(
+                key="unknown_referenced_assets",
+                label="Unknown Referenced Assets",
+                count=source_counts["unknown_referenced_assets"],
+            ),
+        ],
+        warnings=warnings,
+    )
 
 
 def list_cloudinary_assets(max_results: int = 500) -> list[CloudinaryCleanupAsset]:

--- a/api/tests/test_cloudinary_cleanup.py
+++ b/api/tests/test_cloudinary_cleanup.py
@@ -1,14 +1,18 @@
-import pytest
-import cloudinary.exceptions
-from django.contrib.auth.models import User
 from io import BytesIO
 from zipfile import ZipFile
 
+import cloudinary.exceptions
+import pytest
+from django.contrib.auth.models import User
+
 from api.cloudinary_cleanup import (
+    REFERENCED_BREAKDOWN_WORKFLOW_IMAGE_PATHS,
     CloudinaryCleanupAsset,
     stream_cloudinary_cleanup_archive,
+    summarize_referenced_public_ids,
 )
-from api.models import Image
+from api.models import GlazeCombination, GlazeType, Image
+from api.workflow import _workflow
 
 URL = "/api/admin/cloudinary-cleanup/"
 ARCHIVE_URL = "/api/admin/cloudinary-cleanup/archive/"
@@ -84,8 +88,117 @@ class TestCloudinaryCleanup:
                     "created_at": "2026-05-06T12:05:00Z",
                 },
             ],
-            "summary": {"total": 2, "referenced": 1, "unused": 1},
+            "summary": {
+                "total": 2,
+                "referenced": 1,
+                "unused": 1,
+                "referenced_breakdown": [
+                    {"key": "piece_list", "label": "PieceList", "count": 0},
+                    {
+                        "key": "piece_state_images",
+                        "label": "Piece State Images",
+                        "count": 0,
+                    },
+                    {"key": "glaze_tiles", "label": "Glaze Tiles", "count": 0},
+                    {
+                        "key": "glaze_combinations",
+                        "label": "Glaze Combinations",
+                        "count": 0,
+                    },
+                    {
+                        "key": "unknown_referenced_assets",
+                        "label": "Unknown Referenced Assets",
+                        "count": 1,
+                    },
+                ],
+                "reference_warnings": [
+                    "Found 1 referenced assets not explained by known source paths."
+                ],
+            },
         }
+
+    def test_reference_breakdown_warns_when_glaze_tiles_lack_images(self):
+        tile_image = Image.objects.create(
+            user=None,
+            url="https://res.cloudinary.com/demo/image/upload/glaze/used.jpg",
+            cloud_name="demo",
+            cloudinary_public_id="glaze/used",
+        )
+        GlazeType.objects.create(
+            user=None,
+            name="Celadon",
+            test_tile_image=tile_image,
+        )
+        GlazeType.objects.create(user=None, name="Tenmoku")
+
+        breakdown = summarize_referenced_public_ids()
+
+        assert [
+            {"key": source.key, "label": source.label, "count": source.count}
+            for source in breakdown.sources
+        ] == [
+            {"key": "piece_list", "label": "PieceList", "count": 0},
+            {"key": "piece_state_images", "label": "Piece State Images", "count": 0},
+            {"key": "glaze_tiles", "label": "Glaze Tiles", "count": 1},
+            {"key": "glaze_combinations", "label": "Glaze Combinations", "count": 0},
+            {
+                "key": "unknown_referenced_assets",
+                "label": "Unknown Referenced Assets",
+                "count": 0,
+            },
+        ]
+        assert breakdown.warnings == [
+            "Found fewer references than glaze tiles (1 of 2)."
+        ]
+
+    def test_reference_breakdown_counts_duplicate_source_occurrences(self):
+        shared_image = Image.objects.create(
+            user=None,
+            url="https://res.cloudinary.com/demo/image/upload/glaze/shared.jpg",
+            cloud_name="demo",
+            cloudinary_public_id="glaze/shared",
+        )
+        GlazeType.objects.create(
+            user=None,
+            name="Celadon",
+            test_tile_image=shared_image,
+        )
+        GlazeCombination.objects.create(
+            user=None,
+            name="Celadon",
+            test_tile_image=shared_image,
+        )
+
+        breakdown = summarize_referenced_public_ids({"glaze/shared"})
+
+        assert [
+            {"key": source.key, "label": source.label, "count": source.count}
+            for source in breakdown.sources
+        ] == [
+            {"key": "piece_list", "label": "PieceList", "count": 0},
+            {"key": "piece_state_images", "label": "Piece State Images", "count": 0},
+            {"key": "glaze_tiles", "label": "Glaze Tiles", "count": 1},
+            {"key": "glaze_combinations", "label": "Glaze Combinations", "count": 1},
+            {
+                "key": "unknown_referenced_assets",
+                "label": "Unknown Referenced Assets",
+                "count": 0,
+            },
+        ]
+        assert breakdown.warnings == []
+
+    def test_reference_breakdown_covers_every_workflow_image_field(self):
+        image_paths = set()
+        for global_name, config in _workflow.get("globals", {}).items():
+            for field_name, field_def in config.get("fields", {}).items():
+                if isinstance(field_def, dict) and field_def.get("type") == "image":
+                    image_paths.add(f"globals.{global_name}.{field_name}")
+        for state in _workflow.get("states", []):
+            for field_name, field_def in state.get("fields", {}).items():
+                if isinstance(field_def, dict) and field_def.get("type") == "image":
+                    image_paths.add(f"states.{state['id']}.{field_name}")
+
+        assert image_paths == REFERENCED_BREAKDOWN_WORKFLOW_IMAGE_PATHS
 
     def test_delete_rejects_referenced_assets(self, client, user, monkeypatch):
         admin = User.objects.create(

--- a/api/views.py
+++ b/api/views.py
@@ -27,6 +27,7 @@ from .cloudinary_cleanup import (
     delete_cloudinary_assets,
     list_cloudinary_assets,
     stream_cloudinary_cleanup_archive,
+    summarize_referenced_public_ids,
 )
 from .manual_tile_imports import import_manual_tile_records
 from .models import (
@@ -681,7 +682,29 @@ def cloudinary_widget_sign(request: Request) -> Response:
                         },
                     },
                 },
-                "summary": {"type": "object"},
+                "summary": {
+                    "type": "object",
+                    "properties": {
+                        "total": {"type": "integer"},
+                        "referenced": {"type": "integer"},
+                        "unused": {"type": "integer"},
+                        "referenced_breakdown": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "key": {"type": "string"},
+                                    "label": {"type": "string"},
+                                    "count": {"type": "integer"},
+                                },
+                            },
+                        },
+                        "reference_warnings": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                    },
+                },
             },
         },
         503: {"type": "object"},
@@ -715,6 +738,9 @@ def admin_cloudinary_cleanup(request: Request) -> Response:
                 {"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE
             )
         unused = [asset for asset in assets if not asset.referenced]
+        referenced_breakdown = summarize_referenced_public_ids(
+            {asset.public_id for asset in assets}
+        )
         return Response(
             {
                 "assets": [
@@ -733,6 +759,15 @@ def admin_cloudinary_cleanup(request: Request) -> Response:
                     "total": len(assets),
                     "referenced": len(assets) - len(unused),
                     "unused": len(unused),
+                    "referenced_breakdown": [
+                        {
+                            "key": source.key,
+                            "label": source.label,
+                            "count": source.count,
+                        }
+                        for source in referenced_breakdown.sources
+                    ],
+                    "reference_warnings": referenced_breakdown.warnings,
                 },
             }
         )
@@ -777,7 +812,9 @@ def admin_cloudinary_cleanup_archive(
         assets = list_cloudinary_assets()
         unused = [asset for asset in assets if not asset.referenced]
     except ValueError as exc:
-        return Response({"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+        return Response(
+            {"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE
+        )
 
     response = StreamingHttpResponse(
         stream_cloudinary_cleanup_archive(unused),

--- a/docs/agents/glaze-domain.md
+++ b/docs/agents/glaze-domain.md
@@ -78,6 +78,8 @@ clay_weight_grams:
 
 The `image` type is a DSL-level annotation: at the model layer it is stored as a `JSONField` containing `{"url": "...", "cloudinary_public_id": "..."}` (both fields required; `cloudinary_public_id` is nullable for URL-only images). `_resolve_field_def` resolves it to a JSON Schema object with `url` and `cloudinary_public_id` properties so validation enforces the correct structure. The Django admin renders a Cloudinary upload widget instead of a plain text input, and the widget stores the complete object on upload. Use `image` for any field that holds a Cloudinary-hosted image — the stored `cloudinary_public_id` enables enumerating all referenced assets for cleanup workflows.
 
+When adding a new `type: image` field to `workflow.yml`, update the Cloudinary cleanup referenced-source breakdown in `api/cloudinary_cleanup.py` at the same time. `api/tests/test_cloudinary_cleanup.py::TestCloudinaryCleanup::test_reference_breakdown_covers_every_workflow_image_field` intentionally fails when workflow image paths are not listed in the breakdown coverage set.
+
 _Ref field_ — two sub-forms, distinguished by the `@` prefix:
 
 ```yaml

--- a/web/src/pages/CloudinaryCleanupPage.tsx
+++ b/web/src/pages/CloudinaryCleanupPage.tsx
@@ -19,12 +19,14 @@ import {
   TableHead,
   TablePagination,
   TableRow,
+  Tooltip,
   Typography,
 } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
 import DownloadIcon from "@mui/icons-material/Download";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import SearchIcon from "@mui/icons-material/Search";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 
 import {
   deleteCloudinaryCleanupAssets,
@@ -55,6 +57,50 @@ function formatCreatedAt(value: string | null) {
 
 function formatCloudinaryLocation(asset: CloudinaryCleanupAsset) {
   return [asset.cloud_name, asset.path_prefix].filter(Boolean).join(" / ");
+}
+
+function ReferencedBreakdown({
+  summary,
+}: {
+  summary: CloudinaryCleanupScanResponse["summary"];
+}) {
+  const warnings = summary.reference_warnings ?? [];
+  const breakdown = summary.referenced_breakdown ?? [];
+
+  return (
+    <Stack spacing={0.75}>
+      <Stack direction="row" spacing={1} alignItems="center">
+        <Typography variant="h5">{summary.referenced}</Typography>
+        {warnings.length > 0 && (
+          <Tooltip title={warnings.join(" ")}>
+            <WarningAmberIcon color="warning" fontSize="small" />
+          </Tooltip>
+        )}
+      </Stack>
+      {breakdown.length > 0 && (
+        <Stack spacing={0.25}>
+          {breakdown.map((source) => (
+            <Typography
+              key={source.key}
+              variant="caption"
+              color="text.secondary"
+              sx={{ display: "flex", justifyContent: "space-between", gap: 1 }}
+            >
+              <span>{source.label}</span>
+              <Box component="span" sx={{ fontVariantNumeric: "tabular-nums" }}>
+                {source.count}
+              </Box>
+            </Typography>
+          ))}
+        </Stack>
+      )}
+      {warnings.map((warning) => (
+        <Typography key={warning} variant="caption" color="warning.main">
+          {warning}
+        </Typography>
+      ))}
+    </Stack>
+  );
 }
 
 export default function CloudinaryCleanupPage() {
@@ -122,6 +168,8 @@ export default function CloudinaryCleanupPage() {
             total: current.summary.total - publicIds.length,
             referenced: current.summary.referenced,
             unused: remaining.length,
+            referenced_breakdown: current.summary.referenced_breakdown,
+            reference_warnings: current.summary.reference_warnings,
           },
         };
       });
@@ -200,9 +248,7 @@ export default function CloudinaryCleanupPage() {
             <Typography variant="caption" color="text.secondary">
               Referenced
             </Typography>
-            <Typography variant="h5">
-              {scanResult.summary.referenced}
-            </Typography>
+            <ReferencedBreakdown summary={scanResult.summary} />
           </Paper>
           <Paper sx={{ px: 2, py: 1.5, flex: 1 }}>
             <Typography variant="caption" color="text.secondary">

--- a/web/src/util/__tests__/api.test.ts
+++ b/web/src/util/__tests__/api.test.ts
@@ -707,7 +707,15 @@ describe("upload endpoints", () => {
           created_at: "2026-05-06T12:00:00Z",
         },
       ],
-      summary: { total: 1, referenced: 0, unused: 1 },
+      summary: {
+        total: 1,
+        referenced: 0,
+        unused: 1,
+        referenced_breakdown: [
+          { key: "piece_list", label: "PieceList", count: 0 },
+        ],
+        reference_warnings: [],
+      },
     };
     mockClient.get.mockResolvedValue({ data: payload });
 

--- a/web/src/util/api.ts
+++ b/web/src/util/api.ts
@@ -650,6 +650,12 @@ export type CloudinaryCleanupScanResponse = {
     total: number;
     referenced: number;
     unused: number;
+    referenced_breakdown: {
+      key: string;
+      label: string;
+      count: number;
+    }[];
+    reference_warnings: string[];
   };
 };
 


### PR DESCRIPTION
## Summary
- add source occurrence breakdowns and warnings to the Cloudinary cleanup referenced summary
- surface unknown referenced assets when scanned IDs are not explained by known source paths
- document workflow image-field cleanup coverage and test duplicate reference behavior

## Tests
- source env.sh && gz_format
- rtk bazel test //api:api_admin_test
- rtk bazel build --config=lint //web/...