### PR TITLE
Disable history editing on shared pieces (#394)

### DIFF
--- a/api/tests/test_async_tasks.py
+++ b/api/tests/test_async_tasks.py
@@ -317,7 +317,9 @@ class TestRemoteDetectSubjectCrop:
         piece = Piece.objects.create(user=user, name="Mug", thumbnail=image)
 
         # Configure remote URL
-        monkeypatch.setattr(settings, "REMOTE_REMBG_URL", "https://remote.ai/", raising=False)
+        monkeypatch.setattr(
+            settings, "REMOTE_REMBG_URL", "https://remote.ai/", raising=False
+        )
 
         # Mock image download
         mock_response_get = type(
@@ -336,7 +338,9 @@ class TestRemoteDetectSubjectCrop:
         posted_calls = []
 
         def mock_post(url, data=None, json=None, headers=None, timeout=None):
-            posted_calls.append({"url": url, "data": data, "json": json, "headers": headers})
+            posted_calls.append(
+                {"url": url, "data": data, "json": json, "headers": headers}
+            )
             return mock_response_post
 
         monkeypatch.setattr("requests.post", mock_post)
@@ -355,7 +359,10 @@ class TestRemoteDetectSubjectCrop:
         assert len(posted_calls) == 1
         assert posted_calls[0]["url"] == "https://remote.ai/"
         # It should now send the base image.url directly
-        assert posted_calls[0]["json"]["url"] == "https://res.cloudinary.com/demo/image/upload/v1/pieces/mug.jpg"
+        assert (
+            posted_calls[0]["json"]["url"]
+            == "https://res.cloudinary.com/demo/image/upload/v1/pieces/mug.jpg"
+        )
         assert posted_calls[0]["data"] is None
 
         task.refresh_from_db()

--- a/api/tests/test_migrations_completeness.py
+++ b/api/tests/test_migrations_completeness.py
@@ -1,7 +1,9 @@
-import pytest
-import os
 import glob
+import os
+
+import pytest
 from django.conf import settings
+
 
 @pytest.mark.django_db
 def test_migrations_completeness():
@@ -13,30 +15,30 @@ def test_migrations_completeness():
     # Path to migrations in the source tree (or as seen by the test runner)
     # When running under Bazel, this should point to the runfiles.
     migrations_dir = os.path.join(settings.BASE_DIR, "api", "migrations")
-    
+
     # Get all .py files in migrations directory, excluding __init__.py
     migration_files = glob.glob(os.path.join(migrations_dir, "*.py"))
     migration_files = [f for f in migration_files if not f.endswith("__init__.py")]
-    
+
     # Extract just the filenames for comparison
     migration_filenames = {os.path.basename(f) for f in migration_files}
-    
+
     # Now check what Django's migration loader sees (which depends on what's in the PYTHONPATH/runfiles)
-    from django.db.migrations.loader import MigrationLoader
     from django.db import connections
-    
+    from django.db.migrations.loader import MigrationLoader
+
     loader = MigrationLoader(connections["default"])
-    
+
     # Get all migrations registered for the 'api' app
     registered_migrations = {
         m[1] for m in loader.disk_migrations.keys() if m[0] == "api"
     }
-    
+
     # Convert filenames to migration names (e.g. '0001_initial.py' -> '0001_initial')
     expected_migration_names = {os.path.splitext(f)[0] for f in migration_filenames}
-    
+
     missing_from_loader = expected_migration_names - registered_migrations
-    
+
     assert not missing_from_loader, (
         f"Migrations found on disk but missing from Django loader: {missing_from_loader}. "
         "Check if they are missing from api/BUILD.bazel."

--- a/api/tests/test_piece_detail.py
+++ b/api/tests/test_piece_detail.py
@@ -227,6 +227,24 @@ class TestPieceDetail:
         assert response.status_code == 200
         assert response.json()["shared"] is True
 
+    def test_owner_cannot_enable_edit_mode_on_shared_piece(self, client, piece):
+        PieceState.objects.create(user=piece.user, piece=piece, state="completed")
+        piece.shared = True
+        piece.save()
+
+        response = client.patch(
+            f"/api/pieces/{piece.id}/",
+            {"is_editable": True},
+            format="json",
+        )
+
+        assert response.status_code == 400
+        assert response.json() == {
+            "non_field_errors": [
+                "A piece cannot be shared while in editable mode. Seal the piece before sharing, or unshare before editing."
+            ]
+        }
+
     def test_owner_cannot_share_non_terminal_piece(self, client, piece):
         response = client.patch(
             f"/api/pieces/{piece.id}/",

--- a/tools/piece_image_crop_service.py
+++ b/tools/piece_image_crop_service.py
@@ -24,15 +24,25 @@ try:
 
     image = (
         modal.Image.debian_slim()
-        .pip_install("fastapi", "uvicorn", "rembg", "onnxruntime", "pillow", "pillow-heif", "requests")
+        .pip_install(
+            "fastapi",
+            "uvicorn",
+            "rembg",
+            "onnxruntime",
+            "pillow",
+            "pillow-heif",
+            "requests",
+        )
         # Pre-download the model into the image to reduce cold start latency
         # We use the full 'u2net' model for better accuracy than the 'u2netp' lite version.
-        .run_commands("python -c \"from rembg import new_session; new_session('u2net')\"")
+        .run_commands(
+            "python -c \"from rembg import new_session; new_session('u2net')\""
+        )
     )
-    
+
     # We use a secret to protect the endpoint
     secret = modal.Secret.from_name("piece-image-crop-secret")
-    
+
     app = modal.App("piece-image-crop-service", image=image, secrets=[secret])
 
     @app.function()
@@ -46,22 +56,22 @@ except ImportError:
 
 def create_app():
     """Factory to create the FastAPI app with heavy imports deferred."""
-    from fastapi import FastAPI, Request, Response, Header, HTTPException
+    import requests
+    from fastapi import FastAPI, Header, HTTPException, Request, Response
     from PIL import Image, ImageOps
     from pillow_heif import register_heif_opener
     from rembg import new_session, remove
-    import requests
-    from urllib3.util import Retry
     from requests.adapters import HTTPAdapter
+    from urllib3.util import Retry
 
     # Register HEIF support (HEIC conversion handled here)
     register_heif_opener()
 
     fastapi_instance = FastAPI(title="Piece Image Crop Service")
-    
+
     # Using the full u2net model for improved accuracy (higher memory but better edge detection)
     _SESSION = new_session("u2net")
-    
+
     # Simple token-based auth
     EXPECTED_TOKEN = os.environ.get("AUTH_TOKEN")
 
@@ -81,7 +91,7 @@ def create_app():
         adapter = HTTPAdapter(max_retries=retry_strategy)
         session.mount("https://", adapter)
         session.mount("http://", adapter)
-        
+
         resp = session.get(url, timeout=timeout)
         resp.raise_for_status()
         return resp.content
@@ -90,9 +100,9 @@ def create_app():
     async def detect_crop(request: Request, x_api_key: str = Header(None)):
         """Receive image bytes OR a URL and return a relative crop box."""
         await verify_auth(x_api_key)
-        
+
         content_type = request.headers.get("Content-Type")
-        
+
         try:
             if content_type == "application/json":
                 # Handle URL-based request
@@ -105,14 +115,14 @@ def create_app():
             else:
                 # Handle raw bytes
                 image_bytes = await request.body()
-                
+
             if not image_bytes:
                 return Response(content="Empty image data", status_code=400)
 
             # HEIC -> JPG/RGBA conversion happens during Image.open thanks to register_heif_opener
             input_image = Image.open(io.BytesIO(image_bytes))
             input_image = ImageOps.exif_transpose(input_image)
-            
+
             # Implementation Detail: Optimized resizing for ML processing.
             # We downscale to a reasonable max dimension to save memory and speed up rembg.
             MAX_DIM = 1600
@@ -143,7 +153,7 @@ def create_app():
             subj_h = lower - upper
             pad_w = int(subj_w * 0.10)
             pad_h = int(subj_h * 0.10)
-            
+
             left = max(0, left - pad_w)
             upper = max(0, upper - pad_h)
             right = min(width, right + pad_w)
@@ -173,4 +183,5 @@ def create_app():
 # `bazel run //tools:piece_image_crop_service`, __main__ is the entry point.
 if __name__ == "__main__":
     import uvicorn
+
     uvicorn.run(create_app(), host="0.0.0.0", port=8080)

--- a/tools/tests/test_piece_image_crop_service.py
+++ b/tools/tests/test_piece_image_crop_service.py
@@ -6,18 +6,17 @@ without downloading any model weights.
 """
 
 import io
-import sys
 import os
 import unittest
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 from PIL import Image
 
-
 # ---------------------------------------------------------------------------
 # Helpers: synthetic alpha masks
 # ---------------------------------------------------------------------------
+
 
 def _make_rgba(width: int, height: int, alpha: np.ndarray) -> Image.Image:
     """Create an RGBA PIL image with the given alpha channel (numpy uint8 array)."""
@@ -47,12 +46,14 @@ def _noisy_mask(width: int, height: int, subject_box, noise_box) -> np.ndarray:
 # Tests
 # ---------------------------------------------------------------------------
 
+
 class TestDownloadWithRetry(unittest.TestCase):
     """Tests for the download_with_retry helper."""
 
     def _get_fn(self):
         # Import late so that other heavy deps (rembg) are already patched
         from tools.piece_image_crop_service import create_app  # noqa
+
         # We need to call create_app() with rembg mocked to retrieve the closure.
         # Instead, test the logic independently by reconstructing a minimal version.
         import requests
@@ -95,8 +96,11 @@ class TestContourFiltering(unittest.TestCase):
     def _compute_bbox(self, alpha_np, width, height, padding=0.10):
         """Run the same contour logic as the service. Returns (left, upper, right, lower)."""
         import cv2
+
         _, binary_mask = cv2.threshold(alpha_np, 127, 255, cv2.THRESH_BINARY)
-        contours, _ = cv2.findContours(binary_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        contours, _ = cv2.findContours(
+            binary_mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
+        )
         if not contours:
             return None
         largest = max(contours, key=cv2.contourArea)
@@ -127,13 +131,15 @@ class TestContourFiltering(unittest.TestCase):
     def test_noise_blob_ignored(self):
         W, H = 200, 200
         # Large subject at [50,50]→[150,150]; tiny noise at [0,0]→[5,5]
-        alpha = _noisy_mask(W, H, subject_box=(50, 50, 150, 150), noise_box=(0, 0, 5, 5))
+        alpha = _noisy_mask(
+            W, H, subject_box=(50, 50, 150, 150), noise_box=(0, 0, 5, 5)
+        )
         left, upper, right, lower = self._compute_bbox(alpha, W, H, padding=0.0)
 
         # Without padding, bbox should exactly match the subject (plus 1px because boundingRect is inclusive)
         self.assertEqual(left, 50)
         self.assertEqual(upper, 50)
-        self.assertLessEqual(right, 151)   # within 1px
+        self.assertLessEqual(right, 151)  # within 1px
         self.assertLessEqual(lower, 151)
 
     def test_padding_clamped_to_image_bounds(self):
@@ -179,14 +185,18 @@ class TestAuthVerification(unittest.TestCase):
 
     def setUp(self):
         # Patch rembg before importing create_app so model weights are never loaded
-        self._rembg_patcher = patch.dict("sys.modules", {
-            "rembg": MagicMock(),
-            "pillow_heif": MagicMock(),
-        })
+        self._rembg_patcher = patch.dict(
+            "sys.modules",
+            {
+                "rembg": MagicMock(),
+                "pillow_heif": MagicMock(),
+            },
+        )
         self._rembg_patcher.start()
 
         # rembg.new_session must return something; rembg.remove must return an RGBA image
         import rembg
+
         alpha = _single_blob_mask(100, 100, (20, 20, 80, 80))
         fake_output = _make_rgba(100, 100, alpha)
         rembg.new_session = MagicMock(return_value=MagicMock())
@@ -201,22 +211,30 @@ class TestAuthVerification(unittest.TestCase):
             os.environ["AUTH_TOKEN"] = token
 
         # Import inside test so the mock is already in sys.modules
-        from tools.piece_image_crop_service import create_app
         from fastapi.testclient import TestClient
+
+        from tools.piece_image_crop_service import create_app
+
         app = create_app()
         return TestClient(app)
 
     def test_no_token_configured_allows_any_request(self):
         client = self._make_client(token=None)
         img_bytes = io.BytesIO()
-        _make_rgba(100, 100, _single_blob_mask(100, 100, (10, 10, 90, 90))).save(img_bytes, format="PNG")
-        resp = client.post("/", content=img_bytes.getvalue(), headers={"Content-Type": "image/png"})
+        _make_rgba(100, 100, _single_blob_mask(100, 100, (10, 10, 90, 90))).save(
+            img_bytes, format="PNG"
+        )
+        resp = client.post(
+            "/", content=img_bytes.getvalue(), headers={"Content-Type": "image/png"}
+        )
         self.assertEqual(resp.status_code, 200)
 
     def test_valid_token_is_accepted(self):
         client = self._make_client(token="secret")
         img_bytes = io.BytesIO()
-        _make_rgba(100, 100, _single_blob_mask(100, 100, (10, 10, 90, 90))).save(img_bytes, format="PNG")
+        _make_rgba(100, 100, _single_blob_mask(100, 100, (10, 10, 90, 90))).save(
+            img_bytes, format="PNG"
+        )
         resp = client.post(
             "/",
             content=img_bytes.getvalue(),
@@ -227,7 +245,9 @@ class TestAuthVerification(unittest.TestCase):
     def test_invalid_token_returns_403(self):
         client = self._make_client(token="secret")
         img_bytes = io.BytesIO()
-        _make_rgba(100, 100, _single_blob_mask(100, 100, (10, 10, 90, 90))).save(img_bytes, format="PNG")
+        _make_rgba(100, 100, _single_blob_mask(100, 100, (10, 10, 90, 90))).save(
+            img_bytes, format="PNG"
+        )
         resp = client.post(
             "/",
             content=img_bytes.getvalue(),

--- a/tools/visualize_crops.py
+++ b/tools/visualize_crops.py
@@ -107,6 +107,7 @@ def main() -> None:
         # --- DB mode: pull recent images ---
         os.environ.setdefault("DJANGO_SETTINGS_MODULE", "backend.settings")
         import django
+
         django.setup()
         from api.models import Image as ApiImage  # noqa: PLC0415
 

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   useState,
 } from "react";
+import axios from "axios";
 import {
   Alert,
   alpha,
@@ -14,6 +15,7 @@ import {
   Divider,
   IconButton,
   TextField,
+  Tooltip,
   Typography,
   useTheme,
 } from "@mui/material";
@@ -135,36 +137,72 @@ function EditableToggle({ piece, onPieceUpdated }: PieceDetailProps) {
         is_editable: !piece.is_editable,
       });
       onPieceUpdated(updated);
-    } catch {
-      setError("Failed to update. Please try again.");
+    } catch (e: unknown) {
+      if (axios.isAxiosError(e) && e.response?.data) {
+        const data = e.response.data;
+        const msg =
+          typeof data === "string"
+            ? data
+            : data.non_field_errors?.[0] ||
+              (typeof data === "object" ? Object.values(data).flat()[0] : null);
+        setError(String(msg || "Failed to update. Please try again."));
+      } else {
+        setError("Failed to update. Please try again.");
+      }
     } finally {
       setSaving(false);
     }
   }
 
+  const disabledReason = piece.shared
+    ? "This piece is publicly shared. Unshare it to edit history."
+    : null;
+
   return (
     <Box>
-      {piece.is_editable ? (
-        <Button
-          variant="contained"
-          size="small"
-          startIcon={<LockIcon fontSize="small" />}
-          onClick={toggle}
-          disabled={saving || !!seqError}
+      <Tooltip
+        title={disabledReason || ""}
+        disableHoverListener={!disabledReason}
+        arrow
+      >
+        <span>
+          {piece.is_editable ? (
+            <Button
+              variant="contained"
+              size="small"
+              startIcon={<LockIcon fontSize="small" />}
+              onClick={toggle}
+              disabled={saving || !!seqError}
+            >
+              Seal changes
+            </Button>
+          ) : (
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<HistoryIcon fontSize="small" />}
+              onClick={toggle}
+              disabled={saving || !!disabledReason}
+              sx={{ borderStyle: "dashed", color: "text.secondary" }}
+            >
+              Edit piece history
+            </Button>
+          )}
+        </span>
+      </Tooltip>
+      {disabledReason && (
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{
+            ml: { sm: 1.5 },
+            mt: { xs: 0.5, sm: 0 },
+            display: { xs: "block", sm: "inline-block" },
+            verticalAlign: "middle",
+          }}
         >
-          Seal changes
-        </Button>
-      ) : (
-        <Button
-          variant="outlined"
-          size="small"
-          startIcon={<HistoryIcon fontSize="small" />}
-          onClick={toggle}
-          disabled={saving}
-          sx={{ borderStyle: "dashed", color: "text.secondary" }}
-        >
-          Edit piece history
-        </Button>
+          {disabledReason}
+        </Typography>
       )}
       {seqError && (
         <Typography variant="caption" color="error" sx={{ ml: 1 }}>


### PR DESCRIPTION
Disables the ability to edit the history of a piece while it is publicly shared.

## Problem
Currently, users can attempt to edit the history of a piece even if it is shared. While the backend correctly validates and rejects these updates, the UI provides no indication of why the action is restricted, often resulting in generic error messages.

## Solution
This PR updates the `PieceDetail` view to proactively disable history editing for shared pieces and provides clear explanatory feedback.

### Backend
- Added a test case to `api/tests/test_piece_detail.py` verifying that pieces cannot be put into editable mode while shared.

### Frontend
- **EditableToggle Restriction**: The "Edit piece history" button is now disabled when `piece.shared` is true.
- **User Feedback**: 
    - Added a `Tooltip` for desktop users explaining the restriction.
    - Added a `Typography` caption for mobile users or immediate visibility.
- **Improved Error Handling**: Updated the toggle logic to extract and display specific backend validation errors (e.g., from `non_field_errors`).

## Verification
- [x] Backend tests passed: `//api:api_piece_test`
- [x] Frontend tests passed: `//web:web_piece_detail_test`
- [x] Manual verification performed on local dev server.

Closes #394
