### PR TITLE
test: achieve 100% test coverage for issue 344

### DIFF
--- a/api/tests/test_public_library_commands.py
+++ b/api/tests/test_public_library_commands.py
@@ -9,6 +9,27 @@ from django.core.management.base import CommandError
 
 from api.models import COMPOSITE_NAME_SEPARATOR, ClayBody, GlazeCombination, GlazeType
 from api.utils import bootstrap_dev_user
+from api.management.commands.load_public_library import _extract_cloud_name
+
+
+class TestExtractCloudName:
+    def test_valid_url(self):
+        url = "https://res.cloudinary.com/demo/image/upload/v1/glaze/celadon.jpg"
+        assert _extract_cloud_name(url) == "demo"
+
+    def test_invalid_hostname(self):
+        url = "https://example.com/demo/image/upload/v1/glaze/celadon.jpg"
+        assert _extract_cloud_name(url) is None
+
+    def test_malformed_path(self):
+        url = "https://res.cloudinary.com/demo/image/"
+        assert _extract_cloud_name(url) is None
+
+    def test_not_a_url(self):
+        assert _extract_cloud_name("not_a_url") is None
+
+    def test_empty_string(self):
+        assert _extract_cloud_name("") is None
 
 
 @pytest.mark.django_db
@@ -276,6 +297,19 @@ class TestLoadPublicLibrary:
         )
 
         with pytest.raises(CommandError, match="Unknown model"):
+            call_command("load_public_library", fixture=str(fixture))
+
+    def test_raises_for_non_list_fixture(self, tmp_path):
+        fixture = self._write_fixture(tmp_path, {"model": "api.claybody", "fields": {"name": "X"}})
+        with pytest.raises(CommandError, match="Fixture must be a JSON array of records."):
+            call_command("load_public_library", fixture=str(fixture))
+
+    def test_raises_for_missing_name_field(self, tmp_path):
+        fixture = self._write_fixture(
+            tmp_path,
+            [{"model": "api.claybody", "fields": {"short_description": "A body"}}],
+        )
+        with pytest.raises(CommandError, match='Record for model api.claybody is missing a "name" field'):
             call_command("load_public_library", fixture=str(fixture))
 
     def test_roundtrip_dump_then_load(self, tmp_path, django_user_model):

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -465,6 +465,16 @@ js_library(
     ],
 )
 
+js_library(
+    name = "cloudinary_cleanup_page_src",
+    srcs = ["src/pages/CloudinaryCleanupPage.tsx"],
+    deps = [
+        ":node_modules",
+        ":util_lib",
+    ],
+)
+
+
 # ocrDetection.ts is the pure-logic module shared by GlazeImportToolPage and its unit tests.
 js_library(
     name = "ocr_detection_src",
@@ -720,6 +730,17 @@ vitest_test(
 )
 
 vitest_test(
+    name = "web_cloudinary_cleanup_test",
+    srcs = [
+        "src/pages/__tests__/CloudinaryCleanupPage.test.tsx",
+    ],
+    tags = ["ibazel_notify_changes"],
+    deps = [
+        ":cloudinary_cleanup_page_src",
+    ],
+)
+
+vitest_test(
     name = "web_glaze_import_test",
     srcs = [
         "src/pages/__tests__/GlazeImportCropStage.test.tsx",
@@ -785,6 +806,17 @@ vitest_test(
 )
 
 vitest_test(
+    name = "web_format_test",
+    srcs = [
+        "src/util/__tests__/format.test.ts",
+    ],
+    tags = ["ibazel_notify_changes"],
+    deps = [
+        ":util_lib",
+    ],
+)
+
+vitest_test(
     name = "web_app_test",
     srcs = ["src/App.test.tsx"],
     tags = ["ibazel_notify_changes"],
@@ -802,6 +834,8 @@ test_suite(
     tests = [
         ":web_api_test",
         ":web_app_test",
+        ":web_cloudinary_cleanup_test",
+        ":web_format_test",
         ":web_glaze_gallery_test",
         ":web_glaze_import_test",
         ":web_image_lightbox_test",

--- a/web/src/pages/__tests__/CloudinaryCleanupPage.test.tsx
+++ b/web/src/pages/__tests__/CloudinaryCleanupPage.test.tsx
@@ -16,6 +16,7 @@ describe("CloudinaryCleanupPage", () => {
         public_id: "asset1",
         cloud_name: "cloud1",
         url: "url1",
+        thumbnail_url: "",
         bytes: 1024,
         created_at: "2023-01-01",
         path_prefix: "p",
@@ -24,6 +25,7 @@ describe("CloudinaryCleanupPage", () => {
         public_id: "asset2",
         cloud_name: "cloud1",
         url: "url2",
+        thumbnail_url: "",
         bytes: 2048,
         created_at: "2023-01-02",
         path_prefix: "p",
@@ -56,8 +58,8 @@ describe("CloudinaryCleanupPage", () => {
 
     expect(screen.getByText("1.0 KB")).toBeDefined();
 
-    // Select an asset
-    const checkbox = screen.getByLabelText("Select asset1");
+    // Deselect asset2 so only asset1 is selected
+    const checkbox = screen.getByLabelText("Select asset2");
     fireEvent.click(checkbox);
 
     const deleteButton = screen.getByRole("button", {
@@ -73,6 +75,131 @@ describe("CloudinaryCleanupPage", () => {
       expect(api.deleteCloudinaryCleanupAssets).toHaveBeenCalledWith([
         "asset1",
       ]);
+    });
+  });
+  it("handles select all and deselect all", async () => {
+    const mockAssets: api.CloudinaryCleanupAsset[] = [
+      {
+        public_id: "asset1",
+        cloud_name: "cloud1",
+        url: "url1",
+        thumbnail_url: "",
+        bytes: 1024,
+        created_at: "2023-01-01",
+        path_prefix: "p",
+      },
+      {
+        public_id: "asset2",
+        cloud_name: "cloud1",
+        url: "url2",
+        thumbnail_url: "",
+        bytes: 2048,
+        created_at: "2023-01-02",
+        path_prefix: "p",
+      },
+    ];
+
+    vi.mocked(api.scanCloudinaryCleanupAssets).mockResolvedValue({
+      assets: mockAssets,
+      summary: {
+        total: 10,
+        referenced: 8,
+        unused: 2,
+        referenced_breakdown: [],
+        reference_warnings: [],
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <CloudinaryCleanupPage />
+      </MemoryRouter>,
+    );
+
+    const scanButton = screen.getByRole("button", { name: /Scan Assets/i });
+    fireEvent.click(scanButton);
+
+    await waitFor(() => {
+      expect(screen.getByText("asset1")).toBeDefined();
+    });
+
+    const selectAllCheckbox = screen.getByLabelText("Select all on this page");
+    
+    // Deselect all
+    fireEvent.click(selectAllCheckbox);
+    expect(screen.getByRole("button", { name: /Delete Selected \(0\)/i })).toBeDefined();
+
+    // Select all
+    fireEvent.click(selectAllCheckbox);
+    expect(screen.getByRole("button", { name: /Delete Selected \(2\)/i })).toBeDefined();
+  });
+
+  it("handles scan failure", async () => {
+    vi.mocked(api.scanCloudinaryCleanupAssets).mockRejectedValue(new Error("Network Error"));
+
+    render(
+      <MemoryRouter>
+        <CloudinaryCleanupPage />
+      </MemoryRouter>,
+    );
+
+    const scanButton = screen.getByRole("button", { name: /Scan Assets/i });
+    fireEvent.click(scanButton);
+
+    await waitFor(() => {
+      expect(screen.getByText("Unable to scan Cloudinary assets.")).toBeDefined();
+    });
+  });
+
+  it("handles delete failure", async () => {
+    const mockAssets: api.CloudinaryCleanupAsset[] = [
+      {
+        public_id: "asset1",
+        cloud_name: "cloud1",
+        url: "url1",
+        thumbnail_url: "",
+        bytes: 1024,
+        created_at: "2023-01-01",
+        path_prefix: "p",
+      },
+    ];
+
+    vi.mocked(api.scanCloudinaryCleanupAssets).mockResolvedValue({
+      assets: mockAssets,
+      summary: {
+        total: 10,
+        referenced: 8,
+        unused: 2,
+        referenced_breakdown: [],
+        reference_warnings: [],
+      },
+    });
+
+    vi.mocked(api.deleteCloudinaryCleanupAssets).mockRejectedValue(new Error("Network Error"));
+
+    render(
+      <MemoryRouter>
+        <CloudinaryCleanupPage />
+      </MemoryRouter>,
+    );
+
+    const scanButton = screen.getByRole("button", { name: /Scan Assets/i });
+    fireEvent.click(scanButton);
+
+    await waitFor(() => {
+      expect(screen.getByText("asset1")).toBeDefined();
+    });
+
+    const deleteButton = screen.getByRole("button", {
+      name: /Delete Selected \(1\)/i,
+    });
+    fireEvent.click(deleteButton);
+
+    const confirmButton = screen.getByRole("button", { name: "Delete" });
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(screen.getByText("Unable to delete the selected assets.")).toBeDefined();
     });
   });
 });

--- a/web/src/util/__tests__/format.test.ts
+++ b/web/src/util/__tests__/format.test.ts
@@ -1,0 +1,32 @@
+import { expect, it, describe } from "vitest";
+import { formatValue } from "../format";
+
+describe("formatValue", () => {
+  it("formats boolean values", () => {
+    expect(formatValue(true)).toBe("Yes");
+    expect(formatValue(false)).toBe("No");
+  });
+
+  it("formats object with name property", () => {
+    expect(formatValue({ name: "foo" })).toBe("foo");
+  });
+
+  it("returns empty string when object name is not a string", () => {
+    expect(formatValue({ name: 42 })).toBe("");
+  });
+
+  it("throws on unsupported type", () => {
+    expect(() => formatValue(42n)).toThrow("Unsupported value type");
+  });
+
+  it("handles null, undefined, and empty string", () => {
+    expect(formatValue(null)).toBe("");
+    expect(formatValue(undefined)).toBe("");
+    expect(formatValue("")).toBe("");
+  });
+
+  it("formats strings and numbers", () => {
+    expect(formatValue("test")).toBe("test");
+    expect(formatValue(123)).toBe("123");
+  });
+});


### PR DESCRIPTION
Closes #344

This PR addresses the test coverage thresholds requested in issue #344:

- Adds `web/src/util/__tests__/format.test.ts` to explicitly cover the `formatValue` utility paths (booleans, named objects, type errors) ensuring 100% coverage.
- Expands `api/tests/test_public_library_commands.py` covering the `_extract_cloud_name` helper and standard `CommandError` error paths.
- Expands `web/src/pages/__tests__/CloudinaryCleanupPage.test.tsx` testing suite handling asynchronous interaction states such as scan/delete failures and checkbox toggle events (select all & deselect).
- Adds `web_cloudinary_cleanup_test` and `web_format_test` test targets to `web/BUILD.bazel`.

## Verification

- [x] All backend and frontend tests fully pass via `rtk bazel test //...`
- [x] Test coverage explicitly checks the paths outlined in the issue.
