### PR TITLE
fix: make PieceList 'Shared' filter an AND condition and visually distinct

### DIFF
--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -34,11 +34,17 @@ interface FilterOption {
   label: string;
 }
 
-const FILTER_OPTIONS: FilterOption[] = [
+const STATE_FILTER_OPTIONS: FilterOption[] = [
   { value: "wip", label: "Active" },
   { value: "completed", label: "Completed" },
   { value: "discarded", label: "Recycled" },
-  { value: "shared", label: "Shared" },
+];
+
+const SHARED_FILTER_OPTION: FilterOption = { value: "shared", label: "Shared" };
+
+const FILTER_OPTIONS: FilterOption[] = [
+  ...STATE_FILTER_OPTIONS,
+  SHARED_FILTER_OPTION,
 ];
 
 function matchesFilter(piece: PieceSummary, filter: FilterCategory): boolean {
@@ -353,17 +359,26 @@ const PieceList = (props: PieceListProps) => {
 
   const filteredPieces = useMemo(() => {
     return pieces.filter((piece) => {
+      const stateFilters = activeFilters.filter((f) => f !== "shared");
+      const sharedFilterActive = activeFilters.includes("shared");
+
       const matchesState =
-        activeFilters.length === 0
+        stateFilters.length === 0
           ? true
-          : activeFilters.some((filter) => matchesFilter(piece, filter));
+          : stateFilters.some((filter) => matchesFilter(piece, filter));
+
+      const matchesShared = sharedFilterActive
+        ? matchesFilter(piece, "shared")
+        : true;
+
       const matchesTags =
         activeTagIds.length === 0
           ? true
           : activeTagIds.every((id) =>
               (piece.tags ?? []).some((pieceTag) => pieceTag.id === id),
             );
-      return matchesState && matchesTags;
+
+      return matchesState && matchesShared && matchesTags;
     });
   }, [pieces, activeFilters, activeTagIds]);
 
@@ -542,8 +557,15 @@ const PieceList = (props: PieceListProps) => {
             }}
           >
             {/* Status filter chips */}
-            <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.75 }}>
-              {FILTER_OPTIONS.map((opt) => {
+            <Box
+              sx={{
+                display: "flex",
+                flexWrap: "wrap",
+                gap: 0.75,
+                alignItems: "center",
+              }}
+            >
+              {STATE_FILTER_OPTIONS.map((opt) => {
                 const active = activeFilters.includes(opt.value);
                 return (
                   <Chip
@@ -564,6 +586,39 @@ const PieceList = (props: PieceListProps) => {
                   />
                 );
               })}
+
+              <Box
+                sx={{
+                  width: "1px",
+                  bgcolor: "divider",
+                  mx: 0.5,
+                  alignSelf: "stretch",
+                  minHeight: "16px",
+                }}
+              />
+
+              <Chip
+                key={SHARED_FILTER_OPTION.value}
+                label={SHARED_FILTER_OPTION.label}
+                size="small"
+                onClick={() => toggleFilter(SHARED_FILTER_OPTION.value)}
+                sx={{
+                  cursor: "pointer",
+                  bgcolor: activeFilters.includes(SHARED_FILTER_OPTION.value)
+                    ? "primary.main"
+                    : alpha("#000", 0.18),
+                  color: activeFilters.includes(SHARED_FILTER_OPTION.value)
+                    ? "primary.contrastText"
+                    : "text.secondary",
+                  border: "1px solid",
+                  borderColor: activeFilters.includes(SHARED_FILTER_OPTION.value)
+                    ? "primary.main"
+                    : "divider",
+                  fontFamily: "'JetBrains Mono', 'Fira Mono', monospace",
+                  fontSize: "0.6875rem",
+                  "&:hover": { filter: "brightness(1.12)" },
+                }}
+              />
             </Box>
 
             {/* Tag filter: chips for active tags + "+ tag" button to open picker */}

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -339,6 +339,45 @@ describe("PieceList", () => {
       });
       expect(screen.getByText("Mug")).toBeInTheDocument();
     });
+
+    it("filters pieces using AND between state and shared filters", async () => {
+      const user = userEvent.setup();
+      const pieces = [
+        makePiece({
+          id: "id-1",
+          name: "Active Shared",
+          current_state: { state: "designed" } as any,
+          shared: true,
+        }),
+        makePiece({
+          id: "id-2",
+          name: "Active Not Shared",
+          current_state: { state: "designed" } as any,
+          shared: false,
+        }),
+        makePiece({
+          id: "id-3",
+          name: "Completed Shared",
+          current_state: { state: "completed" } as any,
+          shared: true,
+        }),
+      ];
+      renderPieceList(pieces);
+
+      await openFilters(user);
+
+      // Select "Active"
+      const activeChip = screen.getAllByText("Active").find((el) => el.closest('[role="button"]'));
+      await user.click(activeChip!.closest('[role="button"]')!);
+
+      // Select "Shared"
+      const sharedChip = screen.getAllByText("Shared").find((el) => el.closest('[role="button"]'));
+      await user.click(sharedChip!.closest('[role="button"]')!);
+
+      expect(screen.getByText("Active Shared")).toBeInTheDocument();
+      expect(screen.queryByText("Active Not Shared")).not.toBeInTheDocument();
+      expect(screen.queryByText("Completed Shared")).not.toBeInTheDocument();
+    });
   });
 
   describe("tag filtering", () => {


### PR DESCRIPTION
## Description
Currently, when filtering the PieceList, the 'Shared' filter uses an 'OR' predicate when combined with the state filters (Active, Completed, Recycled). This is often unintuitive as users expect category filters to narrow down results.

This PR changes the 'Shared' filter to act as an 'AND' predicate alongside any selected state filters. It also adds a visual divider in the UI to distinguish the 'Shared' toggle from the status-based chips.

## Changes
- Modified `filteredPieces` logic in `PieceList.tsx` to separate state filters and the shared filter.
- Added a vertical divider between state chips and the 'Shared' chip in the filter panel.
- Added a unit test in `PieceList.test.tsx` to verify the AND behavior.

## Verification
- Ran `rtk bazel test //web:web_piece_list_test` (Passed)
- Ran `rtk bazel build //web:tsc_check //web:eslint_check` (Passed)

Closes #310