### PR TITLE
perf(tests): disable WhiteNoise autorefresh, replace userEvent.type with fireEvent.change

### DIFF
--- a/backend/test_settings.py
+++ b/backend/test_settings.py
@@ -7,3 +7,8 @@ PASSWORD_HASHERS = [
 
 # Tests opt into dev bootstrap behavior explicitly when needed.
 DEV_BOOTSTRAP_ENABLED = False
+
+# Prevent WhiteNoise from rescanning the static file tree on every middleware
+# instantiation. Each API test request triggers load_middleware, and without
+# this flag WhiteNoise calls update_files_dictionary (~0.013s) every time.
+WHITENOISE_AUTOREFRESH = False

--- a/web/src/components/__tests__/GlobalEntryDialog.test.tsx
+++ b/web/src/components/__tests__/GlobalEntryDialog.test.tsx
@@ -288,7 +288,7 @@ describe("GlobalEntryDialog", () => {
       }),
       { target: { value: "Iron" } },
     );
-    await userEvent.click(screen.getByRole("option", { name: "Iron Red" }));
+    await userEvent.click(await screen.findByRole("option", { name: "Iron Red" }));
 
     await waitFor(() =>
       expect(api.fetchGlobalEntriesWithFilters).toHaveBeenLastCalledWith(
@@ -312,7 +312,7 @@ describe("GlobalEntryDialog", () => {
       screen.getByRole("combobox", { name: "Firing Temperature" }),
       { target: { value: "Cone" } },
     );
-    await userEvent.click(screen.getByRole("option", { name: "Cone 6" }));
+    await userEvent.click(await screen.findByRole("option", { name: "Cone 6" }));
 
     await waitFor(() =>
       expect(api.fetchGlobalEntriesWithFilters).toHaveBeenLastCalledWith(
@@ -456,13 +456,13 @@ describe("GlobalEntryDialog", () => {
       screen.getByRole("combobox", { name: "Layer 1" }),
       { target: { value: "Iron" } },
     );
-    await userEvent.click(screen.getByRole("option", { name: "Iron Red" }));
+    await userEvent.click(await screen.findByRole("option", { name: "Iron Red" }));
     await userEvent.click(screen.getByRole("button", { name: "Add layer" }));
     fireEvent.change(
       screen.getByRole("combobox", { name: "Layer 2" }),
       { target: { value: "Clear" } },
     );
-    await userEvent.click(screen.getByRole("option", { name: "Clear" }));
+    await userEvent.click(await screen.findByRole("option", { name: "Clear" }));
     await userEvent.click(
       screen.getByRole("button", { name: "Create Glaze Combination" }),
     );
@@ -521,13 +521,13 @@ describe("GlobalEntryDialog", () => {
       screen.getByRole("combobox", { name: "Layer 1" }),
       { target: { value: "Iron" } },
     );
-    await userEvent.click(screen.getByRole("option", { name: "Iron Red" }));
+    await userEvent.click(await screen.findByRole("option", { name: "Iron Red" }));
     await userEvent.click(screen.getByRole("button", { name: "Add layer" }));
     fireEvent.change(
       screen.getByRole("combobox", { name: "Layer 2" }),
       { target: { value: "Clear" } },
     );
-    await userEvent.click(screen.getByRole("option", { name: "Clear" }));
+    await userEvent.click(await screen.findByRole("option", { name: "Clear" }));
 
     const removeButtons = screen.getAllByRole("button", { name: "Remove" });
     await userEvent.click(removeButtons[1]);

--- a/web/src/components/__tests__/GlobalEntryDialog.test.tsx
+++ b/web/src/components/__tests__/GlobalEntryDialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import GlobalEntryDialog from "../GlobalEntryDialog";
 import * as api from "../../util/api";
@@ -282,11 +282,11 @@ describe("GlobalEntryDialog", () => {
       ),
     );
 
-    await userEvent.type(
+    fireEvent.change(
       screen.getByRole("combobox", {
         name: "Contains glaze types (all must match)",
       }),
-      "Iron",
+      { target: { value: "Iron" } },
     );
     await userEvent.click(screen.getByRole("option", { name: "Iron Red" }));
 
@@ -308,9 +308,9 @@ describe("GlobalEntryDialog", () => {
       />,
     );
 
-    await userEvent.type(
+    fireEvent.change(
       screen.getByRole("combobox", { name: "Firing Temperature" }),
-      "Cone",
+      { target: { value: "Cone" } },
     );
     await userEvent.click(screen.getByRole("option", { name: "Cone 6" }));
 
@@ -390,9 +390,9 @@ describe("GlobalEntryDialog", () => {
     );
 
     await userEvent.click(screen.getByRole("tab", { name: "Create" }));
-    await userEvent.type(
+    fireEvent.change(
       screen.getByRole("textbox", { name: "Location" }),
-      "Studio K",
+      { target: { value: "Studio K" } },
     );
     await userEvent.click(screen.getByRole("button", { name: "Create Location" }));
 
@@ -419,9 +419,9 @@ describe("GlobalEntryDialog", () => {
     );
 
     await userEvent.click(screen.getByRole("tab", { name: "Create" }));
-    await userEvent.type(
+    fireEvent.change(
       screen.getByRole("textbox", { name: "Location" }),
-      "Studio K",
+      { target: { value: "Studio K" } },
     );
     await userEvent.click(screen.getByRole("button", { name: "Create Location" }));
 
@@ -452,15 +452,15 @@ describe("GlobalEntryDialog", () => {
     );
 
     await userEvent.click(screen.getByRole("tab", { name: "Create" }));
-    await userEvent.type(
+    fireEvent.change(
       screen.getByRole("combobox", { name: "Layer 1" }),
-      "Iron",
+      { target: { value: "Iron" } },
     );
     await userEvent.click(screen.getByRole("option", { name: "Iron Red" }));
     await userEvent.click(screen.getByRole("button", { name: "Add layer" }));
-    await userEvent.type(
+    fireEvent.change(
       screen.getByRole("combobox", { name: "Layer 2" }),
-      "Clear",
+      { target: { value: "Clear" } },
     );
     await userEvent.click(screen.getByRole("option", { name: "Clear" }));
     await userEvent.click(
@@ -517,15 +517,15 @@ describe("GlobalEntryDialog", () => {
     );
 
     await userEvent.click(screen.getByRole("tab", { name: "Create" }));
-    await userEvent.type(
+    fireEvent.change(
       screen.getByRole("combobox", { name: "Layer 1" }),
-      "Iron",
+      { target: { value: "Iron" } },
     );
     await userEvent.click(screen.getByRole("option", { name: "Iron Red" }));
     await userEvent.click(screen.getByRole("button", { name: "Add layer" }));
-    await userEvent.type(
+    fireEvent.change(
       screen.getByRole("combobox", { name: "Layer 2" }),
-      "Clear",
+      { target: { value: "Clear" } },
     );
     await userEvent.click(screen.getByRole("option", { name: "Clear" }));
 

--- a/web/src/components/__tests__/WorkflowState.test.tsx
+++ b/web/src/components/__tests__/WorkflowState.test.tsx
@@ -585,9 +585,9 @@ describe("WorkflowState", () => {
       screen.getByRole("button", { name: "Browse Kiln Location" }),
     );
     await userEvent.click(screen.getByRole("tab", { name: "Create" }));
-    await userEvent.type(
+    fireEvent.change(
       screen.getByRole("textbox", { name: "Location" }),
-      "New Kiln",
+      { target: { value: "New Kiln" } },
     );
     await userEvent.click(screen.getByRole("button", { name: "Create Location" }));
     await waitFor(() =>


### PR DESCRIPTION
Closes #290

## Summary

Addresses the P1 and P2 items from the test performance audit:

- **`WHITENOISE_AUTOREFRESH = False`** in `backend/test_settings.py` — WhiteNoise was rescanning the static file tree on every middleware instantiation (~228 calls per test run), accounting for ~2.6s measured via the Bazel-injected cProfile. This single flag eliminates the per-request rescan.
- **`fireEvent.change` for Autocomplete and plain text inputs** in `GlobalEntryDialog.test.tsx` and `WorkflowState.test.tsx` — tests that used `userEvent.type()` to populate inputs where per-keystroke behavior is not the requirement. `userEvent.type` dispatches a full browser event sequence per character; `fireEvent.change` fires one synthetic event with the final value.

## Measured results

**Backend** (Bazel-injected cProfile, merged across all `//api:api_test` targets):

| Metric | Before | After |
|--------|--------|-------|
| Total profiled time | 26.4s | 19.3s |
| Total function calls | 55M | 30M |
| WhiteNoise in top-15 hotspots | yes | no |

**Frontend** (vitest, selected tests):

| Test | Before | After |
|------|--------|-------|
| `filters browse results (multi-select)` | ~700ms | 216ms |
| `filters browse results (single-select)` | ~525ms | 128ms |
| `creates a simple global entry` | ~370ms | 93ms |
| `creates a composed entry from layers` | ~960ms | 304ms |
| `removes a layer row` | ~445ms | 297ms |

## What was not changed

- `MD5PasswordHasher` and `DEV_BOOTSTRAP_ENABLED = False` were already present in `test_settings.py` — no change needed.
- P3 (splitting `PieceDetail.test.tsx`) is structural and tracked separately in #290.
- `PieceList` tag-filter tests use `userEvent.click` (not `userEvent.type`) — no change there.

## Test plan

- [x] `rtk bazel test //api:api_test //tests/...` — all pass
- [x] `cd web && npm test` — all 454 tests pass
