### PR TITLE
feat: remote offloading for rembg subject detection

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,3 +49,26 @@ jobs:
             --title "Build ${{ env.DEPLOY_SHA }}" \
             --notes "Docker image: \`ghcr.io/shaoster/glaze:${{ env.DEPLOY_SHA }}\`" \
             --latest
+
+  deploy-modal:
+    name: Deploy ML Microservice to Modal
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ env.DEPLOY_SHA }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install Modal
+        run: pip install modal
+
+      - name: Deploy to Modal
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        run: modal deploy tools/piece_image_crop_service.py

--- a/README.md
+++ b/README.md
@@ -357,11 +357,18 @@ To maintain stability on hardware with <1GB RAM, Glaze supports offloading the h
 5.  **Capture the URL**: The output will provide a permanent URL, e.g., `https://your-workspace-name--crop.modal.run`.
 
 #### Step 2: Configure the Backend (Run on the PRODUCTION host / Droplet)
-1.  **Update Environment**: Add the URL and Token to your production `.env` file:
-    ```bash
-    REMOTE_REMBG_URL="https://your-workspace-name--crop.modal.run"
-    MODAL_AUTH_TOKEN="your-secret-token"
-    ```
+Update your production `.env` file with the following variables:
+
+| Variable | Description |
+| :--- | :--- |
+| `REMOTE_REMBG_URL` | The URL of your deployed Modal service (e.g. `https://phil--crop.modal.run`). |
+| `MODAL_AUTH_TOKEN` | The secure token you generated for the `piece-image-crop-secret`. |
+
+```bash
+# Example .env additions
+REMOTE_REMBG_URL="https://your-workspace-name--crop.modal.run"
+MODAL_AUTH_TOKEN="your-secure-random-token"
+```
 2.  **Restart Service**: 
     ```bash
     cd ~/glaze

--- a/README.md
+++ b/README.md
@@ -343,15 +343,26 @@ Cloudinary is optional — if the env vars are not set, the config endpoint retu
 
 ## Remote Rembg Offloading (Modal)
 
-To avoid Out-of-Memory (OOM) errors on low-memory servers (e.g. 1GB RAM), Glaze supports offloading the background removal task to a remote microservice.
-
-### Modal.com Deployment
-
-1. **Setup**: `pip install modal && modal auth login` (or set `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET`).
-2. **Deploy**: `modal deploy tools/remote_rembg_service.py`.
-3. **Configure**: Set `REMOTE_REMBG_URL="https://your-app-name.modal.run"` in your `.env.local` or production environment.
-
 When `REMOTE_REMBG_URL` is set, Glaze skips local ML processing and POSTs image data to this endpoint. If not set, it falls back to a local, memory-optimized `u2netp` model.
+
+### Deployment Runbook
+
+#### Step 1: Deploy the Microservice (Run from your LOCAL machine)
+1.  **Install Modal**: `pip install modal`
+2.  **Authenticate**: `modal auth login` (or set `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` variables).
+3.  **Deploy**: `modal deploy tools/remote_rembg_service.py`
+4.  **Capture the URL**: The output will provide a permanent URL, e.g., `https://shaoster--glaze-rembg-web.modal.run`.
+
+#### Step 2: Configure the Backend (Run on the PRODUCTION host / Droplet)
+1.  **Update Environment**: Add the URL to your production `.env` file:
+    ```bash
+    REMOTE_REMBG_URL="https://your-app-name.modal.run"
+    ```
+2.  **Restart Service**: 
+    ```bash
+    cd ~/glaze
+    docker compose up -d
+    ```
 
 ## Google OAuth (web)
 
@@ -571,12 +582,6 @@ Agent and contributor documentation lives in [`docs/agents/`](docs/agents/) and 
 | [`docs/agents/glaze-domain.md`](docs/agents/glaze-domain.md)                   | Everything specific to this project: workflow state machine, `custom_fields` DSL, data model, key constraints, and Glaze-specific conventions layered on top of each stack (Django model patterns, frontend module aliases, component inventory, Cloudinary/OAuth flows, protected files, project-specific definition-of-done checks). **Add content here** when it is specific to Glaze's domain, data model, or architecture. |
 | [`docs/agents/django-drf-python.md`](docs/agents/django-drf-python.md)         | Generic Django + DRF conventions reusable in any project: serializer rules, CORS, session auth, user-isolation patterns, test approach. **Add content here** only if it applies to Django/DRF projects in general, with no Glaze-specific models or endpoints.                                                                                                                                                                  |
 | [`docs/agents/typescript-react-vite.md`](docs/agents/typescript-react-vite.md) | Generic React + TypeScript + Vite conventions reusable in any project: MUI usage, strict TS rules, theming tokens, Axios usage, async test patterns. **Add content here** only if it applies to React/TS/Vite projects in general, with no Glaze-specific components or data pipelines.                                                                                                                                         |
-| [`docs/agents/github-interactions.md`](docs/agents/github-interactions.md)     | Generic GitHub agent conventions reusable in any project: `--body-file` pattern, branch naming, scope-limit categories, PR ownership labels, definition-of-done checklist. **Add content here** only if it applies to any GitHub-hosted project.                                                                                                                                                                                |
-| [`docs/agents/dev.md`](docs/agents/dev.md)                                     | Glaze-specific development setup and test commands: starting the backend and web, all three test suites, CI, and per-layer "what to test" checklists. **Add content here** for setup steps, test commands, or CI details specific to this repo.                                                                                                                                                                                 |
-
-- **Local Path**: Defaults to `u2netp` (memory-efficient) with pre-processing downscaling (640px max) to minimize RSS usage.
-- **Remote Path**: Activated via `REMOTE_REMBG_URL`. Offloads processing to a FastAPI microservice.
-- **Microservice**: Located at `tools/remote_rembg_service.py`, designed for deployment to **Modal.com**. It supports native auto-scaling and "scale-to-zero" to minimize costs. |
 | [`docs/agents/github-interactions.md`](docs/agents/github-interactions.md)     | Generic GitHub agent conventions reusable in any project: `--body-file` pattern, branch naming, scope-limit categories, PR ownership labels, definition-of-done checklist. **Add content here** only if it applies to any GitHub-hosted project.                                                                                                                                                                                |
 | [`docs/agents/dev.md`](docs/agents/dev.md)                                     | Glaze-specific development setup and test commands: starting the backend and web, all three test suites, CI, and per-layer "what to test" checklists. **Add content here** for setup steps, test commands, or CI details specific to this repo.                                                                                                                                                                                 |
 

--- a/README.md
+++ b/README.md
@@ -351,12 +351,12 @@ When `REMOTE_REMBG_URL` is set, Glaze skips local ML processing and POSTs image 
 1.  **Install Modal**: `pip install modal`
 2.  **Authenticate**: `modal setup` (or set `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` variables).
 3.  **Deploy**: `modal deploy tools/piece_image_crop_service.py`
-4.  **Capture the URL**: The output will provide a permanent URL, e.g., `https://shaoster--glaze-rembg-web.modal.run`.
+4.  **Capture the URL**: The output will provide a permanent URL, e.g., `https://your-workspace-name--crop.modal.run`.
 
 #### Step 2: Configure the Backend (Run on the PRODUCTION host / Droplet)
 1.  **Update Environment**: Add the URL to your production `.env` file:
     ```bash
-    REMOTE_REMBG_URL="https://your-app-name.modal.run"
+    REMOTE_REMBG_URL="https://your-workspace-name--crop.modal.run"
     ```
 2.  **Restart Service**: 
     ```bash

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ npm run dev
 # Remote ML Offload (Optional, for 1GB RAM servers)
 pip install modal
 modal setup
-modal deploy tools/remote_rembg_service.py
+modal deploy tools/piece_image_crop_service.py
 
 # Type generation (backend must be running on port 8080)
 cd web
@@ -350,7 +350,7 @@ When `REMOTE_REMBG_URL` is set, Glaze skips local ML processing and POSTs image 
 #### Step 1: Deploy the Microservice (Run from your LOCAL machine)
 1.  **Install Modal**: `pip install modal`
 2.  **Authenticate**: `modal setup` (or set `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` variables).
-3.  **Deploy**: `modal deploy tools/remote_rembg_service.py`
+3.  **Deploy**: `modal deploy tools/piece_image_crop_service.py`
 4.  **Capture the URL**: The output will provide a permanent URL, e.g., `https://shaoster--glaze-rembg-web.modal.run`.
 
 #### Step 2: Configure the Backend (Run on the PRODUCTION host / Droplet)

--- a/README.md
+++ b/README.md
@@ -275,6 +275,11 @@ cd web
 npm install
 npm run dev
 
+# Remote ML Offload (Optional, for 1GB RAM servers)
+pip install modal
+modal auth login
+modal deploy tools/remote_rembg_service.py
+
 # Type generation (backend must be running on port 8080)
 cd web
 npm run generate-types
@@ -335,6 +340,18 @@ export CLOUDINARY_PUBLIC_UPLOAD_FOLDER=glaze_public   # optional; public library
 4. Images are rendered via `CloudinaryImage`, which uses `public_id` to request viewport-appropriate renditions (auto format, auto quality, size-matched to context).
 
 Cloudinary is optional — if the env vars are not set, the config endpoint returns 503 and the UI falls back to URL-paste mode.
+
+## Remote Rembg Offloading (Modal)
+
+To avoid Out-of-Memory (OOM) errors on low-memory servers (e.g. 1GB RAM), Glaze supports offloading the background removal task to a remote microservice.
+
+### Modal.com Deployment
+
+1. **Setup**: `pip install modal && modal auth login` (or set `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET`).
+2. **Deploy**: `modal deploy tools/remote_rembg_service.py`.
+3. **Configure**: Set `REMOTE_REMBG_URL="https://your-app-name.modal.run"` in your `.env.local` or production environment.
+
+When `REMOTE_REMBG_URL` is set, Glaze skips local ML processing and POSTs image data to this endpoint. If not set, it falls back to a local, memory-optimized `u2netp` model.
 
 ## Google OAuth (web)
 
@@ -554,6 +571,12 @@ Agent and contributor documentation lives in [`docs/agents/`](docs/agents/) and 
 | [`docs/agents/glaze-domain.md`](docs/agents/glaze-domain.md)                   | Everything specific to this project: workflow state machine, `custom_fields` DSL, data model, key constraints, and Glaze-specific conventions layered on top of each stack (Django model patterns, frontend module aliases, component inventory, Cloudinary/OAuth flows, protected files, project-specific definition-of-done checks). **Add content here** when it is specific to Glaze's domain, data model, or architecture. |
 | [`docs/agents/django-drf-python.md`](docs/agents/django-drf-python.md)         | Generic Django + DRF conventions reusable in any project: serializer rules, CORS, session auth, user-isolation patterns, test approach. **Add content here** only if it applies to Django/DRF projects in general, with no Glaze-specific models or endpoints.                                                                                                                                                                  |
 | [`docs/agents/typescript-react-vite.md`](docs/agents/typescript-react-vite.md) | Generic React + TypeScript + Vite conventions reusable in any project: MUI usage, strict TS rules, theming tokens, Axios usage, async test patterns. **Add content here** only if it applies to React/TS/Vite projects in general, with no Glaze-specific components or data pipelines.                                                                                                                                         |
+| [`docs/agents/github-interactions.md`](docs/agents/github-interactions.md)     | Generic GitHub agent conventions reusable in any project: `--body-file` pattern, branch naming, scope-limit categories, PR ownership labels, definition-of-done checklist. **Add content here** only if it applies to any GitHub-hosted project.                                                                                                                                                                                |
+| [`docs/agents/dev.md`](docs/agents/dev.md)                                     | Glaze-specific development setup and test commands: starting the backend and web, all three test suites, CI, and per-layer "what to test" checklists. **Add content here** for setup steps, test commands, or CI details specific to this repo.                                                                                                                                                                                 |
+
+- **Local Path**: Defaults to `u2netp` (memory-efficient) with pre-processing downscaling (640px max) to minimize RSS usage.
+- **Remote Path**: Activated via `REMOTE_REMBG_URL`. Offloads processing to a FastAPI microservice.
+- **Microservice**: Located at `tools/remote_rembg_service.py`, designed for deployment to **Modal.com**. It supports native auto-scaling and "scale-to-zero" to minimize costs. |
 | [`docs/agents/github-interactions.md`](docs/agents/github-interactions.md)     | Generic GitHub agent conventions reusable in any project: `--body-file` pattern, branch naming, scope-limit categories, PR ownership labels, definition-of-done checklist. **Add content here** only if it applies to any GitHub-hosted project.                                                                                                                                                                                |
 | [`docs/agents/dev.md`](docs/agents/dev.md)                                     | Glaze-specific development setup and test commands: starting the backend and web, all three test suites, CI, and per-layer "what to test" checklists. **Add content here** for setup steps, test commands, or CI details specific to this repo.                                                                                                                                                                                 |
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ npm run dev
 
 # Remote ML Offload (Optional, for 1GB RAM servers)
 pip install modal
-modal auth login
+modal setup
 modal deploy tools/remote_rembg_service.py
 
 # Type generation (backend must be running on port 8080)
@@ -349,7 +349,7 @@ When `REMOTE_REMBG_URL` is set, Glaze skips local ML processing and POSTs image 
 
 #### Step 1: Deploy the Microservice (Run from your LOCAL machine)
 1.  **Install Modal**: `pip install modal`
-2.  **Authenticate**: `modal auth login` (or set `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` variables).
+2.  **Authenticate**: `modal setup` (or set `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` variables).
 3.  **Deploy**: `modal deploy tools/remote_rembg_service.py`
 4.  **Capture the URL**: The output will provide a permanent URL, e.g., `https://shaoster--glaze-rembg-web.modal.run`.
 

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ export CLOUDINARY_PUBLIC_UPLOAD_FOLDER=glaze_public   # optional; public library
 
 Cloudinary is optional — if the env vars are not set, the config endpoint returns 503 and the UI falls back to URL-paste mode.
 
-## Remote Rembg Offloading (Modal)
+## Remote Piece Image Crop Offloading (Modal)
 
 To maintain stability on hardware with <1GB RAM, Glaze supports offloading the heavy `rembg` background removal task to a serverless microservice.
 

--- a/README.md
+++ b/README.md
@@ -343,20 +343,24 @@ Cloudinary is optional — if the env vars are not set, the config endpoint retu
 
 ## Remote Rembg Offloading (Modal)
 
-When `REMOTE_REMBG_URL` is set, Glaze skips local ML processing and POSTs image data to this endpoint. If not set, it falls back to a local, memory-optimized `u2netp` model.
+To maintain stability on hardware with <1GB RAM, Glaze supports offloading the heavy `rembg` background removal task to a serverless microservice.
 
-### Deployment Runbook
+- **Optimized Dispatch**: The system offloads the **Cloudinary URL** directly to the remote service. This ensures the production host does not have to download or process the image bytes, saving bandwidth and memory.
+- **Security**: The service is secured with an API Key (`X-API-Key`) validated against a `modal.Secret`.
+- **Local Fallback**: If `REMOTE_REMBG_URL` is not configured, the system falls back to a local `u2netp` model with 640px downscaling.
 
 #### Step 1: Deploy the Microservice (Run from your LOCAL machine)
-1.  **Install Modal**: `pip install modal`
-2.  **Authenticate**: `modal setup` (or set `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` variables).
-3.  **Deploy**: `modal deploy tools/piece_image_crop_service.py`
-4.  **Capture the URL**: The output will provide a permanent URL, e.g., `https://your-workspace-name--crop.modal.run`.
+1.  **Set up Auth Token**: Create a Modal secret named `piece-image-crop-secret` with an `AUTH_TOKEN` key.
+2.  **Install Modal**: `pip install modal`
+3.  **Authenticate**: `modal setup`
+4.  **Deploy**: `modal deploy tools/piece_image_crop_service.py`
+5.  **Capture the URL**: The output will provide a permanent URL, e.g., `https://your-workspace-name--crop.modal.run`.
 
 #### Step 2: Configure the Backend (Run on the PRODUCTION host / Droplet)
-1.  **Update Environment**: Add the URL to your production `.env` file:
+1.  **Update Environment**: Add the URL and Token to your production `.env` file:
     ```bash
     REMOTE_REMBG_URL="https://your-workspace-name--crop.modal.run"
+    MODAL_AUTH_TOKEN="your-secret-token"
     ```
 2.  **Restart Service**: 
     ```bash

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -117,7 +117,7 @@ def detect_subject_crop(task: AsyncTask) -> dict | None:
     from cloudinary import CloudinaryImage
 
     from .models import Image, Piece, PieceStateImage
-    from .utils import calculate_subject_crop
+    from .utils import calculate_subject_crop, calculate_subject_crop_remote
 
     params = task.input_params or {}
     image_id = params.get("image_id")
@@ -150,8 +150,14 @@ def detect_subject_crop(task: AsyncTask) -> dict | None:
     response = requests.get(download_url, timeout=30)
     response.raise_for_status()
 
-    logger.info(f"Image downloaded ({len(response.content)} bytes). Starting rembg.")
-    crop = calculate_subject_crop(response.content)
+    from django.conf import settings
+
+    if getattr(settings, "REMOTE_REMBG_URL", None):
+        logger.info("Using remote service for subject detection.")
+        crop = calculate_subject_crop_remote(response.content)
+    else:
+        logger.info("Using local rembg for subject detection.")
+        crop = calculate_subject_crop(response.content)
     if not crop:
         return {"status": "skipped", "reason": "No subject detected"}
 

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -136,25 +136,25 @@ def detect_subject_crop(task: AsyncTask) -> dict | None:
     if not image.cloud_name or not image.cloudinary_public_id:
         return {"status": "skipped", "reason": "Not a Cloudinary image"}
 
-    # Download image bytes. We request a JPG version from Cloudinary to ensure
-    # compatibility with Pillow/rembg and reduce bandwidth for large raw uploads.
-    download_url = CloudinaryImage(image.cloudinary_public_id).build_url(
-        cloud_name=image.cloud_name,
-        secure=True,
-        format="jpg",
-        quality="auto",
-        width=1500,
-        crop="limit",
-    )
     from django.conf import settings
 
     if getattr(settings, "REMOTE_REMBG_URL", None):
-        logger.info("Using remote service for subject detection (offloading URL).")
-        # Offload the URL directly to Modal so it handles the download and processing.
-        # This saves the production host from downloading and then re-uploading the bytes.
-        crop = calculate_subject_crop_remote(image_url=download_url)
+        logger.info("Using remote service (offloading base URL).")
+        # Offload the original URL. The remote service handles pre-processing,
+        # resizing, and format conversion (e.g. HEIC -> JPG).
+        crop = calculate_subject_crop_remote(image_url=image.url)
     else:
-        logger.info(f"Downloading image from {download_url} for local processing (timeout=30s)")
+        logger.info("Using local rembg. Optimizing download for constrained host.")
+        # Local fallback still uses Cloudinary optimizations to prevent OOM on the Droplet.
+        download_url = CloudinaryImage(image.cloudinary_public_id).build_url(
+            cloud_name=image.cloud_name,
+            secure=True,
+            format="jpg",
+            quality="auto",
+            width=1500,
+            crop="limit",
+        )
+        logger.info(f"Downloading optimized image from {download_url}")
         response = requests.get(download_url, timeout=30)
         response.raise_for_status()
         crop = calculate_subject_crop(response.content)

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -146,17 +146,17 @@ def detect_subject_crop(task: AsyncTask) -> dict | None:
         width=1500,
         crop="limit",
     )
-    logger.info(f"Downloading image from {download_url} (timeout=30s)")
-    response = requests.get(download_url, timeout=30)
-    response.raise_for_status()
-
     from django.conf import settings
 
     if getattr(settings, "REMOTE_REMBG_URL", None):
-        logger.info("Using remote service for subject detection.")
-        crop = calculate_subject_crop_remote(response.content)
+        logger.info("Using remote service for subject detection (offloading URL).")
+        # Offload the URL directly to Modal so it handles the download and processing.
+        # This saves the production host from downloading and then re-uploading the bytes.
+        crop = calculate_subject_crop_remote(image_url=download_url)
     else:
-        logger.info("Using local rembg for subject detection.")
+        logger.info(f"Downloading image from {download_url} for local processing (timeout=30s)")
+        response = requests.get(download_url, timeout=30)
+        response.raise_for_status()
         crop = calculate_subject_crop(response.content)
     if not crop:
         return {"status": "skipped", "reason": "No subject detected"}

--- a/api/tests/test_async_tasks.py
+++ b/api/tests/test_async_tasks.py
@@ -297,3 +297,68 @@ class TestDetectSubjectCropTask:
         assert task.status == AsyncTask.Status.SUCCESS
         assert task.result["status"] == "skipped"
         assert missing_psi_id in task.result["reason"]
+
+
+@pytest.mark.django_db(transaction=True)
+class TestRemoteDetectSubjectCrop:
+    """Verifies offloading to an external service via REMOTE_REMBG_URL."""
+
+    def test_calls_remote_service_when_configured(self, user, monkeypatch):
+        from django.conf import settings
+
+        from api.models import Image, Piece
+
+        image = Image.objects.create(
+            url="https://res.cloudinary.com/demo/image/upload/v1/pieces/mug.jpg",
+            cloud_name="demo",
+            cloudinary_public_id="pieces/mug",
+            user=user,
+        )
+        piece = Piece.objects.create(user=user, name="Mug", thumbnail=image)
+
+        # Configure remote URL
+        monkeypatch.setattr(settings, "REMOTE_REMBG_URL", "https://remote.ai/", raising=False)
+
+        # Mock image download
+        mock_response_get = type(
+            "R", (), {"raise_for_status": lambda self: None, "content": b"image_data"}
+        )()
+        monkeypatch.setattr("requests.get", lambda *a, **k: mock_response_get)
+
+        # Mock remote POST response
+        crop_data = {"x": 0.1, "y": 0.2, "width": 0.3, "height": 0.4}
+        mock_response_post = type(
+            "R",
+            (),
+            {"raise_for_status": lambda self: None, "json": lambda self: crop_data},
+        )()
+
+        posted_data = []
+
+        def mock_post(url, data, headers, timeout):
+            posted_data.append((url, data, headers))
+            return mock_response_post
+
+        monkeypatch.setattr("requests.post", mock_post)
+
+        task = AsyncTask.objects.create(
+            user=user,
+            task_type="detect_subject_crop",
+            input_params={"image_id": str(image.id), "piece_id": str(piece.id)},
+        )
+
+        from api.tasks import InMemoryTaskInterface
+
+        InMemoryTaskInterface()._run_task(task.id)
+
+        # Verify remote service was called
+        assert len(posted_data) == 1
+        assert posted_data[0][0] == "https://remote.ai/"
+        assert posted_data[0][1] == b"image_data"
+
+        task.refresh_from_db()
+        assert task.status == AsyncTask.Status.SUCCESS
+        assert task.result["crop"] == crop_data
+
+        piece.refresh_from_db()
+        assert piece.thumbnail_crop == crop_data

--- a/api/tests/test_async_tasks.py
+++ b/api/tests/test_async_tasks.py
@@ -333,10 +333,10 @@ class TestRemoteDetectSubjectCrop:
             {"raise_for_status": lambda self: None, "json": lambda self: crop_data},
         )()
 
-        posted_data = []
+        posted_calls = []
 
-        def mock_post(url, data, headers, timeout):
-            posted_data.append((url, data, headers))
+        def mock_post(url, data=None, json=None, headers=None, timeout=None):
+            posted_calls.append({"url": url, "data": data, "json": json, "headers": headers})
             return mock_response_post
 
         monkeypatch.setattr("requests.post", mock_post)
@@ -351,10 +351,11 @@ class TestRemoteDetectSubjectCrop:
 
         InMemoryTaskInterface()._run_task(task.id)
 
-        # Verify remote service was called
-        assert len(posted_data) == 1
-        assert posted_data[0][0] == "https://remote.ai/"
-        assert posted_data[0][1] == b"image_data"
+        # Verify remote service was called with URL, not bytes
+        assert len(posted_calls) == 1
+        assert posted_calls[0]["url"] == "https://remote.ai/"
+        assert posted_calls[0]["json"]["url"].startswith("https://res.cloudinary.com/")
+        assert posted_calls[0]["data"] is None  # Should not send bytes
 
         task.refresh_from_db()
         assert task.status == AsyncTask.Status.SUCCESS

--- a/api/tests/test_async_tasks.py
+++ b/api/tests/test_async_tasks.py
@@ -351,11 +351,12 @@ class TestRemoteDetectSubjectCrop:
 
         InMemoryTaskInterface()._run_task(task.id)
 
-        # Verify remote service was called with URL, not bytes
+        # Verify remote service was called with base URL, not bytes
         assert len(posted_calls) == 1
         assert posted_calls[0]["url"] == "https://remote.ai/"
-        assert posted_calls[0]["json"]["url"].startswith("https://res.cloudinary.com/")
-        assert posted_calls[0]["data"] is None  # Should not send bytes
+        # It should now send the base image.url directly
+        assert posted_calls[0]["json"]["url"] == "https://res.cloudinary.com/demo/image/upload/v1/pieces/mug.jpg"
+        assert posted_calls[0]["data"] is None
 
         task.refresh_from_db()
         assert task.status == AsyncTask.Status.SUCCESS

--- a/api/utils.py
+++ b/api/utils.py
@@ -136,6 +136,35 @@ def calculate_subject_crop(image_bytes: bytes) -> dict | None:
     }
 
 
+def calculate_subject_crop_remote(image_bytes: bytes) -> dict | None:
+    """Offload subject detection to a remote ML service.
+
+    Expects a POST endpoint that takes image bytes and returns a JSON
+    relative crop box: {"x": float, "y": float, "width": float, "height": float}.
+    """
+    remote_url = getattr(settings, "REMOTE_REMBG_URL", None)
+    if not remote_url:
+        logger.warning(
+            "calculate_subject_crop_remote called but REMOTE_REMBG_URL is not set."
+        )
+        return None
+
+    logger.info(f"Offloading subject detection to remote service: {remote_url}")
+    try:
+        response = requests.post(
+            remote_url,
+            data=image_bytes,
+            headers={"Content-Type": "application/octet-stream"},
+            timeout=60,
+        )
+        response.raise_for_status()
+        crop = response.json()
+        return crop_to_dict(crop)
+    except Exception as e:
+        logger.error(f"Remote subject detection failed: {e}")
+        return None
+
+
 def get_or_create_location(user, name: str | None):
     """Return a Location for *user* with the given *name*, creating it if needed.
 

--- a/api/utils.py
+++ b/api/utils.py
@@ -136,13 +136,17 @@ def calculate_subject_crop(image_bytes: bytes) -> dict | None:
     }
 
 
-def calculate_subject_crop_remote(image_bytes: bytes) -> dict | None:
+def calculate_subject_crop_remote(
+    image_bytes: bytes | None = None, image_url: str | None = None
+) -> dict | None:
     """Offload subject detection to a remote ML service.
 
-    Expects a POST endpoint that takes image bytes and returns a JSON
-    relative crop box: {"x": float, "y": float, "width": float, "height": float}.
+    Accepts either raw image bytes or a public image URL.
+    Returns a JSON relative crop box: {"x": float, "y": float, "width": float, "height": float}.
     """
     remote_url = getattr(settings, "REMOTE_REMBG_URL", None)
+    auth_token = getattr(settings, "MODAL_AUTH_TOKEN", None)
+
     if not remote_url:
         logger.warning(
             "calculate_subject_crop_remote called but REMOTE_REMBG_URL is not set."
@@ -150,13 +154,25 @@ def calculate_subject_crop_remote(image_bytes: bytes) -> dict | None:
         return None
 
     logger.info(f"Offloading subject detection to remote service: {remote_url}")
+    headers = {}
+    if auth_token:
+        headers["X-API-Key"] = auth_token
+
     try:
-        response = requests.post(
-            remote_url,
-            data=image_bytes,
-            headers={"Content-Type": "application/octet-stream"},
-            timeout=60,
-        )
+        if image_url:
+            # URL-based dispatch (saves bandwidth and memory on the host)
+            response = requests.post(
+                remote_url, json={"url": image_url}, headers=headers, timeout=60
+            )
+        elif image_bytes:
+            # Fallback to byte-based dispatch
+            headers["Content-Type"] = "application/octet-stream"
+            response = requests.post(
+                remote_url, data=image_bytes, headers=headers, timeout=60
+            )
+        else:
+            raise ValueError("Either image_bytes or image_url must be provided")
+
         response.raise_for_status()
         crop = response.json()
         return crop_to_dict(crop)

--- a/api/views.py
+++ b/api/views.py
@@ -820,7 +820,6 @@ def admin_cloudinary_cleanup(request: Request) -> Response:
 def admin_cloudinary_cleanup_archive(
     request: Request,
 ) -> StreamingHttpResponse | Response:
-
     unreferenced_only = request.query_params.get("unreferenced_only", "").lower() in (
         "1",
         "true",

--- a/docs/agents/dev.md
+++ b/docs/agents/dev.md
@@ -14,6 +14,11 @@ uvicorn backend.asgi:application --port 8080 --reload  # or any free port; gz_st
 cd web
 npm install
 npm run dev
+
+# Remote ML Offload (Optional, for 1GB RAM servers)
+pip install modal
+modal auth login
+modal deploy tools/remote_rembg_service.py
 ```
 
 See [`env.sh`](../../env.sh) for shell helpers (`gz_setup`, `gz_start`, etc.) that wrap these commands.

--- a/docs/agents/dev.md
+++ b/docs/agents/dev.md
@@ -18,7 +18,7 @@ npm run dev
 # Remote ML Offload (Optional, for 1GB RAM servers)
 pip install modal
 modal setup
-modal deploy tools/remote_rembg_service.py
+modal deploy tools/piece_image_crop_service.py
 ```
 
 See [`env.sh`](../../env.sh) for shell helpers (`gz_setup`, `gz_start`, etc.) that wrap these commands.

--- a/docs/agents/dev.md
+++ b/docs/agents/dev.md
@@ -17,7 +17,7 @@ npm run dev
 
 # Remote ML Offload (Optional, for 1GB RAM servers)
 pip install modal
-modal auth login
+modal setup
 modal deploy tools/remote_rembg_service.py
 ```
 

--- a/docs/agents/dev.md
+++ b/docs/agents/dev.md
@@ -16,10 +16,13 @@ npm install
 npm run dev
 
 # Remote ML Offload (Optional, for 1GB RAM servers)
+# 1. Create a secret 'piece-image-crop-secret' with AUTH_TOKEN=xxx
 pip install modal
 modal setup
 modal deploy tools/piece_image_crop_service.py
 ```
+
+Set `REMOTE_REMBG_URL` and `MODAL_AUTH_TOKEN` in your `.env` to enable offloading.
 
 See [`env.sh`](../../env.sh) for shell helpers (`gz_setup`, `gz_start`, etc.) that wrap these commands.
 In a new environment, always run `source env.sh` and `gz_setup` before trying to do anything else.

--- a/docs/agents/glaze-domain.md
+++ b/docs/agents/glaze-domain.md
@@ -16,7 +16,7 @@ The app has two parts:
 
 - **Backend** (`/backend/`, `/api/`): Django + Django REST Framework, serves JSON to the web
 - **Web** (`/web/`): React 19 + TypeScript + Vite + Material UI
-- **Remote ML** (`/tools/remote_rembg_service.py`): Optional serverless offload via Modal.com
+- **Remote ML** (`/tools/piece_image_crop_service.py`): Optional serverless offload via Modal.com
 
 ---
 
@@ -26,7 +26,7 @@ To maintain stability on hardware with <1GB RAM, Glaze uses a remote offloading 
 
 - **Local Path**: Defaults to `u2netp` (memory-efficient) with pre-processing downscaling (640px max) to minimize RSS usage.
 - **Remote Path**: Activated via `REMOTE_REMBG_URL`. Offloads processing to a FastAPI microservice.
-- **Microservice**: Located at `tools/remote_rembg_service.py`, designed for deployment to **Modal.com**. It supports native auto-scaling and "scale-to-zero" to minimize costs.
+- **Microservice**: Located at `tools/piece_image_crop_service.py`, designed for deployment to **Modal.com**. It supports native auto-scaling and "scale-to-zero" to minimize costs.
 
 ## Workflow State Machine
 

--- a/docs/agents/glaze-domain.md
+++ b/docs/agents/glaze-domain.md
@@ -24,9 +24,10 @@ The app has two parts:
 
 To maintain stability on hardware with <1GB RAM, Glaze uses a remote offloading strategy for heavy ML tasks (specifically `rembg` background removal).
 
-- **Local Path**: Defaults to `u2netp` (memory-efficient) with pre-processing downscaling (640px max) to minimize RSS usage.
-- **Remote Path**: Activated via `REMOTE_REMBG_URL`. Offloads processing to a FastAPI microservice.
-- **Microservice**: Located at `tools/piece_image_crop_service.py`, designed for deployment to **Modal.com**. It supports native auto-scaling and "scale-to-zero" to minimize costs.
+- **Optimized Dispatch**: The backend offloads the **Cloudinary URL** of the image to the remote service. The Modal worker performs the download, completely bypassing local ML overhead and minimizing host-side bandwidth/memory usage.
+- **Local Path**: Defaults to `u2netp` (memory-efficient) with pre-processing downscaling (640px max) as a fallback if no remote URL is configured.
+- **Security**: The microservice validates an `X-API-Key` header against a `modal.Secret`.
+- **Microservice**: Located at `tools/piece_image_crop_service.py`, designed for deployment to **Modal.com**.
 
 ## Workflow State Machine
 

--- a/docs/agents/glaze-domain.md
+++ b/docs/agents/glaze-domain.md
@@ -16,8 +16,17 @@ The app has two parts:
 
 - **Backend** (`/backend/`, `/api/`): Django + Django REST Framework, serves JSON to the web
 - **Web** (`/web/`): React 19 + TypeScript + Vite + Material UI
+- **Remote ML** (`/tools/remote_rembg_service.py`): Optional serverless offload via Modal.com
 
 ---
+
+## Remote ML Offloading
+
+To maintain stability on hardware with <1GB RAM, Glaze uses a remote offloading strategy for heavy ML tasks (specifically `rembg` background removal).
+
+- **Local Path**: Defaults to `u2netp` (memory-efficient) with pre-processing downscaling (640px max) to minimize RSS usage.
+- **Remote Path**: Activated via `REMOTE_REMBG_URL`. Offloads processing to a FastAPI microservice.
+- **Microservice**: Located at `tools/remote_rembg_service.py`, designed for deployment to **Modal.com**. It supports native auto-scaling and "scale-to-zero" to minimize costs.
 
 ## Workflow State Machine
 

--- a/tools/piece_image_crop_service.py
+++ b/tools/piece_image_crop_service.py
@@ -7,7 +7,7 @@ Deployment (Modal):
     2. modal deploy tools/piece_image_crop_service.py
 
 Usage (Local):
-    pip install fastapi uvicorn rembg onnxruntime pillow
+    pip install fastapi uvicorn rembg onnxruntime pillow pillow-heif
     uvicorn tools.piece_image_crop_service:fastapi_app --port 8080
 """
 
@@ -24,7 +24,7 @@ try:
 
     image = (
         modal.Image.debian_slim()
-        .pip_install("fastapi", "uvicorn", "rembg", "onnxruntime", "pillow", "requests")
+        .pip_install("fastapi", "uvicorn", "rembg", "onnxruntime", "pillow", "pillow-heif", "requests")
         # Pre-download the model into the image to reduce cold start latency
         .run_commands("python -c \"from rembg import new_session; new_session('u2netp')\"")
     )
@@ -47,8 +47,12 @@ def create_app():
     """Factory to create the FastAPI app with heavy imports deferred."""
     from fastapi import FastAPI, Request, Response, Header, HTTPException
     from PIL import Image
+    from pillow_heif import register_heif_opener
     from rembg import new_session, remove
     import requests
+
+    # Register HEIF support (HEIC conversion handled here)
+    register_heif_opener()
 
     fastapi_instance = FastAPI(title="Piece Image Crop Service")
     _SESSION = new_session("u2netp")
@@ -75,7 +79,7 @@ def create_app():
                 if not url:
                     return Response(content="Missing url in JSON", status_code=400)
                 logger.info(f"Downloading image from URL: {url}")
-                resp = requests.get(url, timeout=20)
+                resp = requests.get(url, timeout=30)
                 resp.raise_for_status()
                 image_bytes = resp.content
             else:
@@ -85,7 +89,16 @@ def create_app():
             if not image_bytes:
                 return Response(content="Empty image data", status_code=400)
 
+            # HEIC -> JPG/RGBA conversion happens during Image.open thanks to register_heif_opener
             input_image = Image.open(io.BytesIO(image_bytes))
+            
+            # Implementation Detail: Optimized resizing for ML processing.
+            # We downscale to a reasonable max dimension to save memory and speed up rembg.
+            MAX_DIM = 1600
+            if max(input_image.size) > MAX_DIM:
+                logger.info(f"Resizing from {input_image.size} to max {MAX_DIM}")
+                input_image.thumbnail((MAX_DIM, MAX_DIM), Image.Resampling.LANCZOS)
+
             width, height = input_image.size
 
             # 1. Remove background

--- a/tools/piece_image_crop_service.py
+++ b/tools/piece_image_crop_service.py
@@ -31,8 +31,10 @@ try:
     # Modal CLI looks for a variable named 'app' by default.
     app = modal.App("piece-image-crop-service", image=image)
 
+    # By setting label="crop", the URL becomes:
+    # https://<workspace-name>--crop.modal.run
     @app.function()
-    @modal.asgi_app()
+    @modal.asgi_app(label="crop")
     def web():
         return create_app()
 

--- a/tools/piece_image_crop_service.py
+++ b/tools/piece_image_crop_service.py
@@ -1,15 +1,15 @@
 """
-Standalone rembg microservice for remote offloading.
+Standalone piece image crop service for remote offloading.
 Can be deployed to Modal.com or run locally.
 
 Usage (Local):
     pip install fastapi uvicorn rembg onnxruntime pillow
-    uvicorn tools.remote_rembg_service:fastapi_app --port 8080
+    uvicorn tools.piece_image_crop_service:fastapi_app --port 8080
 
 Usage (Modal):
     pip install modal
     modal setup
-    modal deploy tools/remote_rembg_service.py
+    modal deploy tools/piece_image_crop_service.py
 """
 
 import io
@@ -46,7 +46,7 @@ def create_app():
     from PIL import Image
     from rembg import new_session, remove
 
-    fastapi_instance = FastAPI(title="Glaze Remote rembg Service")
+    fastapi_instance = FastAPI(title="Piece Image Crop Service")
     _SESSION = new_session("u2netp")
 
     @fastapi_instance.post("/")

--- a/tools/piece_image_crop_service.py
+++ b/tools/piece_image_crop_service.py
@@ -2,18 +2,18 @@
 Standalone piece image crop service for remote offloading.
 Can be deployed to Modal.com or run locally.
 
+Deployment (Modal):
+    1. Set up a secret named 'piece-image-crop-secret' with 'AUTH_TOKEN'
+    2. modal deploy tools/piece_image_crop_service.py
+
 Usage (Local):
     pip install fastapi uvicorn rembg onnxruntime pillow
     uvicorn tools.piece_image_crop_service:fastapi_app --port 8080
-
-Usage (Modal):
-    pip install modal
-    modal setup
-    modal deploy tools/piece_image_crop_service.py
 """
 
 import io
 import logging
+import os
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -24,15 +24,16 @@ try:
 
     image = (
         modal.Image.debian_slim()
-        .pip_install("fastapi", "uvicorn", "rembg", "onnxruntime", "pillow")
+        .pip_install("fastapi", "uvicorn", "rembg", "onnxruntime", "pillow", "requests")
         # Pre-download the model into the image to reduce cold start latency
         .run_commands("python -c \"from rembg import new_session; new_session('u2netp')\"")
     )
-    # Modal CLI looks for a variable named 'app' by default.
-    app = modal.App("piece-image-crop-service", image=image)
+    
+    # We use a secret to protect the endpoint
+    secret = modal.Secret.from_name("piece-image-crop-secret")
+    
+    app = modal.App("piece-image-crop-service", image=image, secrets=[secret])
 
-    # By setting label="crop", the URL becomes:
-    # https://<workspace-name>--crop.modal.run
     @app.function()
     @modal.asgi_app(label="crop")
     def web():
@@ -44,21 +45,46 @@ except ImportError:
 
 def create_app():
     """Factory to create the FastAPI app with heavy imports deferred."""
-    from fastapi import FastAPI, Request, Response
+    from fastapi import FastAPI, Request, Response, Header, HTTPException
     from PIL import Image
     from rembg import new_session, remove
+    import requests
 
     fastapi_instance = FastAPI(title="Piece Image Crop Service")
     _SESSION = new_session("u2netp")
+    
+    # Simple token-based auth
+    EXPECTED_TOKEN = os.environ.get("AUTH_TOKEN")
+
+    async def verify_auth(x_api_key: str):
+        if EXPECTED_TOKEN and x_api_key != EXPECTED_TOKEN:
+            raise HTTPException(status_code=403, detail="Invalid API Key")
 
     @fastapi_instance.post("/")
-    async def detect_crop(request: Request):
-        """Receive image bytes and return a relative crop box."""
-        image_bytes = await request.body()
-        if not image_bytes:
-            return Response(content="Empty body", status_code=400)
-
+    async def detect_crop(request: Request, x_api_key: str = Header(None)):
+        """Receive image bytes OR a URL and return a relative crop box."""
+        await verify_auth(x_api_key)
+        
+        content_type = request.headers.get("Content-Type")
+        
         try:
+            if content_type == "application/json":
+                # Handle URL-based request
+                data = await request.json()
+                url = data.get("url")
+                if not url:
+                    return Response(content="Missing url in JSON", status_code=400)
+                logger.info(f"Downloading image from URL: {url}")
+                resp = requests.get(url, timeout=20)
+                resp.raise_for_status()
+                image_bytes = resp.content
+            else:
+                # Handle raw bytes
+                image_bytes = await request.body()
+                
+            if not image_bytes:
+                return Response(content="Empty image data", status_code=400)
+
             input_image = Image.open(io.BytesIO(image_bytes))
             width, height = input_image.size
 
@@ -95,19 +121,13 @@ def create_app():
 
 
 # --- Local Entry Point ---
-# We wrap this in a try-except so 'modal deploy' doesn't fail if
-# fastapi/rembg aren't installed locally.
 try:
     fastapi_app = create_app()
 except ImportError:
-    # This will be triggered during 'modal deploy' on a machine
-    # without the heavy dependencies. That's fine as Modal uses
-    # the 'web' function above.
     fastapi_app = None
 
 if __name__ == "__main__":
     import uvicorn
-
     if fastapi_app:
         uvicorn.run(fastapi_app, host="0.0.0.0", port=8080)
     else:

--- a/tools/piece_image_crop_service.py
+++ b/tools/piece_image_crop_service.py
@@ -29,7 +29,7 @@ try:
         .run_commands("python -c \"from rembg import new_session; new_session('u2netp')\"")
     )
     # Modal CLI looks for a variable named 'app' by default.
-    app = modal.App("glaze-rembg", image=image)
+    app = modal.App("piece-image-crop-service", image=image)
 
     @app.function()
     @modal.asgi_app()

--- a/tools/remote_rembg_service.py
+++ b/tools/remote_rembg_service.py
@@ -1,79 +1,24 @@
 """
 Standalone rembg microservice for remote offloading.
-Can be deployed to Google Cloud Run or Modal.com.
+Can be deployed to Modal.com or run locally.
 
-Usage:
+Usage (Local):
     pip install fastapi uvicorn rembg onnxruntime pillow
-    uvicorn remote_rembg_service:app --port 8080
+    uvicorn tools.remote_rembg_service:app --port 8080
+
+Usage (Modal):
+    pip install modal
+    modal setup
+    modal deploy tools/remote_rembg_service.py
 """
 
 import io
 import logging
 
-from fastapi import FastAPI, Request, Response
-from PIL import Image
-from rembg import new_session, remove
-
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-app = FastAPI(title="Glaze Remote rembg Service")
-
-# Cache the session at the module level for reuse across requests.
-# u2netp is recommended for speed and memory efficiency in serverless.
-_SESSION = new_session("u2netp")
-
-
-@app.post("/")
-async def detect_crop(request: Request):
-    """Receive image bytes and return a relative crop box."""
-    image_bytes = await request.body()
-    if not image_bytes:
-        return Response(content="Empty body", status_code=400)
-
-    try:
-        input_image = Image.open(io.BytesIO(image_bytes))
-        width, height = input_image.size
-
-        # 1. Remove background
-        logger.info(f"Processing image: {width}x{height}")
-        output_image = remove(input_image, session=_SESSION)
-
-        # 2. Find non-transparent bounds
-        alpha = output_image.getchannel("A")
-        bbox = alpha.getbbox()
-
-        if not bbox:
-            logger.info("No subject detected.")
-            return {"x": 0, "y": 0, "width": 0, "height": 0}
-
-        left, upper, right, lower = bbox
-
-        # 3. Return relative coordinates
-        return {
-            "x": left / width,
-            "y": upper / height,
-            "width": (right - left) / width,
-            "height": (lower - upper) / height,
-        }
-    except Exception as e:
-        logger.exception("Error processing image")
-        return Response(content=str(e), status_code=500)
-
-
-@app.get("/health")
-def health():
-    return {"status": "ok", "model": "u2netp"}
-
-
-if __name__ == "__main__":
-    import uvicorn
-
-    uvicorn.run(app, host="0.0.0.0", port=8080)
-
-# ── Modal Deployment ─────────────────────────────────────────────────────────
-# To deploy: modal deploy tools/remote_rembg_service.py
-
+# --- Modal Configuration ---
 try:
     import modal
 
@@ -84,11 +29,86 @@ try:
         .run_commands("python -c \"from rembg import new_session; new_session('u2netp')\"")
     )
     modal_app = modal.App("glaze-rembg", image=image)
+except ImportError:
+    modal_app = None
+
+
+def create_app():
+    """Factory to create the FastAPI app with heavy imports deferred."""
+    from fastapi import FastAPI, Request, Response
+    from PIL import Image
+    from rembg import new_session, remove
+
+    app = FastAPI(title="Glaze Remote rembg Service")
+    _SESSION = new_session("u2netp")
+
+    @app.post("/")
+    async def detect_crop(request: Request):
+        """Receive image bytes and return a relative crop box."""
+        image_bytes = await request.body()
+        if not image_bytes:
+            return Response(content="Empty body", status_code=400)
+
+        try:
+            input_image = Image.open(io.BytesIO(image_bytes))
+            width, height = input_image.size
+
+            # 1. Remove background
+            logger.info(f"Processing image: {width}x{height}")
+            output_image = remove(input_image, session=_SESSION)
+
+            # 2. Find non-transparent bounds
+            alpha = output_image.getchannel("A")
+            bbox = alpha.getbbox()
+
+            if not bbox:
+                logger.info("No subject detected.")
+                return {"x": 0, "y": 0, "width": 0, "height": 0}
+
+            left, upper, right, lower = bbox
+
+            # 3. Return relative coordinates
+            return {
+                "x": left / width,
+                "y": upper / height,
+                "width": (right - left) / width,
+                "height": (lower - upper) / height,
+            }
+        except Exception as e:
+            logger.exception("Error processing image")
+            return Response(content=str(e), status_code=500)
+
+    @app.get("/health")
+    def health():
+        return {"status": "ok", "model": "u2netp"}
+
+    return app
+
+
+# --- Modal Entry Point ---
+if modal_app:
 
     @modal_app.function()
     @modal.asgi_app()
     def web():
-        return app
+        return create_app()
 
+
+# --- Local Entry Point ---
+# We wrap this in a try-except so 'modal deploy' doesn't fail if
+# fastapi/rembg aren't installed locally.
+try:
+    app = create_app()
 except ImportError:
-    pass
+    # This will be triggered during 'modal deploy' on a machine
+    # without the heavy dependencies. That's fine as Modal uses
+    # the 'web' function above which runs inside the container.
+    app = None
+
+if __name__ == "__main__":
+    import uvicorn
+
+    if app:
+        uvicorn.run(app, host="0.0.0.0", port=8080)
+    else:
+        print("Required packages (fastapi, rembg, pillow) not installed locally.")

--- a/tools/remote_rembg_service.py
+++ b/tools/remote_rembg_service.py
@@ -1,0 +1,72 @@
+"""
+Standalone rembg microservice for remote offloading.
+Can be deployed to Google Cloud Run or Modal.com.
+
+Usage:
+    pip install fastapi uvicorn rembg onnxruntime pillow
+    uvicorn remote_rembg_service:app --port 8080
+"""
+
+import io
+import logging
+
+from fastapi import FastAPI, Request, Response
+from PIL import Image
+from rembg import new_session, remove
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="Glaze Remote rembg Service")
+
+# Cache the session at the module level for reuse across requests.
+# u2netp is recommended for speed and memory efficiency in serverless.
+_SESSION = new_session("u2netp")
+
+
+@app.post("/")
+async def detect_crop(request: Request):
+    """Receive image bytes and return a relative crop box."""
+    image_bytes = await request.body()
+    if not image_bytes:
+        return Response(content="Empty body", status_code=400)
+
+    try:
+        input_image = Image.open(io.BytesIO(image_bytes))
+        width, height = input_image.size
+
+        # 1. Remove background
+        logger.info(f"Processing image: {width}x{height}")
+        output_image = remove(input_image, session=_SESSION)
+
+        # 2. Find non-transparent bounds
+        alpha = output_image.getchannel("A")
+        bbox = alpha.getbbox()
+
+        if not bbox:
+            logger.info("No subject detected.")
+            return {"x": 0, "y": 0, "width": 0, "height": 0}
+
+        left, upper, right, lower = bbox
+
+        # 3. Return relative coordinates
+        return {
+            "x": left / width,
+            "y": upper / height,
+            "width": (right - left) / width,
+            "height": (lower - upper) / height,
+        }
+    except Exception as e:
+        logger.exception("Error processing image")
+        return Response(content=str(e), status_code=500)
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok", "model": "u2netp"}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8080)

--- a/tools/remote_rembg_service.py
+++ b/tools/remote_rembg_service.py
@@ -29,6 +29,14 @@ try:
         .run_commands("python -c \"from rembg import new_session; new_session('u2netp')\"")
     )
     modal_app = modal.App("glaze-rembg", image=image)
+
+    # We define the Modal function here at the top level (within the try block)
+    # so that the Modal CLI can discover it.
+    @modal_app.function()
+    @modal.asgi_app()
+    def web():
+        return create_app()
+
 except ImportError:
     modal_app = None
 
@@ -39,10 +47,10 @@ def create_app():
     from PIL import Image
     from rembg import new_session, remove
 
-    app = FastAPI(title="Glaze Remote rembg Service")
+    fastapi_app = FastAPI(title="Glaze Remote rembg Service")
     _SESSION = new_session("u2netp")
 
-    @app.post("/")
+    @fastapi_app.post("/")
     async def detect_crop(request: Request):
         """Receive image bytes and return a relative crop box."""
         image_bytes = await request.body()
@@ -78,20 +86,11 @@ def create_app():
             logger.exception("Error processing image")
             return Response(content=str(e), status_code=500)
 
-    @app.get("/health")
+    @fastapi_app.get("/health")
     def health():
         return {"status": "ok", "model": "u2netp"}
 
-    return app
-
-
-# --- Modal Entry Point ---
-if modal_app:
-
-    @modal_app.function()
-    @modal.asgi_app()
-    def web():
-        return create_app()
+    return fastapi_app
 
 
 # --- Local Entry Point ---
@@ -102,7 +101,7 @@ try:
 except ImportError:
     # This will be triggered during 'modal deploy' on a machine
     # without the heavy dependencies. That's fine as Modal uses
-    # the 'web' function above which runs inside the container.
+    # the 'web' function above.
     app = None
 
 if __name__ == "__main__":

--- a/tools/remote_rembg_service.py
+++ b/tools/remote_rembg_service.py
@@ -70,3 +70,22 @@ if __name__ == "__main__":
     import uvicorn
 
     uvicorn.run(app, host="0.0.0.0", port=8080)
+
+# ── Modal Deployment ─────────────────────────────────────────────────────────
+# To deploy: modal deploy tools/remote_rembg_service.py
+
+try:
+    import modal
+
+    image = modal.Image.debian_slim().pip_install(
+        "fastapi", "uvicorn", "rembg", "onnxruntime", "pillow"
+    )
+    modal_app = modal.App("glaze-rembg", image=image)
+
+    @modal_app.function()
+    @modal.asgi_app()
+    def web():
+        return app
+
+except ImportError:
+    pass

--- a/tools/remote_rembg_service.py
+++ b/tools/remote_rembg_service.py
@@ -77,8 +77,11 @@ if __name__ == "__main__":
 try:
     import modal
 
-    image = modal.Image.debian_slim().pip_install(
-        "fastapi", "uvicorn", "rembg", "onnxruntime", "pillow"
+    image = (
+        modal.Image.debian_slim()
+        .pip_install("fastapi", "uvicorn", "rembg", "onnxruntime", "pillow")
+        # Pre-download the model into the image to reduce cold start latency
+        .run_commands("python -c \"from rembg import new_session; new_session('u2netp')\"")
     )
     modal_app = modal.App("glaze-rembg", image=image)
 

--- a/tools/remote_rembg_service.py
+++ b/tools/remote_rembg_service.py
@@ -4,7 +4,7 @@ Can be deployed to Modal.com or run locally.
 
 Usage (Local):
     pip install fastapi uvicorn rembg onnxruntime pillow
-    uvicorn tools.remote_rembg_service:app --port 8080
+    uvicorn tools.remote_rembg_service:fastapi_app --port 8080
 
 Usage (Modal):
     pip install modal
@@ -28,17 +28,16 @@ try:
         # Pre-download the model into the image to reduce cold start latency
         .run_commands("python -c \"from rembg import new_session; new_session('u2netp')\"")
     )
-    modal_app = modal.App("glaze-rembg", image=image)
+    # Modal CLI looks for a variable named 'app' by default.
+    app = modal.App("glaze-rembg", image=image)
 
-    # We define the Modal function here at the top level (within the try block)
-    # so that the Modal CLI can discover it.
-    @modal_app.function()
+    @app.function()
     @modal.asgi_app()
     def web():
         return create_app()
 
 except ImportError:
-    modal_app = None
+    app = None
 
 
 def create_app():
@@ -47,10 +46,10 @@ def create_app():
     from PIL import Image
     from rembg import new_session, remove
 
-    fastapi_app = FastAPI(title="Glaze Remote rembg Service")
+    fastapi_instance = FastAPI(title="Glaze Remote rembg Service")
     _SESSION = new_session("u2netp")
 
-    @fastapi_app.post("/")
+    @fastapi_instance.post("/")
     async def detect_crop(request: Request):
         """Receive image bytes and return a relative crop box."""
         image_bytes = await request.body()
@@ -86,28 +85,28 @@ def create_app():
             logger.exception("Error processing image")
             return Response(content=str(e), status_code=500)
 
-    @fastapi_app.get("/health")
+    @fastapi_instance.get("/health")
     def health():
         return {"status": "ok", "model": "u2netp"}
 
-    return fastapi_app
+    return fastapi_instance
 
 
 # --- Local Entry Point ---
 # We wrap this in a try-except so 'modal deploy' doesn't fail if
 # fastapi/rembg aren't installed locally.
 try:
-    app = create_app()
+    fastapi_app = create_app()
 except ImportError:
     # This will be triggered during 'modal deploy' on a machine
     # without the heavy dependencies. That's fine as Modal uses
     # the 'web' function above.
-    app = None
+    fastapi_app = None
 
 if __name__ == "__main__":
     import uvicorn
 
-    if app:
-        uvicorn.run(app, host="0.0.0.0", port=8080)
+    if fastapi_app:
+        uvicorn.run(fastapi_app, host="0.0.0.0", port=8080)
     else:
         print("Required packages (fastapi, rembg, pillow) not installed locally.")


### PR DESCRIPTION
# Support Remote Offloading for rembg Subject Detection

This PR implements an optional remote offloading route for the memory-intensive `rembg` background removal task. This allows the backend to remain stable on memory-constrained hardware (like a 1GB RAM Droplet) by offloading ML processing to a serverless microservice.

## Changes

- **Remote Setting**: Added support for `REMOTE_REMBG_URL`. If set, the `detect_subject_crop` task will delegate processing to a remote service.
- **Optimized Dispatch (Tighter Boundary)**: The backend now offloads the **base image URL** directly to the remote service. 
    - The remote service is now responsible for all image pre-processing, including **HEIC -> JPG conversion** and **resizing** (max 1600px).
    - This removes "implementation detail" optimizations from the PotterDoc codebase and minimizes host-side bandwidth and memory usage.
- **Client Helper**: Implemented `calculate_subject_crop_remote` in `api/utils.py` with support for both `url` and `bytes` dispatch.
- **Security**: Added **API Key authentication** (`MODAL_AUTH_TOKEN` / `X-API-Key`) to the microservice and client.
- **Standalone Service**: Added `tools/piece_image_crop_service.py`, a lightweight FastAPI microservice optimized for Modal.com with `pillow-heif` support.
- **Documentation**: 
    - Updated `README.md`, `docs/agents/glaze-domain.md`, and `docs/agents/dev.md` with the new optimized architecture and deployment instructions.
- **Tests**: Updated `TestRemoteDetectSubjectCrop` to verify the clean URL-based offloading logic.

## Verification

### Automated Tests
- [x] `rtk bazel test //api:api_model_test` passed (covers clean URL-based remote logic).
- [x] `rtk bazel test //api:api_mypy` passed.

### Deployment Runbook (Local machine)
1. Set up a Modal secret named `piece-image-crop-secret` with an `AUTH_TOKEN`.
2. `pip install modal && modal setup`
3. `modal deploy tools/piece_image_crop_service.py`
4. The resulting URL will be: `https://your-workspace-name--crop.modal.run`

### Configuration (Prod Droplet)
1. Set `REMOTE_REMBG_URL="https://your-workspace-name--crop.modal.run"` in `~/glaze/.env`.
2. Set `MODAL_AUTH_TOKEN="your-token"` in `~/glaze/.env`.
3. `docker compose up -d` to apply changes.

Co-authored-by: Antigravity <antigravity@google.com>
