### PR TITLE
fix: keep eslint Bazel action off stale outputs

### DIFF
--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -73,6 +73,17 @@ ts_project(
     tags = ["lint"],
 )
 
+ESLINT_INPUTS = glob(
+    [
+        "*.config.ts",
+        "src/**/*.ts",
+        "src/**/*.tsx",
+    ],
+    exclude = [
+        "src/util/generated-types.ts",  # genrule output, not a source-tree input
+    ],
+)
+
 eslint_pkg.eslint(
     name = "eslint_run",
     srcs = [
@@ -81,8 +92,7 @@ eslint_pkg.eslint(
         ":web_test_configs",
         ":web_test_files",
     ],
-    args = [
-        ".",
+    args = ESLINT_INPUTS + [
         "--max-warnings=0",
     ],
     chdir = package_name(),


### PR DESCRIPTION
## Summary

- Pass explicit declared web lint inputs to the Bazel ESLint action instead of `.`.
- Keep ESLint scoped to current checkout source/test/config files so stale copied outputs under `bazel-out` cannot affect lint or coverage.

## Validation

- `rtk bazel build --config=lint //web/...`
- `rtk bazel coverage --combined_report=lcov --cache_test_results=false //...`
- `rtk bazel aquery --include_commandline 'mnemonic("Eslint", //web:eslint_run)'` confirmed the action lists explicit paths instead of `.`.

## Notes

`gz_format` was attempted and failed on pre-existing Ruff issues in `tools/tests/test_piece_image_crop_service.py`; it did not modify this PR.

Closes #409
