### PR TITLE
Annotate single-instance assumptions (closes #274)

### DIFF
--- a/api/tasks.py
+++ b/api/tasks.py
@@ -8,7 +8,12 @@ from .models import AsyncTask
 
 logger = logging.getLogger(__name__)
 
-# Single shared executor for background tasks in development.
+# Per-process executor for background tasks. AsyncTask state is DB-backed
+# (so any API instance can poll status), but execution is bound to whichever
+# instance accepted the submission — submitting via this executor on instance
+# A means instance A is the only worker that will run it. A multi-instance
+# topology must replace this with a shared-broker backend before #275 (nginx
+# upstreams) lands; see #436.
 _executor = ThreadPoolExecutor(max_workers=1)
 
 TaskCallable = Callable[[AsyncTask], Any]
@@ -54,6 +59,10 @@ class InMemoryTaskInterface:
         # The shared executor is healthy iff it hasn't been shut down. After
         # shutdown, any subsequent .submit() raises RuntimeError, which would
         # surface to callers as a 500 — readiness should fail closed first.
+        # Note: this check is per-process; a "ready" answer from instance A
+        # says nothing about instance B's executor. Replacing this backend
+        # with a shared broker (#436) is what makes the readiness signal
+        # cluster-wide rather than instance-local.
         return not _executor._shutdown
 
     def submit(self, task: AsyncTask) -> None:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,8 +4,14 @@ set -e
 python manage.py migrate --no-input
 python manage.py collectstatic --no-input
 python manage.py load_public_library --skip-if-missing
-# On startup, fail all tasks marked as RUNNING or PENDING because in an 
+# On startup, fail all tasks marked as RUNNING or PENDING because in an
 # InMemoryTaskInterface setup, no tasks can survive a process restart.
+#
+# WARNING: this runs on EVERY container start. With multiple API instances
+# behind nginx (#275/#273), instance B's restart would fail tasks that
+# instance A is actively running. Move this out of per-instance startup
+# (one-shot deploy job, advisory-lock-gated, or replace via shared broker)
+# before the rolling-deploy work lands. See #437.
 python manage.py clear_stuck_tasks --hours 0
 
 exec python -m gunicorn backend.asgi:application \


### PR DESCRIPTION
## Summary

Multi-instance API safety audit (#274). Findings are captured as issues rather than checked-in docs (per direction — repo audit docs risk drifting from reality and misleading future contributors). This PR's diff is small on purpose: only the two hotspots that encode load-bearing single-instance assumptions get inline annotations so readers of the code see the constraint without leaving the file.

- \`api/tasks.py\` — \`_executor\` and \`InMemoryTaskInterface.health_check\` now flag their per-process scope and link #436.
- \`docker-entrypoint.sh\` — the existing \`clear_stuck_tasks\` comment now warns that running it on per-instance restart would clobber peer-instance work, links #437.

## Findings (full results in #274)

**Confirmed-safe surface:** DB-backed sessions; stateless view handlers; module-level state in \`api/workflow.py\`/\`api/serializer_registry.py\`/\`api/views.py\` is read-only after import; all side-effecting paths land in shared infra (Cloudinary + Postgres); WhiteNoise serves identical per-instance \`staticfiles/\`; \`api/logging.py\` uses \`contextvars\`; no code path imports \`django.core.cache\`.

**Filed follow-ups (all milestone-tagged):**
- #436 — Replace \`InMemoryTaskInterface\` with shared-broker task backend (BLOCKS #275/#273)
- #437 — Move \`clear_stuck_tasks\` out of per-instance startup
- #438 — Set explicit \`CACHES\` backend before adding multi-instance routing

Closes #274.

## Test plan

- [ ] CI green (lint, coverage, image).
- [ ] \`bazel test //api:api_test //tests:common_test\` locally — passed (verified before push).
- [ ] Spot-check that the linked issue numbers (#436, #437) resolve from inline comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)