### PR TITLE
Fix Cloudinary cleanup archive streaming

### DIFF
--- a/api/tests/test_cloudinary_cleanup.py
+++ b/api/tests/test_cloudinary_cleanup.py
@@ -358,6 +358,8 @@ class TestCloudinaryCleanup:
 
         assert response.status_code == 200
         assert response["Content-Type"] == "application/zip"
+        assert response["Cache-Control"] == "no-store"
+        assert response["X-Accel-Buffering"] == "no"
         archive_bytes = b"".join(response.streaming_content)
         with ZipFile(BytesIO(archive_bytes)) as archive:
             assert sorted(archive.namelist()) == [

--- a/api/views.py
+++ b/api/views.py
@@ -839,6 +839,8 @@ def admin_cloudinary_cleanup_archive(
         content_type="application/zip",
     )
     response["Content-Disposition"] = f'attachment; filename="{filename}"'
+    response["Cache-Control"] = "no-store"
+    response["X-Accel-Buffering"] = "no"
     return response
 
 

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -118,6 +118,13 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = "backend.wsgi.application"
+ASGI_APPLICATION = "backend.asgi.application"
+
+# Production sits behind Nginx, which terminates TLS and proxies to Gunicorn over
+# plain HTTP. Trust only the proxy's X-Forwarded-Proto value so Django still
+# treats external HTTPS requests as secure.
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+USE_X_FORWARDED_HOST = True
 
 
 # Database

--- a/nginx/glaze-tailscale.conf
+++ b/nginx/glaze-tailscale.conf
@@ -23,6 +23,18 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
+
+    location /api/admin/cloudinary-cleanup/archive/ {
+        proxy_pass http://localhost:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_read_timeout 1h;
+        proxy_send_timeout 1h;
+    }
 }
 
 # Redirect plain HTTP to HTTPS within the Tailscale network.

--- a/nginx/glaze.conf
+++ b/nginx/glaze.conf
@@ -21,4 +21,16 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
+
+    location /api/admin/cloudinary-cleanup/archive/ {
+        proxy_pass http://localhost:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_read_timeout 1h;
+        proxy_send_timeout 1h;
+    }
 }


### PR DESCRIPTION
## Summary
- Convert the Cloudinary cleanup archive producer to an async iterator backed by `httpx.AsyncClient`, so Django ASGI can stream it without consuming the whole sync iterator into memory first.
- Configure Django's ASGI app setting and trusted HTTPS proxy header for production behind Nginx.
- Mark the archive response as unbuffered/no-store and add archive-specific Nginx proxy settings with buffering disabled plus longer stream timeouts for both public and Tailscale templates.

## Verification
- `source env.sh && gz_setup`
- `rtk bazel test //api:api_admin_test`
- `rtk bazel test //api:api_mypy`

Note: `nginx -t` was not run locally because the `nginx` binary is not installed in this environment.

Closes #297