### PR TITLE
Share Cloudinary upload plumbing

### DIFF
--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -147,7 +147,9 @@ js_library(
 js_library(
     name = "util_lib",
     srcs = [
+        "src/cloudinary-widget.d.ts",
         "src/util/api.ts",
+        "src/util/cloudinaryUpload.ts",
         "src/util/format.ts",
         "src/util/normalizeWorkflowFields.ts",
         "src/util/optionalValues.ts",

--- a/web/src/cloudinary-widget.d.ts
+++ b/web/src/cloudinary-widget.d.ts
@@ -1,7 +1,7 @@
 // Type declarations for the Cloudinary Upload Widget loaded from CDN.
 // https://cloudinary.com/documentation/upload_widget
 
-interface CloudinaryUploadWidgetResult {
+export interface CloudinaryUploadWidgetResult {
   event: string;
   info: {
     secure_url: string;
@@ -11,13 +11,13 @@ interface CloudinaryUploadWidgetResult {
   };
 }
 
-interface CloudinaryUploadWidget {
+export interface CloudinaryUploadWidget {
   open: () => void;
   close: () => void;
   destroy: () => void;
 }
 
-interface CloudinaryUploadWidgetOptions {
+export interface CloudinaryUploadWidgetOptions {
   cloudName: string;
   apiKey: string;
   uploadSignature: (

--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -21,11 +21,10 @@ import {
 } from "@mui/material";
 import type { PieceDetail, PieceState } from "../util/types";
 import {
-  fetchCloudinaryWidgetConfig,
-  signCloudinaryWidgetParams,
   updateCurrentState,
   type UpdateStatePayload,
 } from "../util/api";
+import { openCloudinaryUploadWidget } from "../util/cloudinaryUpload";
 import {
   getCustomFieldDefinitions,
 } from "../util/workflow";
@@ -320,13 +319,6 @@ export default function WorkflowState({
     }
     setUploadError(null);
     setWidgetLoading(true);
-    let config;
-    try {
-      config = await fetchCloudinaryWidgetConfig();
-    } catch {
-      setUploadError("Failed to load upload configuration. Please try again.");
-      return;
-    }
     // Keeps the iframe hidden until it is ready (removed on display-changed: shown).
     const hideStyle = document.createElement("style");
     hideStyle.textContent = 'iframe[title="Upload Widget"] { opacity: 0; }';
@@ -339,19 +331,19 @@ export default function WorkflowState({
       'iframe[title="Upload Widget"] { top: env(safe-area-inset-top) !important; height: calc(100dvh - env(safe-area-inset-top)) !important; }';
     document.head.appendChild(safeAreaStyle);
 
-    const uploadWidget = window.cloudinary?.createUploadWidget(
-      {
-        cloudName: config.cloud_name,
-        apiKey: config.api_key,
-        uploadSignature: (callback, paramsToSign) => {
-          signCloudinaryWidgetParams(paramsToSign as Record<string, unknown>)
-            .then(callback)
-            .catch(() =>
-              setUploadError("Failed to sign upload. Please try again."),
-            );
-        },
-        ...(config.folder ? { folder: config.folder } : {}),
-        ...(config.upload_preset ? { uploadPreset: config.upload_preset } : {}),
+    const cleanupWidgetStyles = () => {
+      hideStyle.remove();
+      safeAreaStyle.remove();
+    };
+    const uploadWidget = await openCloudinaryUploadWidget({
+      messages: {
+        configError: "Failed to load upload configuration. Please try again.",
+        unavailableError:
+          "Upload widget is not available in this browser. Please try again.",
+        signatureError: "Failed to sign upload. Please try again.",
+        uploadError: "Upload failed. Please try again.",
+      },
+      widgetOptions: {
         sources: ["local", "camera"],
         multiple: true,
         resourceType: "image",
@@ -374,12 +366,13 @@ export default function WorkflowState({
           frame: { background: "#00000000" },
         } as { palette: Record<string, string> },
       },
-      (error, result) => {
-        if (result?.event === "display-changed") {
-          const state =
-            typeof result.info === "string"
-              ? result.info
-              : (result.info as Record<string, unknown>)?.state;
+      callbacks: {
+        onError: (message) => {
+          setWidgetLoading(false);
+          cleanupWidgetStyles();
+          setUploadError(message);
+        },
+        onDisplayChange: (state) => {
           if (state === "shown") {
             setWidgetLoading(false);
             hideStyle.remove();
@@ -393,15 +386,8 @@ export default function WorkflowState({
           } else if (state === "hidden" || state === "destroyed") {
             safeAreaStyle.remove();
           }
-        }
-        if (error) {
-          setWidgetLoading(false);
-          hideStyle.remove();
-          safeAreaStyle.remove();
-          setUploadError("Upload failed. Please try again.");
-          return;
-        }
-        if (result?.event === "success") {
+        },
+        onSuccess: (result, config) => {
           const newImage = {
             url: result.info.secure_url,
             caption: "",
@@ -410,10 +396,13 @@ export default function WorkflowState({
             crop: null,
           };
           saveUploadedImage(newImage);
-        }
+        },
       },
-    );
-    uploadWidget?.open();
+    });
+    if (!uploadWidget) {
+      setWidgetLoading(false);
+      cleanupWidgetStyles();
+    }
   }
 
   function handleFieldChange(name: string, value: string) {

--- a/web/src/components/__tests__/WorkflowState.test.tsx
+++ b/web/src/components/__tests__/WorkflowState.test.tsx
@@ -8,6 +8,7 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import WorkflowState from "../WorkflowState";
+import type { CloudinaryUploadWidgetOptions } from "../../cloudinary-widget";
 import type { ResolvedCustomField } from "../../util/workflow";
 import {
   buildCustomFieldInputMap,
@@ -933,6 +934,33 @@ describe("WorkflowState", () => {
     await waitFor(() =>
       expect(
         screen.getByText("Upload failed. Please try again."),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("widget signature failure shows error message", async () => {
+    let uploadSignature:
+      | CloudinaryUploadWidgetOptions["uploadSignature"]
+      | undefined;
+    window.cloudinary = {
+      createUploadWidget: vi.fn((options) => {
+        uploadSignature = options.uploadSignature;
+        return { open: vi.fn(), close: noop, destroy: noop };
+      }),
+      openUploadWidget: vi.fn(),
+    };
+    vi.mocked(api.signCloudinaryWidgetParams).mockRejectedValue(
+      new Error("sign failed"),
+    );
+    render(<WorkflowState {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Upload Image" }));
+
+    await waitFor(() => expect(uploadSignature).toBeDefined());
+    uploadSignature?.(vi.fn(), { timestamp: "123" });
+    await waitFor(() =>
+      expect(
+        screen.getByText("Failed to sign upload. Please try again."),
       ).toBeInTheDocument(),
     );
   });

--- a/web/src/pages/GlazeImportToolPage.tsx
+++ b/web/src/pages/GlazeImportToolPage.tsx
@@ -22,12 +22,12 @@ import FactCheckIcon from "@mui/icons-material/FactCheck";
 import CloudUploadIcon from "@mui/icons-material/CloudUpload";
 import MergeIcon from "@mui/icons-material/MergeType";
 import {
-  fetchCloudinaryWidgetConfig,
+  extractErrorMessage,
   importManualSquareCropRecords,
-  signCloudinaryWidgetParams,
   type CloudinaryWidgetConfig,
   type ManualSquareCropImportResponse,
 } from "../util/api";
+import { openCloudinaryUploadWidget } from "../util/cloudinaryUpload";
 import GlazeImportCropStage from "./glazeImportTool/GlazeImportCropStage";
 import GlazeImportImportStage from "./glazeImportTool/GlazeImportImportStage";
 import GlazeImportOcrStage from "./glazeImportTool/GlazeImportOcrStage";
@@ -289,53 +289,30 @@ export default function GlazeImportToolPage() {
   async function startCloudinaryUpload() {
     setWidgetError(null);
     setWidgetUploading(true);
-    let config: CloudinaryWidgetConfig;
-    try {
-      config = await fetchCloudinaryWidgetConfig();
-    } catch {
-      setWidgetUploading(false);
-      setWidgetError("Failed to load Cloudinary upload configuration.");
-      return;
-    }
-
-    if (!window.cloudinary?.createUploadWidget) {
-      setWidgetUploading(false);
-      setWidgetError(
-        "Cloudinary upload widget is not available in this browser.",
-      );
-      return;
-    }
-
-    const widget = window.cloudinary.createUploadWidget(
-      {
-        cloudName: config.cloud_name,
-        apiKey: config.api_key,
-        uploadSignature: (callback, paramsToSign) => {
-          signCloudinaryWidgetParams(paramsToSign as Record<string, unknown>)
-            .then(callback)
-            .catch(() => setWidgetError("Failed to sign Cloudinary upload."));
-        },
-        ...(config.folder ? { folder: config.folder } : {}),
+    const widget = await openCloudinaryUploadWidget({
+      messages: {
+        configError: "Failed to load Cloudinary upload configuration.",
+        unavailableError:
+          "Cloudinary upload widget is not available in this browser.",
+        signatureError: "Failed to sign Cloudinary upload.",
+        uploadError: "Cloudinary upload failed.",
+      },
+      widgetOptions: {
         sources: ["local"],
         multiple: true,
         resourceType: "image",
       },
-      async (error, result) => {
-        if (error) {
+      callbacks: {
+        onError: (message) => {
           setWidgetUploading(false);
-          setWidgetError("Cloudinary upload failed.");
-          return;
-        }
-        if (result?.event === "display-changed") {
-          const displayState =
-            typeof result.info === "string"
-              ? result.info
-              : (result.info as Record<string, unknown>)?.state;
-          if (displayState === "shown") {
+          setWidgetError(message);
+        },
+        onDisplayChange: (state) => {
+          if (state === "shown") {
             setWidgetUploading(false);
           }
-        }
-        if (result?.event === "success") {
+        },
+        onSuccess: async (result, config) => {
           const publicId = String(result.info.public_id || "");
           const originalFilename = String(
             result.info.original_filename || publicId || "upload",
@@ -415,11 +392,12 @@ export default function GlazeImportToolPage() {
               ),
             );
           }
-        }
+        },
       },
-    );
-
-    widget.open();
+    });
+    if (!widget) {
+      setWidgetUploading(false);
+    }
   }
 
   function confirmDeleteRecord(id: string) {
@@ -492,7 +470,7 @@ export default function GlazeImportToolPage() {
       setImportResult(result);
       setActiveTab(TAB_IMPORT);
     } catch (error) {
-      setImportError(error instanceof Error ? error.message : "Import failed.");
+      setImportError(extractErrorMessage(error, "Import failed."));
       setImportBuildProgress((current) =>
         current.map((entry) =>
           entry.status !== "ready"

--- a/web/src/pages/__tests__/GlazeImportToolPage.test.tsx
+++ b/web/src/pages/__tests__/GlazeImportToolPage.test.tsx
@@ -3,12 +3,25 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import GlazeImportToolPage from "../GlazeImportToolPage";
+import type { CloudinaryUploadWidgetOptions } from "../../cloudinary-widget";
 import {
   fetchCloudinaryWidgetConfig,
   importManualSquareCropRecords,
+  signCloudinaryWidgetParams,
 } from "../../util/api";
 
 vi.mock("../../util/api", () => ({
+  extractErrorMessage: vi.fn((error: unknown, defaultMessage: string) => {
+    const data = (error as { response?: { data?: unknown } }).response?.data;
+    if (typeof data === "object" && data !== null) {
+      const nonFieldErrors = (data as { non_field_errors?: unknown })
+        .non_field_errors;
+      if (Array.isArray(nonFieldErrors) && nonFieldErrors[0]) {
+        return String(nonFieldErrors[0]);
+      }
+    }
+    return error instanceof Error ? error.message : defaultMessage;
+  }),
   fetchCloudinaryWidgetConfig: vi.fn(),
   importManualSquareCropRecords: vi.fn(),
   signCloudinaryWidgetParams: vi.fn(),
@@ -333,6 +346,93 @@ describe("GlazeImportToolPage", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Cloudinary upload failed.")).toBeInTheDocument();
+    });
+  });
+
+  it("shows an error when Cloudinary upload signing fails", async () => {
+    let uploadSignature:
+      | CloudinaryUploadWidgetOptions["uploadSignature"]
+      | undefined;
+    window.cloudinary = {
+      createUploadWidget: vi.fn((options) => {
+        uploadSignature = options.uploadSignature;
+        return { open: vi.fn(), close: () => {}, destroy: () => {} };
+      }),
+      openUploadWidget: vi.fn(),
+    };
+    vi.mocked(fetchCloudinaryWidgetConfig).mockResolvedValue({
+      cloud_name: "demo-cloud",
+      api_key: "demo-key",
+    });
+    vi.mocked(signCloudinaryWidgetParams).mockRejectedValue(
+      new Error("sign failed"),
+    );
+
+    render(<GlazeImportToolPage />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Upload Via Cloudinary" }),
+    );
+
+    await waitFor(() => expect(uploadSignature).toBeDefined());
+    uploadSignature?.(vi.fn(), { timestamp: "123" });
+    await waitFor(() => {
+      expect(
+        screen.getByText("Failed to sign Cloudinary upload."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows formatted API validation errors when import fails", async () => {
+    vi.mocked(createWorker).mockResolvedValue({
+      writeText: vi.fn().mockResolvedValue(undefined),
+      setParameters: vi.fn().mockResolvedValue(undefined),
+      recognize: vi.fn().mockResolvedValue({
+        data: { text: "Ash Blue", confidence: 91 },
+      }),
+      terminate: vi.fn().mockResolvedValue(undefined),
+    } as never);
+    vi.mocked(importManualSquareCropRecords).mockRejectedValue({
+      isAxiosError: true,
+      response: {
+        data: { non_field_errors: ["Import records are invalid."] },
+      },
+    });
+
+    const { container } = render(<GlazeImportToolPage />);
+    const input = container.querySelector('input[type="file"]');
+    const file = new File(["image-bytes"], "ash-blue.png", {
+      type: "image/png",
+    });
+
+    fireEvent.change(input!, { target: { files: [file] } });
+    await screen.findByText("ash-blue.png");
+    fireEvent.click(screen.getByText("ash-blue.png"));
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Continue To OCR" }),
+    );
+    fireEvent.click((await screen.findAllByText("ash-blue.png"))[0]);
+    fireEvent.click(
+      (await screen.findAllByRole("button", { name: "Run OCR" }))[0],
+    );
+    await screen.findByText("Parsed as: Ash Blue");
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Continue To Review" }),
+    );
+    const reviewRecordList = screen.getByRole("list");
+    fireEvent.click(await within(reviewRecordList).findByText("Ash Blue"));
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Mark reviewed for import" }),
+    );
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Continue To Import" }),
+    );
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Run Bulk Import" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Import records are invalid.")).toBeInTheDocument();
     });
   });
 

--- a/web/src/util/cloudinaryUpload.ts
+++ b/web/src/util/cloudinaryUpload.ts
@@ -1,0 +1,91 @@
+import {
+  fetchCloudinaryWidgetConfig,
+  signCloudinaryWidgetParams,
+  type CloudinaryWidgetConfig,
+} from "./api";
+import type {
+  CloudinaryUploadWidget,
+  CloudinaryUploadWidgetOptions,
+  CloudinaryUploadWidgetResult,
+} from "../cloudinary-widget";
+
+export type CloudinaryUploadMessages = {
+  configError: string;
+  unavailableError: string;
+  signatureError: string;
+  uploadError: string;
+};
+
+export type CloudinaryUploadCallbacks = {
+  onError: (message: string) => void;
+  onDisplayChange?: (state: string) => void;
+  onSuccess: (
+    result: CloudinaryUploadWidgetResult,
+    config: CloudinaryWidgetConfig,
+  ) => void | Promise<void>;
+};
+
+export type CloudinaryUploadOptions = {
+  messages: CloudinaryUploadMessages;
+  widgetOptions?: Partial<CloudinaryUploadWidgetOptions>;
+  callbacks: CloudinaryUploadCallbacks;
+};
+
+function displayStateFrom(result: CloudinaryUploadWidgetResult) {
+  if (typeof result.info === "string") {
+    return result.info;
+  }
+  return (result.info as Record<string, unknown>).state;
+}
+
+export async function openCloudinaryUploadWidget({
+  messages,
+  widgetOptions,
+  callbacks,
+}: CloudinaryUploadOptions): Promise<CloudinaryUploadWidget | null> {
+  let config: CloudinaryWidgetConfig;
+  try {
+    config = await fetchCloudinaryWidgetConfig();
+  } catch {
+    callbacks.onError(messages.configError);
+    return null;
+  }
+
+  if (!window.cloudinary?.createUploadWidget) {
+    callbacks.onError(messages.unavailableError);
+    return null;
+  }
+
+  const widget = window.cloudinary.createUploadWidget(
+    {
+      cloudName: config.cloud_name,
+      apiKey: config.api_key,
+      uploadSignature: (callback, paramsToSign) => {
+        signCloudinaryWidgetParams(paramsToSign as Record<string, unknown>)
+          .then(callback)
+          .catch(() => callbacks.onError(messages.signatureError));
+      },
+      ...(config.folder ? { folder: config.folder } : {}),
+      ...(config.upload_preset ? { uploadPreset: config.upload_preset } : {}),
+      ...widgetOptions,
+    },
+    (error, result) => {
+      if (error) {
+        callbacks.onError(messages.uploadError);
+        return;
+      }
+      if (result?.event === "display-changed") {
+        const state = displayStateFrom(result);
+        if (typeof state === "string") {
+          callbacks.onDisplayChange?.(state);
+        }
+      }
+      if (result?.event === "success") {
+        void callbacks.onSuccess(result, config);
+      }
+    },
+  );
+
+  widget.open();
+  return widget;
+}


### PR DESCRIPTION
## Summary

- Extract shared Cloudinary widget setup/signing/error plumbing into `web/src/util/cloudinaryUpload.ts`.
- Update `WorkflowState` and `GlazeImportToolPage` to use the shared upload helper while preserving their existing user-facing messages.
- Reuse `extractErrorMessage` for import-tool API failures and add tests for signing failures plus DRF validation messages.

## Validation

- `rtk bazel test //web:web_glaze_import_test //web:web_workflow_state_test //web:web_api_test`
- `rtk bazel build --config=lint //web/...`
- `rtk bazel test //...`
- `rtk bazel build --config=lint //...`

Note: `gz_format` reformatted the touched frontend files, then stopped on pre-existing Python lint issues in `tools/tests/test_piece_image_crop_service.py`. The unrelated formatter side effects were removed, and `rtk bazel build --config=lint //...` passes.

Closes #408
