### PR TITLE
Rework Notes UI in PieceDetail

### DIFF
--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -416,11 +416,15 @@ export default function WorkflowState({
         <TextField
           label="Notes"
           multiline
-          minRows={3}
           value={notes}
           onChange={(e) => dispatch({ type: "set_notes", notes: e.target.value })}
           slotProps={{ htmlInput: { maxLength: 2000 } }}
           fullWidth
+          sx={{
+            mb: 1.5,
+            "& .MuiInputBase-root": { fontSize: "0.875rem" },
+            "& .MuiInputLabel-root": { fontSize: "0.875rem" },
+          }}
         />
       )}
       {customFieldDefs.length > 0 && (


### PR DESCRIPTION
### Description

This PR reworks the "Notes" UI in the PieceDetail view (specifically within the WorkflowState component) to improve layout and usability.

### Changes
- **Dynamic Expansion:** Removed minRows={3} from the Notes TextField, allowing it to start as a single line and expand as the user types.
- **Compact Styling:** Reduced the default font size for both the input text and the label to 0.875rem.
- **Improved Spacing:** Added mb: 1.5 to the Notes field to provide consistent padding between it and subsequent custom fields.

### Verification
- **Tests:** Ran rtk bazel test //web:web_workflow_state_test and confirmed it passes.
- **Linting:** Verified clean build with rtk bazel build --config=lint //web/...

Closes https://github.com/shaoster/glaze/issues/321
