### PR TITLE
fix: async task queue deadlocks and orphaned task recovery

### DIFF
--- a/api/BUILD.bazel
+++ b/api/BUILD.bazel
@@ -104,6 +104,7 @@ py_test(
     name = "api_model_test",
     size = "medium",
     srcs = _CONFTEST + [
+        "tests/test_async_maintenance.py",
         "tests/test_async_tasks.py",
         "tests/test_global_entries.py",
         "tests/test_globals.py",
@@ -112,6 +113,7 @@ py_test(
         "tests/test_utils.py",
     ],
     args = [
+        "api/tests/test_async_maintenance.py",
         "api/tests/test_async_tasks.py",
         "api/tests/test_model_factory.py",
         "api/tests/test_globals.py",

--- a/api/apps.py
+++ b/api/apps.py
@@ -3,3 +3,24 @@ from django.apps import AppConfig
 
 class ApiConfig(AppConfig):
     name = "api"
+
+    def ready(self):
+        import os
+        import sys
+
+        # Only run cleanup when starting the actual web server (runserver or gunicorn/uvicorn).
+        # This prevents failing tasks during migrations, shell, or other management commands.
+        is_manage_py = os.path.basename(sys.argv[0]) == "manage.py"
+        is_server_cmd = is_manage_py and ("runserver" in sys.argv or "runserver_plus" in sys.argv)
+        is_prod_server = "gunicorn" in sys.argv[0] or "uvicorn" in sys.argv[0]
+
+        if is_server_cmd or is_prod_server:
+            from .tasks import fail_stuck_tasks
+
+            try:
+                # On startup, we can safely fail ALL tasks that are marked as RUNNING or PENDING
+                # because in an InMemoryTaskInterface setup, no tasks can survive a process restart.
+                fail_stuck_tasks(hours=0)
+            except Exception:
+                # Fail silently to avoid blocking startup if the database is not yet ready/migrated.
+                pass

--- a/api/management/commands/clear_stuck_tasks.py
+++ b/api/management/commands/clear_stuck_tasks.py
@@ -1,0 +1,66 @@
+import logging
+
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from api.models import AsyncTask
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Clear any background tasks permanently stuck in RUNNING or PENDING state."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Print what would be done without modifying the database.",
+        )
+        parser.add_argument(
+            "--hours",
+            type=int,
+            default=1,
+            help="Threshold in hours. Tasks older than this will be failed.",
+        )
+
+    def handle(self, *args, **options):
+        from api.tasks import fail_stuck_tasks
+
+        dry_run = options["dry_run"]
+        hours = options["hours"]
+
+        if dry_run:
+            from datetime import timedelta
+
+            from django.utils import timezone
+
+            from api.models import AsyncTask
+
+            threshold = timezone.now() - timedelta(hours=hours)
+            stuck_tasks = AsyncTask.objects.filter(
+                status__in=[AsyncTask.Status.RUNNING, AsyncTask.Status.PENDING],
+                last_modified__lt=threshold,
+            )
+            count = stuck_tasks.count()
+            if count == 0:
+                self.stdout.write(self.style.SUCCESS("No stuck tasks found."))
+            else:
+                self.stdout.write(
+                    f"Would mark {count} tasks as FAILED (older than {hours} hour(s))."
+                )
+                for task in stuck_tasks:
+                    self.stdout.write(
+                        f"  - Task {task.id} (type: {task.task_type}, status: {task.status})"
+                    )
+            return
+
+        count = fail_stuck_tasks(hours=hours)
+        if count == 0:
+            self.stdout.write(self.style.SUCCESS("No stuck tasks found."))
+        else:
+            self.stdout.write(
+                self.style.SUCCESS(f"Successfully marked {count} stuck tasks as FAILED.")
+            )

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -9,7 +9,7 @@ from .models import AsyncTask
 logger = logging.getLogger(__name__)
 
 # Single shared executor for background tasks in development.
-_executor = ThreadPoolExecutor(max_workers=4)
+_executor = ThreadPoolExecutor(max_workers=2)
 
 TaskCallable = Callable[[AsyncTask], Any]
 
@@ -46,33 +46,42 @@ class InMemoryTaskInterface:
         transaction.on_commit(lambda: _executor.submit(self._run_task, task.id))
 
     def _run_task(self, task_id: Any) -> None:
-        # Re-fetch task to ensure we have the latest state in this thread.
-        try:
-            task = AsyncTask.objects.get(id=task_id)
-        except AsyncTask.DoesNotExist:
-            logger.error(f"Async task {task_id} not found for execution.")
-            return
+        from django.db import close_old_connections
 
-        task.status = AsyncTask.Status.RUNNING
-        task.save(update_fields=["status", "last_modified"])
-
-        task_fn = TaskRegistry.get(task.task_type)
-        if not task_fn:
-            task.status = AsyncTask.Status.FAILURE
-            task.error = f"Unknown task type: {task.task_type}"
-            task.save(update_fields=["status", "error", "last_modified"])
-            return
+        # Close any stale connections before starting
+        close_old_connections()
 
         try:
-            result = task_fn(task)
-            task.status = AsyncTask.Status.SUCCESS
-            task.result = result
-            task.save(update_fields=["status", "result", "last_modified"])
-        except Exception as e:
-            logger.exception(f"Error executing task {task.task_type} ({task.id})")
-            task.status = AsyncTask.Status.FAILURE
-            task.error = str(e)
-            task.save(update_fields=["status", "error", "last_modified"])
+            # Re-fetch task to ensure we have the latest state in this thread.
+            try:
+                task = AsyncTask.objects.get(id=task_id)
+            except AsyncTask.DoesNotExist:
+                logger.error(f"Async task {task_id} not found for execution.")
+                return
+
+            task.status = AsyncTask.Status.RUNNING
+            task.save(update_fields=["status", "last_modified"])
+
+            task_fn = TaskRegistry.get(task.task_type)
+            if not task_fn:
+                task.status = AsyncTask.Status.FAILURE
+                task.error = f"Unknown task type: {task.task_type}"
+                task.save(update_fields=["status", "error", "last_modified"])
+                return
+
+            try:
+                result = task_fn(task)
+                task.status = AsyncTask.Status.SUCCESS
+                task.result = result
+                task.save(update_fields=["status", "result", "last_modified"])
+            except Exception as e:
+                logger.exception(f"Error executing task {task.task_type} ({task.id})")
+                task.status = AsyncTask.Status.FAILURE
+                task.error = str(e)
+                task.save(update_fields=["status", "error", "last_modified"])
+        finally:
+            # Clean up connections so the thread pool doesn't leak them
+            close_old_connections()
 
 
 # Global interface instance.
@@ -166,3 +175,26 @@ def detect_subject_crop(task: AsyncTask) -> dict | None:
             }
 
     return {"status": "success", "crop": crop, "updated": updated}
+
+
+def fail_stuck_tasks(hours: int = 1) -> int:
+    """Find and fail tasks stuck in RUNNING or PENDING for too long."""
+    from datetime import timedelta
+
+    from django.utils import timezone
+
+    from .models import AsyncTask
+
+    threshold = timezone.now() - timedelta(hours=hours)
+    stuck_tasks = AsyncTask.objects.filter(
+        status__in=[AsyncTask.Status.RUNNING, AsyncTask.Status.PENDING],
+        last_modified__lt=threshold,
+    )
+    count = stuck_tasks.count()
+    if count > 0:
+        stuck_tasks.update(
+            status=AsyncTask.Status.FAILURE,
+            error="Task timed out or was orphaned during a server restart.",
+            last_modified=timezone.now(),
+        )
+    return count

--- a/api/tests/test_async_maintenance.py
+++ b/api/tests/test_async_maintenance.py
@@ -1,0 +1,57 @@
+import pytest
+from datetime import timedelta
+from django.core.management import call_command
+from django.utils import timezone
+from api.models import AsyncTask
+from api.tasks import fail_stuck_tasks
+
+@pytest.mark.django_db
+class TestAsyncMaintenance:
+    def test_fail_stuck_tasks_logic(self, user):
+        # 1. Create a truly recent running task (within 1h threshold)
+        now = timezone.now()
+        t1 = AsyncTask.objects.create(user=user, task_type="ping", status=AsyncTask.Status.RUNNING)
+        
+        # 2. Create a "stuck" task (older than 2h)
+        # We use .update() to bypass auto_now on last_modified
+        t2 = AsyncTask.objects.create(user=user, task_type="ping", status=AsyncTask.Status.RUNNING)
+        AsyncTask.objects.filter(id=t2.id).update(last_modified=now - timedelta(hours=2))
+        
+        # 3. Create a pending task (older than 2h)
+        t3 = AsyncTask.objects.create(user=user, task_type="ping", status=AsyncTask.Status.PENDING)
+        AsyncTask.objects.filter(id=t3.id).update(last_modified=now - timedelta(hours=2))
+
+        count = fail_stuck_tasks(hours=1)
+        
+        assert count == 2
+        
+        t1.refresh_from_db()
+        t2.refresh_from_db()
+        t3.refresh_from_db()
+        
+        assert t1.status == AsyncTask.Status.RUNNING
+        assert t2.status == AsyncTask.Status.FAILURE
+        assert t3.status == AsyncTask.Status.FAILURE
+        assert "orphaned" in t2.error
+
+    def test_clear_stuck_tasks_command(self, user):
+        now = timezone.now()
+        t1 = AsyncTask.objects.create(user=user, task_type="ping", status=AsyncTask.Status.RUNNING)
+        AsyncTask.objects.filter(id=t1.id).update(last_modified=now - timedelta(hours=2))
+        
+        # Run command
+        call_command("clear_stuck_tasks", hours=1)
+        
+        t1.refresh_from_db()
+        assert t1.status == AsyncTask.Status.FAILURE
+
+    def test_clear_stuck_tasks_command_dry_run(self, user):
+        now = timezone.now()
+        t1 = AsyncTask.objects.create(user=user, task_type="ping", status=AsyncTask.Status.RUNNING)
+        AsyncTask.objects.filter(id=t1.id).update(last_modified=now - timedelta(hours=2))
+        
+        # Run command with dry-run
+        call_command("clear_stuck_tasks", hours=1, dry_run=True)
+        
+        t1.refresh_from_db()
+        assert t1.status == AsyncTask.Status.RUNNING  # Unchanged

--- a/api/utils.py
+++ b/api/utils.py
@@ -39,11 +39,15 @@ def calculate_subject_crop(image_bytes: bytes) -> dict | None:
     import io
 
     from PIL import Image
-    from rembg import remove
+    from rembg import new_session, remove
 
     # 1. Remove background
     input_image = Image.open(io.BytesIO(image_bytes))
-    output_image = remove(input_image)
+    
+    # Use a thread-local session to prevent ONNX Runtime deadlocks
+    # when run concurrently within the background ThreadPoolExecutor.
+    session = new_session("u2net")
+    output_image = remove(input_image, session=session)
 
     # 2. Find non-transparent bounds
     alpha = output_image.getchannel("A")


### PR DESCRIPTION
## Problem / Motivation
The `InMemoryTaskInterface` background worker was prone to indefinite hangs due to:
1. **ONNX Deadlocks**: Concurrent `rembg` calls shared a global session.
2. **Connection Leaks**: Background threads didn't close DB connections.
3. **Orphaned Tasks**: Tasks remained `RUNNING` in the DB after server restarts.

## Proposed Solution
- **Resource Management**: Added `close_old_connections()` to task threads.
- **Concurrency Fix**: Fresh `rembg` session per call and reduced worker pool to 2.
- **Automated Recovery**: Startup hook fails orphaned tasks from previous runs.
- **Maintenance Tool**: New `manage.py clear_stuck_tasks` command.

## Acceptance Criteria
- [x] Background threads release connections correctly.
- [x] Concurrent crop detection no longer deadlocks.
- [x] Thread pool limited to 2 workers.
- [x] Orphaned tasks failed on startup.
- [x] Comprehensive tests for maintenance logic.

Closes #348
