### PR TITLE
feat: computed state references

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -1,7 +1,7 @@
 import json
 import os
 import re
-from typing import Any, ClassVar, cast
+from typing import Any, ClassVar
 
 import cloudinary
 from adminsortable2.admin import SortableAdminBase, SortableInlineAdminMixin
@@ -741,7 +741,12 @@ class PieceStateImageInline(SortableInlineAdminMixin, admin.TabularInline):
 
 def _get_custom_form_fields(state_id: str) -> dict[str, forms.Field]:
     from django.apps import apps
-    from .workflow import build_custom_fields_schema, get_global_config, get_global_ref_fields_for_state
+
+    from .workflow import (
+        build_custom_fields_schema,
+        get_global_config,
+        get_global_ref_fields_for_state,
+    )
 
     schema = build_custom_fields_schema(state_id)
     properties = schema.get("properties", {})
@@ -806,7 +811,8 @@ class PieceStateAdminForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         from django.apps import apps
-        from .workflow import get_global_ref_fields_for_state, get_global_config
+
+        from .workflow import get_global_config, get_global_ref_fields_for_state
 
         super().__init__(*args, **kwargs)
         self.custom_field_names = [
@@ -897,9 +903,7 @@ class PieceStateAdmin(ExportMixin, SortableAdminBase, admin.ModelAdmin):
     list_select_related = ("piece",)
     inlines = [PieceStateImageInline]
 
-    def get_fields(
-        self, request: HttpRequest, obj: PieceState | None = None
-    ) -> Any:
+    def get_fields(self, request: HttpRequest, obj: PieceState | None = None) -> Any:
         fields = list(super().get_fields(request, obj))
         if obj and obj.state:
             custom_fields = _get_custom_form_fields(obj.state)
@@ -950,6 +954,4 @@ class PieceStateAdmin(ExportMixin, SortableAdminBase, admin.ModelAdmin):
                     clear_fields.add(field_name)
 
         if global_ref_pks or clear_fields:
-            _write_global_ref_rows(
-                obj, global_ref_fields, global_ref_pks, clear_fields
-            )
+            _write_global_ref_rows(obj, global_ref_fields, global_ref_pks, clear_fields)

--- a/api/model_factories.py
+++ b/api/model_factories.py
@@ -87,6 +87,9 @@ class GlobalModel(models.Model):
     # names remain safe to embed in a composite name.
     _computed_name: ClassVar[bool] = False
 
+    # Every concrete subclass is guaranteed to have a name (field or property).
+    name: str
+
     class Meta:
         abstract = True
 

--- a/api/models.py
+++ b/api/models.py
@@ -2,6 +2,7 @@ import uuid
 from typing import TYPE_CHECKING, Any
 
 import jsonschema
+from django.apps import apps
 from django.conf import settings
 from django.db import models
 from django.db.models import Q
@@ -45,6 +46,7 @@ from .workflow import (
     get_compose_from,
     get_global_config,
     get_global_names,
+    get_global_ref_fields_for_state,
     get_state_global_ref_map,
     get_taggable_globals,
     is_factory_global,
@@ -302,6 +304,44 @@ class PieceState(models.Model):
 
     def __str__(self) -> str:
         return f"{self.piece.name} → {self.state}"
+
+    def resolve_custom_field(self, field_name: str) -> Any:
+        """Resolve a field value, following state-ref markers transitively.
+
+        Checks ``custom_fields`` for the field or a marker string. If a marker
+        is found, traverses history to find the authoritative ancestor. If
+        not in ``custom_fields``, checks global-ref junction tables.
+        """
+        val = self.custom_fields.get(field_name)
+        if isinstance(val, str) and val.startswith("[") and val.endswith("]"):
+            marker = val[1:-1]
+            if "." in marker:
+                src_state_id, src_field_name = marker.split(".", 1)
+                ancestor = (
+                    self.piece.states.filter(state=src_state_id)
+                    .order_by("-created")
+                    .first()
+                )
+                if ancestor:
+                    return ancestor.resolve_custom_field(src_field_name)
+
+        if val is not None:
+            return val
+
+        # Not in custom_fields. Check junction tables for global refs.
+        global_ref_map = get_global_ref_fields_for_state(self.state)
+        if field_name in global_ref_map:
+            global_name = global_ref_map[field_name]
+            config = get_global_config(global_name)
+            ref_model = apps.get_model("api", f"PieceState{config['model']}Ref")
+            try:
+                ref_row = ref_model.objects.select_related(global_name).get(
+                    piece_state=self, field_name=field_name
+                )
+                return getattr(ref_row, global_name)
+            except ref_model.DoesNotExist:
+                return None
+        return None
 
 
 class PieceStateImage(models.Model):

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -260,22 +260,27 @@ class PieceStateSerializer(serializers.ModelSerializer):
     def get_custom_fields(self, obj: PieceState) -> dict:
         """Merge inline JSON blob with global-ref junction table lookups.
 
+        Follows state-ref markers to resolve live values from ancestors.
         Global ref fields are returned as {id, name} objects; inline fields
         are returned as their raw JSON values.
         """
-        result = dict(obj.custom_fields or {})
-        global_ref_fields = get_global_ref_fields_for_state(obj.state)
-        for field_name, global_name in global_ref_fields.items():
-            config = get_global_config(global_name)
-            ref_model = apps.get_model("api", f"PieceState{config['model']}Ref")
-            try:
-                ref_row = ref_model.objects.select_related(global_name).get(
-                    piece_state=obj, field_name=field_name
-                )
-                global_obj = getattr(ref_row, global_name)
-                result[field_name] = {"id": str(global_obj.pk), "name": global_obj.name}
-            except ref_model.DoesNotExist:
-                pass
+        from .models import GlobalModel
+
+        result = {}
+        # Iterate over all fields defined for this state in the workflow.
+        from .workflow import _STATE_MAP
+
+        state_config = _STATE_MAP.get(obj.state, {})
+        fields = state_config.get("fields", {})
+        for field_name in fields:
+            val = obj.resolve_custom_field(field_name)
+            if val is None:
+                continue
+
+            if isinstance(val, GlobalModel):
+                result[field_name] = {"id": str(val.pk), "name": val.name}
+            else:
+                result[field_name] = val
         return result
 
     @extend_schema_field(serializers.CharField(allow_null=True))
@@ -504,7 +509,7 @@ def _resolve_additional_field_payload(
     *,
     clear_empty_refs: bool = False,
 ) -> tuple[dict, dict[str, str], dict[str, str], set[str]]:
-    """Split inline JSON fields from global refs and copy state-ref defaults."""
+    """Split inline JSON fields from global refs and copy state-ref markers."""
     global_ref_fields = get_global_ref_fields_for_state(state_id)
     inline_fields: dict = {}
     global_ref_pks: dict[str, str] = {}
@@ -522,30 +527,15 @@ def _resolve_additional_field_payload(
 
     state_refs = get_state_ref_fields(state_id)
     for field_name, (source_state_id, source_field_name) in state_refs.items():
-        ancestor = (
-            piece.states.filter(state=source_state_id).order_by("-created").first()
-        )
-        if ancestor is None:
-            continue
-        if field_name in global_ref_fields:
-            if field_name in global_ref_pks or field_name in clear_global_ref_fields:
-                continue
-            src_global_name = global_ref_fields[field_name]
-            src_config = get_global_config(src_global_name)
-            src_ref_model = apps.get_model("api", f"PieceState{src_config['model']}Ref")
-            try:
-                src_row = src_ref_model.objects.get(
-                    piece_state=ancestor, field_name=source_field_name
-                )
-                global_ref_pks[field_name] = str(
-                    getattr(src_row, f"{src_global_name}_id")
-                )
-            except src_ref_model.DoesNotExist:
-                pass
-        elif field_name not in inline_fields and source_field_name in (
-            ancestor.custom_fields or {}
-        ):
-            inline_fields[field_name] = ancestor.custom_fields[source_field_name]
+        # Force marker for ALL state-refs, ignoring client input for those fields.
+        inline_fields[field_name] = f"[{source_state_id}.{source_field_name}]"
+
+        # Ensure state-refs are not written to junction tables even if they
+        # resolve to global refs. They will be resolved lazily instead.
+        if field_name in global_ref_pks:
+            del global_ref_pks[field_name]
+        if field_name in clear_global_ref_fields:
+            clear_global_ref_fields.remove(field_name)
 
     return inline_fields, global_ref_fields, global_ref_pks, clear_global_ref_fields
 

--- a/api/tests/test_patch_current_state.py
+++ b/api/tests/test_patch_current_state.py
@@ -252,10 +252,10 @@ class TestPatchCurrentState:
         assert response.json()["current_state"]["custom_fields"]["glaze_combination"][
             "id"
         ] == str(combo.pk)
-        assert ref_model.objects.filter(
+        # With lazy resolution, no junction row is created for state-refs.
+        assert not ref_model.objects.filter(
             piece_state=current,
             field_name="glaze_combination",
-            glaze_combination=combo,
         ).exists()
 
     def test_update_validation_error_when_custom_fields_save_fails(

--- a/api/tests/test_piece_state_admin_relational.py
+++ b/api/tests/test_piece_state_admin_relational.py
@@ -1,8 +1,10 @@
 import pytest
-from django.contrib.admin.sites import AdminSite
-from api.admin import PieceStateAdmin, _get_custom_form_fields
-from api.models import Piece, PieceState, GlazeCombination
 from django import forms
+from django.contrib.admin.sites import AdminSite
+
+from api.admin import PieceStateAdmin, _get_custom_form_fields
+from api.models import GlazeCombination, Piece, PieceState
+
 
 @pytest.mark.django_db
 def test_piece_state_admin_form_has_relational_fields(user):
@@ -11,7 +13,7 @@ def test_piece_state_admin_form_has_relational_fields(user):
     state = PieceState.objects.create(
         user=user,
         piece=piece,
-        state="glazed" # 'glazed' has 'glaze_combination' ref
+        state="glazed",  # 'glazed' has 'glaze_combination' ref
     )
 
     admin = PieceStateAdmin(PieceState, AdminSite())
@@ -23,30 +25,28 @@ def test_piece_state_admin_form_has_relational_fields(user):
     assert isinstance(form.fields["custom_glaze_combination"], forms.ModelChoiceField)
     assert form.fields["custom_glaze_combination"].queryset.model == GlazeCombination
 
+
 @pytest.mark.django_db
 def test_get_custom_form_fields_includes_relational_fields():
     # 'glazed' state has 'glaze_combination' which is a global ref
     fields = _get_custom_form_fields("glazed")
-    
+
     assert "custom_glaze_combination" in fields
     assert isinstance(fields["custom_glaze_combination"], forms.ModelChoiceField)
     assert fields["custom_glaze_combination"].queryset.model == GlazeCombination
 
+
 @pytest.mark.django_db
 def test_piece_state_admin_save_relational_fields(user):
     from api.models import PieceStateGlazeCombinationRef
-    
+
     piece = Piece.objects.create(user=user, name="Test Piece")
-    state = PieceState.objects.create(
-        user=user,
-        piece=piece,
-        state="glazed"
-    )
+    state = PieceState.objects.create(user=user, piece=piece, state="glazed")
     gc = GlazeCombination.objects.create(user=user, name="Test Glaze")
-    
+
     admin = PieceStateAdmin(PieceState, AdminSite())
     form_class = admin.get_form(None, obj=state, change=True)
-    
+
     # Simulate saving the form
     form_data = {
         "user": user.id,
@@ -58,35 +58,29 @@ def test_piece_state_admin_save_relational_fields(user):
     }
     form = form_class(data=form_data, instance=state)
     assert form.is_valid(), form.errors
-    
-    admin.save_model(None, state, form, True)
-    
-    # Verify junction row exists
-    ref = PieceStateGlazeCombinationRef.objects.get(piece_state=state, field_name="glaze_combination")
-    assert ref.glaze_combination == gc
 
+    admin.save_model(None, state, form, True)
+
+    # Verify junction row exists
+    ref = PieceStateGlazeCombinationRef.objects.get(
+        piece_state=state, field_name="glaze_combination"
+    )
+    assert ref.glaze_combination == gc
 
 
 @pytest.mark.django_db
 def test_piece_state_admin_load_relational_fields(user):
     from api.models import PieceStateGlazeCombinationRef
-    
+
     piece = Piece.objects.create(user=user, name="Test Piece")
-    state = PieceState.objects.create(
-        user=user,
-        piece=piece,
-        state="glazed"
-    )
+    state = PieceState.objects.create(user=user, piece=piece, state="glazed")
     gc = GlazeCombination.objects.create(user=user, name="Test Glaze")
     PieceStateGlazeCombinationRef.objects.create(
-        piece_state=state,
-        field_name="glaze_combination",
-        glaze_combination=gc
+        piece_state=state, field_name="glaze_combination", glaze_combination=gc
     )
-    
+
     admin = PieceStateAdmin(PieceState, AdminSite())
     form_class = admin.get_form(None, obj=state, change=True)
     form = form_class(instance=state)
-    
-    assert form.initial["custom_glaze_combination"] == gc.id
 
+    assert form.initial["custom_glaze_combination"] == gc.id

--- a/api/tests/test_piece_states.py
+++ b/api/tests/test_piece_states.py
@@ -211,9 +211,9 @@ class TestPieceStates:
             == 1000
         )
 
-    def test_state_ref_client_value_not_overridden(self, client, piece):
-        # If the client explicitly supplies a value for a state ref field, the
-        # auto-population should not override it.
+    def test_state_ref_client_value_ignored(self, client, piece):
+        # Fields defined as state-refs are read-only: client input is ignored
+        # and the marker is always used.
         client.post(
             f"/api/pieces/{piece.id}/states/",
             {"state": "wheel_thrown", "custom_fields": {"clay_weight_lbs": 1000}},
@@ -225,9 +225,10 @@ class TestPieceStates:
             format="json",
         )
         assert response.status_code == 201
+        # It should resolve to 1000 (from ancestor) NOT 999 (client input)
         assert (
             response.json()["current_state"]["custom_fields"]["pre_trim_weight_lbs"]
-            == 999
+            == 1000
         )
 
     def test_global_ref_state_ref_auto_populated_on_transition(self, client, piece):

--- a/api/tests/test_workflow_helpers.py
+++ b/api/tests/test_workflow_helpers.py
@@ -396,8 +396,18 @@ def test_build_custom_fields_schema_resolves_state_refs_recursively(monkeypatch)
     assert schema == {
         "type": "object",
         "properties": {
-            "kiln_temperature_c": {"type": "integer"},
-            "cone": {"type": "string", "enum": ["04", "03", "02", "01"]},
+            "kiln_temperature_c": {
+                "anyOf": [
+                    {"type": "integer"},
+                    {"pattern": r"^\[[a-z_]+\.[a-z_]+\]$", "type": "string"},
+                ]
+            },
+            "cone": {
+                "anyOf": [
+                    {"enum": ["04", "03", "02", "01"], "type": "string"},
+                    {"pattern": r"^\[[a-z_]+\.[a-z_]+\]$", "type": "string"},
+                ]
+            },
         },
         "additionalProperties": False,
     }

--- a/api/workflow.py
+++ b/api/workflow.py
@@ -443,9 +443,25 @@ def build_custom_fields_schema(state_id: str) -> dict:
     required: list[str] = []
 
     for field_name, field_def in dsl_fields.items():
-        if _resolve_to_global_ref(field_def) is not None:
+        # Global refs (starting with @) are stored in junction tables and excluded
+        # from the inline custom_fields schema. State refs are now stored as
+        # markers in custom_fields and must be included.
+        is_direct_global_ref = "$ref" in field_def and field_def["$ref"].startswith("@")
+        if is_direct_global_ref:
             continue
-        properties[field_name] = _resolve_field_def(field_def)
+
+        field_schema = _resolve_field_def(field_def)
+        # If it's a state-ref, allow either the resolved type OR a marker string.
+        if "$ref" in field_def and not field_def["$ref"].startswith("@"):
+            properties[field_name] = {
+                "anyOf": [
+                    field_schema,
+                    {"type": "string", "pattern": r"^\[[a-z_]+\.[a-z_]+\]$"},
+                ]
+            }
+        else:
+            properties[field_name] = field_schema
+
         if field_def.get("required", False):
             required.append(field_name)
 


### PR DESCRIPTION
## Summary

Transition from eager "copy-on-create" strategy for state references (`$ref: "ancestor_state.field_name"`) to lazy, live resolution at the model layer.

This implementation ensures that changes to fields in ancestor states propagate automatically to all downstream states that reference them, eliminates data duplication in the `custom_fields` JSON blob, and enforces the intended read-only contract for referenced fields in successor states.

## Changes

- **Reference Markers**: `PieceState.custom_fields` now stores `[state_id.field_name]` markers for all state-ref fields.
- **Lazy Resolution**: Added `PieceState.resolve_custom_field(field_name)` to dynamically resolve values by traversing piece history.
- **Serializer Updates**: 
    - `PieceStateCreateSerializer` and `PieceStateUpdateSerializer` (via `_resolve_additional_field_payload`) now force marker injection for state-refs, ignoring client-provided values.
    - `PieceStateSerializer.get_custom_fields` utilizes the new model-level resolution logic.
- **Junction Tables**: State-refs that resolve to global types are now stored as markers in `custom_fields` instead of redundant junction rows.
- **Schema Validation**: Updated `build_custom_fields_schema` to allow markers for state-ref fields.
- **Mypy**: Added `name` type hint to `GlobalModel` to satisfy attribute checks on resolved global objects.

## Verification

- Verified live propagation of both inline and global-ref values using a reproduction script.
- Confirmed that client attempts to overwrite state-ref fields are ignored.
- Updated and verified all affected tests in `api/tests/`.
- All backend tests passing: `rtk bazel test //api:api_test`.
- Mypy passing: `rtk bazel test //api:api_mypy`.

Closes #314
