### PR TITLE
Allow multiple image selection in upload widget

### DIFF
--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -284,7 +284,7 @@ export default function WorkflowState({
         ...(config.folder ? { folder: config.folder } : {}),
         ...(config.upload_preset ? { uploadPreset: config.upload_preset } : {}),
         sources: ["local", "camera"],
-        multiple: false,
+        multiple: true,
         resourceType: "image",
         styles: {
           palette: {


### PR DESCRIPTION
## Summary

- Set `multiple: true` in the Cloudinary upload widget options in `WorkflowState.tsx` so the mobile file picker allows selecting more than one image at a time.
- Each uploaded image is processed by the existing `success` event handler, which saves images to the server individually — no handler changes needed.

Closes #285

## Test plan

- [ ] On mobile (or browser DevTools mobile emulation), open a piece and tap the upload button — the file picker should allow multi-select
- [ ] Select 2+ images; each should appear in the image list after upload
- [ ] Single-image upload still works normally
- [ ] `rtk bazel test //web:web_test` passes
- [ ] `rtk bazel build --config=lint //web/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
