### PR TITLE
fix: automate migration inclusion in OCI image

### DIFF
--- a/.agents/skills/github-pr/SKILL.md
+++ b/.agents/skills/github-pr/SKILL.md
@@ -64,6 +64,7 @@ Before opening or pushing to a PR, verify every item:
 - [ ] Every commit has a short descriptive title with detailed bullets in the body explaining what and why
 - [ ] Refactoring alongside functional changes described separately in commit and PR body
 - [ ] All tests pass: `rtk bazel test //...`
+- [ ] All database migrations are included in the build: `bazel query 'labels(srcs, //api:migrations)'`
 - [ ] All linters pass: `rtk bazel build --config=lint //...`
 - [ ] Build succeeds: `gz_build`
 - [ ] Autoformat all touched files: `gz_format`

--- a/api/BUILD.bazel
+++ b/api/BUILD.bazel
@@ -56,31 +56,12 @@ py_library(
 
 filegroup(
     name = "api_commands",
-    srcs = [
-        "management/__init__.py",
-        "management/commands/__init__.py",
-        "management/commands/backpopulate_crops.py",
-        "management/commands/clear_crops.py",
-        "management/commands/clear_stuck_tasks.py",
-        "management/commands/dump_public_library.py",
-        "management/commands/import_test_tile_images.py",
-        "management/commands/load_public_library.py",
-        "management/commands/restore_images_from_backup.py",
-    ],
+    srcs = glob(["management/**/*.py"]),
 )
 
 filegroup(
     name = "migrations",
-    srcs = [
-        "migrations/0001_initial.py",
-        "migrations/0002_piece_shared.py",
-        "migrations/0003_rename_custom_fields.py",
-        "migrations/0004_normalize_images.py",
-        "migrations/0005_image_crops.py",
-        "migrations/0006_asynctask.py",
-        "migrations/0007_piece_showcase_fields_piece_showcase_story.py",
-        "migrations/__init__.py",
-    ],
+    srcs = glob(["migrations/*.py"]),
     visibility = ["//visibility:public"],
 )
 
@@ -312,6 +293,19 @@ py_test(
     ],
 )
 
+py_test(
+    name = "api_migration_test",
+    size = "small",
+    srcs = _CONFTEST + [
+        "tests/test_migrations_completeness.py",
+    ],
+    args = ["api/tests/test_migrations_completeness.py"],
+    data = _TEST_DATA,
+    env = _TEST_ENV,
+    main = "//tools:pytest_main.py",
+    deps = _TEST_DEPS,
+)
+
 # ── API test suite ────────────────────────────────────────────────────────────
 # Aggregate target: `bazel test //api:api_test` runs all API tests.
 # Individual targets above run only when their inputs change.
@@ -325,5 +319,6 @@ test_suite(
         ":api_model_test",
         ":api_piece_test",
         ":api_workflow_test",
+        ":api_migration_test",
     ],
 )

--- a/api/tests/test_migrations_completeness.py
+++ b/api/tests/test_migrations_completeness.py
@@ -1,0 +1,43 @@
+import pytest
+import os
+import glob
+from django.conf import settings
+
+@pytest.mark.django_db
+def test_migrations_completeness():
+    """
+    Verifies that all migration files present in the api/migrations directory
+    are actually available at runtime. This prevents Bazel-built OCI images
+    from missing migrations that weren't explicitly added to BUILD.bazel.
+    """
+    # Path to migrations in the source tree (or as seen by the test runner)
+    # When running under Bazel, this should point to the runfiles.
+    migrations_dir = os.path.join(settings.BASE_DIR, "api", "migrations")
+    
+    # Get all .py files in migrations directory, excluding __init__.py
+    migration_files = glob.glob(os.path.join(migrations_dir, "*.py"))
+    migration_files = [f for f in migration_files if not f.endswith("__init__.py")]
+    
+    # Extract just the filenames for comparison
+    migration_filenames = {os.path.basename(f) for f in migration_files}
+    
+    # Now check what Django's migration loader sees (which depends on what's in the PYTHONPATH/runfiles)
+    from django.db.migrations.loader import MigrationLoader
+    from django.db import connections
+    
+    loader = MigrationLoader(connections["default"])
+    
+    # Get all migrations registered for the 'api' app
+    registered_migrations = {
+        m[1] for m in loader.disk_migrations.keys() if m[0] == "api"
+    }
+    
+    # Convert filenames to migration names (e.g. '0001_initial.py' -> '0001_initial')
+    expected_migration_names = {os.path.splitext(f)[0] for f in migration_filenames}
+    
+    missing_from_loader = expected_migration_names - registered_migrations
+    
+    assert not missing_from_loader, (
+        f"Migrations found on disk but missing from Django loader: {missing_from_loader}. "
+        "Check if they are missing from api/BUILD.bazel."
+    )


### PR DESCRIPTION
## Problem / Motivation
A 500 Internal Server Error occurred in production because migrations `0008` and `0009` were missing from the OCI image. This was due to `api/BUILD.bazel` manually listing migration files and management commands, leading to silent omissions when new files were added.

## Proposed Solution
- **Automated Build Inclusion**: Refactored `api/BUILD.bazel` to use `glob(["migrations/*.py"])` and `glob(["management/**/*.py"])`.
- **Runtime Verification**: Added a new test `api/tests/test_migrations_completeness.py` that compares the migrations present on disk (via Bazel runfiles) with those registered by the Django migration loader.
- **Process Safeguard**: Updated the 'Definition of Done' in `.agents/skills/github-pr/SKILL.md` to require verification of migration inclusion.

## Acceptance Criteria
- [x] All database migrations (0001-0009) are included in the build.
- [x] `api_migration_test` passes.
- [x] DoD rule updated.

Closes #376
