### PR TITLE
Remove bogus auto-crop on image upload

### DIFF
--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -14,7 +14,6 @@ import {
 } from "@mui/material";
 import type { PieceDetail, PieceState } from "../util/types";
 import {
-  fetchCloudinaryAutoCrop,
   fetchCloudinaryWidgetConfig,
   signCloudinaryWidgetParams,
   updateCurrentState,
@@ -338,18 +337,11 @@ export default function WorkflowState({
           };
           setSavingImage(true);
           setImageError(null);
-          fetchCloudinaryAutoCrop({
-            cloudName: config.cloud_name,
-            publicId: result.info.public_id,
+          updateCurrentState(pieceId, {
+            notes,
+            images: [...images, { ...newImage, crop: null }],
+            custom_fields: normalizedAdditionalFields,
           })
-            .catch(() => null)
-            .then((crop) =>
-              updateCurrentState(pieceId, {
-                notes,
-                images: [...images, { ...newImage, crop }],
-                custom_fields: normalizedAdditionalFields,
-              }),
-            )
             .then((result) => {
               dispatch({
                 type: "replace_base_state",

--- a/web/src/components/__tests__/WorkflowState.test.tsx
+++ b/web/src/components/__tests__/WorkflowState.test.tsx
@@ -175,9 +175,6 @@ vi.mock("../../util/api", () => ({
   fetchCloudinaryWidgetConfig: vi
     .fn()
     .mockResolvedValue({ cloud_name: "demo", api_key: "123456" }),
-  fetchCloudinaryAutoCrop: vi
-    .fn()
-    .mockResolvedValue({ x: 0.1, y: 0.2, width: 0.7, height: 0.6 }),
   signCloudinaryWidgetParams: vi.fn().mockResolvedValue("mock-signature"),
 }));
 
@@ -845,7 +842,7 @@ describe("WorkflowState", () => {
     expect(uploadAction).toHaveClass("MuiFab-root");
   });
 
-  it("successful widget upload immediately saves the image to state", async () => {
+  it("successful widget upload saves the image to state with no crop", async () => {
     const updated = makePieceDetail();
     vi.mocked(api.updateCurrentState).mockResolvedValue(updated);
     setupUploadWidget({
@@ -854,41 +851,6 @@ describe("WorkflowState", () => {
     });
     render(<WorkflowState {...defaultProps} />);
     fireEvent.click(screen.getByRole("button", { name: "Upload Image" }));
-    await waitFor(() =>
-      expect(api.fetchCloudinaryAutoCrop).toHaveBeenCalledWith(
-        { cloudName: "demo", publicId: "sample" },
-      ),
-    );
-    await waitFor(() =>
-      expect(api.updateCurrentState).toHaveBeenCalledWith(
-        "test-piece-id",
-        expect.objectContaining({
-          images: expect.arrayContaining([
-            expect.objectContaining({
-              url: "https://res.cloudinary.com/demo/image/upload/sample.jpg",
-              cloudinary_public_id: "sample",
-              crop: { x: 0.1, y: 0.2, width: 0.7, height: 0.6 },
-            }),
-          ]),
-        }),
-      ),
-    );
-  });
-
-  it("still saves uploaded images when Cloudinary crop detection fails", async () => {
-    const updated = makePieceDetail();
-    vi.mocked(api.updateCurrentState).mockResolvedValue(updated);
-    vi.mocked(api.fetchCloudinaryAutoCrop).mockRejectedValueOnce(
-      new Error("getinfo failed"),
-    );
-    setupUploadWidget({
-      secure_url: "https://res.cloudinary.com/demo/image/upload/sample.jpg",
-      public_id: "sample",
-    });
-
-    render(<WorkflowState {...defaultProps} />);
-    fireEvent.click(screen.getByRole("button", { name: "Upload Image" }));
-
     await waitFor(() =>
       expect(api.updateCurrentState).toHaveBeenCalledWith(
         "test-piece-id",

--- a/web/src/util/__tests__/api.test.ts
+++ b/web/src/util/__tests__/api.test.ts
@@ -574,69 +574,6 @@ describe("upload endpoints", () => {
     expect(signature).toBe("signed-value");
   });
 
-  it("parseCloudinaryAutoCrop normalizes pixel getinfo coordinates", async () => {
-    const { parseCloudinaryAutoCrop } = await loadApiModule();
-
-    expect(
-      parseCloudinaryAutoCrop({
-        input: { width: 1000, height: 800 },
-        g_auto_info: { x: 100, y: 80, width: 500, height: 400 },
-      }),
-    ).toEqual({ x: 0.1, y: 0.1, width: 0.5, height: 0.5 });
-  });
-
-  it("parseCloudinaryAutoCrop handles nested w/h crops and invalid payloads", async () => {
-    const { parseCloudinaryAutoCrop } = await loadApiModule();
-
-    expect(
-      parseCloudinaryAutoCrop({
-        nested: [{ ignored: true }, { x: 0.2, y: 0.3, w: 0.4, h: 0.5 }],
-      }),
-    ).toEqual({ x: 0.2, y: 0.3, width: 0.4, height: 0.5 });
-    expect(parseCloudinaryAutoCrop({ input: { width: 100, height: 100 } })).toBeNull();
-    expect(
-      parseCloudinaryAutoCrop({
-        crop: { x: "bad", y: 0, width: 1, height: 1 },
-      }),
-    ).toBeNull();
-  });
-
-  it("fetchCloudinaryAutoCrop fetches getinfo JSON and returns null for non-ok responses", async () => {
-    const { cloudinaryGetinfoUrl, fetchCloudinaryAutoCrop } = await loadApiModule();
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: vi.fn().mockResolvedValue({
-          crop: { x: 0.1, y: 0.2, width: 0.3, height: 0.4 },
-        }),
-      })
-      .mockResolvedValueOnce({ ok: false });
-    vi.stubGlobal("fetch", fetchMock);
-    const params = { cloudName: "demo", publicId: "pieces/mug" };
-
-    expect(cloudinaryGetinfoUrl(params)).toBe(
-      "https://res.cloudinary.com/demo/image/upload/c_crop,g_auto,w_750/fl_getinfo/v1/pieces/mug",
-    );
-    expect(cloudinaryGetinfoUrl({ cloudName: "", publicId: "pieces/mug" })).toBeNull();
-    expect(cloudinaryGetinfoUrl({ cloudName: "demo", publicId: "" })).toBeNull();
-
-    await expect(fetchCloudinaryAutoCrop(params)).resolves.toEqual({
-      x: 0.1,
-      y: 0.2,
-      width: 0.3,
-      height: 0.4,
-    });
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://res.cloudinary.com/demo/image/upload/c_crop,g_auto,w_750/fl_getinfo/v1/pieces/mug",
-    );
-    await expect(fetchCloudinaryAutoCrop(params)).resolves.toBeNull();
-    await expect(
-      fetchCloudinaryAutoCrop({ cloudName: "", publicId: "pieces/mug" }),
-    ).resolves.toBeNull();
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-  });
-
   it("importManualSquareCropRecords posts multipart data with payload and matching files", async () => {
     const { importManualSquareCropRecords } = await loadApiModule();
     mockClient.post.mockResolvedValue({

--- a/web/src/util/api.ts
+++ b/web/src/util/api.ts
@@ -14,10 +14,6 @@
  * this module.
  */
 import axios from "axios";
-import { Cloudinary } from "@cloudinary/url-gen";
-import { crop as cropAction } from "@cloudinary/url-gen/actions/resize";
-import { getInfo } from "@cloudinary/url-gen/qualifiers/flag";
-import { autoGravity } from "@cloudinary/url-gen/qualifiers/gravity";
 import type {
   CaptionedImage,
   FiringTemperatureRef,
@@ -60,11 +56,6 @@ export type CloudinaryWidgetConfig = {
   api_key: string;
   folder?: string;
   upload_preset?: string;
-};
-
-export type CloudinaryAutoCropInfo = {
-  input?: { width?: number; height?: number };
-  [key: string]: unknown;
 };
 
 // ---------------------------------------------------------------------------
@@ -118,57 +109,6 @@ function normalizeCrop(value: unknown): ImageCrop | null {
   };
 }
 
-function readCropCandidate(value: unknown): Record<string, unknown> | null {
-  if (Array.isArray(value)) {
-    for (const entry of value) {
-      const crop = readCropCandidate(entry);
-      if (crop) return crop;
-    }
-    return null;
-  }
-  if (!value || typeof value !== "object") return null;
-  const record = value as Record<string, unknown>;
-  if (
-    ("x" in record && "y" in record && "width" in record && "height" in record) ||
-    ("x" in record && "y" in record && "w" in record && "h" in record)
-  ) {
-    return record;
-  }
-  for (const nested of Object.values(record)) {
-    const crop = readCropCandidate(nested);
-    if (crop) return crop;
-  }
-  return null;
-}
-
-export function parseCloudinaryAutoCrop(info: CloudinaryAutoCropInfo): ImageCrop | null {
-  const candidate = readCropCandidate(info);
-  if (!candidate) return null;
-  const inputWidth = Number(info.input?.width);
-  const inputHeight = Number(info.input?.height);
-  const raw = {
-    x: Number(candidate.x),
-    y: Number(candidate.y),
-    width: Number(candidate.width ?? candidate.w),
-    height: Number(candidate.height ?? candidate.h),
-  };
-  if (![raw.x, raw.y, raw.width, raw.height].every(Number.isFinite)) {
-    return null;
-  }
-  if (
-    inputWidth > 1 &&
-    inputHeight > 1 &&
-    (raw.x > 1 || raw.y > 1 || raw.width > 1 || raw.height > 1)
-  ) {
-    return normalizeCrop({
-      x: raw.x / inputWidth,
-      y: raw.y / inputHeight,
-      width: raw.width / inputWidth,
-      height: raw.height / inputHeight,
-    });
-  }
-  return normalizeCrop(raw);
-}
 
 function mapStateSummary(raw: Wire<StateSummary>): StateSummary {
   return { state: raw.state as State };
@@ -550,36 +490,6 @@ export async function signCloudinaryWidgetParams(
     },
   );
   return data.signature;
-}
-
-export function cloudinaryGetinfoUrl(params: {
-  cloudName: string;
-  publicId: string;
-  width?: number;
-}): string | null {
-  const cloudName = params.cloudName.trim();
-  const publicId = params.publicId.trim();
-  if (!cloudName || !publicId) return null;
-  const cld = new Cloudinary({
-    cloud: { cloudName },
-    url: { analytics: false },
-  });
-  return cld
-    .image(publicId)
-    .resize(cropAction().width(params.width ?? 750).gravity(autoGravity()))
-    .addFlag(getInfo())
-    .toURL();
-}
-
-export async function fetchCloudinaryAutoCrop(params: {
-  cloudName: string;
-  publicId: string;
-}): Promise<ImageCrop | null> {
-  const url = cloudinaryGetinfoUrl(params);
-  if (!url) return null;
-  const response = await fetch(url);
-  if (!response.ok) return null;
-  return parseCloudinaryAutoCrop((await response.json()) as CloudinaryAutoCropInfo);
 }
 
 export type ManualSquareCropImportRecordPayload = {


### PR DESCRIPTION
## Summary

- Removes the `fetchCloudinaryAutoCrop` call that ran on every image upload, which was using Cloudinary's `g_auto` gravity to detect the pottery subject and store a crop region — causing gallery images to show only a small ~25% sub-region of the original photo
- Deletes all the supporting dead code: `cloudinaryGetinfoUrl`, `fetchCloudinaryAutoCrop`, `parseCloudinaryAutoCrop`, `readCropCandidate`, `CloudinaryAutoCropInfo`, and unused `@cloudinary/url-gen` imports from `api.ts`
- Updates tests accordingly

## Manual cleanup performed

Queried production for all `PieceStateImage` rows with non-null `crop` and `Piece` rows with non-null `thumbnail_crop`:

- **4 `PieceStateImage` rows** had crop data, all on piece `a7e5282d-5509-42ea-ac0e-99760638d2ee` (state `completed`, orders 0–3)
- **0 `Piece.thumbnail_crop` rows** were affected

Cleared with:
```python
PieceStateImage.objects.filter(crop__isnull=False).update(crop=None)
```

Closes #284
