### PR TITLE
Enable historical image uploads

### DIFF
--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -634,7 +634,6 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
               initialPieceState={rewindedState}
               pieceId={piece.id}
               onSaved={onPieceUpdated}
-              hideImageUpload
               saveStateFn={(payload) =>
                 updatePastState(piece.id, rewindedState.id, payload)
               }

--- a/web/src/components/PieceHistory.tsx
+++ b/web/src/components/PieceHistory.tsx
@@ -337,7 +337,6 @@ export default function PieceHistory({
                           initialPieceState={ps}
                           pieceId={piece.id}
                           onSaved={onPieceUpdated}
-                          hideImageUpload
                           saveStateFn={(payload) =>
                             updatePastState(piece.id, ps.id, payload)
                           }


### PR DESCRIPTION
## Description

Enables "Upload Image" functionality for historical states within the Piece Detail view when in editable mode. 

Previously, historical states (both in the "rewound" view and the timeline) were hardcoded to hide the image upload trigger. This PR removes those restrictions, allowing users to add images to any state in a piece's history as long as the piece is in "Edit piece history" mode.

## Changes

- **PieceDetail.tsx**: Removed `hideImageUpload` from the historical state view.
- **PieceHistory.tsx**: Removed `hideImageUpload` from the timeline state view.

## Verification

- Verified that the "Upload Image" button appears for historical states in editable mode using a temporary reproduction test.
- Verified that the button is still hidden when NOT in editable mode (via `readOnly` prop which is still respected).
- All web tests passed.

Fixes #395
