### PR TITLE
Add Django Admin link to user menu (#322)

### DIFF
--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -773,6 +773,15 @@ vitest_test(
     ],
 )
 
+vitest_test(
+    name = "web_app_test",
+    srcs = ["src/App.test.tsx"],
+    tags = ["ibazel_notify_changes"],
+    deps = [
+        ":web_lib",
+    ],
+)
+
 # ── Web test suite ────────────────────────────────────────────────────────────
 # Aggregate target: `bazel test //web:web_test` runs all web tests.
 # Individual targets above run only when their inputs change.
@@ -781,6 +790,7 @@ test_suite(
     name = "web_test",
     tests = [
         ":web_api_test",
+        ":web_app_test",
         ":web_glaze_gallery_test",
         ":web_glaze_import_test",
         ":web_image_lightbox_test",

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -322,6 +322,22 @@ describe("App auth flow", () => {
     });
   });
 
+  it("shows the Admin Tool menu item only for admin users and redirects to /admin/", async () => {
+    vi.mocked(fetchCurrentUser).mockResolvedValue(MOCK_ADMIN_USER);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /new piece/i }),
+      ).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText("Pat Potter"));
+    const adminLink = screen.getByText("Admin Tool").closest("a");
+    expect(adminLink).toHaveAttribute("href", "/admin/");
+  });
+
   it("does not show the manual crop tool menu item for non-admin users", async () => {
     vi.mocked(fetchCurrentUser).mockResolvedValue(MOCK_USER);
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -37,6 +37,7 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import LogoutIcon from "@mui/icons-material/Logout";
 import CropFreeIcon from "@mui/icons-material/CropFree";
 import CleaningServicesIcon from "@mui/icons-material/CleaningServices";
+import AdminPanelSettingsIcon from "@mui/icons-material/AdminPanelSettings";
 import { alpha, ThemeProvider, createTheme } from "@mui/material/styles";
 
 import { GoogleOAuthProvider, GoogleLogin } from "@react-oauth/google";
@@ -633,6 +634,16 @@ function AppShell({
                   <CleaningServicesIcon fontSize="small" />
                 </ListItemIcon>
                 Cloudinary Cleanup
+              </MenuItem>
+              <MenuItem
+                component="a"
+                href="/admin/"
+                onClick={() => setMenuAnchor(null)}
+              >
+                <ListItemIcon>
+                  <AdminPanelSettingsIcon fontSize="small" />
+                </ListItemIcon>
+                Admin Tool
               </MenuItem>
             </>
           ) : null}


### PR DESCRIPTION
## Objective
Add a new item "Admin Tool" to the user dropdown menu in the header. This option is only visible to admin (`is_staff`) users and should redirect the user to the Django admin page (`/admin/`).

## Changes
- **`web/src/App.tsx`**:
    - Imported `AdminPanelSettingsIcon` from `@mui/icons-material/AdminPanelSettings`.
    - Added a `MenuItem` to the user dropdown menu within the `currentUser.is_staff` conditional block.
    - Configured the `MenuItem` to use `component="a"` with `href="/admin/"` for full-page navigation to the Django admin site.
- **`web/src/App.test.tsx`**:
    - Added a new test case "shows the Admin Tool menu item only for admin users and redirects to /admin/" to verify the correct rendering and link destination for staff users.
- **`web/BUILD.bazel`**:
    - Added a new `vitest_test` target named `web_app_test` for `src/App.test.tsx`.
    - Included `web_app_test` in the `web_test` suite to ensure it is part of the regular test runs.

Closes #322
