### PR TITLE
docs: add explicit issue worktree flow

### DIFF
--- a/.agents/skills/do-issue-worktree/SKILL.md
+++ b/.agents/skills/do-issue-worktree/SKILL.md
@@ -1,0 +1,122 @@
+---
+model: opus
+created: 2026-05-07
+modified: 2026-05-07
+reviewed: 2026-05-07
+name: do-issue-worktree
+description: |
+  Start new issue or PR work with an explicit /do #<issue-number> flow. Use when
+  a developer asks an agent to implement a GitHub issue, continue a PR, or start
+  a feature branch and the first action must be creating and announcing a
+  repo-local worktree.
+allowed-tools: Bash, Read, Write, Edit, Grep, Glob, TodoWrite
+---
+
+# Do Issue Worktree
+
+Use this skill for the explicit Glaze agent invocation:
+
+```text
+/do #292
+```
+
+The point is to make the worktree contract impossible to miss. Before analysis,
+implementation, tests, or GitHub comments, create an isolated repo-local
+worktree and print the path in a copy-friendly form.
+
+## Trigger
+
+Use this skill when the prompt asks to:
+
+- `/do #<issue-number>`
+- work on a GitHub issue
+- implement a feature branch
+- continue a PR in a fresh branch
+- start any change that should become its own PR
+
+If the user explicitly asks to work in the current checkout, ask for
+confirmation before skipping the worktree.
+
+## Required First Output
+
+Print this before any code changes:
+
+```text
+Worktree: /absolute/path/to/glaze/.agent-worktrees/<agent>/issue-<N>-<slug>
+```
+
+Keep it on its own line so the developer can copy it or use `gz_cd <pattern>`.
+
+## Flow
+
+1. Read the issue title and body from GitHub.
+2. Create a short slug from the issue title.
+3. Create the branch as `issue/<N>-<slug>`.
+4. Create the worktree at `.agent-worktrees/<agent>/issue-<N>-<slug>`.
+5. Announce the absolute worktree path.
+6. Continue all analysis, edits, tests, commits, pushes, and PR work from that
+   worktree root.
+
+Example:
+
+```bash
+git worktree add .agent-worktrees/codex/issue-292-vibe-coding-flow \
+  -b issue/292-vibe-coding-flow main
+```
+
+Use the agent name that matches the running tool, such as `codex`, `claude`, or
+`cursor`.
+
+## Worktree Setup
+
+After creating the worktree:
+
+- Run commands from the worktree root.
+- Use `source env.sh && gz_setup` before verification in a new environment.
+- Use plain `gz_setup` for the normal shared `.venv` and `web/node_modules`
+  flow.
+- Use `gz_setup --isolated` only when changing Python or Node dependencies.
+- If starting servers manually, open a dedicated terminal tab for that worktree
+  and run `gz_start` there.
+
+Do not re-source `env.sh` from a different worktree in an existing terminal that
+already has servers running.
+
+## Implementation Rules
+
+- Keep one issue per worktree and one focused branch per issue.
+- Do not edit files outside the announced worktree unless the user explicitly
+  asks.
+- Use the documented Glaze commands from `docs/agents/dev.md`.
+- Keep `workflow.yml`, migrations, dependency files, CI, and deployment config
+  within the protected-change rules in the agent docs.
+- When opening a PR, include `Closes #<N>` in the PR body and apply the agent's
+  ownership label.
+
+## Cleanup
+
+Clean up after the PR is merged or the branch is abandoned:
+
+```bash
+gz_stop
+git worktree remove .agent-worktrees/<agent>/issue-<N>-<slug>
+git worktree prune
+git branch -d issue/<N>-<slug>
+```
+
+Use `git branch -D` only for an abandoned unmerged branch after confirming the
+work is no longer needed.
+
+If a local server is still running in the worktree, stop it first with `gz_stop`
+from that worktree's terminal. `git worktree remove` should not be forced over
+running or dirty worktrees.
+
+## Quick Developer Handoff
+
+When handing the worktree back to the developer, include:
+
+- the worktree path
+- the branch name
+- any server URL if one was started
+- the exact verification command(s) run
+- cleanup commands if the PR is merged or abandoned

--- a/.agents/skills/git-worktree-agent-workflow/SKILL.md
+++ b/.agents/skills/git-worktree-agent-workflow/SKILL.md
@@ -9,7 +9,8 @@ description: |
   Use when multiple issues get mixed into a single branch (contamination), when you
   need parallel work on independent issues, or when separating mixed commits into
   clean single-purpose PRs. Enables launching subagents with isolated working
-  directories that can work simultaneously without conflicts.
+  directories that can work simultaneously without conflicts. For a normal
+  single-issue start such as /do #292, use do-issue-worktree instead.
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, Task, TodoWrite
 ---
 
@@ -17,11 +18,15 @@ allowed-tools: Bash, Read, Write, Edit, Grep, Glob, Task, TodoWrite
 
 Orchestrate parallel agent workflows using git worktrees for isolated, concurrent issue resolution.
 
+For ordinary single-issue work, prefer the smaller `do-issue-worktree` skill.
+This skill is for multi-issue orchestration, branch contamination recovery, and
+patch redistribution.
+
 ## When to Use This Skill
 
 | Use this skill when... | Use standard workflow instead when... |
 |------------------------|--------------------------------------|
-| Multiple issues mixed into one branch (contamination) | Single issue, clean branch |
+| Multiple issues mixed into one branch (contamination) | Single issue, clean branch; use `do-issue-worktree` |
 | Need parallel work on independent issues | Issues must be done sequentially |
 | Separating mixed commits into clean PRs | Commits already properly separated |
 | Complex multi-agent coordination needed | Simple single-agent task |
@@ -78,31 +83,36 @@ git stash drop 2>/dev/null || true
 
 ### Step 2: Create isolated worktrees
 
-Create independent working directories for each issue inside `./worktrees/`.
+Create independent working directories for each issue inside
+`.agent-worktrees/<agent>/`.
 
 ```bash
-# Ensure worktrees directory exists (gitignored)
-mkdir -p worktrees
+# Ensure the agent worktree directory exists (gitignored)
+mkdir -p .agent-worktrees/codex
 
 # Create worktree for each issue
-git worktree add ./worktrees/issue-47 -b wt/issue-47 main
-git worktree add ./worktrees/issue-49 -b wt/issue-49 main
-git worktree add ./worktrees/issue-50 -b wt/issue-50 main
+git worktree add .agent-worktrees/codex/issue-47-fix-auth -b issue/47-fix-auth main
+git worktree add .agent-worktrees/codex/issue-49-add-export -b issue/49-add-export main
+git worktree add .agent-worktrees/codex/issue-50-clean-tags -b issue/50-clean-tags main
 
 # List all worktrees
 git worktree list
 
 # Each worktree:
-# - Lives inside ./worktrees/ (within the project directory)
+# - Lives inside .agent-worktrees/<agent>/ (within the project directory)
 # - Shares the same .git database (efficient)
 # - Has an independent branch
 # - Can be worked on simultaneously
 # - Requires no additional permissions (already in project dir)
 ```
 
-**Naming convention**: `./worktrees/issue-{N}` with branch `wt/issue-{N}`
+**Naming convention**:
+- Worktree: `.agent-worktrees/<agent>/issue-<N>-<slug>`
+- Branch: `issue/<N>-<slug>`
 
-**Why `./worktrees/`**: Keeping worktrees inside the project directory means agents already have file permissions — no `additionalDirectories` configuration needed. The `/worktrees/` entry in `.gitignore` prevents git from tracking worktree contents.
+**Why `.agent-worktrees/`**: Keeping worktrees inside the project directory means
+agents already have file permissions, share the repo-local bootstrap, and avoid
+tool-reserved paths like `.codex`.
 
 ### Step 3: Apply existing work
 
@@ -110,7 +120,7 @@ Distribute saved patches to appropriate worktrees.
 
 **For complete patches (single-issue commits)**:
 ```bash
-git -C ./worktrees/issue-47 am /tmp/patches/0001-feat-issue-47-implementation.patch
+git -C .agent-worktrees/codex/issue-47-fix-auth am /tmp/patches/0001-feat-issue-47-implementation.patch
 ```
 
 **For mixed patches (multi-issue commits)**:
@@ -119,12 +129,12 @@ git -C ./worktrees/issue-47 am /tmp/patches/0001-feat-issue-47-implementation.pa
 git show <commit> -- path/to/file1 path/to/file2 > /tmp/patches/issue-47-files.patch
 
 # Apply to appropriate worktree
-git -C ./worktrees/issue-47 apply /tmp/patches/issue-47-files.patch
+git -C .agent-worktrees/codex/issue-47-fix-auth apply /tmp/patches/issue-47-files.patch
 ```
 
 **For partial work (needs agent completion)**:
 ```bash
-git -C ./worktrees/issue-50 apply /tmp/patches/partial-work.patch
+git -C .agent-worktrees/codex/issue-50-clean-tags apply /tmp/patches/partial-work.patch
 # Agent will complete remaining work
 ```
 
@@ -136,7 +146,7 @@ Launch agents to complete work in their respective worktrees.
 
 **Agent prompt template**:
 ```
-You are working in the worktree at: {repo_root}/worktrees/issue-{N}
+You are working in the worktree at: {repo_root}/.agent-worktrees/{agent}/issue-{N}-{slug}
 
 **Issue #{N}**: {issue title}
 
@@ -154,7 +164,7 @@ You are working in the worktree at: {repo_root}/worktrees/issue-{N}
 
    Co-Authored-By: Claude <noreply@anthropic.com>
 
-DO NOT modify any files outside the worktree at {repo_root}/worktrees/issue-{N}
+DO NOT modify any files outside the worktree at {repo_root}/.agent-worktrees/{agent}/issue-{N}-{slug}
 ```
 
 **Parallelization**: Agents run simultaneously because:
@@ -168,12 +178,12 @@ Push branches and create PRs in order.
 
 ```bash
 # From each worktree, push to origin
-git -C ./worktrees/issue-47 push origin wt/issue-47:fix/issue-47
+git -C .agent-worktrees/codex/issue-47-fix-auth push origin issue/47-fix-auth
 
 # Create PR
-gh pr create --head fix/issue-47 --base main \
+gh pr create --head issue/47-fix-auth --base main \
   --title "fix: {description}" \
-  --body "Fixes #47"
+  --body-file /tmp/pr-issue-47.md
 ```
 
 **Why sequential**: PRs are created one at a time to:
@@ -187,15 +197,15 @@ Remove worktrees and temporary branches after PRs are merged.
 
 ```bash
 # Remove worktrees
-git worktree remove ./worktrees/issue-47
-git worktree remove ./worktrees/issue-49
-git worktree remove ./worktrees/issue-50
+git worktree remove .agent-worktrees/codex/issue-47-fix-auth
+git worktree remove .agent-worktrees/codex/issue-49-add-export
+git worktree remove .agent-worktrees/codex/issue-50-clean-tags
 
 # Prune stale worktree references
 git worktree prune
 
 # Delete local branches
-git branch -D wt/issue-47 wt/issue-49 wt/issue-50
+git branch -d issue/47-fix-auth issue/49-add-export issue/50-clean-tags
 
 # Clean up patches and empty worktrees directory
 rm -rf /tmp/patches/
@@ -203,7 +213,7 @@ rm -rf /tmp/patches/
 # Note: rmdir only removes empty directories. If worktrees remain (intentionally
 # or due to errors), the directory is preserved. This is correct behavior - manual
 # cleanup is needed if worktrees are still in use.
-rmdir worktrees 2>/dev/null || true
+rmdir .agent-worktrees/codex 2>/dev/null || true
 ```
 
 ## Orchestrator Responsibilities
@@ -237,7 +247,7 @@ Each subagent handles:
 | Issues with dependencies | Sequential worktrees (order matters) |
 | Contaminated PR | Preserve -> Reset -> Worktrees -> Reapply |
 | Partial work exists | Apply patch -> Agent completes |
-| Work from scratch | Create worktree -> Agent implements |
+| Work from scratch | Use `do-issue-worktree` for the first issue, or create parallel worktrees here for several issues |
 
 ## Verification Checklist
 
@@ -266,16 +276,16 @@ Each subagent handles:
 | Context | Command |
 |---------|---------|
 | List worktrees | `git worktree list --porcelain` |
-| Create worktrees dir | `mkdir -p worktrees` |
-| Create worktree | `git worktree add ./worktrees/issue-N -b wt/issue-N main` |
-| Remove worktree | `git worktree remove ./worktrees/issue-N` |
+| Create worktrees dir | `mkdir -p .agent-worktrees/<agent>` |
+| Create worktree | `git worktree add .agent-worktrees/<agent>/issue-N-slug -b issue/N-slug main` |
+| Remove worktree | `git worktree remove .agent-worktrees/<agent>/issue-N-slug` |
 | Preserve commits | `git format-patch <base>..HEAD -o /tmp/patches/` |
-| Apply patch (am) | `git -C ./worktrees/issue-N am /tmp/patches/*.patch` |
-| Apply patch (apply) | `git -C ./worktrees/issue-N apply /tmp/patches/file.patch` |
+| Apply patch (am) | `git -C .agent-worktrees/<agent>/issue-N-slug am /tmp/patches/*.patch` |
+| Apply patch (apply) | `git -C .agent-worktrees/<agent>/issue-N-slug apply /tmp/patches/file.patch` |
 | Extract file changes | `git show <commit> -- path/to/file > /tmp/patch.patch` |
-| Check worktree status | `git -C ./worktrees/issue-N status --porcelain` |
-| Run tests in worktree | `cd ./worktrees/issue-N && npm test` |
-| Push worktree branch | `git push origin wt/issue-N:fix/issue-N` |
+| Check worktree status | `git -C .agent-worktrees/<agent>/issue-N-slug status --porcelain` |
+| Run tests in worktree | `source env.sh && gz_test` from the worktree root |
+| Push worktree branch | `git push -u origin issue/N-slug` |
 
 ## Quick Reference
 
@@ -300,10 +310,10 @@ Orchestrator (main repo)
     |
     +--- Step 1: Analyze & preserve contaminated work
     |
-    +--- Step 2: Create worktrees (mkdir -p worktrees)
-    |         +-- ./worktrees/issue-47 (complete patch)
-    |         +-- ./worktrees/issue-49 (complete patch)
-    |         +-- ./worktrees/issue-50 (partial, needs agent)
+    +--- Step 2: Create worktrees (mkdir -p .agent-worktrees/<agent>)
+    |         +-- .agent-worktrees/codex/issue-47-fix-auth (complete patch)
+    |         +-- .agent-worktrees/codex/issue-49-add-export (complete patch)
+    |         +-- .agent-worktrees/codex/issue-50-clean-tags (partial, needs agent)
     |
     +--- Step 3: Apply patches
     |         +-- git am (complete patches)
@@ -311,10 +321,10 @@ Orchestrator (main repo)
     |
     +--- Step 4: Launch agents IN PARALLEL
     |         |
-    |         +---> Agent 1 -> ./worktrees/issue-50
+    |         +---> Agent 1 -> .agent-worktrees/codex/issue-50-clean-tags
     |         |         +-- Completes work, commits
     |         |
-    |         +---> Agent 2 -> ./worktrees/issue-XX
+    |         +---> Agent 2 -> .agent-worktrees/codex/issue-XX-slug
     |                   +-- Implements from scratch, commits
     |
     +--- Step 5: Sequential integration
@@ -325,7 +335,7 @@ Orchestrator (main repo)
     +--- Step 6: Cleanup
               +-- Remove worktrees
               +-- Delete local branches
-              +-- rmdir worktrees (if empty)
+              +-- rmdir .agent-worktrees/<agent> (if empty)
 ```
 
 ## Related Skills

--- a/.claude/do-issue-worktree.md
+++ b/.claude/do-issue-worktree.md
@@ -1,0 +1,1 @@
+../.agents/skills/do-issue-worktree/SKILL.md

--- a/README.md
+++ b/README.md
@@ -113,6 +113,54 @@ source env.sh
 
 **AI coding agents (Claude Code, Codex, Cursor agent):** a companion script [`env-agent.sh`](env-agent.sh) provides a silent, lightweight bootstrap (venv activation + `.env.local` loading) for non-interactive shells. Claude Code picks it up via `.claude/settings.json`; Codex and other agents inherit it through `BASH_ENV` when launched from an `env.sh`-sourced terminal. Prefer repo-local worktrees under `.agent-worktrees/...` instead of `/tmp`; the bootstrap detects the active git worktree root automatically and falls back to the main checkout's `.env.local` and `.venv` when the worktree does not have its own yet. `gz_setup` reuses the shared `.venv` and `web/node_modules` by default, and `gz_setup --isolated` creates worktree-local dependency installs when a branch is changing Python or Node packages. Keep repo-local Codex-specific config in `.agent-config/codex/` rather than `.codex`, which may be reserved by the local Codex installation. See [`docs/agents/dev.md`](docs/agents/dev.md) for details.
 
+### Vibe Coding With Agents
+
+When you want an agent to implement an issue or start a PR-sized change, use the
+explicit issue flow:
+
+```text
+/do #292
+```
+
+That prompt tells the agent to create a branch like `issue/292-vibe-coding-flow`
+and a repo-local worktree like
+`.agent-worktrees/codex/issue-292-vibe-coding-flow` before it analyzes or edits
+anything. The agent should immediately print a copy-friendly line:
+
+```text
+Worktree: /home/phil/code/glaze/.agent-worktrees/codex/issue-292-vibe-coding-flow
+```
+
+Open a dedicated terminal tab for that worktree and jump into it with:
+
+```bash
+gz_cd 292
+```
+
+From there, use the normal helpers:
+
+```bash
+gz_setup
+gz_start
+```
+
+Each agent gets its own worktree under `.agent-worktrees/<agent>/...`, and each
+issue gets its own branch. Keep one terminal per worktree so `gz_start`,
+`gz_stop`, logs, and port files stay scoped to the right code checkout.
+
+After the PR is merged or abandoned, stop any servers from that worktree's
+terminal and clean up the local checkout:
+
+```bash
+gz_stop
+git worktree remove .agent-worktrees/codex/issue-292-vibe-coding-flow
+git worktree prune
+git branch -d issue/292-vibe-coding-flow
+```
+
+Use `git branch -D` only for an abandoned unmerged branch after confirming the
+work is no longer needed.
+
 ### Local secrets and config (git-safe)
 
 Keep local-only settings in `.env.local` files; they are gitignored by default:

--- a/docs/agents/dev.md
+++ b/docs/agents/dev.md
@@ -131,6 +131,33 @@ When multiple agents (Claude, Codex, etc.) are working on separate PRs in parall
 
 7. **Agent-initiated `gz_start` is unnecessary.** `gz_start` is a single shell command; the lifecycle problem (who stops the servers?) is already solved by the EXIT trap on terminal close. Just run `gz_start` manually in the worktree's tab.
 
+### Explicit `/do #<issue>` agent flow
+
+For new issue work, use the `do-issue-worktree` skill. A prompt such as
+`/do #292` means the agent must create and announce a repo-local worktree before
+issue analysis or code changes:
+
+```text
+Worktree: /home/phil/code/glaze/.agent-worktrees/codex/issue-292-vibe-coding-flow
+```
+
+Use `.agent-worktrees/<agent>/issue-<N>-<slug>` for the worktree and
+`issue/<N>-<slug>` for the branch. The developer can then open a new terminal
+tab, run `gz_cd <N>`, and use `gz_start` there if they want to review the app.
+
+After the PR is merged or the branch is abandoned, stop servers in that
+worktree's terminal and remove the local worktree:
+
+```bash
+gz_stop
+git worktree remove .agent-worktrees/<agent>/issue-<N>-<slug>
+git worktree prune
+git branch -d issue/<N>-<slug>
+```
+
+Use `git branch -D` only for abandoned unmerged work after confirming the branch
+is no longer needed.
+
 ### Adding a new Python package
 
 Bazel resolves Python packages from `requirements.lock` (pin-compiled from `requirements-dev.txt`). Three steps are required when adding a new package:
@@ -233,6 +260,13 @@ Reusable agent skills live in [`.agents/skills/`](../../.agents/skills/). Each s
 | ----------- | -------------------------------------------------------------------------------------------------------------------- |
 | Codex       | Reads `.agents/skills/` natively — no setup needed                                                                   |
 | Claude Code | Reads `.claude/<name>.md`; each skill has a git-tracked symlink there pointing into `.agents/skills/<name>/SKILL.md` |
+
+Key local skills:
+
+| Skill                         | Use                                                                                          |
+| ----------------------------- | -------------------------------------------------------------------------------------------- |
+| `do-issue-worktree`           | Start a single issue or PR-sized change with `/do #<issue>` and an immediate worktree setup. |
+| `git-worktree-agent-workflow` | Coordinate parallel worktrees or recover mixed work that needs to be split into focused PRs. |
 
 ### Adding a new skill
 


### PR DESCRIPTION
## What Changed

- Added a new `do-issue-worktree` agent skill for the explicit `/do #<issue>` flow.
- Added the Claude skill symlink so Claude Code can load the same shared skill.
- Updated the existing worktree orchestration skill to point single-issue work to the new skill and use Glaze's `.agent-worktrees/<agent>/...` conventions.
- Documented the developer-facing vibe coding workflow in `README.md`, including `gz_cd`, `gz_setup`, `gz_start`, and local cleanup.
- Added the explicit `/do #<issue>` lifecycle to `docs/agents/dev.md`.

## Why

Agents were sometimes starting work before establishing whether they were in an isolated worktree. This gives developers a crisp prompt and gives agents a concrete first action: create and announce the worktree before doing anything else.

## Validation

- `git diff --check`

Closes #292
