### PR TITLE
Stream Cloudinary cleanup archives asynchronously

### DIFF
--- a/api/cloudinary_cleanup.py
+++ b/api/cloudinary_cleanup.py
@@ -2,7 +2,7 @@ import logging
 import os
 import posixpath
 from collections import Counter
-from collections.abc import Iterator
+from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Any, cast
 from urllib.parse import urlparse
@@ -11,8 +11,8 @@ from zipfile import ZIP_DEFLATED, ZipFile
 import cloudinary
 import cloudinary.api
 import cloudinary.exceptions
-from cloudinary import CloudinaryImage
 import httpx
+from cloudinary import CloudinaryImage
 
 from .models import GlazeCombination, GlazeType, Image, Piece, PieceStateImage
 
@@ -305,11 +305,11 @@ class _StreamingZipBuffer:
         return None
 
 
-def stream_cloudinary_cleanup_archive(
+async def stream_cloudinary_cleanup_archive(
     assets: list[CloudinaryCleanupAsset],
-) -> Iterator[bytes]:
+) -> AsyncIterator[bytes]:
     buffer = _StreamingZipBuffer()
-    with httpx.Client(timeout=60) as client:
+    async with httpx.AsyncClient(timeout=60) as client:
         with ZipFile(cast(Any, buffer), "w", ZIP_DEFLATED) as archive:
             used_names: set[str] = set()
             for asset in assets:
@@ -324,10 +324,10 @@ def stream_cloudinary_cleanup_archive(
                     member_name = f"{stem}-{index}{extension}"
                 used_names.add(member_name)
 
-                with client.stream("GET", asset.url) as response:
+                async with client.stream("GET", asset.url) as response:
                     response.raise_for_status()
                     with archive.open(member_name, "w") as member:
-                        for chunk in response.iter_bytes(1024 * 1024):
+                        async for chunk in response.aiter_bytes(1024 * 1024):
                             member.write(chunk)
                             for c in buffer.flush_chunks():
                                 yield c

--- a/api/tests/test_cloudinary_cleanup.py
+++ b/api/tests/test_cloudinary_cleanup.py
@@ -1,3 +1,5 @@
+import asyncio
+from collections.abc import AsyncIterable
 from io import BytesIO
 from zipfile import ZipFile
 
@@ -16,6 +18,10 @@ from api.workflow import _workflow
 
 URL = "/api/admin/cloudinary-cleanup/"
 ARCHIVE_URL = "/api/admin/cloudinary-cleanup/archive/"
+
+
+async def _collect_async_bytes(chunks: AsyncIterable[bytes]) -> bytes:
+    return b"".join([chunk async for chunk in chunks])
 
 
 @pytest.mark.django_db
@@ -327,23 +333,23 @@ class TestCloudinaryCleanup:
             def raise_for_status(self) -> None:
                 pass
 
-            def iter_bytes(self, chunk_size: int):
+            async def aiter_bytes(self, chunk_size: int):
                 yield self._body
 
-            def __enter__(self):
+            async def __aenter__(self):
                 return self
 
-            def __exit__(self, *args):
+            async def __aexit__(self, *args):
                 pass
 
         class FakeClient:
             def __init__(self, timeout: int):
                 pass
 
-            def __enter__(self):
+            async def __aenter__(self):
                 return self
 
-            def __exit__(self, *args):
+            async def __aexit__(self, *args):
                 pass
 
             def stream(self, method: str, url: str):
@@ -352,7 +358,7 @@ class TestCloudinaryCleanup:
         monkeypatch.setattr(
             "api.cloudinary_cleanup.cloudinary.api.resources", fake_resources
         )
-        monkeypatch.setattr("api.cloudinary_cleanup.httpx.Client", FakeClient)
+        monkeypatch.setattr("api.cloudinary_cleanup.httpx.AsyncClient", FakeClient)
 
         response = client.get(ARCHIVE_URL + "?unreferenced_only=true")
 
@@ -360,7 +366,8 @@ class TestCloudinaryCleanup:
         assert response["Content-Type"] == "application/zip"
         assert response["Cache-Control"] == "no-store"
         assert response["X-Accel-Buffering"] == "no"
-        archive_bytes = b"".join(response.streaming_content)
+        assert response.is_async
+        archive_bytes = asyncio.run(_collect_async_bytes(response.streaming_content))
         with ZipFile(BytesIO(archive_bytes)) as archive:
             assert sorted(archive.namelist()) == [
                 "demo/glaze_dev/piece/another.webp",
@@ -378,24 +385,24 @@ class TestCloudinaryCleanup:
             def raise_for_status(self) -> None:
                 pass
 
-            def iter_bytes(self, chunk_size: int):
+            async def aiter_bytes(self, chunk_size: int):
                 yield f"bytes from {self._url}".encode()
 
-            def __enter__(self):
+            async def __aenter__(self):
                 opened_urls.append(self._url)
                 return self
 
-            def __exit__(self, *args):
+            async def __aexit__(self, *args):
                 pass
 
         class FakeClient:
             def __init__(self, timeout: int):
                 pass
 
-            def __enter__(self):
+            async def __aenter__(self):
                 return self
 
-            def __exit__(self, *args):
+            async def __aexit__(self, *args):
                 pass
 
             def stream(self, method: str, url: str):
@@ -425,9 +432,14 @@ class TestCloudinaryCleanup:
                 referenced=False,
             ),
         ]
-        monkeypatch.setattr("api.cloudinary_cleanup.httpx.Client", FakeClient)
+        monkeypatch.setattr("api.cloudinary_cleanup.httpx.AsyncClient", FakeClient)
 
-        first_chunk = next(stream_cloudinary_cleanup_archive(assets), b"")
+        async def first_archive_chunk() -> bytes:
+            async for chunk in stream_cloudinary_cleanup_archive(assets):
+                return chunk
+            return b""
+
+        first_chunk = asyncio.run(first_archive_chunk())
 
         assert first_chunk
         assert opened_urls == ["https://example.com/first.jpg"]


### PR DESCRIPTION
## Summary
- Convert the Cloudinary cleanup archive producer to an async iterator backed by `httpx.AsyncClient`.
- Keep the zip stream lazy under Django ASGI so `StreamingHttpResponse` does not consume the synchronous iterator into memory.
- Update archive tests to assert async streaming content and async lazy asset fetching.

## Verification
- `rtk bazel test //api:api_admin_test //api:api_mypy`

Follow-up to #298 for the production RSS growth observed after the initial proxy/settings fix.

Closes #297