### PR TITLE
Fix WhiteNoise sync iterator warning

### DIFF
--- a/backend/BUILD.bazel
+++ b/backend/BUILD.bazel
@@ -29,6 +29,7 @@ py_library(
         requirement("psycopg2-binary"),
         requirement("django-import-export"),
         requirement("django-meta"),
+        requirement("aiofiles"),
     ],
     visibility = ["//visibility:public"],
 )

--- a/requirements.lock
+++ b/requirements.lock
@@ -4,6 +4,10 @@
 #
 #    pip-compile --generate-hashes --output-file=requirements.lock requirements-dev.txt
 #
+aiofiles==25.1.0 \
+    --hash=sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2 \
+    --hash=sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695
+    # via -r requirements.txt
 anyio==4.13.0 \
     --hash=sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708 \
     --hash=sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,3 +59,4 @@ whitenoise==6.9.0
 logtail-python
 rembg
 onnxruntime
+aiofiles


### PR DESCRIPTION
Fixes #340

**Context**
Django's ASGI handler logs the following warning when serving static files locally and in production via ASGI:
`StreamingHttpResponse must consume synchronous iterators in order to serve them asynchronously. Use an asynchronous iterator instead.`

This warning is triggered by `WhiteNoiseMiddleware` yielding synchronous file handles. WhiteNoise supports async file serving but requires the `aiofiles` dependency to do so.

**Changes**
* Added `aiofiles` to `requirements.txt` as a runtime dependency.
* Updated `requirements.lock` via `pip-compile`.
* Added `requirement("aiofiles")` to `backend/BUILD.bazel` `backend_lib` deps.

**Verification**
* Verified full Bazel test suite passes (`rtk bazel test //...`).
* Verified linting passes (`rtk bazel build --config=lint //...`).