### PR TITLE
feat: inline insert/delete affordances for history states

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -326,12 +326,17 @@ def piece_current_state(request: Request, piece_id: str) -> Response:
     request=PieceStateUpdateSerializer,
     responses={200: PieceDetailSerializer},
 )
-@api_view(["PATCH"])
+@extend_schema(
+    methods=["DELETE"],
+    responses={200: PieceDetailSerializer},
+)
+@api_view(["PATCH", "DELETE"])
 @permission_classes([IsAuthenticated])
 def piece_past_state(request: Request, piece_id: str, state_id: str) -> Response:
-    """Patch a past (sealed) state while the piece is in editable mode.
+    """Patch or delete a past (sealed) state while the piece is in editable mode.
 
     Returns 403 if the piece is not currently in editable mode.
+    DELETE also returns 403 if the targeted state is 'designed'.
     """
     piece = get_object_or_404(_piece_queryset(request), pk=piece_id)
     if not piece.is_editable:
@@ -340,6 +345,15 @@ def piece_past_state(request: Request, piece_id: str, state_id: str) -> Response
             status=status.HTTP_403_FORBIDDEN,
         )
     ps = get_object_or_404(piece.states, pk=state_id)
+    if request.method == "DELETE":
+        if ps.state == "designed":
+            return Response(
+                {"detail": "Cannot delete the 'designed' state."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        ps.delete()
+        piece.refresh_from_db()
+        return Response(_serialize_piece_detail(piece, request))
     serializer = PieceStateUpdateSerializer(data=request.data)
     serializer.is_valid(raise_exception=True)
     serializer.update(ps, serializer.validated_data)

--- a/web/src/components/GlazeCombinationGallery.tsx
+++ b/web/src/components/GlazeCombinationGallery.tsx
@@ -35,7 +35,7 @@ import type {
   GlazeCombinationEntry,
   GlazeCombinationImageEntry,
 } from "../util/types";
-import { formatState } from "../util/types";
+import { formatState } from "../util/workflow";
 import { useAsync } from "../util/useAsync";
 
 const EMPTY_STATE_MESSAGE =

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -24,7 +24,7 @@ import HistoryIcon from "@mui/icons-material/History";
 import LockIcon from "@mui/icons-material/Lock";
 import { useBlocker } from "react-router-dom";
 import type { PieceDetail as PieceDetailType } from "../util/types";
-import { formatState, isTerminalState, validateHistorySequence } from "../util/types";
+import { formatState, isTerminalState, validateHistorySequence } from "../util/workflow";
 import {
   getCustomFieldDefinitions,
 } from "../util/workflow";

--- a/web/src/components/PieceHistory.tsx
+++ b/web/src/components/PieceHistory.tsx
@@ -1,22 +1,20 @@
 import { useEffect, useRef, useState } from "react";
-import AddIcon from "@mui/icons-material/Add";
+import CloseIcon from "@mui/icons-material/Close";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import HistoryIcon from "@mui/icons-material/History";
+import AddIcon from "@mui/icons-material/Add";
 import {
   alpha,
   Box,
-  Button,
   Chip,
+  CircularProgress,
   Collapse,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
+  IconButton,
   List,
   ListItem,
   ListItemText,
+  Menu,
   MenuItem,
-  TextField,
   Tooltip,
   Typography,
 } from "@mui/material";
@@ -25,8 +23,12 @@ import type {
   PieceState,
   State,
 } from "../util/types";
-import { formatPastState, formatState, STATES } from "../util/types";
-import { addPieceState, updatePastState } from "../util/api";
+import {
+  formatPastState,
+  formatState,
+  insertableStatesBetween,
+} from "../util/workflow";
+import { addPieceState, deletePieceState, updatePastState } from "../util/api";
 import WorkflowState from "./WorkflowState";
 
 type PieceHistoryProps = {
@@ -37,101 +39,62 @@ type PieceHistoryProps = {
   onRewind?: (id: string | null) => void;
 };
 
-function AddMissingStateDialog({
-  open,
-  onClose,
+function InsertButton({
+  predecessor,
+  presentStates,
   piece,
   onPieceUpdated,
 }: {
-  open: boolean;
-  onClose: () => void;
+  predecessor: State;
+  presentStates: ReadonlySet<State>;
   piece: PieceDetailType;
   onPieceUpdated: (updated: PieceDetailType) => void;
 }) {
-  const presentStates = new Set<State>(piece.history.map((ps) => ps.state));
-  const availableStates = (STATES as State[]).filter(
-    (s) => !presentStates.has(s),
-  );
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [loading, setLoading] = useState(false);
 
-  const [selectedState, setSelectedState] = useState<State | "">("");
-  const [notes, setNotes] = useState("");
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const insertable = insertableStatesBetween(predecessor, presentStates);
+  if (insertable.length === 0) return null;
 
-  function handleClose() {
-    setSelectedState("");
-    setNotes("");
-    setError(null);
-    onClose();
-  }
-
-  async function handleSubmit() {
-    if (!selectedState) return;
-    setSaving(true);
-    setError(null);
+  async function handleSelect(state: State) {
+    setAnchorEl(null);
+    setLoading(true);
     try {
-      const updated = await addPieceState(piece.id, {
-        state: selectedState as PieceState["state"],
-        notes: notes.trim() || undefined,
-      });
+      const updated = await addPieceState(piece.id, { state });
       onPieceUpdated(updated);
-      handleClose();
-    } catch {
-      setError("Failed to add state. Please try again.");
     } finally {
-      setSaving(false);
+      setLoading(false);
     }
   }
 
   return (
-    <Dialog open={open} onClose={handleClose} fullWidth maxWidth="xs">
-      <DialogTitle>Add missing state</DialogTitle>
-      <DialogContent>
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 0.5 }}>
-          <TextField
-            select
-            label="State"
-            value={selectedState}
-            onChange={(e) => setSelectedState(e.target.value as State)}
-            fullWidth
+    <Box sx={{ display: "flex", justifyContent: "center", my: 0.25 }}>
+      {loading ? (
+        <CircularProgress size={16} />
+      ) : (
+        <>
+          <IconButton
             size="small"
+            aria-label="Insert state"
+            onClick={(e) => setAnchorEl(e.currentTarget)}
+            sx={{ opacity: 0.5, "&:hover": { opacity: 1 } }}
           >
-            {availableStates.map((s) => (
-              <MenuItem key={s} value={s}>
+            <AddIcon fontSize="small" />
+          </IconButton>
+          <Menu
+            anchorEl={anchorEl}
+            open={Boolean(anchorEl)}
+            onClose={() => setAnchorEl(null)}
+          >
+            {insertable.map((s) => (
+              <MenuItem key={s} onClick={() => handleSelect(s as State)}>
                 {formatState(s)}
               </MenuItem>
             ))}
-          </TextField>
-          <TextField
-            label="Notes"
-            multiline
-            rows={3}
-            value={notes}
-            onChange={(e) => setNotes(e.target.value)}
-            fullWidth
-            size="small"
-            slotProps={{ htmlInput: { maxLength: 2000 } }}
-          />
-          {error && (
-            <Typography variant="caption" color="error">
-              {error}
-            </Typography>
-          )}
-        </Box>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={handleClose} disabled={saving}>
-          Cancel
-        </Button>
-        <Button
-          variant="contained"
-          onClick={handleSubmit}
-          disabled={!selectedState || saving}
-        >
-          Add state
-        </Button>
-      </DialogActions>
-    </Dialog>
+          </Menu>
+        </>
+      )}
+    </Box>
   );
 }
 
@@ -143,10 +106,10 @@ export default function PieceHistory({
   onRewind,
 }: PieceHistoryProps) {
   const [historyOpen, setHistoryOpen] = useState(false);
-  const [addDialogOpen, setAddDialogOpen] = useState(false);
   const isEditable = piece?.is_editable ?? false;
   const containerRef = useRef<HTMLDivElement>(null);
   const prevIsEditableRef = useRef(isEditable);
+  const [deletingStateId, setDeletingStateId] = useState<string | null>(null);
 
   useEffect(() => {
     if (isEditable && !prevIsEditableRef.current) {
@@ -157,6 +120,10 @@ export default function PieceHistory({
   }, [isEditable]);
 
   if (pastHistory.length === 0 && !isEditable) return null;
+
+  const presentStates = new Set<State>(
+    piece?.history.map((ps) => ps.state) ?? [],
+  );
 
   const rewindIndex = rewindedStateId
     ? pastHistory.findIndex((ps) => ps.id === rewindedStateId)
@@ -196,94 +163,148 @@ export default function PieceHistory({
         </Typography>
       </Box>
       <Collapse in={historyOpen}>
-        <List dense sx={{ display: "grid", gap: 1.25 }}>
+        <List dense sx={{ display: "grid", gap: 0 }}>
           {pastHistory.map((ps, i) => {
             const isRewinded = ps.id === rewindedStateId;
             const isAfterRewind = rewindIndex !== -1 && i > rewindIndex;
+
+            // Predecessor for insert-before affordance
+            const predecessor: State | null =
+              i === 0
+                ? (piece?.history[0]?.state ?? null)
+                : pastHistory[i - 1]?.state ?? null;
+
+            // Only show insert affordance in edit mode, with a valid predecessor,
+            // and NOT before the last item (no affordance after pastHistory.at(-1))
+            // — actually show before each item (between predecessor and item[i])
+            const showInsert =
+              isEditable &&
+              piece &&
+              onPieceUpdated &&
+              predecessor !== null &&
+              i < pastHistory.length; // always true, but explicit
+
             if (isEditable && piece && onPieceUpdated) {
               return (
-                <Tooltip
-                  key={ps.id ?? i}
-                  title={
-                    isRewinded
-                      ? "Click to stop viewing this state"
-                      : "Click to view and edit this state"
-                  }
-                  placement="top-start"
-                  disableHoverListener={!onRewind}
-                >
-                  <ListItem
-                    disableGutters
-                    onClick={
-                      onRewind
-                        ? () => onRewind(isRewinded ? null : ps.id)
-                        : undefined
+                <Box key={ps.id ?? i}>
+                  {showInsert && predecessor && (
+                    <InsertButton
+                      predecessor={predecessor}
+                      presentStates={presentStates}
+                      piece={piece}
+                      onPieceUpdated={onPieceUpdated}
+                    />
+                  )}
+                  <Tooltip
+                    title={
+                      isRewinded
+                        ? "Click to stop viewing this state"
+                        : "Click to view and edit this state"
                     }
-                    sx={(theme) => ({
-                      px: 1.5,
-                      py: 1.5,
-                      borderRadius: 3,
-                      border: "1px solid",
-                      borderColor: isRewinded ? "primary.main" : "divider",
-                      backgroundColor: alpha(
-                        theme.palette.background.default,
-                        0.34,
-                      ),
-                      flexDirection: "column",
-                      alignItems: "flex-start",
-                      cursor: onRewind ? "pointer" : "default",
-                      opacity: isAfterRewind ? 0.35 : 1,
-                      pointerEvents: isAfterRewind ? "none" : "auto",
-                      transition: "opacity 0.2s, border-color 0.2s",
-                    })}
+                    placement="top-start"
+                    disableHoverListener={!onRewind}
                   >
-                    <Box
-                      sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 1,
-                        mb: 0.75,
-                        width: "100%",
-                      }}
+                    <ListItem
+                      disableGutters
+                      onClick={
+                        onRewind
+                          ? () => onRewind(isRewinded ? null : ps.id)
+                          : undefined
+                      }
+                      sx={(theme) => ({
+                        px: 1.5,
+                        py: 1.5,
+                        borderRadius: 3,
+                        border: "1px solid",
+                        borderColor: isRewinded ? "primary.main" : "divider",
+                        backgroundColor: alpha(
+                          theme.palette.background.default,
+                          0.34,
+                        ),
+                        flexDirection: "column",
+                        alignItems: "flex-start",
+                        cursor: onRewind ? "pointer" : "default",
+                        opacity: isAfterRewind ? 0.35 : 1,
+                        pointerEvents: isAfterRewind ? "none" : "auto",
+                        transition: "opacity 0.2s, border-color 0.2s",
+                      })}
                     >
-                      <Typography
-                        variant="caption"
+                      <Box
                         sx={{
-                          color: isRewinded ? "primary.main" : "text.secondary",
-                          letterSpacing: "0.1em",
-                          textTransform: "uppercase",
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 1,
+                          mb: 0.75,
+                          width: "100%",
                         }}
                       >
-                        {formatPastState(ps.state)}
-                      </Typography>
-                      {isRewinded && (
-                        <Chip
-                          icon={<HistoryIcon />}
-                          label="Viewing"
-                          size="small"
-                          color="primary"
-                          variant="outlined"
-                          sx={{ height: 18, fontSize: "0.65rem" }}
+                        <Typography
+                          variant="caption"
+                          sx={{
+                            color: isRewinded ? "primary.main" : "text.secondary",
+                            letterSpacing: "0.1em",
+                            textTransform: "uppercase",
+                            flexGrow: 1,
+                          }}
+                        >
+                          {formatPastState(ps.state)}
+                        </Typography>
+                        {isRewinded && (
+                          <Chip
+                            icon={<HistoryIcon />}
+                            label="Viewing"
+                            size="small"
+                            color="primary"
+                            variant="outlined"
+                            sx={{ height: 18, fontSize: "0.65rem" }}
+                          />
+                        )}
+                        {ps.state !== "designed" && (
+                          <Box onClick={(e) => e.stopPropagation()}>
+                            {deletingStateId === ps.id ? (
+                              <CircularProgress size={16} />
+                            ) : (
+                              <IconButton
+                                size="small"
+                                aria-label={`Delete ${formatPastState(ps.state)} state`}
+                                onClick={async () => {
+                                  setDeletingStateId(ps.id);
+                                  try {
+                                    const updated = await deletePieceState(
+                                      piece.id,
+                                      ps.id,
+                                    );
+                                    onPieceUpdated(updated);
+                                  } finally {
+                                    setDeletingStateId(null);
+                                  }
+                                }}
+                                sx={{ opacity: 0.5, "&:hover": { opacity: 1 } }}
+                              >
+                                <CloseIcon fontSize="small" />
+                              </IconButton>
+                            )}
+                          </Box>
+                        )}
+                      </Box>
+                      <Box
+                        sx={{ width: "100%" }}
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <WorkflowState
+                          key={ps.id}
+                          initialPieceState={ps}
+                          pieceId={piece.id}
+                          onSaved={onPieceUpdated}
+                          hideImageUpload
+                          saveStateFn={(payload) =>
+                            updatePastState(piece.id, ps.id, payload)
+                          }
                         />
-                      )}
-                    </Box>
-                    <Box
-                      sx={{ width: "100%" }}
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      <WorkflowState
-                        key={ps.id}
-                        initialPieceState={ps}
-                        pieceId={piece.id}
-                        onSaved={onPieceUpdated}
-                        hideImageUpload
-                        saveStateFn={(payload) =>
-                          updatePastState(piece.id, ps.id, payload)
-                        }
-                      />
-                    </Box>
-                  </ListItem>
-                </Tooltip>
+                      </Box>
+                    </ListItem>
+                  </Tooltip>
+                </Box>
               );
             }
             return (
@@ -316,25 +337,6 @@ export default function PieceHistory({
             );
           })}
         </List>
-        {isEditable && piece && onPieceUpdated && (
-          <Box sx={{ mt: 1 }}>
-            <Button
-              variant="outlined"
-              size="small"
-              startIcon={<AddIcon />}
-              onClick={() => setAddDialogOpen(true)}
-              sx={{ borderStyle: "dashed" }}
-            >
-              Add missing state
-            </Button>
-            <AddMissingStateDialog
-              open={addDialogOpen}
-              onClose={() => setAddDialogOpen(false)}
-              piece={piece}
-              onPieceUpdated={onPieceUpdated}
-            />
-          </Box>
-        )}
       </Collapse>
     </Box>
   );

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -13,7 +13,7 @@ import {
 } from "@mui/material";
 import { alpha, useTheme } from "@mui/material/styles";
 import type { PieceSummary, TagEntry } from "../util/types";
-import { formatState, isTerminalState, SUCCESSORS } from "../util/types";
+import { formatState, isTerminalState, SUCCESSORS } from "../util/workflow";
 import type { PieceSortOrder } from "../util/api";
 import { DEFAULT_PIECE_SORT, PIECE_SORT_OPTIONS } from "../util/api";
 import { Masonry } from "masonic";

--- a/web/src/components/PieceShareControls.tsx
+++ b/web/src/components/PieceShareControls.tsx
@@ -11,7 +11,7 @@ import { jpg } from "@cloudinary/url-gen/qualifiers/format";
 import { auto as autoQuality } from "@cloudinary/url-gen/qualifiers/quality";
 import { autoGravity } from "@cloudinary/url-gen/qualifiers/gravity";
 import type { PieceDetail, Thumbnail } from "../util/types";
-import { formatState } from "../util/types";
+import { formatState } from "../util/workflow";
 import { updatePiece } from "../util/api";
 
 const SHARE_IMAGE_SIZE = 600;

--- a/web/src/components/StateTransition.tsx
+++ b/web/src/components/StateTransition.tsx
@@ -16,7 +16,7 @@ import {
   getStateDescription,
   isTerminalState,
   SUCCESSORS,
-} from "../util/types";
+} from "../util/workflow";
 
 // Fixed height for each successor chip row — must match the sx on the wrapper Box below.
 const SUCCESSOR_ROW_HEIGHT = 36;

--- a/web/src/components/__tests__/PieceHistory.test.tsx
+++ b/web/src/components/__tests__/PieceHistory.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { act, render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { act, render, screen, fireEvent, waitFor } from "@testing-library/react";
 import PieceHistory from "../PieceHistory";
 import type { PieceDetail as PieceDetailType, PieceState } from "../../util/types";
 import * as api from "../../util/api";
@@ -14,7 +14,7 @@ vi.mock("../../../workflow.yml", () => ({
         visible: true,
         friendly_name: "Designing",
         description: "Design phase.",
-        successors: [],
+        successors: ["wheel_thrown"],
         past_friendly_name: "Designed",
       },
       {
@@ -35,6 +35,7 @@ vi.mock("../../util/api", () => ({
   updateCurrentState: vi.fn(),
   updatePastState: vi.fn(),
   addPieceState: vi.fn(),
+  deletePieceState: vi.fn(),
   updatePiece: vi.fn(),
 }));
 
@@ -202,12 +203,17 @@ describe("PieceHistory", () => {
     expect(screen.queryByText("First")).not.toBeInTheDocument();
   });
 
-  it("renders 'Add missing state' button when is_editable and history is open", async () => {
-    const piece = makePiece({ is_editable: true });
+  it("renders 'Insert state' button when is_editable and insertable states exist", async () => {
+    // designed → wheel_thrown is possible; history only has designed
+    const designedState = makeState({ id: "designed-id", state: "designed" });
+    const piece = makePiece({
+      is_editable: true,
+      history: [designedState],
+    });
     await act(async () => {
       render(
         <PieceHistory
-          pastHistory={[makeState({ state: "designed" })]}
+          pastHistory={[designedState]}
           piece={piece}
           onPieceUpdated={vi.fn()}
         />,
@@ -215,16 +221,20 @@ describe("PieceHistory", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: /show history/i }));
     expect(
-      screen.getByRole("button", { name: /add missing state/i }),
+      screen.getByRole("button", { name: /insert state/i }),
     ).toBeInTheDocument();
   });
 
-  it("does not render 'Add missing state' button when not editable", async () => {
-    const piece = makePiece({ is_editable: false });
+  it("does not render 'Insert state' button when not editable", async () => {
+    const designedState = makeState({ id: "designed-id", state: "designed" });
+    const piece = makePiece({
+      is_editable: false,
+      history: [designedState],
+    });
     await act(async () => {
       render(
         <PieceHistory
-          pastHistory={[makeState({ state: "designed" })]}
+          pastHistory={[designedState]}
           piece={piece}
           onPieceUpdated={vi.fn()}
         />,
@@ -232,114 +242,130 @@ describe("PieceHistory", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: /show history/i }));
     expect(
-      screen.queryByRole("button", { name: /add missing state/i }),
+      screen.queryByRole("button", { name: /insert state/i }),
     ).not.toBeInTheDocument();
   });
 
-  it("opens 'Add missing state' dialog on button click", async () => {
-    const piece = makePiece({ is_editable: true });
-    await act(async () => {
-      render(
-        <PieceHistory
-          pastHistory={[makeState({ state: "designed" })]}
-          piece={piece}
-          onPieceUpdated={vi.fn()}
-        />,
-      );
-    });
-    fireEvent.click(screen.getByRole("button", { name: /show history/i }));
-    fireEvent.click(screen.getByRole("button", { name: /add missing state/i }));
-    await waitFor(() => {
-      expect(screen.getByRole("dialog")).toBeInTheDocument();
-    });
-  });
-
-  it("adds a missing state and resets the dialog", async () => {
+  it("clicking 'Insert state' opens a menu and selecting calls addPieceState", async () => {
     const updated = makePiece();
     vi.mocked(api.addPieceState).mockResolvedValue(updated);
     const onPieceUpdated = vi.fn();
-    const piece = makePiece({ is_editable: true });
+    const designedState = makeState({ id: "designed-id", state: "designed" });
+    const piece = makePiece({
+      is_editable: true,
+      history: [designedState],
+    });
     await act(async () => {
       render(
         <PieceHistory
-          pastHistory={[makeState({ state: "designed" })]}
+          pastHistory={[designedState]}
           piece={piece}
           onPieceUpdated={onPieceUpdated}
         />,
       );
     });
-
     fireEvent.click(screen.getByRole("button", { name: /show history/i }));
-    fireEvent.click(screen.getByRole("button", { name: /add missing state/i }));
-    const dialog = screen.getByRole("dialog");
-    fireEvent.mouseDown(screen.getByLabelText("State"));
-    fireEvent.click(screen.getByRole("option", { name: "Throwing" }));
-    fireEvent.change(within(dialog).getByLabelText("Notes"), {
-      target: { value: " forgot this step " },
-    });
-    fireEvent.click(screen.getByRole("button", { name: /^add state$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /insert state/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /throwing/i }));
 
     await waitFor(() => {
       expect(api.addPieceState).toHaveBeenCalledWith("piece-id-1", {
         state: "wheel_thrown",
-        notes: "forgot this step",
       });
     });
     expect(onPieceUpdated).toHaveBeenCalledWith(updated);
-    await waitFor(() => {
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-    });
   });
 
-  it("keeps the add dialog open and shows an error when adding fails", async () => {
-    vi.mocked(api.addPieceState).mockRejectedValue(new Error("boom"));
-    const piece = makePiece({ is_editable: true });
+  it("renders delete button on non-designed historical states in edit mode", async () => {
+    const wheelState = makeState({ id: "wt-id", state: "wheel_thrown" });
+    const designedState = makeState({ id: "d-id", state: "designed" });
+    const piece = makePiece({
+      is_editable: true,
+      history: [designedState, wheelState],
+    });
     await act(async () => {
       render(
         <PieceHistory
-          pastHistory={[makeState({ state: "designed" })]}
+          pastHistory={[designedState, wheelState]}
           piece={piece}
           onPieceUpdated={vi.fn()}
         />,
       );
     });
-
     fireEvent.click(screen.getByRole("button", { name: /show history/i }));
-    fireEvent.click(screen.getByRole("button", { name: /add missing state/i }));
-    fireEvent.mouseDown(screen.getByLabelText("State"));
-    fireEvent.click(screen.getByRole("option", { name: "Throwing" }));
-    fireEvent.click(screen.getByRole("button", { name: /^add state$/i }));
-
     expect(
-      await screen.findByText("Failed to add state. Please try again."),
+      screen.getByRole("button", { name: /delete.*state/i }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("dialog")).toBeInTheDocument();
   });
 
-  it("clears add dialog fields when canceling", async () => {
-    const piece = makePiece({ is_editable: true });
+  it("does not render delete button on designed state", async () => {
+    const designedState = makeState({ id: "d-id", state: "designed" });
+    const piece = makePiece({
+      is_editable: true,
+      history: [designedState],
+    });
     await act(async () => {
       render(
         <PieceHistory
-          pastHistory={[makeState({ state: "designed" })]}
+          pastHistory={[designedState]}
           piece={piece}
           onPieceUpdated={vi.fn()}
         />,
       );
     });
-
     fireEvent.click(screen.getByRole("button", { name: /show history/i }));
-    fireEvent.click(screen.getByRole("button", { name: /add missing state/i }));
-    fireEvent.change(within(screen.getByRole("dialog")).getByLabelText("Notes"), {
-      target: { value: "discard me" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
-    await waitFor(() => {
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-    });
+    expect(
+      screen.queryByRole("button", { name: /delete designed state/i }),
+    ).not.toBeInTheDocument();
+  });
 
-    fireEvent.click(screen.getByRole("button", { name: /add missing state/i }));
-    expect(within(screen.getByRole("dialog")).getByLabelText("Notes")).toHaveValue("");
+  it("does not render delete button in read mode", async () => {
+    const wheelState = makeState({ id: "wt-id", state: "wheel_thrown" });
+    const designedState = makeState({ id: "d-id", state: "designed" });
+    const piece = makePiece({
+      is_editable: false,
+      history: [designedState, wheelState],
+    });
+    await act(async () => {
+      render(
+        <PieceHistory
+          pastHistory={[designedState, wheelState]}
+          piece={piece}
+          onPieceUpdated={vi.fn()}
+        />,
+      );
+    });
+    fireEvent.click(screen.getByRole("button", { name: /show history/i }));
+    expect(
+      screen.queryByRole("button", { name: /delete/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("clicking delete calls deletePieceState and triggers onPieceUpdated", async () => {
+    const updated = makePiece();
+    vi.mocked(api.deletePieceState).mockResolvedValue(updated);
+    const onPieceUpdated = vi.fn();
+    const wheelState = makeState({ id: "wt-id", state: "wheel_thrown" });
+    const designedState = makeState({ id: "d-id", state: "designed" });
+    const piece = makePiece({
+      is_editable: true,
+      history: [designedState, wheelState],
+    });
+    await act(async () => {
+      render(
+        <PieceHistory
+          pastHistory={[designedState, wheelState]}
+          piece={piece}
+          onPieceUpdated={onPieceUpdated}
+        />,
+      );
+    });
+    fireEvent.click(screen.getByRole("button", { name: /show history/i }));
+    fireEvent.click(screen.getByRole("button", { name: /delete.*state/i }));
+    await waitFor(() => {
+      expect(api.deletePieceState).toHaveBeenCalledWith("piece-id-1", "wt-id");
+    });
+    expect(onPieceUpdated).toHaveBeenCalledWith(updated);
   });
 
   it("renders editable Notes fields for past states when is_editable", async () => {

--- a/web/src/util/api.ts
+++ b/web/src/util/api.ts
@@ -328,6 +328,16 @@ export async function updatePastState(
   return mapPieceDetail(data);
 }
 
+export async function deletePieceState(
+  pieceId: string,
+  stateId: string,
+): Promise<PieceDetail> {
+  const { data } = await client.delete<Wire<PieceDetail>>(
+    `pieces/${pieceId}/states/${stateId}/`,
+  );
+  return mapPieceDetail(data);
+}
+
 export type UpdatePiecePayload = {
   name?: string;
   current_location?: string;

--- a/web/src/util/types.ts
+++ b/web/src/util/types.ts
@@ -1,34 +1,4 @@
 import type { components } from "./generated-types";
-import workflow from "../../../workflow.yml";
-import { formatState as _formatState } from "./workflow";
-export {
-  formatState,
-  formatPastState,
-  getStateDescription,
-  getStateMetadata,
-  isTerminalState,
-} from "./workflow";
-
-type WorkflowState = {
-  id: string;
-  visible: boolean;
-  friendly_name: string;
-  past_friendly_name: string;
-  description: string;
-  successors?: string[];
-  terminal?: boolean;
-};
-
-// Runtime constants derived from workflow.json.
-// STATES preserves lifecycle order; SUCCESSORS encodes the transition graph.
-// Neither is expressed in the OpenAPI schema, so they stay anchored to workflow.json.
-export const STATES = (workflow.states as WorkflowState[]).map(({ id }) => id);
-export const SUCCESSORS: Record<string, string[]> = Object.fromEntries(
-  (workflow.states as WorkflowState[]).map(({ id, successors }) => [
-    id,
-    successors ?? [],
-  ]),
-);
 
 // State type from the generated schema — stays in sync with backend validation.
 export type State = components["schemas"]["StateEnum"];
@@ -99,23 +69,6 @@ export type PieceDetail = PieceSummary & {
   current_state: PieceState;
   history: PieceState[];
 };
-
-// Returns null if the history+current sequence has all valid transitions, or an
-// error string for the first invalid step (e.g. "'Glazing' is not a valid successor of 'Designing'").
-export function validateHistorySequence(
-  history: PieceState[],
-  currentState: PieceState,
-): string | null {
-  const allStates = [...history, currentState];
-  for (let i = 0; i < allStates.length - 1; i++) {
-    const from = allStates[i].state;
-    const to = allStates[i + 1].state;
-    if (!(SUCCESSORS[from] ?? []).includes(to)) {
-      return `'${_formatState(to)}' is not a valid successor of '${_formatState(from)}'`;
-    }
-  }
-  return null;
-}
 
 // GlazeCombination entry and related types — derived from generated OpenAPI types.
 export type GlazeTypeRef = components["schemas"]["GlazeTypeRef"];

--- a/web/src/util/workflow.test.ts
+++ b/web/src/util/workflow.test.ts
@@ -341,6 +341,7 @@ import {
   isFavoritableGlobal,
   isTerminalState,
   isTaggableGlobal,
+  insertableStatesBetween,
 } from "./workflow";
 
 describe("formatWorkflowFieldLabel", () => {
@@ -837,5 +838,28 @@ describe("isTaggableGlobal", () => {
 
   it("returns false for an unknown global", () => {
     expect(isTaggableGlobal("nonexistent")).toBe(false);
+  });
+});
+
+describe("insertableStatesBetween", () => {
+  it("returns all successors of designed when only designed is present", () => {
+    const result = insertableStatesBetween("designed", new Set(["designed"]));
+    expect(result).toEqual(expect.arrayContaining(["wheel_thrown", "handbuilt"]));
+    expect(result).toHaveLength(2);
+  });
+
+  it("filters out already-present states", () => {
+    const result = insertableStatesBetween("designed", new Set(["designed", "wheel_thrown"]));
+    expect(result).toEqual(["handbuilt"]);
+  });
+
+  it("returns empty when all successors are already present", () => {
+    const result = insertableStatesBetween("designed", new Set(["designed", "wheel_thrown", "handbuilt"]));
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty for a terminal state with no successors", () => {
+    const result = insertableStatesBetween("completed", new Set(["designed", "completed"]));
+    expect(result).toEqual([]);
   });
 });

--- a/web/src/util/workflow.ts
+++ b/web/src/util/workflow.ts
@@ -9,6 +9,9 @@
  * duplicated elsewhere in the app; derive them from the exports here.
  */
 import workflow from "../../../workflow.yml";
+import type { components } from "./generated-types";
+
+type State = components["schemas"]["StateEnum"];
 
 type FieldType =
   | "string"
@@ -115,6 +118,13 @@ const STATE_MAP = new Map<string, WorkflowStateDefinition>(
   workflowDef.states.map((state) => [state.id, state]),
 );
 const GLOBALS_MAP = workflowDef.globals ?? {};
+
+// Runtime constants derived from workflow.yml.
+// STATES preserves lifecycle order; SUCCESSORS encodes the transition graph.
+export const STATES = workflowDef.states.map(({ id }) => id);
+export const SUCCESSORS: Record<string, string[]> = Object.fromEntries(
+  workflowDef.states.map(({ id, successors }) => [id, successors ?? []]),
+);
 
 function toTitleWords(value: string): string {
   return value
@@ -642,6 +652,38 @@ function buildSummaryItem(
     };
   }
   return null;
+}
+
+/**
+ * Returns null if the history+current sequence has all valid transitions, or an
+ * error string for the first invalid step.
+ */
+export function validateHistorySequence(
+  history: { state: State }[],
+  currentState: { state: State },
+): string | null {
+  const allStates = [...history, currentState];
+  for (let i = 0; i < allStates.length - 1; i++) {
+    const from = allStates[i].state;
+    const to = allStates[i + 1].state;
+    if (!(SUCCESSORS[from] ?? []).includes(to)) {
+      return `'${formatState(to)}' is not a valid successor of '${formatState(from)}'`;
+    }
+  }
+  return null;
+}
+
+/**
+ * Returns the states that could be inserted immediately after `predecessor`
+ * that are not already present in `presentStates`.
+ */
+export function insertableStatesBetween(
+  predecessor: State,
+  presentStates: ReadonlySet<State>,
+): State[] {
+  return (SUCCESSORS[predecessor] ?? []).filter(
+    (s) => !presentStates.has(s as State),
+  ) as State[];
 }
 
 function resolveStateFieldRef(


### PR DESCRIPTION
## Summary

- Replaces the bottom-level "Add missing state" button with inline **"+"** `IconButton`s between adjacent history chips in edit mode; clicking opens an anchored MUI `Menu` listing only valid insertable states (constrained to the predecessor's successors, excluding already-present states)
- Adds **"×"** delete buttons on each non-`designed` historical state chip; deletion calls `DELETE /api/pieces/{id}/states/{stateId}/` and updates the piece in place
- No affordance is shown after the latest (current) state — future states cannot be added from the Timeline
- Moves `STATES`, `SUCCESSORS`, `validateHistorySequence`, and new `insertableStatesBetween` into `workflow.ts` (their natural home), fully severing `types.ts`'s dependency on `workflow.ts`

## Refactoring

`types.ts` previously re-exported `formatState`, `formatPastState`, `isTerminalState`, etc. from `workflow.ts` as a convenience barrel, and housed `validateHistorySequence` with a `PieceState[]` signature (requiring the workflow import). This PR:

- Moves all workflow-graph logic (`STATES`, `SUCCESSORS`, `validateHistorySequence`, `insertableStatesBetween`) to `workflow.ts`
- Removes the re-export barrel and the `workflow.ts` import from `types.ts`
- Updates 5 component import sites to import directly from `workflow.ts`
- `validateHistorySequence` is now strongly typed via `State` from generated types

## Test plan

- [ ] `insertableStatesBetween` has pure unit tests in `web/src/util/workflow.test.ts` covering successor filtering and already-present state exclusion
- [ ] `PieceHistory.test.tsx` covers: "+" appears between states with valid successors (edit mode only), "×" appears on non-`designed` states (edit mode only), delete calls `deletePieceState` and fires `onPieceUpdated`
- [ ] `bazel test //...` — 41/41 pass
- [ ] `bazel build --config=lint //...` — clean (pre-existing lint errors in `tools/` unrelated to this PR)
- [ ] TypeScript type check clean

Closes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)
