### PR TITLE
feat(#307): retroactive state editing

### DIFF
--- a/api/BUILD.bazel
+++ b/api/BUILD.bazel
@@ -200,6 +200,7 @@ py_test(
         "tests/test_pieces_create.py",
         "tests/test_pieces_list.py",
         "tests/test_sealed_state.py",
+        "tests/test_editable_mode.py",
     ],
     args = [
         "api/tests/test_pieces_create.py",
@@ -211,6 +212,7 @@ py_test(
         "api/tests/test_analysis.py",
         "api/tests/test_piece_showcase_validation.py",
         "api/tests/test_piece_state_admin_relational.py",
+        "api/tests/test_editable_mode.py",
     ],
     data = _TEST_DATA,
     env = _TEST_ENV,

--- a/api/migrations/0008_add_editable_mode.py
+++ b/api/migrations/0008_add_editable_mode.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0007_piece_showcase_fields_piece_showcase_story"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="piece",
+            name="is_editable",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="piecestate",
+            name="order",
+            field=models.PositiveIntegerField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name="piecestate",
+            name="has_been_edited",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/api/migrations/0009_backfill_piece_state_order.py
+++ b/api/migrations/0009_backfill_piece_state_order.py
@@ -1,0 +1,21 @@
+from django.db import migrations
+
+
+def backfill_order(apps, schema_editor):
+    Piece = apps.get_model("api", "Piece")
+    PieceState = apps.get_model("api", "PieceState")
+    for piece in Piece.objects.all():
+        for i, ps in enumerate(
+            PieceState.objects.filter(piece=piece).order_by("created"), start=1
+        ):
+            PieceState.objects.filter(pk=ps.pk).update(order=i)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0008_add_editable_mode"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_order, migrations.RunPython.noop),
+    ]

--- a/api/models.py
+++ b/api/models.py
@@ -204,13 +204,21 @@ class Piece(models.Model):
     # validated against this version. Hardcoded to the current WORKFLOW_VERSION
     # for now; future work will allow migrating pieces to newer versions.
     workflow_version = models.CharField(max_length=32, default=WORKFLOW_VERSION)
+    # When True, all state invariants are suspended: sealed checks, successor
+    # validation, and sharing are bypassed so past states can be retroactively
+    # added or edited. Shared pieces are inaccessible to non-owners while editable.
+    is_editable = models.BooleanField(default=False)
 
     class Meta:
         ordering = ["-fields_last_modified"]
 
     @property
     def current_state(self) -> "PieceState | None":
-        return self.states.order_by("-created").first()
+        from django.db.models import F
+
+        return self.states.order_by(
+            F("order").desc(nulls_last=True), "-created"
+        ).first()
 
     @property
     def last_modified(self):
@@ -233,6 +241,12 @@ class PieceState(models.Model):
     notes = models.TextField(blank=True, default="")
     created = models.DateTimeField(auto_now_add=True)
     last_modified = models.DateTimeField(auto_now=True)
+    # Sequential position in piece history. Set on creation; shifted up when a
+    # retroactive state is inserted before this one.
+    order = models.PositiveIntegerField(null=True, blank=True)
+    # Set to True when this state is created or edited while piece.is_editable=True.
+    # Silent flag reserved for future analysis; not displayed in the UI.
+    has_been_edited = models.BooleanField(default=False)
     # Inline (non-global-ref) state-specific fields for this state.
     # Global ref fields are stored in per-type junction tables (PieceState*Ref models).
     custom_fields = models.JSONField(default=dict)
@@ -243,7 +257,7 @@ class PieceState(models.Model):
         return self.piece.workflow_version
 
     class Meta:
-        ordering = ["created"]
+        ordering = ["order", "created"]
 
     def __init__(self, *args, **kwargs):
         self._pending_images = kwargs.pop("images", None)
@@ -279,13 +293,22 @@ class PieceState(models.Model):
         if self.user_id is None and self.piece_id:
             self.user = self.piece.user
 
+        if self._state.adding and self.order is None and self.piece_id:
+            from django.db.models import Max
+
+            max_order = self.piece.states.aggregate(Max("order"))["order__max"] or 0
+            self.order = max_order + 1
+
         # Validate inline custom_fields against the DSL schema for this state.
         # Global ref fields are excluded from this schema (they live in junction tables).
         from .workflow import validate_custom_fields
 
         validate_custom_fields(self.state, self.custom_fields)
 
-        if not self._state.adding and not allow_sealed_edit:
+        is_editable = getattr(self.piece, "is_editable", False)
+        if is_editable and not self._state.adding:
+            self.has_been_edited = True
+        if not self._state.adding and not allow_sealed_edit and not is_editable:
             current = self.piece.current_state
             if current is None or current.pk != self.pk:
                 raise ValueError(

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -244,6 +244,7 @@ class PieceStateSerializer(serializers.ModelSerializer):
     class Meta:
         model = PieceState
         fields = [
+            "id",
             "state",
             "notes",
             "created",
@@ -252,6 +253,7 @@ class PieceStateSerializer(serializers.ModelSerializer):
             "custom_fields",
             "previous_state",
             "next_state",
+            "has_been_edited",
         ]
         extra_kwargs = {
             "notes": {"required": True},
@@ -286,18 +288,28 @@ class PieceStateSerializer(serializers.ModelSerializer):
 
     @extend_schema_field(serializers.CharField(allow_null=True))
     def get_previous_state(self, obj: PieceState) -> str | None:
-        prev = (
-            obj.piece.states.filter(created__lt=obj.created)
-            .order_by("-created")
-            .first()
-        )
+        if obj.order is not None:
+            prev = (
+                obj.piece.states.filter(order__lt=obj.order).order_by("-order").first()
+            )
+        else:
+            prev = (
+                obj.piece.states.filter(created__lt=obj.created)
+                .order_by("-created")
+                .first()
+            )
         return prev.state if prev else None
 
     @extend_schema_field(serializers.CharField(allow_null=True))
     def get_next_state(self, obj: PieceState) -> str | None:
-        nxt = (
-            obj.piece.states.filter(created__gt=obj.created).order_by("created").first()
-        )
+        if obj.order is not None:
+            nxt = obj.piece.states.filter(order__gt=obj.order).order_by("order").first()
+        else:
+            nxt = (
+                obj.piece.states.filter(created__gt=obj.created)
+                .order_by("created")
+                .first()
+            )
         return nxt.state if nxt else None
 
     def to_representation(self, instance: PieceState) -> dict:
@@ -350,6 +362,7 @@ class PieceSummarySerializer(serializers.ModelSerializer):
             "last_modified",
             "thumbnail",
             "shared",
+            "is_editable",
             "showcase_story",
             "showcase_fields",
             "can_edit",
@@ -443,7 +456,7 @@ class PieceCreateSerializer(serializers.ModelSerializer):
             current_location=location_obj,
         )
         PieceState.objects.create(
-            user=user, piece=piece, state=ENTRY_STATE, notes=notes
+            user=user, piece=piece, state=ENTRY_STATE, notes=notes, order=1
         )
 
         # Queue auto-detection for thumbnail if Cloudinary and no crop provided.
@@ -487,6 +500,8 @@ class PieceStateCreateSerializer(serializers.ModelSerializer):
 
     def validate_state(self, value: str) -> str:
         piece: Piece = self.context["piece"]
+        if piece.is_editable:
+            return value
         current = piece.current_state
         if current is not None:
             valid_next = SUCCESSORS.get(current.state, [])
@@ -498,6 +513,10 @@ class PieceStateCreateSerializer(serializers.ModelSerializer):
         return value
 
     def create(self, validated_data: dict) -> PieceState:
+        from django.db.models import F, Max
+
+        from .workflow import can_reach
+
         images = validated_data.pop("images", [])
 
         new_state_id: str = validated_data["state"]
@@ -508,6 +527,36 @@ class PieceStateCreateSerializer(serializers.ModelSerializer):
         )
 
         validated_data["custom_fields"] = inline_fields
+
+        if piece.is_editable:
+            existing = list(piece.states.values("state", "order"))
+            pred_orders = [
+                ps["order"]
+                for ps in existing
+                if ps["state"] != new_state_id and can_reach(ps["state"], new_state_id)
+            ]
+            succ_orders = [
+                ps["order"]
+                for ps in existing
+                if ps["state"] != new_state_id and can_reach(new_state_id, ps["state"])
+            ]
+            pred_orders_valid = [o for o in pred_orders if o is not None]
+            succ_orders_valid = [o for o in succ_orders if o is not None]
+            if pred_orders_valid:
+                insert_after = max(pred_orders_valid)
+            elif succ_orders_valid:
+                insert_after = min(succ_orders_valid) - 1
+            else:
+                insert_after = piece.states.aggregate(Max("order"))["order__max"] or 0
+            new_order = insert_after + 1
+            piece.states.filter(order__gte=new_order).update(order=F("order") + 1)
+            validated_data["order"] = new_order
+            validated_data["has_been_edited"] = True
+        else:
+            validated_data["order"] = (
+                piece.states.aggregate(Max("order"))["order__max"] or 0
+            ) + 1
+
         try:
             piece_state = PieceState.objects.create(
                 user=piece.user,
@@ -663,6 +712,7 @@ class PieceUpdateSerializer(serializers.Serializer):
     )
     thumbnail = ThumbnailSerializer(required=False, allow_null=True)
     shared = serializers.BooleanField(required=False)
+    is_editable = serializers.BooleanField(required=False)
     tags = serializers.ListField(child=serializers.CharField(), required=False)
     showcase_story = serializers.CharField(required=False, allow_blank=True)
     showcase_fields = serializers.JSONField(required=False)
@@ -675,6 +725,19 @@ class PieceUpdateSerializer(serializers.Serializer):
         if current is None or current.state not in TERMINAL_STATES:
             raise serializers.ValidationError("Only terminal pieces can be shared.")
         return value
+
+    def validate(self, data: dict) -> dict:
+        piece: Piece | None = self.context.get("piece")
+        would_be_editable = data.get(
+            "is_editable", piece.is_editable if piece else False
+        )
+        would_be_shared = data.get("shared", piece.shared if piece else False)
+        if would_be_editable and would_be_shared:
+            raise serializers.ValidationError(
+                "A piece cannot be shared while in editable mode. "
+                "Seal the piece before sharing, or unshare before editing."
+            )
+        return data
 
     def validate_showcase_fields(self, value):
         if not isinstance(value, list):
@@ -721,6 +784,8 @@ class PieceUpdateSerializer(serializers.Serializer):
                 get_task_interface().submit(task)
         if "shared" in validated_data:
             instance.shared = validated_data["shared"]
+        if "is_editable" in validated_data:
+            instance.is_editable = validated_data["is_editable"]
         if "showcase_story" in validated_data:
             instance.showcase_story = validated_data["showcase_story"]
         if "showcase_fields" in validated_data:

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -31,7 +31,7 @@ def client(user):
 @pytest.fixture
 def piece(user, db):
     p = Piece.objects.create(user=user, name="Test Bowl")
-    PieceState.objects.create(piece=p, state=ENTRY_STATE)
+    PieceState.objects.create(piece=p, state=ENTRY_STATE, order=1)
     return p
 
 

--- a/api/tests/test_editable_mode.py
+++ b/api/tests/test_editable_mode.py
@@ -1,0 +1,417 @@
+"""Tests for retroactive state editing (editable mode) — Issue #307."""
+
+import pytest
+from rest_framework.test import APIClient
+
+from api.models import ENTRY_STATE, SUCCESSORS, Piece, PieceState
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _advance(client, piece_id, state):
+    """Advance a piece to the given state via the API."""
+    response = client.post(
+        f"/api/pieces/{piece_id}/states/",
+        {"state": state},
+        format="json",
+    )
+    assert response.status_code == 201, response.json()
+    return response.json()
+
+
+# ---------------------------------------------------------------------------
+# can_reach() — workflow helper
+# ---------------------------------------------------------------------------
+
+
+def test_can_reach_direct_successor():
+    from api.workflow import can_reach
+
+    assert can_reach("designed", "wheel_thrown") is True
+
+
+def test_can_reach_transitive():
+    from api.workflow import can_reach
+
+    assert can_reach("designed", "bisque_fired") is True
+
+
+def test_can_reach_same_state():
+    from api.workflow import can_reach
+
+    assert can_reach("designed", "designed") is True
+
+
+def test_can_reach_impossible():
+    from api.workflow import can_reach
+
+    # Cannot go backwards in the workflow.
+    assert can_reach("bisque_fired", "designed") is False
+
+
+# ---------------------------------------------------------------------------
+# is_editable toggle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestEditableModeToggle:
+    def test_default_not_editable(self, client, piece):
+        response = client.get(f"/api/pieces/{piece.id}/")
+        assert response.json()["is_editable"] is False
+
+    def test_can_enable_editable_mode(self, client, piece):
+        response = client.patch(
+            f"/api/pieces/{piece.id}/",
+            {"is_editable": True},
+            format="json",
+        )
+        assert response.status_code == 200
+        assert response.json()["is_editable"] is True
+
+    def test_can_seal_piece(self, client, piece):
+        client.patch(f"/api/pieces/{piece.id}/", {"is_editable": True}, format="json")
+        response = client.patch(
+            f"/api/pieces/{piece.id}/", {"is_editable": False}, format="json"
+        )
+        assert response.status_code == 200
+        assert response.json()["is_editable"] is False
+
+    def test_cannot_enable_editable_on_shared_piece(self, client, piece):
+        """A shared piece cannot enter editable mode without unsharing first."""
+        # Put piece in a terminal state so it can be shared.
+        piece.states.all().delete()
+        PieceState.objects.create(piece=piece, state="completed", order=1)
+        client.patch(f"/api/pieces/{piece.id}/", {"shared": True}, format="json")
+
+        response = client.patch(
+            f"/api/pieces/{piece.id}/", {"is_editable": True}, format="json"
+        )
+        assert response.status_code == 400
+
+    def test_cannot_share_editable_piece(self, client, piece):
+        """An editable piece cannot be shared without sealing first."""
+        piece.states.all().delete()
+        PieceState.objects.create(piece=piece, state="completed", order=1)
+        client.patch(f"/api/pieces/{piece.id}/", {"is_editable": True}, format="json")
+
+        response = client.patch(
+            f"/api/pieces/{piece.id}/", {"shared": True}, format="json"
+        )
+        assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Retroactive state insertion and ordering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestRetroactiveStateInsertion:
+    def test_normal_transition_sets_order(self, client, piece):
+        """Advancing normally assigns sequential order values."""
+        next_state = SUCCESSORS[ENTRY_STATE][0]
+        data = _advance(client, piece.id, next_state)
+
+        history = data["history"]
+        assert history[0]["state"] == ENTRY_STATE
+        assert history[1]["state"] == next_state
+        piece.refresh_from_db()
+        orders = list(piece.states.order_by("order").values_list("order", flat=True))
+        assert orders == [1, 2]
+
+    def test_retroactive_insert_between_states(self, client, piece):
+        """Inserting waxed between bisque_fired and glazed places it correctly."""
+        client.patch(f"/api/pieces/{piece.id}/", {"is_editable": True}, format="json")
+        piece.refresh_from_db()
+        # Build history: designed → wheel_thrown → trimmed → submitted_to_bisque_fire
+        # → bisque_fired → glazed (skip waxed intentionally)
+        for state in [
+            "wheel_thrown",
+            "trimmed",
+            "submitted_to_bisque_fire",
+            "bisque_fired",
+        ]:
+            PieceState.objects.create(
+                piece=piece, state=state, order=piece.states.count() + 1
+            )
+        # Add glazed as a direct successor of bisque_fired (skipping waxed).
+        PieceState.objects.create(
+            piece=piece, state="glazed", order=piece.states.count() + 1
+        )
+
+        # Now retroactively insert waxed (bisque_fired → waxed → glazed).
+        response = client.post(
+            f"/api/pieces/{piece.id}/states/",
+            {"state": "waxed", "notes": "forgotten step"},
+            format="json",
+        )
+        assert response.status_code == 201
+
+        history = response.json()["history"]
+        states_in_order = [ps["state"] for ps in history]
+        bisque_idx = states_in_order.index("bisque_fired")
+        waxed_idx = states_in_order.index("waxed")
+        glazed_idx = states_in_order.index("glazed")
+
+        assert bisque_idx < waxed_idx < glazed_idx, (
+            f"Expected bisque_fired < waxed < glazed, got indices "
+            f"{bisque_idx}, {waxed_idx}, {glazed_idx}"
+        )
+
+    def test_retroactive_insert_sets_has_been_edited(self, client, piece):
+        """States created while is_editable=True have has_been_edited=True."""
+        client.patch(f"/api/pieces/{piece.id}/", {"is_editable": True}, format="json")
+        next_state = SUCCESSORS[ENTRY_STATE][0]
+
+        response = client.post(
+            f"/api/pieces/{piece.id}/states/",
+            {"state": next_state},
+            format="json",
+        )
+        assert response.status_code == 201
+        history = response.json()["history"]
+        new_state = next(ps for ps in history if ps["state"] == next_state)
+        assert new_state["has_been_edited"] is True
+
+    def test_normal_transition_does_not_set_has_been_edited(self, client, piece):
+        next_state = SUCCESSORS[ENTRY_STATE][0]
+        response = _advance(client, piece.id, next_state)
+        history = response["history"]
+        new_state = next(ps for ps in history if ps["state"] == next_state)
+        assert new_state["has_been_edited"] is False
+
+    def test_retroactive_insert_with_no_predecessor_or_successor_appends(
+        self, client, piece
+    ):
+        """A state with no reachable predecessors or successors in history appends at end."""
+        client.patch(f"/api/pieces/{piece.id}/", {"is_editable": True}, format="json")
+        piece.refresh_from_db()
+        # designed (order=1), recycled has no common reachability path via normal
+        # transitions; but we can still insert it retroactively.
+        response = client.post(
+            f"/api/pieces/{piece.id}/states/",
+            {"state": "recycled"},
+            format="json",
+        )
+        assert response.status_code == 201
+        history = response.json()["history"]
+        last_state = history[-1]["state"]
+        assert last_state == "recycled"
+
+    def test_successor_validation_bypassed_when_editable(self, client, piece):
+        """Non-sequential state insertion is allowed when piece.is_editable."""
+        client.patch(f"/api/pieces/{piece.id}/", {"is_editable": True}, format="json")
+        response = client.post(
+            f"/api/pieces/{piece.id}/states/",
+            {"state": "bisque_fired"},
+            format="json",
+        )
+        assert response.status_code == 201
+
+    def test_successor_validation_enforced_when_not_editable(self, client, piece):
+        """Non-sequential state insertion is rejected when piece is not editable."""
+        response = client.post(
+            f"/api/pieces/{piece.id}/states/",
+            {"state": "bisque_fired"},
+            format="json",
+        )
+        assert response.status_code == 400
+
+    def test_current_state_reflects_highest_order(self, client, piece):
+        """current_state returns the state with the highest order after retroactive insertion."""
+        client.patch(f"/api/pieces/{piece.id}/", {"is_editable": True}, format="json")
+        piece.refresh_from_db()
+        # Insert glazed first (order=2), then retroactively insert waxed before it.
+        PieceState.objects.create(piece=piece, state="bisque_fired", order=2)
+        PieceState.objects.create(piece=piece, state="glazed", order=3)
+
+        # Insert waxed between bisque_fired and glazed.
+        response = client.post(
+            f"/api/pieces/{piece.id}/states/",
+            {"state": "waxed"},
+            format="json",
+        )
+        assert response.status_code == 201
+        # glazed should now be at the highest order and remain current_state.
+        assert response.json()["current_state"]["state"] == "glazed"
+
+
+# ---------------------------------------------------------------------------
+# Past state PATCH endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestPastStatePatch:
+    def test_returns_403_when_not_editable(self, client, piece):
+        state_id = piece.current_state.pk
+        response = client.patch(
+            f"/api/pieces/{piece.id}/states/{state_id}/",
+            {"notes": "retroactive notes"},
+            format="json",
+        )
+        assert response.status_code == 403
+
+    def test_can_patch_past_state_when_editable(self, client, piece):
+        initial_state = piece.current_state
+        next_state = SUCCESSORS[ENTRY_STATE][0]
+        _advance(client, piece.id, next_state)
+
+        client.patch(f"/api/pieces/{piece.id}/", {"is_editable": True}, format="json")
+        piece.refresh_from_db()
+
+        response = client.patch(
+            f"/api/pieces/{piece.id}/states/{initial_state.pk}/",
+            {"notes": "retroactive edit"},
+            format="json",
+        )
+        assert response.status_code == 200
+        history = response.json()["history"]
+        first = next(ps for ps in history if ps["state"] == ENTRY_STATE)
+        assert first["notes"] == "retroactive edit"
+
+    def test_patch_past_state_sets_has_been_edited(self, client, piece):
+        initial_state = piece.current_state
+        next_state = SUCCESSORS[ENTRY_STATE][0]
+        _advance(client, piece.id, next_state)
+
+        client.patch(f"/api/pieces/{piece.id}/", {"is_editable": True}, format="json")
+        piece.refresh_from_db()
+
+        client.patch(
+            f"/api/pieces/{piece.id}/states/{initial_state.pk}/",
+            {"notes": "retroactive edit"},
+            format="json",
+        )
+        initial_state.refresh_from_db()
+        assert initial_state.has_been_edited is True
+
+    def test_patch_past_state_returns_403_after_sealing(self, client, piece):
+        initial_state = piece.current_state
+        next_state = SUCCESSORS[ENTRY_STATE][0]
+        _advance(client, piece.id, next_state)
+
+        client.patch(f"/api/pieces/{piece.id}/", {"is_editable": True}, format="json")
+        client.patch(f"/api/pieces/{piece.id}/", {"is_editable": False}, format="json")
+
+        response = client.patch(
+            f"/api/pieces/{piece.id}/states/{initial_state.pk}/",
+            {"notes": "blocked"},
+            format="json",
+        )
+        assert response.status_code == 403
+
+    def test_non_owner_cannot_patch_past_state(self, client, piece, other_user):
+        initial_state = piece.current_state
+        piece.is_editable = True
+        piece.save()
+
+        other_client = APIClient()
+        other_client.force_authenticate(user=other_user)
+        response = other_client.patch(
+            f"/api/pieces/{piece.id}/states/{initial_state.pk}/",
+            {"notes": "not my piece"},
+            format="json",
+        )
+        assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Shared piece visibility when editable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestEditableSharedVisibility:
+    def _make_shared_terminal(self, user):
+        p = Piece.objects.create(user=user, name="Shared Piece")
+        PieceState.objects.create(piece=p, state="completed", order=1)
+        p.shared = True
+        p.save()
+        return p
+
+    def test_editable_piece_invisible_to_non_owner(self, piece, other_user):
+        piece.states.all().delete()
+        PieceState.objects.create(piece=piece, state="completed", order=1)
+        piece.shared = True
+        piece.is_editable = True
+        piece.save()
+
+        other_client = APIClient()
+        other_client.force_authenticate(user=other_user)
+        response = other_client.get(f"/api/pieces/{piece.id}/")
+        assert response.status_code == 404
+
+    def test_editable_piece_still_visible_to_owner(self, client, piece):
+        piece.is_editable = True
+        piece.save()
+
+        response = client.get(f"/api/pieces/{piece.id}/")
+        assert response.status_code == 200
+
+    def test_sealed_piece_visible_to_non_owner_again(self, piece, other_user):
+        piece.states.all().delete()
+        PieceState.objects.create(piece=piece, state="completed", order=1)
+        piece.shared = True
+        piece.is_editable = True
+        piece.save()
+
+        # Seal the piece.
+        piece.is_editable = False
+        piece.save()
+
+        other_client = APIClient()
+        other_client.force_authenticate(user=other_user)
+        response = other_client.get(f"/api/pieces/{piece.id}/")
+        assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Glaze combination images analysis — editable pieces excluded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestGlazeCombinationImagesExcludesEditable:
+    def test_editable_piece_excluded(self, client, piece, user):
+        from django.apps import apps
+
+        from api.models import GlazeCombination, Image, PieceStateImage
+
+        gc = GlazeCombination.objects.create(user=user, name="Test Glaze")
+        GlazeCombinationRef = apps.get_model("api", "PieceStateGlazeCombinationRef")
+
+        piece.states.all().delete()
+        glazed = PieceState.objects.create(piece=piece, state="glazed", order=1)
+        GlazeCombinationRef.objects.create(
+            piece_state=glazed, field_name="glaze_combination", glaze_combination=gc
+        )
+        img = Image.objects.create(user=user, url="https://example.com/img.jpg")
+        PieceStateImage.objects.create(piece_state=glazed, image=img, order=1)
+
+        # Without editable: appears in analysis.
+        response = client.get("/api/analysis/glaze-combination-images/")
+        assert response.status_code == 200
+        combo_ids = {entry["glaze_combination"]["id"] for entry in response.json()}
+        assert str(gc.pk) in combo_ids
+
+        # Enable editable mode: disappears from analysis.
+        piece.is_editable = True
+        piece.save()
+        response = client.get("/api/analysis/glaze-combination-images/")
+        combo_ids_editable = {
+            entry["glaze_combination"]["id"] for entry in response.json()
+        }
+        assert str(gc.pk) not in combo_ids_editable
+
+        # Seal: reappears.
+        piece.is_editable = False
+        piece.save()
+        response = client.get("/api/analysis/glaze-combination-images/")
+        combo_ids_sealed = {
+            entry["glaze_combination"]["id"] for entry in response.json()
+        }
+        assert str(gc.pk) in combo_ids_sealed

--- a/api/tests/test_global_entries.py
+++ b/api/tests/test_global_entries.py
@@ -166,6 +166,7 @@ class TestGlobalEntries:
                 "last_modified": piece.last_modified.isoformat().replace("+00:00", "Z"),
                 "thumbnail": None,
                 "shared": False,
+                "is_editable": False,
                 "showcase_story": "",
                 "showcase_fields": [],
                 "can_edit": True,

--- a/api/tests/test_pieces_list.py
+++ b/api/tests/test_pieces_list.py
@@ -36,6 +36,7 @@ class TestPiecesList:
             "last_modified",
             "thumbnail",
             "shared",
+            "is_editable",
             "can_edit",
             "current_state",
             "tags",

--- a/api/urls.py
+++ b/api/urls.py
@@ -36,6 +36,11 @@ urlpatterns = [
     path("pieces/<uuid:piece_id>/", views.piece_detail, name="piece-detail"),
     path("pieces/<uuid:piece_id>/states/", views.piece_states, name="piece-states"),
     path(
+        "pieces/<uuid:piece_id>/states/<uuid:state_id>/",
+        views.piece_past_state,
+        name="piece-past-state",
+    ),
+    path(
         "pieces/<uuid:piece_id>/current_state/",
         views.piece_current_state_detail,
         name="piece-current-state-detail",

--- a/api/views.py
+++ b/api/views.py
@@ -122,8 +122,10 @@ def _piece_queryset(request: Request):
 def _piece_read_queryset(request: Request):
     qs = Piece.objects.prefetch_related("states", "tag_links__tag")
     if request.user.is_authenticated:
-        return qs.filter(Q(user=request.user) | Q(shared=True))
-    return qs.filter(shared=True)
+        # Editable pieces are inaccessible to non-owners even when shared=True,
+        # without altering the shared flag itself.
+        return qs.filter(Q(user=request.user) | Q(shared=True, is_editable=False))
+    return qs.filter(shared=True, is_editable=False)
 
 
 def _serialize_piece_detail(piece: Piece, request: Request):
@@ -315,6 +317,32 @@ def piece_current_state(request: Request, piece_id: str) -> Response:
     serializer = PieceStateUpdateSerializer(data=request.data)
     serializer.is_valid(raise_exception=True)
     serializer.update(current, serializer.validated_data)
+    piece.refresh_from_db()
+    return Response(_serialize_piece_detail(piece, request))
+
+
+@extend_schema(
+    methods=["PATCH"],
+    request=PieceStateUpdateSerializer,
+    responses={200: PieceDetailSerializer},
+)
+@api_view(["PATCH"])
+@permission_classes([IsAuthenticated])
+def piece_past_state(request: Request, piece_id: str, state_id: str) -> Response:
+    """Patch a past (sealed) state while the piece is in editable mode.
+
+    Returns 403 if the piece is not currently in editable mode.
+    """
+    piece = get_object_or_404(_piece_queryset(request), pk=piece_id)
+    if not piece.is_editable:
+        return Response(
+            {"detail": "Piece is not in editable mode."},
+            status=status.HTTP_403_FORBIDDEN,
+        )
+    ps = get_object_or_404(piece.states, pk=state_id)
+    serializer = PieceStateUpdateSerializer(data=request.data)
+    serializer.is_valid(raise_exception=True)
+    serializer.update(ps, serializer.validated_data)
     piece.refresh_from_db()
     return Response(_serialize_piece_detail(piece, request))
 
@@ -1007,7 +1035,10 @@ def glaze_combination_images(request: Request) -> Response:
     # Current states such as "completed" may not carry their own junction row, so
     # use the most recent state that does.
     refs = (
-        GlazeCombinationRef.objects.filter(piece_state__piece__user=request.user)
+        GlazeCombinationRef.objects.filter(
+            piece_state__piece__user=request.user,
+            piece_state__piece__is_editable=False,
+        )
         .values("piece_state__piece_id", "glaze_combination_id")
         .order_by("piece_state__piece_id", "-piece_state__created")
     )
@@ -1027,6 +1058,7 @@ def glaze_combination_images(request: Request) -> Response:
         PieceState.objects.filter(
             piece_id__in=piece_to_combo.keys(),
             piece__user=request.user,  # type: ignore[misc]
+            piece__is_editable=False,
             state__in=qualifying,
             image_links__isnull=False,
         )

--- a/api/workflow.py
+++ b/api/workflow.py
@@ -73,6 +73,25 @@ def get_state_summary(state_id: str) -> dict:
     return dict(_STATE_MAP.get(state_id, {}).get("summary", {}))
 
 
+def can_reach(src_state_id: str, dst_state_id: str) -> bool:
+    """Return True if dst_state_id is reachable from src_state_id in the workflow graph.
+
+    Uses DFS over SUCCESSORS.  Used during retroactive state insertion to
+    determine where in a piece's history a new state logically belongs.
+    """
+    visited: set[str] = set()
+    stack = [src_state_id]
+    while stack:
+        node = stack.pop()
+        if node == dst_state_id:
+            return True
+        if node in visited:
+            continue
+        visited.add(node)
+        stack.extend(SUCCESSORS.get(node, []))
+    return False
+
+
 def get_state_ref_fields(state_id: str) -> dict[str, tuple[str, str]]:
     """Return {field_name: (source_state_id, source_field_name)} for all state ref fields.
 

--- a/env.sh
+++ b/env.sh
@@ -420,7 +420,7 @@ gz_test() {
         # Exclude lint targets from coverage (they don't produce coverage data and slow down the pass)
         local coverage_target
         echo "Determining coverage targets (excluding 'lint' tagged targets)..."
-        coverage_target=$(bazel query "($target) except attr(tags, lint, //...)" 2>/dev/null | tr '\n' ' ')
+        coverage_target=$(bazel query "tests(set($target)) except attr(tags, lint, //...)" 2>/dev/null | tr '\n' ' ')
         if [[ -z "$coverage_target" ]]; then
             echo "No coverage targets found."
             return 0

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -406,6 +406,7 @@ js_library(
         ":image_lightbox_src",
         ":node_modules",
         ":util_lib",
+        ":workflow_state_src",
     ],
 )
 

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -9,6 +9,7 @@ import {
   Alert,
   alpha,
   Box,
+  Button,
   Divider,
   IconButton,
   TextField,
@@ -18,6 +19,8 @@ import {
 import EditIcon from "@mui/icons-material/Edit";
 import CheckIcon from "@mui/icons-material/Check";
 import CloseIcon from "@mui/icons-material/Close";
+import HistoryIcon from "@mui/icons-material/History";
+import LockIcon from "@mui/icons-material/Lock";
 import { useBlocker } from "react-router-dom";
 import type { PieceDetail as PieceDetailType } from "../util/types";
 import { formatState, isTerminalState } from "../util/types";
@@ -112,6 +115,58 @@ function SectionCard({ eyebrow, title, subtitle, children }: SectionCardProps) {
         )}
       </Box>
       <Box sx={{ px: { xs: 1.5, sm: 2 }, pb: 1.5 }}>{children}</Box>
+    </Box>
+  );
+}
+
+function EditableToggle({ piece, onPieceUpdated }: PieceDetailProps) {
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function toggle() {
+    setSaving(true);
+    setError(null);
+    try {
+      const updated = await updatePiece(piece.id, {
+        is_editable: !piece.is_editable,
+      });
+      onPieceUpdated(updated);
+    } catch {
+      setError("Failed to update. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Box>
+      {piece.is_editable ? (
+        <Button
+          variant="contained"
+          size="small"
+          startIcon={<LockIcon fontSize="small" />}
+          onClick={toggle}
+          disabled={saving}
+        >
+          Seal changes
+        </Button>
+      ) : (
+        <Button
+          variant="outlined"
+          size="small"
+          startIcon={<HistoryIcon fontSize="small" />}
+          onClick={toggle}
+          disabled={saving}
+          sx={{ borderStyle: "dashed", color: "text.secondary" }}
+        >
+          Edit piece history
+        </Button>
+      )}
+      {error && (
+        <Typography variant="caption" color="error" sx={{ ml: 1 }}>
+          {error}
+        </Typography>
+      )}
     </Box>
   );
 }
@@ -441,6 +496,11 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
                 <ShareControls piece={piece} onPieceUpdated={onPieceUpdated} />
               </Box>
             )}
+            {canEdit && (
+              <Box sx={{ mb: 1.5 }}>
+                <EditableToggle piece={piece} onPieceUpdated={onPieceUpdated} />
+              </Box>
+            )}
             <Box sx={{ mb: 1.5 }}>
               <SectionCard>
                 <GlobalEntryField
@@ -601,7 +661,11 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
           title="Timeline"
           subtitle={`${pastHistory.length} completed state${pastHistory.length === 1 ? "" : "s"}`}
         >
-          <PieceHistory pastHistory={pastHistory} />
+          <PieceHistory
+            pastHistory={pastHistory}
+            piece={piece}
+            onPieceUpdated={onPieceUpdated}
+          />
         </SectionCard>
       </Box>
 

--- a/web/src/components/PieceHistory.tsx
+++ b/web/src/components/PieceHistory.tsx
@@ -1,17 +1,145 @@
 import { useState } from "react";
+import AddIcon from "@mui/icons-material/Add";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import { alpha, Box, Collapse, List, ListItem, ListItemText, Typography } from "@mui/material";
-import type { PieceState } from "../util/types";
-import { formatPastState } from "../util/types";
+import {
+  alpha,
+  Box,
+  Button,
+  Collapse,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  List,
+  ListItem,
+  ListItemText,
+  MenuItem,
+  TextField,
+  Typography,
+} from "@mui/material";
+import type {
+  PieceDetail as PieceDetailType,
+  PieceState,
+  State,
+} from "../util/types";
+import { formatPastState, formatState, STATES } from "../util/types";
+import { addPieceState, updatePastState } from "../util/api";
+import WorkflowState from "./WorkflowState";
 
 type PieceHistoryProps = {
   pastHistory: PieceState[];
+  piece?: PieceDetailType;
+  onPieceUpdated?: (updated: PieceDetailType) => void;
 };
 
-export default function PieceHistory({ pastHistory }: PieceHistoryProps) {
-  const [historyOpen, setHistoryOpen] = useState(false);
+function AddMissingStateDialog({
+  open,
+  onClose,
+  piece,
+  onPieceUpdated,
+}: {
+  open: boolean;
+  onClose: () => void;
+  piece: PieceDetailType;
+  onPieceUpdated: (updated: PieceDetailType) => void;
+}) {
+  const presentStates = new Set<State>(piece.history.map((ps) => ps.state));
+  const availableStates = (STATES as State[]).filter(
+    (s) => !presentStates.has(s),
+  );
 
-  if (pastHistory.length === 0) return null;
+  const [selectedState, setSelectedState] = useState<State | "">("");
+  const [notes, setNotes] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function handleClose() {
+    setSelectedState("");
+    setNotes("");
+    setError(null);
+    onClose();
+  }
+
+  async function handleSubmit() {
+    if (!selectedState) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const updated = await addPieceState(piece.id, {
+        state: selectedState as PieceState["state"],
+        notes: notes.trim() || undefined,
+      });
+      onPieceUpdated(updated);
+      handleClose();
+    } catch {
+      setError("Failed to add state. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={handleClose} fullWidth maxWidth="xs">
+      <DialogTitle>Add missing state</DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 0.5 }}>
+          <TextField
+            select
+            label="State"
+            value={selectedState}
+            onChange={(e) => setSelectedState(e.target.value as State)}
+            fullWidth
+            size="small"
+          >
+            {availableStates.map((s) => (
+              <MenuItem key={s} value={s}>
+                {formatState(s)}
+              </MenuItem>
+            ))}
+          </TextField>
+          <TextField
+            label="Notes"
+            multiline
+            rows={3}
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            fullWidth
+            size="small"
+            slotProps={{ htmlInput: { maxLength: 2000 } }}
+          />
+          {error && (
+            <Typography variant="caption" color="error">
+              {error}
+            </Typography>
+          )}
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} disabled={saving}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          disabled={!selectedState || saving}
+        >
+          Add state
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export default function PieceHistory({
+  pastHistory,
+  piece,
+  onPieceUpdated,
+}: PieceHistoryProps) {
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [addDialogOpen, setAddDialogOpen] = useState(false);
+  const isEditable = piece?.is_editable ?? false;
+
+  if (pastHistory.length === 0 && !isEditable) return null;
 
   return (
     <Box>
@@ -48,35 +176,98 @@ export default function PieceHistory({ pastHistory }: PieceHistoryProps) {
       </Box>
       <Collapse in={historyOpen}>
         <List dense sx={{ display: "grid", gap: 1.25 }}>
-          {pastHistory.map((ps, i) => (
-            <ListItem
-              key={i}
-              disableGutters
-              sx={(theme) => ({
-                px: 1.5,
-                py: 1.5,
-                borderRadius: 3,
-                border: "1px solid",
-                borderColor: "divider",
-                backgroundColor: alpha(
-                  theme.palette.background.default,
-                  0.34,
-                ),
-                flexDirection: "column",
-                alignItems: "flex-start",
-              })}
-            >
-              <ListItemText
-                primary={formatPastState(ps.state)}
-                secondary={`${ps.created.toLocaleString()}${ps.notes ? " — " + ps.notes : ""}`}
-                slotProps={{
-                  primary: { sx: { color: "text.primary" } },
-                  secondary: { sx: { color: "text.secondary" } },
-                }}
-              />
-            </ListItem>
-          ))}
+          {pastHistory.map((ps, i) =>
+            isEditable && piece && onPieceUpdated ? (
+              <ListItem
+                key={ps.id ?? i}
+                disableGutters
+                sx={(theme) => ({
+                  px: 1.5,
+                  py: 1.5,
+                  borderRadius: 3,
+                  border: "1px solid",
+                  borderColor: "divider",
+                  backgroundColor: alpha(
+                    theme.palette.background.default,
+                    0.34,
+                  ),
+                  flexDirection: "column",
+                  alignItems: "flex-start",
+                })}
+              >
+                <Typography
+                  variant="caption"
+                  sx={{
+                    mb: 0.75,
+                    color: "text.secondary",
+                    letterSpacing: "0.1em",
+                    textTransform: "uppercase",
+                  }}
+                >
+                  {formatPastState(ps.state)}
+                </Typography>
+                <Box sx={{ width: "100%" }}>
+                  <WorkflowState
+                    key={ps.id}
+                    initialPieceState={ps}
+                    pieceId={piece.id}
+                    onSaved={onPieceUpdated}
+                    hideImageUpload
+                    saveStateFn={(payload) =>
+                      updatePastState(piece.id, ps.id, payload)
+                    }
+                  />
+                </Box>
+              </ListItem>
+            ) : (
+              <ListItem
+                key={ps.id ?? i}
+                disableGutters
+                sx={(theme) => ({
+                  px: 1.5,
+                  py: 1.5,
+                  borderRadius: 3,
+                  border: "1px solid",
+                  borderColor: "divider",
+                  backgroundColor: alpha(
+                    theme.palette.background.default,
+                    0.34,
+                  ),
+                  flexDirection: "column",
+                  alignItems: "flex-start",
+                })}
+              >
+                <ListItemText
+                  primary={formatPastState(ps.state)}
+                  secondary={`${ps.created.toLocaleString()}${ps.notes ? " — " + ps.notes : ""}`}
+                  slotProps={{
+                    primary: { sx: { color: "text.primary" } },
+                    secondary: { sx: { color: "text.secondary" } },
+                  }}
+                />
+              </ListItem>
+            ),
+          )}
         </List>
+        {isEditable && piece && onPieceUpdated && (
+          <Box sx={{ mt: 1 }}>
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<AddIcon />}
+              onClick={() => setAddDialogOpen(true)}
+              sx={{ borderStyle: "dashed" }}
+            >
+              Add missing state
+            </Button>
+            <AddMissingStateDialog
+              open={addDialogOpen}
+              onClose={() => setAddDialogOpen(false)}
+              piece={piece}
+              onPieceUpdated={onPieceUpdated}
+            />
+          </Box>
+        )}
       </Collapse>
     </Box>
   );

--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -24,6 +24,7 @@ import {
   fetchCloudinaryWidgetConfig,
   signCloudinaryWidgetParams,
   updateCurrentState,
+  type UpdateStatePayload,
 } from "../util/api";
 import {
   getCustomFieldDefinitions,
@@ -47,6 +48,8 @@ type WorkflowStateProps = {
   onDirtyChange?: (dirty: boolean) => void;
   autosaveDelayMs?: number;
   readOnly?: boolean;
+  hideImageUpload?: boolean;
+  saveStateFn?: (payload: UpdateStatePayload) => Promise<PieceDetail>;
 };
 
 
@@ -159,6 +162,8 @@ export default function WorkflowState({
   onDirtyChange,
   autosaveDelayMs,
   readOnly = false,
+  hideImageUpload = false,
+  saveStateFn,
 }: WorkflowStateProps) {
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [widgetLoading, setWidgetLoading] = useState(false);
@@ -219,15 +224,21 @@ export default function WorkflowState({
       images,
       custom_fields: normalizedCustomFields,
     };
-    const result = await updateCurrentState(pieceId, payload);
-    dispatch({ type: "replace_base_state", pieceState: result.current_state });
+    const saveFn = saveStateFn ?? ((p) => updateCurrentState(pieceId, p));
+    const result = await saveFn(payload);
+    const savedState = saveStateFn
+      ? result.history.find((ps) => ps.id === initialPieceState.id) ?? result.current_state
+      : result.current_state;
+    dispatch({ type: "replace_base_state", pieceState: savedState });
     onSaved(result);
   }, [
     pieceId,
     images,
+    initialPieceState.id,
     normalizedCustomFields,
     notes,
     onSaved,
+    saveStateFn,
   ]);
 
   const autosaveKey = useMemo(
@@ -257,15 +268,20 @@ export default function WorkflowState({
         .catch(() => undefined)
         .then(async () => {
           const nextImages = [...latestImagesRef.current, newImage];
-          const result = await updateCurrentState(pieceId, {
+          const payload = {
             notes,
             images: nextImages,
             custom_fields: normalizedCustomFields,
-          });
-          latestImagesRef.current = result.current_state.images;
+          };
+          const saveFn = saveStateFn ?? ((p) => updateCurrentState(pieceId, p));
+          const result = await saveFn(payload);
+          const savedState = saveStateFn
+            ? result.history.find((ps) => ps.id === initialPieceState.id) ?? result.current_state
+            : result.current_state;
+          latestImagesRef.current = savedState.images;
           dispatch({
             type: "replace_base_state",
-            pieceState: result.current_state,
+            pieceState: savedState,
           });
           onSaved(result);
         });
@@ -280,7 +296,7 @@ export default function WorkflowState({
           }
         });
     },
-    [normalizedCustomFields, notes, onSaved, pieceId],
+    [initialPieceState.id, normalizedCustomFields, notes, onSaved, pieceId, saveStateFn],
   );
 
   useEffect(() => {
@@ -589,7 +605,7 @@ export default function WorkflowState({
         uploadError={uploadError}
         imageError={imageError}
         mobile={isMobileLayout}
-        hidden={readOnly}
+        hidden={readOnly || hideImageUpload}
         onUploadClick={handleUploadWidgetClick}
       />
     </Box>

--- a/web/src/components/__tests__/NewPieceDialog.test.tsx
+++ b/web/src/components/__tests__/NewPieceDialog.test.tsx
@@ -27,8 +27,12 @@ function makePieceDetail(): PieceDetail {
     created: new Date("2024-01-15T10:00:00Z"),
     last_modified: new Date("2024-01-15T10:00:00Z"),
     thumbnail: null,
+    shared: false,
+    is_editable: false,
+    can_edit: true,
     current_location: null,
     current_state: {
+      id: "state-id-1",
       state: "designed",
       notes: "",
       created: new Date("2024-01-15T10:00:00Z"),
@@ -37,8 +41,11 @@ function makePieceDetail(): PieceDetail {
       custom_fields: {},
       previous_state: null,
       next_state: null,
+      has_been_edited: false,
     },
     tags: [],
+    showcase_story: "",
+    showcase_fields: [],
     history: [],
   };
 }

--- a/web/src/components/__tests__/PieceDetail.test.tsx
+++ b/web/src/components/__tests__/PieceDetail.test.tsx
@@ -139,6 +139,7 @@ vi.mock("../../util/api", () => ({
   fetchGlobalEntries: vi.fn().mockResolvedValue([]),
   fetchGlobalEntriesWithFilters: vi.fn().mockResolvedValue([]),
   updateCurrentState: vi.fn(),
+  updatePastState: vi.fn(),
   addPieceState: vi.fn(),
   updatePiece: vi.fn(),
   createTagEntry: vi.fn(),
@@ -150,6 +151,7 @@ vi.mock("../../util/api", () => ({
 
 function makeState(overrides: Partial<PieceState> = {}): PieceState {
   return {
+    id: "state-id-1",
     state: "designed",
     notes: "",
     created: new Date("2024-01-15T10:00:00Z"),
@@ -158,6 +160,7 @@ function makeState(overrides: Partial<PieceState> = {}): PieceState {
     custom_fields: {},
     previous_state: null,
     next_state: null,
+    has_been_edited: false,
     ...overrides,
   };
 }
@@ -175,10 +178,13 @@ function makePiece(overrides: Partial<PieceDetailType> = {}): PieceDetailType {
       cloud_name: null,
     },
     shared: false,
+    is_editable: false,
     can_edit: true,
     current_state: state,
     current_location: "",
     tags: [],
+    showcase_story: "",
+    showcase_fields: [],
     history: [state],
     ...overrides,
   };
@@ -804,6 +810,48 @@ describe("PieceDetail", () => {
       expect(
         screen.getByRole("button", { name: "Save tags" }),
       ).toBeInTheDocument();
+    });
+  });
+
+  describe("editable mode toggle", () => {
+    it("renders 'Edit piece history' button when is_editable=false", async () => {
+      await renderPieceDetail(makePiece({ is_editable: false }));
+      expect(
+        screen.getByRole("button", { name: /edit piece history/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders 'Seal changes' button when is_editable=true", async () => {
+      await renderPieceDetail(makePiece({ is_editable: true }));
+      expect(
+        screen.getByRole("button", { name: /seal changes/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("calls updatePiece with is_editable=true when 'Edit piece history' is clicked", async () => {
+      const updated = makePiece({ is_editable: true });
+      vi.mocked(api.updatePiece).mockResolvedValueOnce(updated);
+      await renderPieceDetail(makePiece({ is_editable: false }));
+      fireEvent.click(screen.getByRole("button", { name: /edit piece history/i }));
+      await waitFor(() => {
+        expect(api.updatePiece).toHaveBeenCalledWith(
+          "piece-id-1",
+          expect.objectContaining({ is_editable: true }),
+        );
+      });
+    });
+
+    it("calls updatePiece with is_editable=false when 'Seal changes' is clicked", async () => {
+      const updated = makePiece({ is_editable: false });
+      vi.mocked(api.updatePiece).mockResolvedValueOnce(updated);
+      await renderPieceDetail(makePiece({ is_editable: true }));
+      fireEvent.click(screen.getByRole("button", { name: /seal changes/i }));
+      await waitFor(() => {
+        expect(api.updatePiece).toHaveBeenCalledWith(
+          "piece-id-1",
+          expect.objectContaining({ is_editable: false }),
+        );
+      });
     });
   });
 });

--- a/web/src/components/__tests__/PieceHistory.test.tsx
+++ b/web/src/components/__tests__/PieceHistory.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { act, render, screen, fireEvent } from "@testing-library/react";
+import { act, render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import PieceHistory from "../PieceHistory";
-import type { PieceState } from "../../util/types";
+import type { PieceDetail as PieceDetailType, PieceState } from "../../util/types";
+import * as api from "../../util/api";
 
 vi.mock("../../../workflow.yml", () => ({
   default: {
@@ -28,8 +29,48 @@ vi.mock("../../../workflow.yml", () => ({
   },
 }));
 
+vi.mock("../../util/api", () => ({
+  fetchGlobalEntries: vi.fn().mockResolvedValue([]),
+  fetchGlobalEntriesWithFilters: vi.fn().mockResolvedValue([]),
+  updateCurrentState: vi.fn(),
+  updatePastState: vi.fn(),
+  addPieceState: vi.fn(),
+  updatePiece: vi.fn(),
+}));
+
+vi.mock("../WorkflowState", () => ({
+  default: ({
+    initialPieceState,
+    onSaved,
+    saveStateFn,
+  }: {
+    initialPieceState: PieceState;
+    onSaved: (updated: PieceDetailType) => void;
+    saveStateFn?: (payload: { notes: string }) => Promise<PieceDetailType>;
+  }) => (
+    <div>
+      <label>
+        Notes
+        <input aria-label="Notes" defaultValue={initialPieceState.notes} />
+      </label>
+      {saveStateFn && (
+        <button
+          type="button"
+          onClick={async () => {
+            const updated = await saveStateFn({ notes: "edited note" });
+            onSaved(updated);
+          }}
+        >
+          Save past state
+        </button>
+      )}
+    </div>
+  ),
+}));
+
 function makeState(overrides: Partial<PieceState> = {}): PieceState {
   return {
+    id: "state-id-1",
     state: "designed",
     notes: "",
     created: new Date("2024-01-15T10:00:00Z"),
@@ -38,6 +79,28 @@ function makeState(overrides: Partial<PieceState> = {}): PieceState {
     previous_state: null,
     next_state: null,
     custom_fields: {},
+    has_been_edited: false,
+    ...overrides,
+  };
+}
+
+function makePiece(overrides: Partial<PieceDetailType> = {}): PieceDetailType {
+  const state = makeState();
+  return {
+    id: "piece-id-1",
+    name: "Test Bowl",
+    created: new Date("2024-01-15T10:00:00Z"),
+    last_modified: new Date("2024-01-15T10:00:00Z"),
+    thumbnail: null,
+    shared: false,
+    is_editable: false,
+    can_edit: true,
+    current_state: state,
+    current_location: "",
+    tags: [],
+    showcase_story: "",
+    showcase_fields: [],
+    history: [state],
     ...overrides,
   };
 }
@@ -137,5 +200,190 @@ describe("PieceHistory", () => {
       screen.queryByRole("button", { name: /view image/i }),
     ).not.toBeInTheDocument();
     expect(screen.queryByText("First")).not.toBeInTheDocument();
+  });
+
+  it("renders 'Add missing state' button when is_editable and history is open", async () => {
+    const piece = makePiece({ is_editable: true });
+    await act(async () => {
+      render(
+        <PieceHistory
+          pastHistory={[makeState({ state: "designed" })]}
+          piece={piece}
+          onPieceUpdated={vi.fn()}
+        />,
+      );
+    });
+    fireEvent.click(screen.getByRole("button", { name: /show history/i }));
+    expect(
+      screen.getByRole("button", { name: /add missing state/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render 'Add missing state' button when not editable", async () => {
+    const piece = makePiece({ is_editable: false });
+    await act(async () => {
+      render(
+        <PieceHistory
+          pastHistory={[makeState({ state: "designed" })]}
+          piece={piece}
+          onPieceUpdated={vi.fn()}
+        />,
+      );
+    });
+    fireEvent.click(screen.getByRole("button", { name: /show history/i }));
+    expect(
+      screen.queryByRole("button", { name: /add missing state/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens 'Add missing state' dialog on button click", async () => {
+    const piece = makePiece({ is_editable: true });
+    await act(async () => {
+      render(
+        <PieceHistory
+          pastHistory={[makeState({ state: "designed" })]}
+          piece={piece}
+          onPieceUpdated={vi.fn()}
+        />,
+      );
+    });
+    fireEvent.click(screen.getByRole("button", { name: /show history/i }));
+    fireEvent.click(screen.getByRole("button", { name: /add missing state/i }));
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+  });
+
+  it("adds a missing state and resets the dialog", async () => {
+    const updated = makePiece();
+    vi.mocked(api.addPieceState).mockResolvedValue(updated);
+    const onPieceUpdated = vi.fn();
+    const piece = makePiece({ is_editable: true });
+    await act(async () => {
+      render(
+        <PieceHistory
+          pastHistory={[makeState({ state: "designed" })]}
+          piece={piece}
+          onPieceUpdated={onPieceUpdated}
+        />,
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /show history/i }));
+    fireEvent.click(screen.getByRole("button", { name: /add missing state/i }));
+    const dialog = screen.getByRole("dialog");
+    fireEvent.mouseDown(screen.getByLabelText("State"));
+    fireEvent.click(screen.getByRole("option", { name: "Throwing" }));
+    fireEvent.change(within(dialog).getByLabelText("Notes"), {
+      target: { value: " forgot this step " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^add state$/i }));
+
+    await waitFor(() => {
+      expect(api.addPieceState).toHaveBeenCalledWith("piece-id-1", {
+        state: "wheel_thrown",
+        notes: "forgot this step",
+      });
+    });
+    expect(onPieceUpdated).toHaveBeenCalledWith(updated);
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  it("keeps the add dialog open and shows an error when adding fails", async () => {
+    vi.mocked(api.addPieceState).mockRejectedValue(new Error("boom"));
+    const piece = makePiece({ is_editable: true });
+    await act(async () => {
+      render(
+        <PieceHistory
+          pastHistory={[makeState({ state: "designed" })]}
+          piece={piece}
+          onPieceUpdated={vi.fn()}
+        />,
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /show history/i }));
+    fireEvent.click(screen.getByRole("button", { name: /add missing state/i }));
+    fireEvent.mouseDown(screen.getByLabelText("State"));
+    fireEvent.click(screen.getByRole("option", { name: "Throwing" }));
+    fireEvent.click(screen.getByRole("button", { name: /^add state$/i }));
+
+    expect(
+      await screen.findByText("Failed to add state. Please try again."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("clears add dialog fields when canceling", async () => {
+    const piece = makePiece({ is_editable: true });
+    await act(async () => {
+      render(
+        <PieceHistory
+          pastHistory={[makeState({ state: "designed" })]}
+          piece={piece}
+          onPieceUpdated={vi.fn()}
+        />,
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /show history/i }));
+    fireEvent.click(screen.getByRole("button", { name: /add missing state/i }));
+    fireEvent.change(within(screen.getByRole("dialog")).getByLabelText("Notes"), {
+      target: { value: "discard me" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /add missing state/i }));
+    expect(within(screen.getByRole("dialog")).getByLabelText("Notes")).toHaveValue("");
+  });
+
+  it("renders editable Notes fields for past states when is_editable", async () => {
+    const piece = makePiece({ is_editable: true });
+    await act(async () => {
+      render(
+        <PieceHistory
+          pastHistory={[makeState({ state: "designed", notes: "old note" })]}
+          piece={piece}
+          onPieceUpdated={vi.fn()}
+        />,
+      );
+    });
+    fireEvent.click(screen.getByRole("button", { name: /show history/i }));
+    await waitFor(() => {
+      expect(screen.getByLabelText("Notes")).toBeInTheDocument();
+    });
+  });
+
+  it("saves edits to a past state through the past-state endpoint", async () => {
+    const updated = makePiece();
+    vi.mocked(api.updatePastState).mockResolvedValue(updated);
+    const onPieceUpdated = vi.fn();
+    const piece = makePiece({ is_editable: true });
+    await act(async () => {
+      render(
+        <PieceHistory
+          pastHistory={[makeState({ id: "past-state-id", state: "designed" })]}
+          piece={piece}
+          onPieceUpdated={onPieceUpdated}
+        />,
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /show history/i }));
+    fireEvent.click(screen.getByRole("button", { name: /save past state/i }));
+
+    await waitFor(() => {
+      expect(api.updatePastState).toHaveBeenCalledWith(
+        "piece-id-1",
+        "past-state-id",
+        { notes: "edited note" },
+      );
+    });
+    expect(onPieceUpdated).toHaveBeenCalledWith(updated);
   });
 });

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -68,6 +68,7 @@ function makePiece(overrides: Partial<PieceSummary> = {}): PieceSummary {
     current_state: { state: "designed" } as any,
     tags: [],
     shared: false,
+    is_editable: false,
     can_edit: true,
     ...overrides,
   };

--- a/web/src/components/__tests__/PiecePhotoGallery.test.tsx
+++ b/web/src/components/__tests__/PiecePhotoGallery.test.tsx
@@ -107,6 +107,7 @@ function makeSingleImage(
 
 function makeUpdatedPiece(overrides: Partial<PieceDetail> = {}): PieceDetail {
   const state = {
+    id: "state-id-1",
     state: "wheel_thrown" as const,
     notes: "Current notes",
     created: new Date("2024-01-16T10:00:00Z"),
@@ -115,6 +116,7 @@ function makeUpdatedPiece(overrides: Partial<PieceDetail> = {}): PieceDetail {
     previous_state: "designed" as const,
     next_state: null,
     custom_fields: {},
+    has_been_edited: false,
   };
   return {
     id: "piece-1",
@@ -122,9 +124,14 @@ function makeUpdatedPiece(overrides: Partial<PieceDetail> = {}): PieceDetail {
     created: new Date("2024-01-15T10:00:00Z"),
     last_modified: new Date("2024-01-16T10:00:00Z"),
     thumbnail: null,
+    shared: false,
+    is_editable: false,
+    can_edit: true,
     current_state: state,
     current_location: "",
     tags: [],
+    showcase_story: "",
+    showcase_fields: [],
     history: [state],
     ...overrides,
   };

--- a/web/src/components/__tests__/PieceShareControls.test.tsx
+++ b/web/src/components/__tests__/PieceShareControls.test.tsx
@@ -17,8 +17,10 @@ function makePiece(overrides: Partial<PieceDetail> = {}): PieceDetail {
     last_modified: new Date("2024-01-15T10:00:00Z"),
     thumbnail: null,
     shared: false,
+    is_editable: false,
     can_edit: true,
     current_state: {
+      id: "state-id-1",
       state: "completed",
       notes: "",
       created: new Date("2024-01-15T10:00:00Z"),
@@ -27,9 +29,12 @@ function makePiece(overrides: Partial<PieceDetail> = {}): PieceDetail {
       custom_fields: {},
       previous_state: null,
       next_state: null,
+      has_been_edited: false,
     },
     current_location: "",
     tags: [],
+    showcase_story: "",
+    showcase_fields: [],
     history: [],
     ...overrides,
   };

--- a/web/src/components/__tests__/TagManager.test.tsx
+++ b/web/src/components/__tests__/TagManager.test.tsx
@@ -36,6 +36,7 @@ vi.mock("../../util/api", () => ({
 
 function makePiece(overrides = {}): PieceDetail {
   const state = {
+    id: "state-id-1",
     state: "designed" as const,
     notes: "",
     created: new Date("2024-01-15T10:00:00Z"),
@@ -44,6 +45,7 @@ function makePiece(overrides = {}): PieceDetail {
     previous_state: null,
     next_state: null,
     custom_fields: {},
+    has_been_edited: false,
   };
   return {
     id: "piece-id-1",
@@ -51,9 +53,14 @@ function makePiece(overrides = {}): PieceDetail {
     created: new Date("2024-01-15T10:00:00Z"),
     last_modified: new Date("2024-01-15T10:00:00Z"),
     thumbnail: null,
+    shared: false,
+    is_editable: false,
+    can_edit: true,
     current_state: state,
     current_location: "",
     tags: [],
+    showcase_story: "",
+    showcase_fields: [],
     history: [state],
     ...overrides,
   };

--- a/web/src/components/__tests__/WorkflowState.test.tsx
+++ b/web/src/components/__tests__/WorkflowState.test.tsx
@@ -170,6 +170,7 @@ vi.mock("../../util/api", () => ({
   fetchGlobalEntries: vi.fn().mockResolvedValue([]),
   fetchGlobalEntriesWithFilters: vi.fn().mockResolvedValue([]),
   updateCurrentState: vi.fn(),
+  updatePastState: vi.fn(),
   updatePiece: vi.fn(),
   createGlobalEntry: vi.fn(),
   toggleGlobalEntryFavorite: vi.fn().mockResolvedValue(undefined),
@@ -196,6 +197,7 @@ vi.mock("../CloudinaryImage", () => ({
 
 function makeState(overrides: Partial<PieceState> = {}): PieceState {
   return {
+    id: "state-id-1",
     state: "designed",
     notes: "",
     created: new Date("2024-01-15T10:00:00Z"),
@@ -204,6 +206,7 @@ function makeState(overrides: Partial<PieceState> = {}): PieceState {
     previous_state: null,
     next_state: null,
     custom_fields: {},
+    has_been_edited: false,
     ...overrides,
   };
 }
@@ -216,9 +219,14 @@ function makePieceDetail(overrides: Partial<PieceDetail> = {}): PieceDetail {
     created: new Date("2024-01-15T10:00:00Z"),
     last_modified: new Date("2024-01-15T10:00:00Z"),
     thumbnail: null,
+    shared: false,
+    is_editable: false,
+    can_edit: true,
     current_state: state,
     current_location: "",
     tags: [],
+    showcase_story: "",
+    showcase_fields: [],
     history: [state],
     ...overrides,
   };
@@ -1234,6 +1242,37 @@ describe("WorkflowState", () => {
       expect(
         screen.queryByRole("button", { name: "Create Glaze Combination" }),
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("saveStateFn prop", () => {
+    it("uses saveStateFn instead of updateCurrentState when provided", async () => {
+      const pieceState = makeState({ id: "past-state-id", notes: "" });
+      const updatedPiece = makePieceDetail({
+        history: [makeState({ id: "past-state-id", notes: "edited" })],
+      });
+      const saveStateFn = vi.fn().mockResolvedValue(updatedPiece);
+
+      render(
+        <WorkflowState
+          initialPieceState={pieceState}
+          pieceId="test-piece-id"
+          onSaved={vi.fn()}
+          autosaveDelayMs={0}
+          saveStateFn={saveStateFn}
+        />,
+      );
+
+      fireEvent.change(screen.getByLabelText("Notes"), {
+        target: { value: "edited" },
+      });
+
+      await waitFor(() => {
+        expect(saveStateFn).toHaveBeenCalledWith(
+          expect.objectContaining({ notes: "edited" }),
+        );
+        expect(api.updateCurrentState).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/web/src/pages/__tests__/PieceListPage.test.tsx
+++ b/web/src/pages/__tests__/PieceListPage.test.tsx
@@ -113,7 +113,10 @@ const EXISTING_PIECE: PieceSummary = {
   current_location: null,
   tags: [],
   shared: false,
+  is_editable: false,
   can_edit: true,
+  showcase_story: "",
+  showcase_fields: [],
 };
 
 describe("PieceListPage", () => {

--- a/web/src/util/__tests__/api.test.ts
+++ b/web/src/util/__tests__/api.test.ts
@@ -174,6 +174,43 @@ describe("piece endpoints", () => {
     expect(result.current_state.next_state).toBe("trimmed");
   });
 
+  it("fetchPiece normalizes valid image crops and drops invalid crops", async () => {
+    const { fetchPiece } = await loadApiModule();
+    mockClient.get.mockResolvedValue({
+      data: {
+        ...wirePieceDetail,
+        current_state: {
+          ...wirePieceState,
+          images: [
+            {
+              ...wireImage,
+              crop: { x: -0.25, y: 0.5, width: 1.25, height: 0.75 },
+            },
+            {
+              ...wireImage,
+              crop: { x: 0, y: 0, width: 0, height: 1 },
+            },
+            {
+              ...wireImage,
+              crop: { x: 0, y: "bad", width: 1, height: 1 },
+            },
+          ],
+        },
+      },
+    });
+
+    const result = await fetchPiece("piece-1");
+
+    expect(result.current_state.images[0].crop).toEqual({
+      x: 0,
+      y: 0.5,
+      width: 1,
+      height: 0.75,
+    });
+    expect(result.current_state.images[1].crop).toBeNull();
+    expect(result.current_state.images[2].crop).toBeNull();
+  });
+
   it("createPiece posts the payload and maps the response", async () => {
     const { createPiece } = await loadApiModule();
     mockClient.post.mockResolvedValue({ data: wirePieceDetail });
@@ -213,6 +250,23 @@ describe("piece endpoints", () => {
     expect(mockClient.patch).toHaveBeenCalledWith("pieces/piece-1/state/", {
       notes: "updated notes",
     });
+    expect(result.id).toBe("piece-1");
+  });
+
+  it("updatePastState patches the specific state endpoint", async () => {
+    const { updatePastState } = await loadApiModule();
+    mockClient.patch.mockResolvedValue({ data: wirePieceDetail });
+
+    const result = await updatePastState("piece-1", "state-1", {
+      notes: "retroactive notes",
+    });
+
+    expect(mockClient.patch).toHaveBeenCalledWith(
+      "pieces/piece-1/states/state-1/",
+      {
+        notes: "retroactive notes",
+      },
+    );
     expect(result.id).toBe("piece-1");
   });
 

--- a/web/src/util/api.ts
+++ b/web/src/util/api.ts
@@ -125,6 +125,7 @@ function mapTagEntry(raw: Wire<TagEntry>): TagEntry {
 
 function mapPieceState(raw: Wire<PieceState>): PieceState {
   return {
+    id: raw.id,
     state: raw.state as State,
     notes: raw.notes,
     created: new Date(raw.created ?? ""),
@@ -133,6 +134,7 @@ function mapPieceState(raw: Wire<PieceState>): PieceState {
     previous_state: raw.previous_state as State | null,
     next_state: raw.next_state as State | null,
     custom_fields: raw.custom_fields ?? {},
+    has_been_edited: raw.has_been_edited ?? false,
   };
 }
 
@@ -144,6 +146,7 @@ function mapPieceSummary(raw: Wire<PieceSummary>): PieceSummary {
     last_modified: new Date(raw.last_modified ?? ""),
     thumbnail: raw.thumbnail as Thumbnail | null,
     shared: raw.shared ?? false,
+    is_editable: raw.is_editable ?? false,
     can_edit: raw.can_edit ?? true,
     current_state: mapStateSummary(raw.current_state),
     current_location: raw.current_location ?? "",
@@ -313,11 +316,24 @@ export async function updateCurrentState(
   return mapPieceDetail(data);
 }
 
+export async function updatePastState(
+  pieceId: string,
+  stateId: string,
+  payload: UpdateStatePayload,
+): Promise<PieceDetail> {
+  const { data } = await client.patch<Wire<PieceDetail>>(
+    `pieces/${pieceId}/states/${stateId}/`,
+    payload,
+  );
+  return mapPieceDetail(data);
+}
+
 export type UpdatePiecePayload = {
   name?: string;
   current_location?: string;
   thumbnail?: Thumbnail | null;
   shared?: boolean;
+  is_editable?: boolean;
   tags?: string[];
   showcase_story?: string;
   showcase_fields?: string[];

--- a/web/src/util/types.ts
+++ b/web/src/util/types.ts
@@ -71,9 +71,11 @@ export type StateSummary = components["schemas"]["StateSummary"] & {
 // Full state record returned in detail responses.
 // Intersection narrows state: string → state: State.
 export type PieceState = Omit<components["schemas"]["PieceState"], "images"> & {
+  id: string;
   state: State;
   images: CaptionedImage[];
   custom_fields: Record<string, unknown>;
+  has_been_edited: boolean;
 };
 
 // Piece list entry. Intersection narrows current_state to use our typed StateSummary.
@@ -84,6 +86,7 @@ export type PieceSummary = Omit<
   current_state: StateSummary;
   thumbnail: Thumbnail | null;
   shared: boolean;
+  is_editable: boolean;
   can_edit: boolean;
   tags: TagEntry[];
   showcase_fields: string[];


### PR DESCRIPTION
## Summary

Implements retroactive state editing for piece histories.

- Adds editable-mode support so owners can temporarily unlock a piece, insert missing workflow states, and patch sealed historical states.
- Adds ordered state history semantics and derives the current state from the highest non-null order.
- Keeps editable pieces owner-only while they are in progress and excludes them from public analysis.
- Adds frontend controls for editing or sealing history, including past-state forms and missing-state insertion.
- Updates backend and frontend tests plus Bazel targets for the editable-history flow, including local coverage gaps in `PieceHistory` and `api.ts`.
- Narrows `gz_test --coverage` target discovery to Bazel test targets so coverage does not expand to generated build and npm labels.

## Validation

- `rtk bazel test //...`
- `rtk bazel coverage --combined_report=lcov --cache_test_results=false //...`
- `rtk bazel build --config=lint //...`
- `gz_test --coverage`
- `gz_test --all --coverage`

Closes #307
