### PR TITLE
fix(api): fix PieceState custom_fields validation in admin

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -817,6 +817,12 @@ class PieceStateAdminForm(forms.ModelForm):
         from .workflow import get_global_config, get_global_ref_fields_for_state
 
         super().__init__(*args, **kwargs)
+
+        # Hide the raw JSON field: it is either unused, or we have typed fields for it
+        if "custom_fields" in self.fields:
+            self.fields["custom_fields"].widget = forms.HiddenInput()
+            self.fields["custom_fields"].required = False
+
         self.custom_field_names = [
             name
             for name in self.fields
@@ -824,11 +830,6 @@ class PieceStateAdminForm(forms.ModelForm):
         ]
 
         if self.custom_field_names:
-            # Hide the raw JSON field if we have typed fields for it
-            if "custom_fields" in self.fields:
-                self.fields["custom_fields"].widget = forms.HiddenInput()
-                self.fields["custom_fields"].required = False
-
             instance = self.instance
             if isinstance(instance, PieceState):
                 # Populating initial values from custom_fields blob (inline fields)

--- a/api/models.py
+++ b/api/models.py
@@ -249,7 +249,7 @@ class PieceState(models.Model):
     has_been_edited = models.BooleanField(default=False)
     # Inline (non-global-ref) state-specific fields for this state.
     # Global ref fields are stored in per-type junction tables (PieceState*Ref models).
-    custom_fields = models.JSONField(default=dict)
+    custom_fields = models.JSONField(default=dict, blank=True)
 
     @property
     def workflow_version(self) -> str:


### PR DESCRIPTION
## Objective
Fix a bug in the Django Admin where saving a PieceState for a state that has no custom fields (e.g., 'Carved') throws a validation error: 'CustomFields is required'.

## Changes
- **api/admin.py**: Updated PieceStateAdminForm.__init__ to unconditionally hide the custom_fields raw JSON input and set required = False. This ensures the field is never required by the browser or Django form validation, regardless of the workflow state.
- **api/models.py**: Added blank=True to the PieceState.custom_fields model field. This is the idiomatic way to mark a JSONField as optional for forms.

## Verification
- Ran backend tests: bazel test //api/...
- Verified that the changes prevent the reported validation error while maintaining correct behavior for states that *do* have custom fields.

Closes https://github.com/shaoster/glaze/issues/336
