### PR TITLE
feat: dynamic validation for Re-seal button in history edit mode

### DIFF
--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -23,7 +23,7 @@ import HistoryIcon from "@mui/icons-material/History";
 import LockIcon from "@mui/icons-material/Lock";
 import { useBlocker } from "react-router-dom";
 import type { PieceDetail as PieceDetailType } from "../util/types";
-import { formatState, isTerminalState } from "../util/types";
+import { formatState, isTerminalState, validateHistorySequence } from "../util/types";
 import {
   getCustomFieldDefinitions,
 } from "../util/workflow";
@@ -122,6 +122,9 @@ function SectionCard({ eyebrow, title, subtitle, children }: SectionCardProps) {
 function EditableToggle({ piece, onPieceUpdated }: PieceDetailProps) {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const seqError = piece.is_editable
+    ? validateHistorySequence(piece.history, piece.current_state)
+    : null;
 
   async function toggle() {
     setSaving(true);
@@ -146,7 +149,7 @@ function EditableToggle({ piece, onPieceUpdated }: PieceDetailProps) {
           size="small"
           startIcon={<LockIcon fontSize="small" />}
           onClick={toggle}
-          disabled={saving}
+          disabled={saving || !!seqError}
         >
           Seal changes
         </Button>
@@ -161,6 +164,11 @@ function EditableToggle({ piece, onPieceUpdated }: PieceDetailProps) {
         >
           Edit piece history
         </Button>
+      )}
+      {seqError && (
+        <Typography variant="caption" color="error" sx={{ ml: 1 }}>
+          {seqError}
+        </Typography>
       )}
       {error && (
         <Typography variant="caption" color="error" sx={{ ml: 1 }}>

--- a/web/src/components/__tests__/PieceDetail.test.tsx
+++ b/web/src/components/__tests__/PieceDetail.test.tsx
@@ -842,9 +842,13 @@ describe("PieceDetail", () => {
     });
 
     it("calls updatePiece with is_editable=false when 'Seal changes' is clicked", async () => {
+      const designed = makeState({ state: "designed" });
+      const thrown = makeState({ state: "wheel_thrown" });
       const updated = makePiece({ is_editable: false });
       vi.mocked(api.updatePiece).mockResolvedValueOnce(updated);
-      await renderPieceDetail(makePiece({ is_editable: true }));
+      await renderPieceDetail(
+        makePiece({ is_editable: true, history: [designed], current_state: thrown }),
+      );
       fireEvent.click(screen.getByRole("button", { name: /seal changes/i }));
       await waitFor(() => {
         expect(api.updatePiece).toHaveBeenCalledWith(
@@ -852,6 +856,28 @@ describe("PieceDetail", () => {
           expect.objectContaining({ is_editable: false }),
         );
       });
+    });
+
+    it("disables 'Seal changes' button when history sequence is invalid", async () => {
+      const designed = makeState({ state: "designed" });
+      const glazed = makeState({ state: "glazed" });
+      await renderPieceDetail(
+        makePiece({ is_editable: true, history: [designed], current_state: glazed }),
+      );
+      expect(
+        screen.getByRole("button", { name: /seal changes/i }),
+      ).toBeDisabled();
+    });
+
+    it("shows error message when history sequence is invalid", async () => {
+      const designed = makeState({ state: "designed" });
+      const glazed = makeState({ state: "glazed" });
+      await renderPieceDetail(
+        makePiece({ is_editable: true, history: [designed], current_state: glazed }),
+      );
+      expect(
+        screen.getByText(/'Glazing' is not a valid successor of 'Designing'/),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/web/src/util/types.ts
+++ b/web/src/util/types.ts
@@ -1,5 +1,6 @@
 import type { components } from "./generated-types";
 import workflow from "../../../workflow.yml";
+import { formatState as _formatState } from "./workflow";
 export {
   formatState,
   formatPastState,
@@ -98,6 +99,23 @@ export type PieceDetail = PieceSummary & {
   current_state: PieceState;
   history: PieceState[];
 };
+
+// Returns null if the history+current sequence has all valid transitions, or an
+// error string for the first invalid step (e.g. "'Glazing' is not a valid successor of 'Designing'").
+export function validateHistorySequence(
+  history: PieceState[],
+  currentState: PieceState,
+): string | null {
+  const allStates = [...history, currentState];
+  for (let i = 0; i < allStates.length - 1; i++) {
+    const from = allStates[i].state;
+    const to = allStates[i + 1].state;
+    if (!(SUCCESSORS[from] ?? []).includes(to)) {
+      return `'${_formatState(to)}' is not a valid successor of '${_formatState(from)}'`;
+    }
+  }
+  return null;
+}
 
 // GlazeCombination entry and related types — derived from generated OpenAPI types.
 export type GlazeTypeRef = components["schemas"]["GlazeTypeRef"];


### PR DESCRIPTION
## Summary

- Adds `validateHistorySequence` to `web/src/util/types.ts` that walks the full state sequence (history + current_state) and returns an error string for the first invalid transition, or `null` if valid
- Disables the "Seal changes" button in `EditableToggle` when the sequence has an invalid transition
- Displays a descriptive error message below the button (e.g. `'Glazing' is not a valid successor of 'Designing'`)
- All validation is derived from `SUCCESSORS` in `workflow.yml` — no hardcoded state names

## Test plan
- [ ] `bazel test //web:web_piece_detail_test` passes (includes 2 new tests)
- [ ] `bazel test //web:tsc_typecheck_typecheck_test` passes
- [ ] Manual: enter history edit mode, reorder states to create an invalid transition → button disabled with error message
- [ ] Manual: fix the sequence → button re-enables

Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)