### PR TITLE
fix: detailed logging for async task debugging

### DIFF
--- a/api/tasks.py
+++ b/api/tasks.py
@@ -43,6 +43,7 @@ class InMemoryTaskInterface:
 
     def submit(self, task: AsyncTask) -> None:
         # Use on_commit to ensure the task record is visible to the background thread.
+        logger.info(f"Submitting task {task.task_type} ({task.id}) to thread pool.")
         transaction.on_commit(lambda: _executor.submit(self._run_task, task.id))
 
     def _run_task(self, task_id: Any) -> None:
@@ -59,6 +60,7 @@ class InMemoryTaskInterface:
                 logger.error(f"Async task {task_id} not found for execution.")
                 return
 
+            logger.info(f"Worker picking up task {task.task_type} ({task.id}).")
             task.status = AsyncTask.Status.RUNNING
             task.save(update_fields=["status", "last_modified"])
 
@@ -74,8 +76,11 @@ class InMemoryTaskInterface:
                 task.status = AsyncTask.Status.SUCCESS
                 task.result = result
                 task.save(update_fields=["status", "result", "last_modified"])
+                logger.info(f"Successfully completed task {task.task_type} ({task.id}).")
             except Exception as e:
-                logger.exception(f"Error executing task {task.task_type} ({task.id})")
+                logger.exception(
+                    f"Fatal error executing task {task.task_type} ({task.id})"
+                )
                 task.status = AsyncTask.Status.FAILURE
                 task.error = str(e)
                 task.save(update_fields=["status", "error", "last_modified"])
@@ -116,6 +121,9 @@ def detect_subject_crop(task: AsyncTask) -> dict | None:
     if not image_id:
         raise ValueError("Missing image_id in task params")
 
+    logger.info(
+        f"Processing detect_subject_crop for image {image_id} (piece={piece_id}, psi={piece_state_image_id})"
+    )
     image = Image.objects.get(id=image_id)
 
     # Cloudinary-backed assets only (as per constraints)
@@ -132,9 +140,11 @@ def detect_subject_crop(task: AsyncTask) -> dict | None:
         width=1500,
         crop="limit",
     )
+    logger.info(f"Downloading image from {download_url} (timeout=30s)")
     response = requests.get(download_url, timeout=30)
     response.raise_for_status()
 
+    logger.info(f"Image downloaded ({len(response.content)} bytes). Starting rembg.")
     crop = calculate_subject_crop(response.content)
     if not crop:
         return {"status": "skipped", "reason": "No subject detected"}

--- a/api/utils.py
+++ b/api/utils.py
@@ -5,12 +5,15 @@ of the api app but do not belong in workflow.py (which is reserved for
 workflow-state-machine logic derived from workflow.yml).
 """
 
+import logging
 import requests
 from cloudinary import CloudinaryImage
 from django.apps import apps
 from django.conf import settings
 from django.db import transaction
 from django.utils import timezone
+
+logger = logging.getLogger(__name__)
 
 DEV_THUMBNAIL_URLS = {
     "bowl": "/thumbnails/bowl.svg",
@@ -46,8 +49,11 @@ def calculate_subject_crop(image_bytes: bytes) -> dict | None:
     
     # Use a thread-local session to prevent ONNX Runtime deadlocks
     # when run concurrently within the background ThreadPoolExecutor.
+    logger.info("Initializing new rembg session (u2net).")
     session = new_session("u2net")
+    logger.info("Running rembg.remove()...")
     output_image = remove(input_image, session=session)
+    logger.info("rembg.remove() completed.")
 
     # 2. Find non-transparent bounds
     alpha = output_image.getchannel("A")


### PR DESCRIPTION
## Problem
Users reported stuck jobs with no logs, making it difficult to determine if the hang occurs during image download, ONNX session initialization, or actual processing.

## Solution
Added granular logging throughout the task lifecycle:
- **api/tasks.py**: Logs when a task is submitted, when a worker picks it up, and when it finishes (success/failure).
- **api/utils.py**: Logs when a new `rembg` session is created and when processing starts/ends.
- **detect_subject_crop**: Logs the target image ID and the Cloudinary download URL (with timeout info).

## Acceptance Criteria
- [x] Logs appear in the worker output for every stage of the `detect_subject_crop` task.
- [x] Errors are logged with tracebacks and task IDs.

Related to #348.
