### PR TITLE
fix(#288): keep safe-area iframe style alive after Cloudinary widget shows

### DIFF
--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -261,14 +261,17 @@ export default function WorkflowState({
       setUploadError("Failed to load upload configuration. Please try again.");
       return;
     }
+    // Keeps the iframe hidden until it is ready (removed on display-changed: shown).
     const hideStyle = document.createElement("style");
-    hideStyle.textContent = [
-      'iframe[title="Upload Widget"] { opacity: 0; }',
-      // On iOS PWA with viewport-fit=cover the status bar overlays the page.
-      // Push the widget iframe below it so its header controls are reachable.
-      'iframe[title="Upload Widget"] { top: env(safe-area-inset-top) !important; height: calc(100dvh - env(safe-area-inset-top)) !important; }',
-    ].join("\n");
+    hideStyle.textContent = 'iframe[title="Upload Widget"] { opacity: 0; }';
     document.head.appendChild(hideStyle);
+    // On iOS PWA with viewport-fit=cover the status bar overlays the page.
+    // Push the widget iframe below it so its header controls are reachable.
+    // This style must persist for the widget's lifetime (not removed with hideStyle).
+    const safeAreaStyle = document.createElement("style");
+    safeAreaStyle.textContent =
+      'iframe[title="Upload Widget"] { top: env(safe-area-inset-top) !important; height: calc(100dvh - env(safe-area-inset-top)) !important; }';
+    document.head.appendChild(safeAreaStyle);
 
     const uploadWidget = window.cloudinary?.createUploadWidget(
       {
@@ -321,11 +324,14 @@ export default function WorkflowState({
               iframe.style.transition = "opacity 0.15s ease-in";
               iframe.style.opacity = "1";
             }
+          } else if (state === "hidden" || state === "destroyed") {
+            safeAreaStyle.remove();
           }
         }
         if (error) {
           setWidgetLoading(false);
           hideStyle.remove();
+          safeAreaStyle.remove();
           setUploadError("Upload failed. Please try again.");
           return;
         }


### PR DESCRIPTION
Closes #288

## Root cause

The fix from #259 (#256) combined two CSS rules into a single `<style>` element (`hideStyle`):

1. `opacity: 0` — hides the iframe during loading (intentionally temporary)
2. `top: env(safe-area-inset-top)` — shifts the iframe below the iOS status bar (must persist)

When the widget fired `display-changed: shown`, `hideStyle.remove()` removed **both** rules. The iframe snapped back to `top: 0`, putting the header controls (close button, My Files tab) behind the status bar. On mobile Safari this was less visible because the browser chrome adds spacing; in the installed PWA (standalone mode) there is no chrome buffer, so the issue was consistently reproducible.

## Fix

Split into two `<style>` elements:

- `hideStyle` — `opacity: 0` only; removed on `display-changed: shown` as before
- `safeAreaStyle` — safe-area positioning; persists while the widget is open, removed on `hidden`/`destroyed` or error

## Test plan

- [ ] Open the Cloudinary upload widget in an installed PWA on iOS — close button and My Files tab should be fully visible below the status bar
- [ ] Confirm the widget still fades in smoothly (opacity transition still works)
- [ ] Upload an image successfully end-to-end
- [ ] `bazel test //...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
