### PR TITLE
feat: add Analysis Dashboard hierarchy to Analyze tab

### DIFF
--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -293,6 +293,23 @@ js_library(
     ],
 )
 
+
+js_library(
+    name = "analysis_src",
+    srcs = [
+        "src/components/AnalysisCard.tsx",
+        "src/components/AnalysisIndex.tsx",
+        "src/components/GlazeCombinationSummary.tsx",
+    ],
+    deps = [
+        ":cloudinary_image_src",
+        ":generated_types",
+        ":node_modules",
+        ":primitive_src",
+        ":util_lib",
+    ],
+)
+
 js_library(
     name = "glaze_gallery_src",
     srcs = ["src/components/GlazeCombinationGallery.tsx"],
@@ -459,6 +476,17 @@ js_library(
         ":tag_manager_src",
         ":util_lib",
         ":workflow_state_src",
+    ],
+)
+
+
+js_library(
+    name = "analyze_page_src",
+    srcs = ["src/pages/AnalyzePage.tsx"],
+    deps = [
+        ":analysis_src",
+        ":glaze_gallery_src",
+        ":node_modules",
     ],
 )
 
@@ -821,6 +849,31 @@ vitest_test(
     ],
 )
 
+
+vitest_test(
+    name = "web_analysis_test",
+    srcs = [
+        "src/components/__tests__/AnalysisCard.test.tsx",
+        "src/components/__tests__/AnalysisIndex.test.tsx",
+        "src/components/__tests__/GlazeCombinationSummary.test.tsx",
+    ],
+    tags = ["ibazel_notify_changes"],
+    deps = [
+        ":analysis_src",
+    ],
+)
+
+vitest_test(
+    name = "web_analyze_page_test",
+    srcs = [
+        "src/pages/__tests__/AnalyzePage.test.tsx",
+    ],
+    tags = ["ibazel_notify_changes"],
+    deps = [
+        ":analyze_page_src",
+    ],
+)
+
 vitest_test(
     name = "web_app_test",
     srcs = ["src/App.test.tsx"],
@@ -837,6 +890,8 @@ vitest_test(
 test_suite(
     name = "web_test",
     tests = [
+        ":web_analysis_test",
+        ":web_analyze_page_test",
         ":web_api_test",
         ":web_app_test",
         ":web_cloudinary_cleanup_test",

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -48,7 +48,7 @@ vi.mock("./components/PieceDetail", () => ({
 }));
 
 vi.mock("./components/GlazeCombinationGallery", () => ({
-  default: () => <div>Glaze Gallery Content</div>,
+  default: () => <div>Glaze Combinations</div>,
 }));
 
 vi.mock("./pages/GlazeImportToolPage", () => ({
@@ -260,7 +260,7 @@ describe("App auth flow", () => {
     await userEvent.click(screen.getByRole("tab", { name: "Analyze" }));
 
     await waitFor(() => {
-      expect(screen.getByText("Glaze Gallery Content")).toBeInTheDocument();
+      expect(screen.getByText("Glaze Combinations")).toBeInTheDocument();
       expect(window.location.pathname).toBe("/analyze");
     });
 
@@ -364,7 +364,7 @@ describe("App auth flow", () => {
     render(<App />);
 
     await waitFor(() => {
-      expect(screen.getByText("Glaze Gallery Content")).toBeInTheDocument();
+      expect(screen.getByText("Glaze Combinations")).toBeInTheDocument();
     });
 
     expect(screen.getByRole("tab", { name: "Analyze" })).toHaveAttribute(

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -687,7 +687,7 @@ function AuthenticatedApp({
           >
             <Route path="/" element={<LandingPage />}>
               <Route index element={<PieceListPage />} />
-              <Route path="analyze" element={<AnalyzePage />} />
+              <Route path="analyze/*" element={<AnalyzePage />} />
             </Route>
             <Route path="/pieces/:id" element={<PieceDetailPage />} />
             <Route

--- a/web/src/components/AnalysisCard.tsx
+++ b/web/src/components/AnalysisCard.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from "react";
+import { Link } from "react-router-dom";
+import {
+  Card,
+  CardActionArea,
+  CardContent,
+  Typography,
+  Box,
+  Stack,
+} from "@mui/material";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+
+interface AnalysisCardProps {
+  title: string;
+  description: string;
+  to: string;
+  summary?: ReactNode;
+}
+
+export default function AnalysisCard({
+  title,
+  description,
+  to,
+  summary,
+}: AnalysisCardProps) {
+  return (
+    <Card variant="outlined">
+      <CardActionArea component={Link} to={to} sx={{ display: "block" }}>
+        <CardContent sx={{ p: 2.5 }}>
+          <Stack spacing={2}>
+            <Box
+              sx={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "flex-start",
+              }}
+            >
+              <Box>
+                <Typography variant="h6" component="h2" gutterBottom>
+                  {title}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {description}
+                </Typography>
+              </Box>
+              <ChevronRightIcon sx={{ color: "text.disabled", mt: 0.5 }} />
+            </Box>
+
+            {summary && <Box>{summary}</Box>}
+          </Stack>
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  );
+}

--- a/web/src/components/AnalysisIndex.tsx
+++ b/web/src/components/AnalysisIndex.tsx
@@ -1,0 +1,41 @@
+import { Stack, Typography, Box, alpha } from "@mui/material";
+import AnalysisCard from "./AnalysisCard";
+import GlazeCombinationSummary from "./GlazeCombinationSummary";
+
+export default function AnalysisIndex() {
+  return (
+    <Stack spacing={2}>
+      <AnalysisCard
+        title="Glaze Combinations"
+        description="Browse images of glaze combinations applied to your pieces."
+        to="/analyze/glaze-combinations"
+        summary={<GlazeCombinationSummary />}
+      />
+
+      <AnalysisCard
+        title="Firing Results"
+        description="Coming soon: Analyze results across different firing programs and temperatures."
+        to="/analyze" // Keep on index for now since it's a placeholder
+        summary={
+          <Box
+            sx={{
+              height: 40,
+              display: "flex",
+              alignItems: "center",
+              px: 1.5,
+              borderRadius: 1,
+              bgcolor: alpha("#000", 0.05),
+              border: "1px dashed",
+              borderColor: "divider",
+              width: "fit-content",
+            }}
+          >
+            <Typography variant="caption" color="text.disabled" sx={{ fontStyle: "italic" }}>
+              Future analysis module
+            </Typography>
+          </Box>
+        }
+      />
+    </Stack>
+  );
+}

--- a/web/src/components/GlazeCombinationSummary.tsx
+++ b/web/src/components/GlazeCombinationSummary.tsx
@@ -1,0 +1,83 @@
+import { Box, Typography, CircularProgress, alpha } from "@mui/material";
+import { fetchGlazeCombinationImages } from "../util/api";
+import { useAsync } from "../util/useAsync";
+import CloudinaryImage from "./CloudinaryImage";
+import type { GlazeCombinationImageEntry } from "../util/types";
+
+export default function GlazeCombinationSummary() {
+  const { data, loading, error } = useAsync<GlazeCombinationImageEntry[]>(
+    fetchGlazeCombinationImages,
+  );
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1, height: 40 }}>
+        <CircularProgress size={16} />
+        <Typography variant="caption" color="text.secondary">
+          Loading...
+        </Typography>
+      </Box>
+    );
+  }
+
+  if (error || !data) {
+    return null;
+  }
+
+  const combinationCount = data.length;
+  // Get up to 4 representative images from different combinations
+  const representativeImages = data
+    .flatMap((entry) => entry.pieces.flatMap((p) => p.images))
+    .slice(0, 4);
+
+  return (
+    <Box>
+      <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: "block" }}>
+        {combinationCount} combination{combinationCount === 1 ? "" : "s"} with images
+      </Typography>
+      <Box sx={{ display: "flex", gap: 0.5 }}>
+        {representativeImages.map((img, idx) => (
+          <Box
+            key={idx}
+            sx={{
+              width: 40,
+              height: 40,
+              borderRadius: 1,
+              overflow: "hidden",
+              bgcolor: alpha("#000", 0.1),
+              border: "1px solid",
+              borderColor: "divider",
+            }}
+          >
+            <CloudinaryImage
+              url={img.url}
+              cloud_name={img.cloud_name}
+              cloudinary_public_id={img.cloudinary_public_id}
+              alt=""
+              context="thumbnail"
+            />
+          </Box>
+        ))}
+        {combinationCount > 4 && (
+          <Box
+            sx={{
+              width: 40,
+              height: 40,
+              borderRadius: 1,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              bgcolor: alpha("#000", 0.05),
+              border: "1px solid",
+              borderColor: "divider",
+            }}
+          >
+            <Typography variant="caption" color="text.secondary" fontWeight="bold">
+              +{combinationCount - 4}
+            </Typography>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/web/src/components/__tests__/AnalysisCard.test.tsx
+++ b/web/src/components/__tests__/AnalysisCard.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import AnalysisCard from "../AnalysisCard";
+
+describe("AnalysisCard", () => {
+  it("renders title and description", () => {
+    render(
+      <MemoryRouter>
+        <AnalysisCard
+          title="Test Title"
+          description="Test Description"
+          to="/test"
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Test Title")).toBeInTheDocument();
+    expect(screen.getByText("Test Description")).toBeInTheDocument();
+  });
+
+  it("renders summary slot when provided", () => {
+    render(
+      <MemoryRouter>
+        <AnalysisCard
+          title="Test Title"
+          description="Test Description"
+          to="/test"
+          summary={<div data-testid="summary">Summary Content</div>}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("summary")).toBeInTheDocument();
+  });
+
+  it("links to the correct destination", () => {
+    render(
+      <MemoryRouter>
+        <AnalysisCard
+          title="Test Title"
+          description="Test Description"
+          to="/test-destination"
+        />
+      </MemoryRouter>,
+    );
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/test-destination");
+  });
+});

--- a/web/src/components/__tests__/AnalysisIndex.test.tsx
+++ b/web/src/components/__tests__/AnalysisIndex.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import AnalysisIndex from "../AnalysisIndex";
+import * as api from "../../util/api";
+
+vi.mock("../../util/api", () => ({
+  fetchGlazeCombinationImages: vi.fn(),
+}));
+
+vi.mock("../CloudinaryImage", () => ({
+  default: () => <div data-testid="mock-image" />,
+}));
+
+describe("AnalysisIndex", () => {
+  it("renders analysis cards", () => {
+    vi.mocked(api.fetchGlazeCombinationImages).mockResolvedValue([]);
+    
+    render(
+      <MemoryRouter>
+        <AnalysisIndex />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Glaze Combinations")).toBeInTheDocument();
+    expect(screen.getByText("Firing Results")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/__tests__/GlazeCombinationSummary.test.tsx
+++ b/web/src/components/__tests__/GlazeCombinationSummary.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import GlazeCombinationSummary from "../GlazeCombinationSummary";
 import * as api from "../../util/api";
 
@@ -45,5 +45,40 @@ describe("GlazeCombinationSummary", () => {
     
     expect(await screen.findByText(/2 combinations with images/i)).toBeInTheDocument();
     expect(screen.getAllByTestId("mock-image")).toHaveLength(2);
+  });
+
+  it("renders error state", async () => {
+    vi.mocked(api.fetchGlazeCombinationImages).mockRejectedValue(new Error("API Error"));
+    render(<GlazeCombinationSummary />);
+    
+    await waitFor(() => {
+      expect(screen.queryByText(/combinations with images/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders '+N' label when more than 4 combinations", async () => {
+    const mockData = Array.from({ length: 6 }, (_, i) => ({
+      glaze_combination: { id: `${i}`, name: `Combo ${i}` },
+      pieces: [{ id: `p${i}`, images: [{ url: `url${i}` }] }],
+    }));
+    vi.mocked(api.fetchGlazeCombinationImages).mockResolvedValue(mockData as any);
+    
+    render(<GlazeCombinationSummary />);
+    
+    expect(await screen.findByText("+2")).toBeInTheDocument();
+  });
+
+  it("renders singular 'combination' when count is 1", async () => {
+    const mockData = [
+      {
+        glaze_combination: { id: "1", name: "Combo 1" },
+        pieces: [{ id: "p1", images: [{ url: "url1" }] }],
+      },
+    ];
+    vi.mocked(api.fetchGlazeCombinationImages).mockResolvedValue(mockData as any);
+    
+    render(<GlazeCombinationSummary />);
+    
+    expect(await screen.findByText("1 combination with images")).toBeInTheDocument();
   });
 });

--- a/web/src/components/__tests__/GlazeCombinationSummary.test.tsx
+++ b/web/src/components/__tests__/GlazeCombinationSummary.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import GlazeCombinationSummary from "../GlazeCombinationSummary";
+import * as api from "../../util/api";
+
+vi.mock("../../util/api", () => ({
+  fetchGlazeCombinationImages: vi.fn(),
+}));
+
+vi.mock("../CloudinaryImage", () => ({
+  default: () => <div data-testid="mock-image" />,
+}));
+
+describe("GlazeCombinationSummary", () => {
+  it("shows loading state", () => {
+    vi.mocked(api.fetchGlazeCombinationImages).mockReturnValue(new Promise(() => {}));
+    render(<GlazeCombinationSummary />);
+    expect(screen.getByText(/Loading.../i)).toBeInTheDocument();
+  });
+
+  it("renders count and thumbnails", async () => {
+    const mockData = [
+      {
+        glaze_combination: { id: "1", name: "Combo 1" },
+        pieces: [
+          {
+            id: "p1",
+            images: [{ url: "url1" }],
+          },
+        ],
+      },
+      {
+        glaze_combination: { id: "2", name: "Combo 2" },
+        pieces: [
+          {
+            id: "p2",
+            images: [{ url: "url2" }],
+          },
+        ],
+      },
+    ];
+    vi.mocked(api.fetchGlazeCombinationImages).mockResolvedValue(mockData as any);
+    
+    render(<GlazeCombinationSummary />);
+    
+    expect(await screen.findByText(/2 combinations with images/i)).toBeInTheDocument();
+    expect(screen.getAllByTestId("mock-image")).toHaveLength(2);
+  });
+});

--- a/web/src/pages/AnalyzePage.tsx
+++ b/web/src/pages/AnalyzePage.tsx
@@ -1,5 +1,47 @@
+import { Routes, Route, Link, useLocation } from "react-router-dom";
+import { Box, Button, Typography } from "@mui/material";
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import AnalysisIndex from "../components/AnalysisIndex";
 import GlazeCombinationGallery from "../components/GlazeCombinationGallery";
 
+function SubRouteHeader({ title }: { title: string }) {
+  return (
+    <Box sx={{ mb: 2, display: "flex", alignItems: "center", gap: 1 }}>
+      <Button
+        component={Link}
+        to="/analyze"
+        variant="text"
+        size="small"
+        startIcon={<ChevronLeftIcon />}
+        sx={{ color: "text.secondary", ml: -1 }}
+      >
+        Back
+      </Button>
+      <Typography variant="h6" component="h1">
+        {title}
+      </Typography>
+    </Box>
+  );
+}
+
 export default function AnalyzePage() {
-  return <GlazeCombinationGallery />;
+  const location = useLocation();
+  const isIndex = location.pathname === "/analyze" || location.pathname === "/analyze/";
+
+  return (
+    <Box>
+      {!isIndex && (
+        <Routes>
+          <Route
+            path="glaze-combinations"
+            element={<SubRouteHeader title="Glaze Combinations" />}
+          />
+        </Routes>
+      )}
+      <Routes>
+        <Route index element={<AnalysisIndex />} />
+        <Route path="glaze-combinations" element={<GlazeCombinationGallery />} />
+      </Routes>
+    </Box>
+  );
 }

--- a/web/src/pages/LandingPage.tsx
+++ b/web/src/pages/LandingPage.tsx
@@ -8,7 +8,7 @@ export const BOTTOM_TAB_BAR_HEIGHT = 56;
 export default function LandingPage() {
   const location = useLocation();
   const navigate = useNavigate();
-  const currentTab = location.pathname === "/analyze" ? "/analyze" : "/";
+  const currentTab = location.pathname.startsWith("/analyze") ? "/analyze" : "/";
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 

--- a/web/src/pages/__tests__/AnalyzePage.test.tsx
+++ b/web/src/pages/__tests__/AnalyzePage.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import AnalyzePage from "../AnalyzePage";
+import * as api from "../../util/api";
+
+vi.mock("../../util/api", () => ({
+  fetchGlazeCombinationImages: vi.fn(),
+}));
+
+vi.mock("../../components/CloudinaryImage", () => ({
+  default: () => <div data-testid="mock-image" />,
+}));
+
+describe("AnalyzePage", () => {
+  it("renders AnalysisIndex by default", async () => {
+    vi.mocked(api.fetchGlazeCombinationImages).mockResolvedValue([]);
+    
+    render(
+      <MemoryRouter initialEntries={["/analyze"]}>
+        <Routes>
+          <Route path="/analyze/*" element={<AnalyzePage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Glaze Combinations")).toBeInTheDocument();
+  });
+
+  it("renders GlazeCombinationGallery on sub-route with back button", async () => {
+    vi.mocked(api.fetchGlazeCombinationImages).mockResolvedValue([]);
+    
+    render(
+      <MemoryRouter initialEntries={["/analyze/glaze-combinations"]}>
+        <Routes>
+          <Route path="/analyze/*" element={<AnalyzePage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole("link", { name: /back/i })).toBeInTheDocument();
+    expect(screen.getByText("Glaze Combinations")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #371.

This PR introduces an Analysis Dashboard as the default view for the 'Analyze' tab, allowing users to discover and navigate between different analysis tools.

Key changes:
- Created `AnalysisIndex` and `AnalysisCard` components for the dashboard.
- Ported `GlazeCombinationGallery` to `/analyze/glaze-combinations`.
- Added `GlazeCombinationSummary` as a visual preview on the dashboard.
- Updated sub-routing in `AnalyzePage` and navigation logic in `LandingPage`.
- Added unit tests for all new components and pages.

Verified with `rtk bazel test //web:web_test`.