### PR TITLE
feat: enable timeline rewind in read-only mode

### DIFF
--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -251,9 +251,7 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
 
   const [rewindedStateId, setRewindedStateId] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!piece.is_editable) setRewindedStateId(null);
-  }, [piece.is_editable]);
+  // Keep rewindedStateId when toggling is_editable to allow viewing history in read-only mode.
 
   const rewindedState = rewindedStateId
     ? pastHistory.find((ps) => ps.id === rewindedStateId) ?? null
@@ -652,7 +650,7 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
           </Box>
         </Box>
 
-        {rewindedState && piece.is_editable ? (
+        {rewindedState ? (
           <SectionCard>
             <Box sx={{ mb: 1.5, display: "flex", alignItems: "center", gap: 1 }}>
               <Chip
@@ -664,7 +662,9 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
                 onDelete={() => setRewindedStateId(null)}
               />
               <Typography variant="caption" color="text.secondary">
-                Editing historical state — later states greyed out in timeline
+                {piece.is_editable
+                  ? "Editing historical state — later states greyed out in timeline"
+                  : "Viewing historical state — read-only"}
               </Typography>
             </Box>
             <WorkflowState
@@ -672,6 +672,8 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
               initialPieceState={rewindedState}
               pieceId={piece.id}
               onSaved={onPieceUpdated}
+              readOnly={!piece.is_editable}
+              hideNotes={!canEdit}
               saveStateFn={(payload) =>
                 updatePastState(piece.id, rewindedState.id, payload)
               }
@@ -686,6 +688,7 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
               onSaved={onPieceUpdated}
               onDirtyChange={setIsDirty}
               readOnly={!canEdit}
+              hideNotes={!canEdit}
             />
           </SectionCard>
         ) : null}
@@ -753,7 +756,7 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
             piece={piece}
             onPieceUpdated={onPieceUpdated}
             rewindedStateId={rewindedStateId}
-            onRewind={piece.is_editable ? setRewindedStateId : undefined}
+            onRewind={setRewindedStateId}
           />
         </SectionCard>
       </Box>

--- a/web/src/components/PieceHistory.tsx
+++ b/web/src/components/PieceHistory.tsx
@@ -218,111 +218,117 @@ export default function PieceHistory({
 
             // Only show insert affordance in edit mode, with a valid predecessor,
             // and NOT before the last item (no affordance after pastHistory.at(-1))
-            // — actually show before each item (between predecessor and item[i])
             const showInsert = canModifyHistory && predecessor !== null;
 
-            if (canModifyHistory && piece && onPieceUpdated) {
-              return (
-                <Box key={ps.id ?? i}>
-                  {showInsert && predecessor && (
-                    <InsertButton
-                      predecessor={predecessor}
-                      presentStates={presentStates}
-                      piece={piece}
-                      onPieceUpdated={onPieceUpdated}
-                    />
-                  )}
-                  <Tooltip
-                    title={
-                      isRewinded
-                        ? "Click to stop viewing this state"
-                        : "Click to view and edit this state"
+            return (
+              <Box key={ps.id ?? i}>
+                {showInsert && predecessor && (
+                  <InsertButton
+                    predecessor={predecessor}
+                    presentStates={presentStates}
+                    piece={piece!}
+                    onPieceUpdated={onPieceUpdated!}
+                  />
+                )}
+                <Tooltip
+                  title={
+                    isRewinded
+                      ? "Click to stop viewing this state"
+                      : canModifyHistory
+                        ? "Click to view and edit this state"
+                        : "Click to view this state"
+                  }
+                  placement="top-start"
+                  disableHoverListener={!onRewind}
+                >
+                  <ListItem
+                    disableGutters
+                    onClick={
+                      onRewind
+                        ? () => onRewind(isRewinded ? null : ps.id)
+                        : undefined
                     }
-                    placement="top-start"
-                    disableHoverListener={!onRewind}
+                    sx={(theme) => ({
+                      px: 1.5,
+                      py: 1.5,
+                      mb: 1,
+                      borderRadius: 3,
+                      border: "1px solid",
+                      borderColor: isRewinded ? "primary.main" : "divider",
+                      backgroundColor: alpha(
+                        theme.palette.background.default,
+                        0.34,
+                      ),
+                      flexDirection: "column",
+                      alignItems: "flex-start",
+                      cursor: onRewind ? "pointer" : "default",
+                      opacity: isAfterRewind ? 0.35 : 1,
+                      transition: "opacity 0.2s, border-color 0.2s",
+                      "&:hover": {
+                        borderColor: onRewind ? "primary.main" : "divider",
+                      },
+                    })}
                   >
-                    <ListItem
-                      disableGutters
-                      onClick={
-                        onRewind
-                          ? () => onRewind(isRewinded ? null : ps.id)
-                          : undefined
-                      }
-                      sx={(theme) => ({
-                        px: 1.5,
-                        py: 1.5,
-                        borderRadius: 3,
-                        border: "1px solid",
-                        borderColor: isRewinded ? "primary.main" : "divider",
-                        backgroundColor: alpha(
-                          theme.palette.background.default,
-                          0.34,
-                        ),
-                        flexDirection: "column",
-                        alignItems: "flex-start",
-                        cursor: onRewind ? "pointer" : "default",
-                        opacity: isAfterRewind ? 0.35 : 1,
-                        transition: "opacity 0.2s, border-color 0.2s",
-                      })}
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 1,
+                        mb: canModifyHistory ? 0.75 : 0,
+                        width: "100%",
+                      }}
                     >
-                      <Box
+                      <Typography
+                        variant="caption"
                         sx={{
-                          display: "flex",
-                          alignItems: "center",
-                          gap: 1,
-                          mb: 0.75,
-                          width: "100%",
+                          color: isRewinded ? "primary.main" : "text.secondary",
+                          letterSpacing: "0.1em",
+                          textTransform: "uppercase",
+                          flexGrow: 1,
                         }}
                       >
-                        <Typography
-                          variant="caption"
-                          sx={{
-                            color: isRewinded ? "primary.main" : "text.secondary",
-                            letterSpacing: "0.1em",
-                            textTransform: "uppercase",
-                            flexGrow: 1,
-                          }}
-                        >
-                          {formatPastState(ps.state)}
-                        </Typography>
-                        {isRewinded && (
-                          <Chip
-                            icon={<HistoryIcon />}
-                            label="Viewing"
-                            size="small"
-                            color="primary"
-                            variant="outlined"
-                            sx={{ height: 18, fontSize: "0.65rem" }}
-                          />
-                        )}
-                        {ps.state !== "designed" && (
-                          <Box onClick={(e) => e.stopPropagation()}>
-                            {deletingStateId === ps.id ? (
-                              <CircularProgress size={16} />
-                            ) : (
-                              <IconButton
-                                size="small"
-                                aria-label={`Delete ${formatPastState(ps.state)} state`}
-                                onClick={async () => {
-                                  dispatch({ type: "start_deleting", id: ps.id });
-                                  try {
-                                    const updated = await deletePieceState(
-                                      piece.id,
-                                      ps.id,
-                                    );
-                                    onPieceUpdated(updated);
-                                  } finally {
-                                    dispatch({ type: "done_deleting" });
-                                  }
-                                }}
-                                sx={{ opacity: 0.5, "&:hover": { opacity: 1 } }}
-                              >
-                                <CloseIcon fontSize="small" />
-                              </IconButton>
-                            )}
-                          </Box>
-                        )}
-                      </Box>
+                        {formatPastState(ps.state)}
+                      </Typography>
+                      {isRewinded && (
+                        <Chip
+                          icon={<HistoryIcon sx={{ fontSize: "0.8rem !important" }} />}
+                          label="Viewing"
+                          size="small"
+                          color="primary"
+                          variant="outlined"
+                          sx={{ height: 18, fontSize: "0.65rem" }}
+                        />
+                      )}
+                      {canModifyHistory && ps.state !== "designed" && (
+                        <Box onClick={(e) => e.stopPropagation()}>
+                          {deletingStateId === ps.id ? (
+                            <CircularProgress size={16} />
+                          ) : (
+                            <IconButton
+                              size="small"
+                              aria-label={`Delete ${formatPastState(ps.state)} state`}
+                              onClick={async () => {
+                                dispatch({ type: "start_deleting", id: ps.id });
+                                try {
+                                  const updated = await deletePieceState(
+                                    piece!.id,
+                                    ps.id,
+                                  );
+                                  onPieceUpdated!(updated);
+                                } finally {
+                                  dispatch({ type: "done_deleting" });
+                                }
+                              }}
+                              sx={{ opacity: 0.5, "&:hover": { opacity: 1 } }}
+                            >
+                              <CloseIcon fontSize="small" />
+                            </IconButton>
+                          )}
+                        </Box>
+                      )}
+                    </Box>
+
+                    {canModifyHistory ? (
                       <Box
                         sx={{ width: "100%" }}
                         onClick={(e) => e.stopPropagation()}
@@ -330,45 +336,26 @@ export default function PieceHistory({
                         <WorkflowState
                           key={ps.id}
                           initialPieceState={ps}
-                          pieceId={piece.id}
-                          onSaved={onPieceUpdated}
+                          pieceId={piece!.id}
+                          onSaved={onPieceUpdated!}
                           saveStateFn={(payload) =>
-                            updatePastState(piece.id, ps.id, payload)
+                            updatePastState(piece!.id, ps.id, payload)
                           }
                         />
                       </Box>
-                    </ListItem>
-                  </Tooltip>
-                </Box>
-              );
-            }
-            return (
-              <ListItem
-                key={ps.id ?? i}
-                disableGutters
-                sx={(theme) => ({
-                  px: 1.5,
-                  py: 1.5,
-                  borderRadius: 3,
-                  border: "1px solid",
-                  borderColor: "divider",
-                  backgroundColor: alpha(
-                    theme.palette.background.default,
-                    0.34,
-                  ),
-                  flexDirection: "column",
-                  alignItems: "flex-start",
-                })}
-              >
-                <ListItemText
-                  primary={formatPastState(ps.state)}
-                  secondary={`${ps.created.toLocaleString()}${ps.notes ? " — " + ps.notes : ""}`}
-                  slotProps={{
-                    primary: { sx: { color: "text.primary" } },
-                    secondary: { sx: { color: "text.secondary" } },
-                  }}
-                />
-              </ListItem>
+                    ) : (
+                      <ListItemText
+                        secondary={`${ps.created.toLocaleString()}${ps.notes ? " — " + ps.notes : ""}`}
+                        secondaryTypographyProps={{
+                          variant: "caption",
+                          sx: { color: "text.secondary" },
+                        }}
+                        sx={{ m: 0 }}
+                      />
+                    )}
+                  </ListItem>
+                </Tooltip>
+              </Box>
             );
           })}
           {showTrailingInsert && piece && onPieceUpdated && (

--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -48,6 +48,7 @@ type WorkflowStateProps = {
   onDirtyChange?: (dirty: boolean) => void;
   autosaveDelayMs?: number;
   readOnly?: boolean;
+  hideNotes?: boolean;
   hideImageUpload?: boolean;
   saveStateFn?: (payload: UpdateStatePayload) => Promise<PieceDetail>;
 };
@@ -162,6 +163,7 @@ export default function WorkflowState({
   onDirtyChange,
   autosaveDelayMs,
   readOnly = false,
+  hideNotes = false,
   hideImageUpload = false,
   saveStateFn,
 }: WorkflowStateProps) {
@@ -427,8 +429,8 @@ export default function WorkflowState({
         textAlign: "left",
       }}
     >
-      {/* Notes — hidden in read-only (public) views */}
-      {!readOnly && (
+      {/* Notes — hidden in public views, disabled in owner read-only views */}
+      {!hideNotes && (
         <TextField
           label="Notes"
           multiline
@@ -436,6 +438,7 @@ export default function WorkflowState({
           onChange={(e) => dispatch({ type: "set_notes", notes: e.target.value })}
           slotProps={{ htmlInput: { maxLength: 2000 } }}
           fullWidth
+          disabled={readOnly}
           sx={{
             mb: 1.5,
             "& .MuiInputBase-root": { fontSize: "0.875rem" },

--- a/web/src/components/__tests__/PieceHistory.test.tsx
+++ b/web/src/components/__tests__/PieceHistory.test.tsx
@@ -504,6 +504,25 @@ describe("PieceHistory", () => {
       // Should not throw when clicking without onRewind
       fireEvent.click(screen.getAllByText("Designed")[0].closest("li")!);
     });
+
+    it("calls onRewind with the state id when a past state is clicked in read-only mode", async () => {
+      const piece = makePiece({ is_editable: false });
+      const onRewind = vi.fn();
+      await act(async () => {
+        render(
+          <PieceHistory
+            pastHistory={[pastState1, pastState2]}
+            piece={piece}
+            onPieceUpdated={vi.fn()}
+            rewindedStateId={null}
+            onRewind={onRewind}
+          />,
+        );
+      });
+      fireEvent.click(screen.getByRole("button", { name: /show history/i }));
+      fireEvent.click(screen.getAllByText("Designed")[0].closest("li")!);
+      expect(onRewind).toHaveBeenCalledWith("state-1");
+    });
   });
 });
 


### PR DESCRIPTION
# Timeline Rewind in PieceDetail

This PR enables the "Timeline Rewind" functionality in the Piece Detail view even when the piece is not in "Edit piece history" mode. This allows users (especially owners) to inspect historical states easily without entering edit mode.

## Key Changes

### 1. `PieceDetail.tsx`
- Removed the restriction that reset `rewindedStateId` when `is_editable` was false.
- Updated UI copy to distinguish between "Viewing" and "Editing" historical states.
- Always pass `setRewindedStateId` to the `onRewind` prop of `PieceHistory`.
- Pass `hideNotes={!canEdit}` to `WorkflowState` to ensure notes are only shown to owners.

### 2. `PieceHistory.tsx`
- Refactored timeline rendering to a unified structure for both editable and read-only modes.
- Enabled `onClick` handlers for state chips in read-only mode.
- Applied consistent visual feedback:
    - Primary border and "Viewing" chip for the active selection.
    - Dimming of states that occurred after the selected historical state.

### 3. `WorkflowState.tsx`
- Added `hideNotes` prop to control visibility.
- Notes field now shows as disabled when `readOnly` is true (instead of hidden), provided `hideNotes` is false. This lets owners see their notes while viewing history.

## Verification

- [x] New regression test in `PieceHistory.test.tsx` verifying read-only click interaction.
- [x] All web tests pass via `bazel test //web/...`.
- [x] Linters pass via `bazel build --config=lint //web/...`.
- [x] Manual verification of UI consistency and note visibility.

Closes #397

Co-Authored-By: Antigravity <noreply@google.com>
