### PR TITLE
feat: update gz_start to use uvicorn for ASGI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ When changing large download endpoints, run the app locally with `gz_start`,
 trigger the same download three times in the browser, and watch the backend RSS:
 
 ```bash
-BACKEND_PID=$(pgrep -f "manage.py runserver.*$(cat .dev-pids/backend.port)")
+BACKEND_PID=$(pgrep -f "uvicorn.*$(cat .dev-pids/backend.port)")
 watch -n 1 "ps -o pid,rss,vsz,cmd -p ${BACKEND_PID}"
 ```
 
@@ -267,7 +267,7 @@ python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements-dev.txt
 python manage.py migrate
-python manage.py runserver 8080
+uvicorn backend.asgi:application --port 8080 --reload
 
 # Web (separate terminal)
 cd web
@@ -683,7 +683,7 @@ Some global types (currently **Clay Bodies** and **Glaze Types**) support a shar
 
 ### Getting to the admin
 
-1. Start the backend (`gz_backend` or `python manage.py runserver 8080`).
+1. Start the backend (`gz_backend` or `uvicorn backend.asgi:application --port 8080 --reload`).
 2. Go to `http://localhost:8080/admin/` and sign in with a Django superuser account.
    - To create a superuser: `gz_manage createsuperuser` (or `python manage.py createsuperuser`).
 

--- a/docs/agents/dev.md
+++ b/docs/agents/dev.md
@@ -8,7 +8,7 @@ python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 python manage.py migrate
-python manage.py runserver 8080  # or any free port; gz_start picks one automatically
+uvicorn backend.asgi:application --port 8080 --reload  # or any free port; gz_start picks one automatically
 
 # Web (separate terminal)
 cd web
@@ -78,7 +78,7 @@ Use `gz_status` to see what is running and on which ports in the current worktre
 
 ```bash
 gz_worktrees               # all worktrees; ● marks those with running servers
-pgrep -a -f "manage.py runserver"   # all Django instances (cross-worktree)
+pgrep -a -f "uvicorn"                # all uvicorn instances (cross-worktree)
 ss -tlnp | grep -E 'node|python'    # all bound ports with owning process
 ```
 
@@ -297,13 +297,13 @@ In another terminal, find the active backend port and Django process:
 
 ```bash
 BACKEND_PORT=$(cat .dev-pids/backend.port)
-pgrep -a -f "manage.py runserver.*${BACKEND_PORT}"
+pgrep -a -f "uvicorn.*${BACKEND_PORT}"
 ```
 
 Watch the backend RSS while exercising the download:
 
 ```bash
-BACKEND_PID=$(pgrep -f "manage.py runserver.*$(cat .dev-pids/backend.port)")
+BACKEND_PID=$(pgrep -f "uvicorn.*$(cat .dev-pids/backend.port)")
 watch -n 1 "ps -o pid,rss,vsz,cmd -p ${BACKEND_PID}"
 ```
 

--- a/docs/agents/django-drf-python.md
+++ b/docs/agents/django-drf-python.md
@@ -16,7 +16,7 @@ python manage.py startapp api
 
 python manage.py migrate
 python manage.py createsuperuser
-python manage.py runserver 8080
+uvicorn backend.asgi:application --port 8080 --reload
 ```
 
 ## Stack

--- a/env.sh
+++ b/env.sh
@@ -407,7 +407,7 @@ gz_backend() {
     app_origin="http://localhost:$web_port"
     echo "$port" > "$_GLAZE_PIDS/backend.port"
     _gz_start backend "$_GLAZE_LOGS/backend.log" \
-        bash -c "source '$venv_root/.venv/bin/activate' && cd '$GLAZE_ROOT' && set -a && [ -f '$env_root/.env.local' ] && source '$env_root/.env.local'; set +a && export APP_ORIGIN='$app_origin' && python manage.py load_public_library --skip-if-missing && python manage.py runserver $port"
+        bash -c "source '$venv_root/.venv/bin/activate' && cd '$GLAZE_ROOT' && set -a && [ -f '$env_root/.env.local' ] && source '$env_root/.env.local'; set +a && export APP_ORIGIN='$app_origin' && python manage.py load_public_library --skip-if-missing && uvicorn backend.asgi:application --host 127.0.0.1 --port $port --reload"
 }
 
 gz_web() {


### PR DESCRIPTION
## Summary
This PR updates the `gz_start` developer helper to use `uvicorn` for the Django backend instead of the standard WSGI-based `runserver`. This change provides full ASGI support in development, ensuring compatibility with async features like the Cloudinary cleanup archive.

## Changes
- **`env.sh`**: Modified `gz_backend` to use `uvicorn backend.asgi:application`.
- **Hot Reloading**: Enabled via `--reload` for development parity.
- **Documentation**: Updated `README.md` and `docs/agents/` with the new commands and monitoring instructions.

## Verification Results
- [x] Backend starts correctly with `gz_start` and loads the public library.
- [x] Hot reloading verified by touching `api/views.py`.
- [x] `gz_stop` cleanly terminates the uvicorn process group (verified with `pgrep`).
- [x] All tests (`rtk bazel test //...`) and linters pass.

Closes #308
