### PR TITLE
fix: remove incorrect WhiteNoise WSGI wrapper from ASGI config

### DIFF
--- a/backend/asgi.py
+++ b/backend/asgi.py
@@ -10,8 +10,6 @@ https://docs.djangoproject.com/en/6.0/howto/deployment/asgi/
 import os
 
 from django.core.asgi import get_asgi_application
-from whitenoise import WhiteNoise
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "backend.settings")
 application = get_asgi_application()
-application = WhiteNoise(application)


### PR DESCRIPTION
## Problem
The server failed to start in the Docker environment with the following error:
`TypeError: WhiteNoise.__call__() missing 1 required positional argument: 'start_response'`

This occurred because `backend/asgi.py` was manually wrapping the ASGI application with the `WhiteNoise` class. The `WhiteNoise` class is a WSGI middleware wrapper and expects the WSGI signature `(environ, start_response)`. When called by an ASGI server like Uvicorn, it fails.

## Solution
Removed the manual `WhiteNoise` wrapping in `backend/asgi.py`. 

WhiteNoise is already correctly configured as a Django middleware in `backend/settings.py` (`whitenoise.middleware.WhiteNoiseMiddleware`), which natively supports ASGI in the version used (6.9.0). This middleware handles static files for both WSGI and ASGI automatically.

## Verification Results
Verified by starting the server manually in a worktree using `uvicorn` and confirming it no longer crashes.

```bash
source env-agent.sh
python -m uvicorn backend.asgi:application --port 8002 --lifespan off
curl -I http://127.0.0.1:8002/
```

