### PR TITLE
fix: resolve //api:api_admin_test failure and update PR DoD

### DIFF
--- a/.agents/skills/github-pr/SKILL.md
+++ b/.agents/skills/github-pr/SKILL.md
@@ -66,6 +66,7 @@ Before opening or pushing to a PR, verify every item:
 - [ ] All tests pass: `rtk bazel test //...`
 - [ ] All linters pass: `rtk bazel build --config=lint //...`
 - [ ] Build succeeds: `gz_build`
+- [ ] Autoformat all touched files: `gz_format`
 - [ ] PR body contains `Closes #<N>` linking to the originating issue
 - [ ] PR title under 70 characters
 - [ ] No debug code, temporary workarounds, or stray `print`/`console.log` statements

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -941,7 +941,7 @@
           "@@rules_python~//tools/publish/requirements_linux.txt": "d576e0d8542df61396a9b38deeaa183c24135ed5e8e73bb9622f298f2671811e",
           "@@rules_fuzzing~//fuzzing/requirements.txt": "ab04664be026b632a0d2a2446c4f65982b7654f5b6851d2f9d399a19b7242a5b",
           "@@rules_python~//tools/publish/requirements_windows.txt": "d18538a3982beab378fd5687f4db33162ee1ece69801f9a451661b1b64286b76",
-          "@@//requirements.lock": "890e778cdd043babc8bd93cc1763dc605dadcb8b224711b2aed413b9b2cef956",
+          "@@//requirements.lock": "bad64bbbbe681aa3337c5cdd016e17f4ccbae29060f434513235c1b9f48ee5a1",
           "@@protobuf~//python/requirements.txt": "983be60d3cec4b319dcab6d48aeb3f5b2f7c3350f26b3a9e97486c37967c73c5",
           "@@rules_python~//tools/publish/requirements_darwin.txt": "095d4a4f3d639dce831cd493367631cd51b53665292ab20194bac2c0c6458fa8"
         },
@@ -951,6 +951,16 @@
           "RULES_PYTHON_REPO_DEBUG_VERBOSITY": null
         },
         "generatedRepoSpecs": {
+          "pip_312_aiofiles": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pip//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "pip_312",
+              "requirement": "aiofiles==25.1.0 --hash=sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2 --hash=sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695"
+            }
+          },
           "pip_312_anyio": {
             "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
             "ruleClassName": "whl_library",
@@ -4429,6 +4439,7 @@
               "repo_name": "pip",
               "extra_hub_aliases": {},
               "whl_map": {
+                "aiofiles": "{\"pip_312_aiofiles\":[{\"version\":\"3.12\"}]}",
                 "anyio": "{\"pip_312_anyio\":[{\"version\":\"3.12\"}]}",
                 "asgiref": "{\"pip_312_asgiref\":[{\"version\":\"3.12\"}]}",
                 "attrs": "{\"pip_312_attrs\":[{\"version\":\"3.12\"}]}",
@@ -4518,6 +4529,7 @@
                 "whitenoise": "{\"pip_312_whitenoise\":[{\"version\":\"3.12\"}]}"
               },
               "packages": [
+                "aiofiles",
                 "anyio",
                 "asgiref",
                 "attrs",

--- a/api/admin.py
+++ b/api/admin.py
@@ -866,8 +866,12 @@ class PieceStateAdminForm(forms.ModelForm):
         from .workflow import get_global_ref_fields_for_state
 
         cleaned_data = super().clean()
-        
-        allow_sealed = cleaned_data.get("allow_sealed_edit", False) if isinstance(cleaned_data, dict) else False
+
+        allow_sealed = (
+            cleaned_data.get("allow_sealed_edit", False)
+            if isinstance(cleaned_data, dict)
+            else False
+        )
         instance = getattr(self, "instance", None)
         if instance and instance.pk and not allow_sealed:
             current = instance.piece.current_state

--- a/api/apps.py
+++ b/api/apps.py
@@ -11,9 +11,12 @@ class ApiConfig(AppConfig):
         # Only run cleanup when starting the actual web server (runserver or gunicorn/uvicorn).
         # This prevents failing tasks during migrations, shell, or other management commands.
         is_manage_py = os.path.basename(sys.argv[0]) == "manage.py"
-        is_server_cmd = is_manage_py and ("runserver" in sys.argv or "runserver_plus" in sys.argv)
+        is_server_cmd = is_manage_py and (
+            "runserver" in sys.argv or "runserver_plus" in sys.argv
+        )
         is_prod_server = "gunicorn" in sys.argv[0] or "uvicorn" in sys.argv[0]
 
         if is_server_cmd or is_prod_server:
             from .logging import setup_logging
+
             setup_logging()

--- a/api/management/commands/clear_stuck_tasks.py
+++ b/api/management/commands/clear_stuck_tasks.py
@@ -1,11 +1,6 @@
 import logging
 
-from datetime import timedelta
-
 from django.core.management.base import BaseCommand
-from django.utils import timezone
-
-from api.models import AsyncTask
 
 logger = logging.getLogger(__name__)
 
@@ -62,5 +57,7 @@ class Command(BaseCommand):
             self.stdout.write(self.style.SUCCESS("No stuck tasks found."))
         else:
             self.stdout.write(
-                self.style.SUCCESS(f"Successfully marked {count} stuck tasks as FAILED.")
+                self.style.SUCCESS(
+                    f"Successfully marked {count} stuck tasks as FAILED."
+                )
             )

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -76,7 +76,9 @@ class InMemoryTaskInterface:
                 task.status = AsyncTask.Status.SUCCESS
                 task.result = result
                 task.save(update_fields=["status", "result", "last_modified"])
-                logger.info(f"Successfully completed task {task.task_type} ({task.id}).")
+                logger.info(
+                    f"Successfully completed task {task.task_type} ({task.id})."
+                )
             except Exception as e:
                 logger.exception(
                     f"Fatal error executing task {task.task_type} ({task.id})"

--- a/api/tests/test_async_maintenance.py
+++ b/api/tests/test_async_maintenance.py
@@ -1,34 +1,47 @@
-import pytest
 from datetime import timedelta
+
+import pytest
 from django.core.management import call_command
 from django.utils import timezone
+
 from api.models import AsyncTask
 from api.tasks import fail_stuck_tasks
+
 
 @pytest.mark.django_db
 class TestAsyncMaintenance:
     def test_fail_stuck_tasks_logic(self, user):
         # 1. Create a truly recent running task (within 1h threshold)
         now = timezone.now()
-        t1 = AsyncTask.objects.create(user=user, task_type="ping", status=AsyncTask.Status.RUNNING)
-        
+        t1 = AsyncTask.objects.create(
+            user=user, task_type="ping", status=AsyncTask.Status.RUNNING
+        )
+
         # 2. Create a "stuck" task (older than 2h)
         # We use .update() to bypass auto_now on last_modified
-        t2 = AsyncTask.objects.create(user=user, task_type="ping", status=AsyncTask.Status.RUNNING)
-        AsyncTask.objects.filter(id=t2.id).update(last_modified=now - timedelta(hours=2))
-        
+        t2 = AsyncTask.objects.create(
+            user=user, task_type="ping", status=AsyncTask.Status.RUNNING
+        )
+        AsyncTask.objects.filter(id=t2.id).update(
+            last_modified=now - timedelta(hours=2)
+        )
+
         # 3. Create a pending task (older than 2h)
-        t3 = AsyncTask.objects.create(user=user, task_type="ping", status=AsyncTask.Status.PENDING)
-        AsyncTask.objects.filter(id=t3.id).update(last_modified=now - timedelta(hours=2))
+        t3 = AsyncTask.objects.create(
+            user=user, task_type="ping", status=AsyncTask.Status.PENDING
+        )
+        AsyncTask.objects.filter(id=t3.id).update(
+            last_modified=now - timedelta(hours=2)
+        )
 
         count = fail_stuck_tasks(hours=1)
-        
+
         assert count == 2
-        
+
         t1.refresh_from_db()
         t2.refresh_from_db()
         t3.refresh_from_db()
-        
+
         assert t1.status == AsyncTask.Status.RUNNING
         assert t2.status == AsyncTask.Status.FAILURE
         assert t3.status == AsyncTask.Status.FAILURE
@@ -36,22 +49,30 @@ class TestAsyncMaintenance:
 
     def test_clear_stuck_tasks_command(self, user):
         now = timezone.now()
-        t1 = AsyncTask.objects.create(user=user, task_type="ping", status=AsyncTask.Status.RUNNING)
-        AsyncTask.objects.filter(id=t1.id).update(last_modified=now - timedelta(hours=2))
-        
+        t1 = AsyncTask.objects.create(
+            user=user, task_type="ping", status=AsyncTask.Status.RUNNING
+        )
+        AsyncTask.objects.filter(id=t1.id).update(
+            last_modified=now - timedelta(hours=2)
+        )
+
         # Run command
         call_command("clear_stuck_tasks", hours=1)
-        
+
         t1.refresh_from_db()
         assert t1.status == AsyncTask.Status.FAILURE
 
     def test_clear_stuck_tasks_command_dry_run(self, user):
         now = timezone.now()
-        t1 = AsyncTask.objects.create(user=user, task_type="ping", status=AsyncTask.Status.RUNNING)
-        AsyncTask.objects.filter(id=t1.id).update(last_modified=now - timedelta(hours=2))
-        
+        t1 = AsyncTask.objects.create(
+            user=user, task_type="ping", status=AsyncTask.Status.RUNNING
+        )
+        AsyncTask.objects.filter(id=t1.id).update(
+            last_modified=now - timedelta(hours=2)
+        )
+
         # Run command with dry-run
         call_command("clear_stuck_tasks", hours=1, dry_run=True)
-        
+
         t1.refresh_from_db()
         assert t1.status == AsyncTask.Status.RUNNING  # Unchanged

--- a/api/tests/test_async_tasks.py
+++ b/api/tests/test_async_tasks.py
@@ -301,4 +301,3 @@ class TestDetectSubjectCropTask:
         assert task.status == AsyncTask.Status.SUCCESS
         assert task.result["status"] == "skipped"
         assert missing_psi_id in task.result["reason"]
-

--- a/api/tests/test_public_library_commands.py
+++ b/api/tests/test_public_library_commands.py
@@ -7,9 +7,9 @@ import pytest
 from django.core.management import call_command
 from django.core.management.base import CommandError
 
+from api.management.commands.load_public_library import _extract_cloud_name
 from api.models import COMPOSITE_NAME_SEPARATOR, ClayBody, GlazeCombination, GlazeType
 from api.utils import bootstrap_dev_user
-from api.management.commands.load_public_library import _extract_cloud_name
 
 
 class TestExtractCloudName:
@@ -300,8 +300,12 @@ class TestLoadPublicLibrary:
             call_command("load_public_library", fixture=str(fixture))
 
     def test_raises_for_non_list_fixture(self, tmp_path):
-        fixture = self._write_fixture(tmp_path, {"model": "api.claybody", "fields": {"name": "X"}})
-        with pytest.raises(CommandError, match="Fixture must be a JSON array of records."):
+        fixture = self._write_fixture(
+            tmp_path, {"model": "api.claybody", "fields": {"name": "X"}}
+        )
+        with pytest.raises(
+            CommandError, match="Fixture must be a JSON array of records."
+        ):
             call_command("load_public_library", fixture=str(fixture))
 
     def test_raises_for_missing_name_field(self, tmp_path):
@@ -309,7 +313,10 @@ class TestLoadPublicLibrary:
             tmp_path,
             [{"model": "api.claybody", "fields": {"short_description": "A body"}}],
         )
-        with pytest.raises(CommandError, match='Record for model api.claybody is missing a "name" field'):
+        with pytest.raises(
+            CommandError,
+            match='Record for model api.claybody is missing a "name" field',
+        ):
             call_command("load_public_library", fixture=str(fixture))
 
     def test_roundtrip_dump_then_load(self, tmp_path, django_user_model):

--- a/api/tests/test_sealed_state.py
+++ b/api/tests/test_sealed_state.py
@@ -35,8 +35,9 @@ class TestSealedState:
 
     def test_admin_form_rejects_sealed_state_without_override(self, piece):
         from django.contrib.admin.sites import AdminSite
+
         from api.admin import PieceStateAdmin
-        
+
         initial_state = piece.current_state
         PieceState.objects.create(piece=piece, state=SUCCESSORS[ENTRY_STATE][0])
         initial_state.refresh_from_db()
@@ -51,13 +52,17 @@ class TestSealedState:
                 "state": initial_state.state,
                 "notes": "Retroactive edit via form",
                 "allow_sealed_edit": False,
-            }
+            },
         )
         assert not form.is_valid()
-        assert "This state is sealed: only the current state of a piece may be modified." in form.errors["__all__"][0]
+        assert (
+            "This state is sealed: only the current state of a piece may be modified."
+            in form.errors["__all__"][0]
+        )
 
     def test_admin_form_allows_sealed_state_with_override(self, piece):
         from django.contrib.admin.sites import AdminSite
+
         from api.admin import PieceStateAdmin
 
         initial_state = piece.current_state
@@ -74,7 +79,7 @@ class TestSealedState:
                 "state": initial_state.state,
                 "notes": "Retroactive edit via form",
                 "allow_sealed_edit": True,
-            }
+            },
         )
         form.is_valid()
         if "__all__" in form.errors:

--- a/api/tests/test_utils.py
+++ b/api/tests/test_utils.py
@@ -114,9 +114,7 @@ class TestBackpopulateCropsCommand:
         )
 
     def _make_superuser(self, email="admin@example.com"):
-        return User.objects.create_superuser(
-            username=email, email=email, password="x"
-        )
+        return User.objects.create_superuser(username=email, email=email, password="x")
 
     def _make_user(self, email="u@example.com"):
         return User.objects.create(username=email, email=email)

--- a/api/utils.py
+++ b/api/utils.py
@@ -4,9 +4,10 @@ This module holds business-logic helpers that are shared across multiple parts
 of the api app but do not belong in workflow.py (which is reserved for
 workflow-state-machine logic derived from workflow.yml).
 """
-from typing import Any
 
 import logging
+from typing import Any
+
 import requests
 from cloudinary import CloudinaryImage
 from django.apps import apps

--- a/api/views.py
+++ b/api/views.py
@@ -814,11 +814,9 @@ def admin_cloudinary_cleanup(request: Request) -> Response:
 )
 @api_view(["GET"])
 @permission_classes([IsAdminUser])
-async def admin_cloudinary_cleanup_archive(
+def admin_cloudinary_cleanup_archive(
     request: Request,
 ) -> StreamingHttpResponse | Response:
-    from asgiref.sync import sync_to_async
-
     unreferenced_only = request.query_params.get("unreferenced_only", "").lower() in (
         "1",
         "true",
@@ -826,8 +824,8 @@ async def admin_cloudinary_cleanup_archive(
         "on",
     )
     try:
-        # list_cloudinary_assets does synchronous network I/O; run in a thread.
-        assets = await sync_to_async(list_cloudinary_assets)()
+        # list_cloudinary_assets does synchronous network I/O.
+        assets = list_cloudinary_assets()
     except ValueError as exc:
         return Response(
             {"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE


### PR DESCRIPTION
## Summary

This PR fixes the `//api:api_admin_test` failure on `main` and updates the `github-pr` skill to include autoformatting in the Definition of Done.

### Changes

- **Backend Fix**: Converted `admin_cloudinary_cleanup_archive` from `async def` to `def`. This resolves an `AssertionError` where DRF's `@api_view` received a coroutine instead of an `HttpResponse`. The view still returns a `StreamingHttpResponse` with an async generator, which Django handles correctly in ASGI mode.
- **Autoformatting**: Applied `gz_format` across the codebase, resulting in stylistic improvements to 10 files and a synchronization of `MODULE.bazel.lock`.
- **Documentation**: Updated the `github-pr` skill to include `gz_format` as a requirement in the Definition of Done.

### Verification Results

#### Automated Tests
- `bazel test //api:api_admin_test` PASSED.

```
INFO: Analyzed target //api:api_admin_test (321 packages loaded, 15950 targets configured).
INFO: Build completed successfully, 6 total actions
//api:api_admin_test                                                     PASSED in 3.7s
```

Co-authored-by: Antigravity <noreply@google.com>
