### PR TITLE
fix: keep screenshots out of web_lib (#410)

### DIFF
--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -170,6 +170,7 @@ js_library(
         exclude = [
             "src/**/*.test.ts",
             "src/**/*.test.tsx",
+            "src/**/__tests__/**",
             "src/util/**/*",
         ],
     ) + [


### PR DESCRIPTION
## Problem / Motivation
The Bazel web source target `//web:web_lib` currently includes test screenshot artifacts under `web/src/components/__tests__/__screenshots__`. These artifacts are reachable from the production image graph and lint inputs, which causes unnecessary invalidation and broadens lint inputs.

## Solution
Tighten the `//web:web_lib` glob in `web/BUILD.bazel` to exclude all `__tests__` directories.

## Acceptance Criteria
- [x] `rtk bazel query 'labels(srcs, //web:web_lib)'` no longer lists files under `web/src/**/__tests__/__screenshots__/**`.
- [x] Screenshots are no longer reachable from `//:image` or `//web:eslint_check`.
- [x] `rtk bazel build //:image` still succeeds.
- [x] All web tests pass.

Closes #410