### PR TITLE
feat: auto-expand and focus Timeline when entering history edit mode

### DIFF
--- a/web/src/components/PieceHistory.tsx
+++ b/web/src/components/PieceHistory.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import AddIcon from "@mui/icons-material/Add";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import HistoryIcon from "@mui/icons-material/History";
@@ -145,6 +145,16 @@ export default function PieceHistory({
   const [historyOpen, setHistoryOpen] = useState(false);
   const [addDialogOpen, setAddDialogOpen] = useState(false);
   const isEditable = piece?.is_editable ?? false;
+  const containerRef = useRef<HTMLDivElement>(null);
+  const prevIsEditableRef = useRef(isEditable);
+
+  useEffect(() => {
+    if (isEditable && !prevIsEditableRef.current) {
+      setHistoryOpen(true);
+      containerRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    }
+    prevIsEditableRef.current = isEditable;
+  }, [isEditable]);
 
   if (pastHistory.length === 0 && !isEditable) return null;
 
@@ -153,7 +163,7 @@ export default function PieceHistory({
     : -1;
 
   return (
-    <Box>
+    <Box ref={containerRef}>
       <Box
         component="button"
         type="button"

--- a/web/src/components/__tests__/PieceHistory.test.tsx
+++ b/web/src/components/__tests__/PieceHistory.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import PieceHistory from "../PieceHistory";
 import type { PieceDetail as PieceDetailType, PieceState } from "../../util/types";
@@ -478,5 +478,72 @@ describe("PieceHistory", () => {
       // Should not throw when clicking without onRewind
       fireEvent.click(screen.getAllByText("Designed")[0].closest("li")!);
     });
+  });
+});
+
+describe("auto-expand on edit mode", () => {
+  let scrollIntoViewMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    scrollIntoViewMock = vi.fn();
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+  });
+
+  afterEach(() => {
+    // @ts-expect-error restore
+    delete window.HTMLElement.prototype.scrollIntoView;
+  });
+
+  it("auto-expands the timeline when is_editable becomes true", async () => {
+    const state = makeState({ state: "designed" });
+    const piece = makePiece({ is_editable: false });
+    const { rerender } = render(
+      <PieceHistory pastHistory={[state]} piece={piece} onPieceUpdated={vi.fn()} />,
+    );
+    expect(screen.getByRole("button", { name: /show history/i })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+
+    await act(async () => {
+      rerender(
+        <PieceHistory
+          pastHistory={[state]}
+          piece={makePiece({ is_editable: true })}
+          onPieceUpdated={vi.fn()}
+        />,
+      );
+    });
+
+    expect(screen.getByRole("button", { name: /hide history/i })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: "smooth", block: "nearest" });
+  });
+
+  it("does not expand the timeline when is_editable stays false", async () => {
+    const state1 = makeState({ id: "s1", state: "designed" });
+    const state2 = makeState({ id: "s2", state: "wheel_thrown" });
+    const piece = makePiece({ is_editable: false });
+    const { rerender } = render(
+      <PieceHistory pastHistory={[state1]} piece={piece} onPieceUpdated={vi.fn()} />,
+    );
+
+    await act(async () => {
+      rerender(
+        <PieceHistory
+          pastHistory={[state1, state2]}
+          piece={makePiece({ is_editable: false })}
+          onPieceUpdated={vi.fn()}
+        />,
+      );
+    });
+
+    expect(screen.getByRole("button", { name: /show history/i })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+    expect(scrollIntoViewMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- When user clicks "Edit piece history", the Timeline accordion now automatically expands and scrolls into view
- Uses a `prevIsEditable` ref to detect only the `false → true` transition (not initial mount)
- `scrollIntoView({ behavior: "smooth", block: "nearest" })` brings the Timeline into focus

## Test plan
- [ ] `rtk bazel test //web:web_piece_history_test` — all 21 tests pass (2 new)
- [ ] Manual: open a piece, click "Edit piece history" — Timeline should expand and scroll into view if it was collapsed

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)