### PR TITLE
Allow direct state selection in Timeline

### DIFF
--- a/web/src/components/PieceHistory.tsx
+++ b/web/src/components/PieceHistory.tsx
@@ -266,7 +266,6 @@ export default function PieceHistory({
                         alignItems: "flex-start",
                         cursor: onRewind ? "pointer" : "default",
                         opacity: isAfterRewind ? 0.35 : 1,
-                        pointerEvents: isAfterRewind ? "none" : "auto",
                         transition: "opacity 0.2s, border-color 0.2s",
                       })}
                     >


### PR DESCRIPTION
Allow users to focus any state in the piece timeline directly, without having to unselect the currently focused state.

### Changes

#### Frontend

- **PieceHistory.tsx**: Removed `pointerEvents: "none"` restriction on historical states that follow the focused "rewound" state. This enables direct switching between states in the timeline.

### Verification Results

- Ran `bazel test //web:web_test` - all 27 tests passed.
- Verified that the "greyed out" visual style remains for states following the focus point, but they are now clickable and correctly shift focus when selected.

Closes #393
