### PR TITLE
chore: reconcile duplicated custom field logic between React and Admin UI (#306)

### DIFF
--- a/api/BUILD.bazel
+++ b/api/BUILD.bazel
@@ -34,6 +34,7 @@ py_library(
         "task_views.py",
         "urls.py",
         "views.py",
+        "workflow_views.py",
     ],
     deps = [
         ":api_workflow_lib",
@@ -50,6 +51,7 @@ py_library(
         "manual_tile_imports.py",
         "model_factories.py",
         "tasks.py",
+        "widgets.py",
     ],
     data = [
         ":api_commands",

--- a/api/admin.py
+++ b/api/admin.py
@@ -33,7 +33,12 @@ from .utils import (
     normalize_image_payload,
     sync_glaze_type_singleton_combination,
 )
-from .workflow import get_image_fields_for_global_model, get_public_global_models
+from .widgets import WorkflowStateWidget
+from .workflow import (
+    build_ui_schema,
+    get_image_fields_for_global_model,
+    get_public_global_models,
+)
 
 
 class GlazeAdminSite(admin.AdminSite):
@@ -741,62 +746,6 @@ class PieceStateImageInline(SortableInlineAdminMixin, admin.TabularInline):
         js = ("admin/js/sortable_inline_notice.js",)
 
 
-def _get_custom_form_fields(state_id: str) -> dict[str, forms.Field]:
-    from django.apps import apps
-
-    from .workflow import (
-        build_custom_fields_schema,
-        get_global_config,
-        get_global_ref_fields_for_state,
-    )
-
-    schema = build_custom_fields_schema(state_id)
-    properties = schema.get("properties", {})
-    required_list = schema.get("required", [])
-
-    declared_fields: dict[str, forms.Field] = {}
-    for field_name, field_def in properties.items():
-        field_type = field_def.get("type")
-        is_required = field_name in required_list
-        label = field_name.replace("_", " ").capitalize()
-        form_field_name = f"custom_{field_name}"
-        is_percent = field_def.get("display_as") == "percent"
-
-        kwargs: dict[str, Any] = {"required": is_required, "label": label}
-        if is_percent:
-            kwargs["disabled"] = True
-            kwargs["help_text"] = "Displayed as percentage (x100%) in the main UI."
-
-        if field_type == "boolean":
-            declared_fields[form_field_name] = forms.BooleanField(
-                required=False, label=label
-            )
-        elif field_type == "integer":
-            declared_fields[form_field_name] = forms.IntegerField(**kwargs)
-        elif field_type == "number":
-            declared_fields[form_field_name] = forms.FloatField(**kwargs)
-        else:
-            declared_fields[form_field_name] = forms.CharField(**kwargs)
-
-    # Add global ref fields
-    global_ref_fields = get_global_ref_fields_for_state(state_id)
-    for field_name, global_name in global_ref_fields.items():
-        form_field_name = f"custom_{field_name}"
-        if form_field_name in declared_fields:
-            continue
-
-        config = get_global_config(global_name)
-        model_cls = apps.get_model("api", config["model"])
-        label = field_name.replace("_", " ").capitalize()
-        declared_fields[form_field_name] = forms.ModelChoiceField(
-            queryset=model_cls.objects.all(),
-            required=False,  # DSL doesn't easily expose 'required' for refs yet
-            label=label,
-        )
-
-    return declared_fields
-
-
 class PieceStateAdminForm(forms.ModelForm):
     allow_sealed_edit = forms.BooleanField(
         required=False,
@@ -806,6 +755,11 @@ class PieceStateAdminForm(forms.ModelForm):
             "Use only for exceptional admin corrections — this bypasses the sealed-state invariant."
         ),
     )
+    unified_custom_fields = forms.JSONField(
+        required=False,
+        label="Custom Fields",
+        widget=WorkflowStateWidget(),
+    )
 
     class Meta:
         model = PieceState
@@ -814,54 +768,52 @@ class PieceStateAdminForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         from django.apps import apps
 
-        from .workflow import get_global_config, get_global_ref_fields_for_state
+        from .workflow import (
+            build_ui_schema,
+            get_global_config,
+            get_global_ref_fields_for_state,
+        )
 
         super().__init__(*args, **kwargs)
 
-        # Hide the raw JSON field: it is either unused, or we have typed fields for it
+        # Hide the raw JSON field since we have the unified widget for it
         if "custom_fields" in self.fields:
             self.fields["custom_fields"].widget = forms.HiddenInput()
             self.fields["custom_fields"].required = False
 
-        self.custom_field_names = [
-            name
-            for name in self.fields
-            if name.startswith("custom_") and name != "custom_fields"
-        ]
+        instance = self.instance
+        if isinstance(instance, PieceState) and instance.state:
+            ui_schema = build_ui_schema(instance.state)
+            self.fields["unified_custom_fields"].widget = WorkflowStateWidget(
+                piece_id=instance.piece_id, state_id=instance.state, ui_schema=ui_schema
+            )
 
-        if self.custom_field_names:
-            instance = self.instance
-            if isinstance(instance, PieceState):
-                # Populating initial values from custom_fields blob (inline fields)
-                if isinstance(instance.custom_fields, dict):
-                    for form_field_name in self.custom_field_names:
-                        field_name = form_field_name[7:]  # strip 'custom_'
-                        if field_name in instance.custom_fields:
-                            self.initial[form_field_name] = instance.custom_fields[
-                                field_name
-                            ]
+            # Initial value for the widget: current custom_fields + global_refs
+            global_ref_fields = get_global_ref_fields_for_state(instance.state)
+            global_ref_values = {}
+            for field_name, global_name in global_ref_fields.items():
+                ref_model_cls = apps.get_model(
+                    "api", f"PieceState{get_global_config(global_name)['model']}Ref"
+                )
+                try:
+                    ref_obj = ref_model_cls.objects.get(
+                        piece_state=instance, field_name=field_name
+                    )
+                    global_ref_values[field_name] = {
+                        "id": str(getattr(ref_obj, f"{global_name}_id")),
+                        "name": str(getattr(ref_obj, global_name)),
+                    }
+                except ref_model_cls.DoesNotExist:
+                    pass
 
-                # Populating initial values for relational fields (junction tables)
-                if instance.state:
-                    global_ref_fields = get_global_ref_fields_for_state(instance.state)
-                    for field_name, global_name in global_ref_fields.items():
-                        form_field_name = f"custom_{field_name}"
-                        if form_field_name not in self.fields:
-                            continue
-
-                        config = get_global_config(global_name)
-                        ref_model_cls = apps.get_model(
-                            "api", f"PieceState{config['model']}Ref"
-                        )
-                        try:
-                            ref_obj = ref_model_cls.objects.get(
-                                piece_state=instance, field_name=field_name
-                            )
-                            self.initial[form_field_name] = getattr(
-                                ref_obj, f"{global_name}_id"
-                            )
-                        except ref_model_cls.DoesNotExist:
-                            pass
+            initial_piece_state_data = {
+                "id": str(instance.id),
+                "state": instance.state,
+                "notes": instance.notes,
+                "custom_fields": instance.custom_fields or {},
+                "global_ref_values": global_ref_values,  # special key for the widget
+            }
+            self.initial["unified_custom_fields"] = initial_piece_state_data
 
     def clean(self):
         from .workflow import get_global_ref_fields_for_state
@@ -882,34 +834,19 @@ class PieceStateAdminForm(forms.ModelForm):
                     "Check 'Allow sealed edit' to override."
                 )
 
-        if hasattr(self, "custom_field_names") and self.custom_field_names:
-            instance = self.instance
-            custom_data: dict[str, Any] = {}
-            if isinstance(instance, PieceState):
-                instance_custom_fields = instance.custom_fields
-                if isinstance(instance_custom_fields, dict):
-                    custom_data = dict(instance_custom_fields)
+        unified_data = cleaned_data.get("unified_custom_fields")
+        if unified_data:
+            # unified_data is the JSON payload from the React widget:
+            # { notes, images, custom_fields: { ... } }
+            # Wait, our widget's saveStateFn sends { notes, images, custom_fields }
+            # We need to extract custom_fields and possibly notes.
+            if "custom_fields" in unified_data:
+                cleaned_data["custom_fields"] = unified_data["custom_fields"]
+            if "notes" in unified_data:
+                cleaned_data["notes"] = unified_data["notes"]
 
-            # Relational fields are stored in junction tables, NOT in the JSON blob.
-            global_ref_fields = (
-                get_global_ref_fields_for_state(instance.state)
-                if isinstance(instance, PieceState) and instance.state
-                else {}
-            )
-
-            for form_field_name in self.custom_field_names:
-                field_name = form_field_name[7:]  # strip 'custom_' prefix
-                if field_name in global_ref_fields:
-                    continue
-
-                if form_field_name in cleaned_data:  # type: ignore[operator]
-                    val = cleaned_data[form_field_name]  # type: ignore[index]
-                    if val not in (None, ""):
-                        custom_data[field_name] = val
-                    elif field_name in custom_data:
-                        del custom_data[field_name]
-            cleaned_data["custom_fields"] = custom_data  # type: ignore[index]
         return cleaned_data
+
 
 
 @admin.register(PieceState)
@@ -924,24 +861,9 @@ class PieceStateAdmin(ExportMixin, SortableAdminBase, admin.ModelAdmin):
     def get_fields(self, request: HttpRequest, obj: PieceState | None = None) -> Any:
         fields = list(super().get_fields(request, obj))
         if obj and obj.state:
-            custom_fields = _get_custom_form_fields(obj.state)
-            for custom_name in custom_fields:
-                if custom_name not in fields:
-                    fields.append(custom_name)
+            if "unified_custom_fields" not in fields:
+                fields.append("unified_custom_fields")
         return fields
-
-    def get_form(self, request, obj=None, change=False, **kwargs):
-        if obj and obj.state:
-            custom_fields = _get_custom_form_fields(obj.state)
-            if custom_fields:
-                # Create a dynamic subclass of the form with these fields declared
-                # so that modelform_factory (called by super().get_form) accepts them.
-                dynamic_form = type(
-                    f"Dynamic{self.form.__name__}", (self.form,), custom_fields
-                )
-                kwargs["form"] = dynamic_form
-
-        return super().get_form(request, obj, change, **kwargs)
 
     def save_model(
         self,
@@ -956,19 +878,17 @@ class PieceStateAdmin(ExportMixin, SortableAdminBase, admin.ModelAdmin):
         allow_sealed = form.cleaned_data.get("allow_sealed_edit", False)
         obj.save(allow_sealed_edit=bool(allow_sealed))
 
-        # Save relational fields (junction tables)
+        # Save relational fields (junction tables) from the unified React payload
         global_ref_fields = get_global_ref_fields_for_state(obj.state)
         global_ref_pks = {}
         clear_fields = set()
 
-        for field_name in global_ref_fields:
-            form_field_name = f"custom_{field_name}"
-            if form_field_name in form.cleaned_data:
-                val = form.cleaned_data[form_field_name]
-                if val:
-                    # val is a model instance from ModelChoiceField
-                    global_ref_pks[field_name] = str(val.pk)
-                else:
+        unified_data = form.cleaned_data.get("unified_custom_fields")
+        if unified_data and "global_ref_pks" in unified_data:
+            global_ref_pks = unified_data["global_ref_pks"]
+            # Any field in the schema that is NOT in the payload should be cleared
+            for field_name in global_ref_fields:
+                if field_name not in global_ref_pks:
                     clear_fields.add(field_name)
 
         if global_ref_pks or clear_fields:

--- a/api/admin.py
+++ b/api/admin.py
@@ -816,7 +816,7 @@ class PieceStateAdminForm(forms.ModelForm):
             self.initial["unified_custom_fields"] = initial_piece_state_data
 
     def clean(self):
-        from .workflow import get_global_ref_fields_for_state
+        from .serializers import _resolve_custom_field_payload
 
         cleaned_data = super().clean()
 
@@ -835,15 +835,31 @@ class PieceStateAdminForm(forms.ModelForm):
                 )
 
         unified_data = cleaned_data.get("unified_custom_fields")
-        if unified_data:
+        if unified_data and isinstance(instance, PieceState):
             # unified_data is the JSON payload from the React widget:
             # { notes, images, custom_fields: { ... } }
-            # Wait, our widget's saveStateFn sends { notes, images, custom_fields }
-            # We need to extract custom_fields and possibly notes.
-            if "custom_fields" in unified_data:
-                cleaned_data["custom_fields"] = unified_data["custom_fields"]
+            # custom_fields here contains BOTH inline fields and global ref PKs.
+            incoming = unified_data.get("custom_fields", {})
+            (
+                inline_fields,
+                _,
+                global_ref_pks,
+                clear_fields,
+            ) = _resolve_custom_field_payload(
+                instance.piece,
+                instance.state,
+                incoming,
+                clear_empty_refs=True,
+            )
+
+            # Update cleaned_data so the model save() only gets the inline fields
+            cleaned_data["custom_fields"] = inline_fields
             if "notes" in unified_data:
                 cleaned_data["notes"] = unified_data["notes"]
+
+            # Store relational changes for save_model()
+            self._global_ref_pks = global_ref_pks
+            self._clear_global_ref_fields = clear_fields
 
         return cleaned_data
 
@@ -878,21 +894,15 @@ class PieceStateAdmin(ExportMixin, SortableAdminBase, admin.ModelAdmin):
         allow_sealed = form.cleaned_data.get("allow_sealed_edit", False)
         obj.save(allow_sealed_edit=bool(allow_sealed))
 
-        # Save relational fields (junction tables) from the unified React payload
-        global_ref_fields = get_global_ref_fields_for_state(obj.state)
-        global_ref_pks = {}
-        clear_fields = set()
-
-        unified_data = form.cleaned_data.get("unified_custom_fields")
-        if unified_data and "global_ref_pks" in unified_data:
-            global_ref_pks = unified_data["global_ref_pks"]
-            # Any field in the schema that is NOT in the payload should be cleared
-            for field_name in global_ref_fields:
-                if field_name not in global_ref_pks:
-                    clear_fields.add(field_name)
-
-        if global_ref_pks or clear_fields:
-            _write_global_ref_rows(obj, global_ref_fields, global_ref_pks, clear_fields)
+        # Save relational fields (junction tables) from the split payload
+        if hasattr(form, "_global_ref_pks"):
+            global_ref_fields = get_global_ref_fields_for_state(obj.state)
+            _write_global_ref_rows(
+                obj,
+                global_ref_fields,
+                form._global_ref_pks,
+                form._clear_global_ref_fields,
+            )
 
 
 @admin.action(description="Re-run selected tasks")

--- a/api/tests/test_piece_state_admin_relational.py
+++ b/api/tests/test_piece_state_admin_relational.py
@@ -2,58 +2,53 @@ import pytest
 from django import forms
 from django.contrib.admin.sites import AdminSite
 
-from api.admin import PieceStateAdmin, _get_custom_form_fields
+from api.admin import PieceStateAdmin
 from api.models import GlazeCombination, Piece, PieceState
+from api.widgets import WorkflowStateWidget
 
 
 @pytest.mark.django_db
-def test_piece_state_admin_form_has_relational_fields(user):
+def test_piece_state_admin_form_has_unified_fields(user):
     # Create a piece and a state that has relational fields
     piece = Piece.objects.create(user=user, name="Test Piece")
     state = PieceState.objects.create(
         user=user,
         piece=piece,
-        state="glazed",  # 'glazed' has 'glaze_combination' ref
+        state="wheel_thrown",  # 'wheel_thrown' has 'clay_body' ref
     )
 
     admin = PieceStateAdmin(PieceState, AdminSite())
     form_class = admin.get_form(None, obj=state, change=True)
     form = form_class(instance=state)
 
-    # Check if 'custom_glaze_combination' is in the form fields
-    assert "custom_glaze_combination" in form.fields
-    assert isinstance(form.fields["custom_glaze_combination"], forms.ModelChoiceField)
-    assert form.fields["custom_glaze_combination"].queryset.model == GlazeCombination
+    # Check if 'unified_custom_fields' is in the form fields
+    assert "unified_custom_fields" in form.fields
+    assert isinstance(form.fields["unified_custom_fields"].widget, WorkflowStateWidget)
 
 
 @pytest.mark.django_db
-def test_get_custom_form_fields_includes_relational_fields():
-    # 'glazed' state has 'glaze_combination' which is a global ref
-    fields = _get_custom_form_fields("glazed")
-
-    assert "custom_glaze_combination" in fields
-    assert isinstance(fields["custom_glaze_combination"], forms.ModelChoiceField)
-    assert fields["custom_glaze_combination"].queryset.model == GlazeCombination
-
-
-@pytest.mark.django_db
-def test_piece_state_admin_save_relational_fields(user):
-    from api.models import PieceStateGlazeCombinationRef
+def test_piece_state_admin_save_unified_relational_fields(user):
+    from django.apps import apps
 
     piece = Piece.objects.create(user=user, name="Test Piece")
-    state = PieceState.objects.create(user=user, piece=piece, state="glazed")
-    gc = GlazeCombination.objects.create(user=user, name="Test Glaze")
+    state = PieceState.objects.create(user=user, piece=piece, state="wheel_thrown")
+    from api.models import ClayBody
+
+    cb = ClayBody.objects.create(user=user, name="Test Clay")
 
     admin = PieceStateAdmin(PieceState, AdminSite())
     form_class = admin.get_form(None, obj=state, change=True)
 
-    # Simulate saving the form
+    # Simulate saving the form with unified payload from React
     form_data = {
         "user": user.id,
         "piece": piece.id,
-        "state": "glazed",
+        "state": "wheel_thrown",
         "custom_fields": "{}",
-        "custom_glaze_combination": gc.id,
+        "unified_custom_fields": {
+            "custom_fields": {"clay_weight_lbs": 2.5},
+            "global_ref_pks": {"clay_body": str(cb.id)},
+        },
         "allow_sealed_edit": True,
     }
     form = form_class(data=form_data, instance=state)
@@ -62,25 +57,33 @@ def test_piece_state_admin_save_relational_fields(user):
     admin.save_model(None, state, form, True)
 
     # Verify junction row exists
-    ref = PieceStateGlazeCombinationRef.objects.get(
-        piece_state=state, field_name="glaze_combination"
-    )
-    assert ref.glaze_combination == gc
+    ref_model_cls = apps.get_model("api", "PieceStateClayBodyRef")
+    ref = ref_model_cls.objects.get(piece_state=state, field_name="clay_body")
+    assert ref.clay_body == cb
+    assert state.custom_fields == {"clay_weight_lbs": 2.5}
 
 
 @pytest.mark.django_db
-def test_piece_state_admin_load_relational_fields(user):
-    from api.models import PieceStateGlazeCombinationRef
+def test_piece_state_admin_load_unified_fields(user):
+    from django.apps import apps
 
     piece = Piece.objects.create(user=user, name="Test Piece")
-    state = PieceState.objects.create(user=user, piece=piece, state="glazed")
-    gc = GlazeCombination.objects.create(user=user, name="Test Glaze")
-    PieceStateGlazeCombinationRef.objects.create(
-        piece_state=state, field_name="glaze_combination", glaze_combination=gc
+    # 'wheel_thrown' has 'clay_weight_lbs' inline field and 'clay_body' global ref
+    state = PieceState.objects.create(
+        user=user, piece=piece, state="wheel_thrown", custom_fields={"clay_weight_lbs": 1.5}
+    )
+    from api.models import ClayBody
+
+    cb = ClayBody.objects.create(user=user, name="Test Clay")
+    ref_model_cls = apps.get_model("api", "PieceStateClayBodyRef")
+    ref_model_cls.objects.create(
+        piece_state=state, field_name="clay_body", clay_body=cb
     )
 
     admin = PieceStateAdmin(PieceState, AdminSite())
     form_class = admin.get_form(None, obj=state, change=True)
     form = form_class(instance=state)
 
-    assert form.initial["custom_glaze_combination"] == gc.id
+    initial_unified = form.initial["unified_custom_fields"]
+    assert initial_unified["custom_fields"] == {"clay_weight_lbs": 1.5}
+    assert initial_unified["global_ref_values"]["clay_body"]["id"] == str(cb.id)

--- a/api/tests/test_piece_state_admin_relational.py
+++ b/api/tests/test_piece_state_admin_relational.py
@@ -46,8 +46,10 @@ def test_piece_state_admin_save_unified_relational_fields(user):
         "state": "wheel_thrown",
         "custom_fields": "{}",
         "unified_custom_fields": {
-            "custom_fields": {"clay_weight_lbs": 2.5},
-            "global_ref_pks": {"clay_body": str(cb.id)},
+            "custom_fields": {
+                "clay_weight_lbs": 2.5,
+                "clay_body": str(cb.id),
+            },
         },
         "allow_sealed_edit": True,
     }

--- a/api/tests/test_piece_state_admin_relational.py
+++ b/api/tests/test_piece_state_admin_relational.py
@@ -89,3 +89,23 @@ def test_piece_state_admin_load_unified_fields(user):
     initial_unified = form.initial["unified_custom_fields"]
     assert initial_unified["custom_fields"] == {"clay_weight_lbs": 1.5}
     assert initial_unified["global_ref_values"]["clay_body"]["id"] == str(cb.id)
+
+
+@pytest.mark.django_db
+def test_piece_state_admin_widget_seeds_hidden_payload(user):
+    piece = Piece.objects.create(user=user, name="Test Piece")
+    state = PieceState.objects.create(user=user, piece=piece, state="wheel_thrown")
+
+    admin = PieceStateAdmin(PieceState, AdminSite())
+    form_class = admin.get_form(None, obj=state, change=True)
+    form = form_class(instance=state)
+
+    rendered = form.fields["unified_custom_fields"].widget.render(
+        "unified_custom_fields",
+        form.initial["unified_custom_fields"],
+    )
+
+    assert (
+        "document.getElementById('id_unified_custom_fields').value = JSON.stringify(initialState);"
+        in rendered
+    )

--- a/api/tests/test_workflow_helpers.py
+++ b/api/tests/test_workflow_helpers.py
@@ -413,6 +413,15 @@ def test_build_custom_fields_schema_resolves_state_refs_recursively(monkeypatch)
     }
 
 
+def test_build_ui_schema_marks_state_refs(monkeypatch):
+    monkeypatch.setattr(workflow_module, "_STATE_MAP", _MOCK_STATE_MAP)
+    monkeypatch.setattr(workflow_module, "_GLOBALS_MAP", _MOCK_GLOBALS_MAP)
+
+    schema = workflow_module.build_ui_schema("trimmed")
+    assert schema["properties"]["pre_trim_weight_lbs"]["x-state-ref"] is True
+    assert "x-global-ref" not in schema["properties"]["pre_trim_weight_lbs"]
+
+
 # ---------------------------------------------------------------------------
 # get_filterable_fields
 # ---------------------------------------------------------------------------

--- a/api/urls.py
+++ b/api/urls.py
@@ -61,6 +61,11 @@ urlpatterns = [
         views.cloudinary_widget_sign,
         name="cloudinary-widget-sign",
     ),
+    path(
+        "workflow/schema/<str:state_id>/",
+        views.workflow_state_schema,
+        name="workflow-state-schema",
+    ),
 ]
 
 # Generate one route per global declared in workflow.yml.  The view factory

--- a/api/views.py
+++ b/api/views.py
@@ -42,6 +42,7 @@ from .piece_views import (
     pieces,
 )
 from .task_views import submit_task, task_detail
+from .workflow_views import workflow_state_schema
 
 __all__ = [
     "_FAVORITES_REGISTRY",
@@ -73,4 +74,5 @@ __all__ = [
     "pieces",
     "submit_task",
     "task_detail",
+    "workflow_state_schema",
 ]

--- a/api/widgets.py
+++ b/api/widgets.py
@@ -63,7 +63,7 @@ class WorkflowStateWidget(forms.Widget):
         {vite_preamble}
         {css_html}
         <div id="{container_id}" class="workflow-state-widget-container"
-             style="min-height: 50px; background: var(--body-bg, #fff); color: var(--body-fg, #333); margin-bottom: 20px; padding-top: 10px;">
+             style="min-height: 50px; background: var(--body-bg, transparent); color: var(--body-fg, inherit); margin-bottom: 20px; border: 0; padding: 0;">
             Loading custom fields...
         </div>
         <input type="hidden" name="{name}" id="id_{name}" value="">

--- a/api/widgets.py
+++ b/api/widgets.py
@@ -1,4 +1,3 @@
-import json
 import os
 from django import forms
 from django.conf import settings
@@ -86,6 +85,7 @@ class WorkflowStateWidget(forms.Widget):
                     
                     const initialState = JSON.parse(document.getElementById('{state_script_id}').textContent);
                     const uiSchema = JSON.parse(document.getElementById('{schema_script_id}').textContent);
+                    document.getElementById('id_{name}').value = JSON.stringify(initialState);
 
                     mountWorkflowStateWidget({{
                         containerId: '{container_id}',

--- a/api/widgets.py
+++ b/api/widgets.py
@@ -1,11 +1,11 @@
 import json
 from django import forms
 from django.conf import settings
+from django.templatetags.static import static
 from django.utils.safestring import mark_safe
 
-class WorkflowStateWidget(forms.Widget):
-    template_name = "api/widgets/workflow_state.html"
 
+class WorkflowStateWidget(forms.Widget):
     def __init__(self, attrs=None, piece_id=None, state_id=None, ui_schema=None):
         super().__init__(attrs)
         self.piece_id = piece_id
@@ -17,35 +17,37 @@ class WorkflowStateWidget(forms.Widget):
         context["widget"]["piece_id"] = str(self.piece_id)
         context["widget"]["state_id"] = self.state_id
         context["widget"]["ui_schema_json"] = json.dumps(self.ui_schema)
-        
+
         # 'value' here is the initial PieceState data as a dict
         context["widget"]["initial_state_json"] = json.dumps(value)
         return context
 
-    @property
-    def media(self):
-        # In a real setup, we would point to the hashed bundle in STATIC_ROOT.
-        # For development/demo, we point to the Vite output.
-        js = [
-            "admin-widget.js",
-        ]
-        return forms.Media(js=js)
-
     def render(self, name, value, attrs=None, renderer=None):
         context = self.get_context(name, value, attrs)
-        
+
         container_id = f"workflow-state-root-{name}"
         initial_state = context["widget"]["initial_state_json"]
         ui_schema = context["widget"]["ui_schema_json"]
         piece_id = context["widget"]["piece_id"]
-        
+
+        # Predictable asset paths from our Vite config
+        js_url = static("admin-widget.js")
+        css_url = static("assets/admin-widget.css")
+
         html = f"""
-        <div id="{container_id}" class="workflow-state-widget-container"></div>
+        <link rel="stylesheet" href="{css_url}">
+        <div id="{container_id}" class="workflow-state-widget-container"
+             style="min-height: 200px; border: 1px solid #ccc; border-radius: 4px; padding: 16px; background: #fff;">
+            Loading custom fields...
+        </div>
         <input type="hidden" name="{name}" id="id_{name}" value="">
-        <script>
+        
+        <script type="module">
+            import {{ mountWorkflowStateWidget }} from "{js_url}";
+            
             document.addEventListener('DOMContentLoaded', function() {{
-                if (window.mountWorkflowStateWidget) {{
-                    window.mountWorkflowStateWidget({{
+                try {{
+                    mountWorkflowStateWidget({{
                         containerId: '{container_id}',
                         pieceId: '{piece_id}',
                         initialPieceState: {initial_state},
@@ -54,23 +56,17 @@ class WorkflowStateWidget(forms.Widget):
                             // console.log('Form dirty:', dirty);
                         }},
                         saveStateFn: function(payload) {{
-                            // In Admin, we don't save via API immediately.
-                            // We update the hidden input so the main Admin "Save" submits it.
+                            // In Admin, we update the hidden input so the main Admin "Save" submits it.
                             document.getElementById('id_{name}').value = JSON.stringify(payload);
-                            return Promise.resolve({{}}); // Mock success
+                            return Promise.resolve({{}}); 
                         }}
                     }});
+                }} catch (e) {{
+                    console.error("Failed to mount WorkflowState widget:", e);
+                    document.getElementById('{container_id}').innerHTML = 
+                        '<div style="color: red;">Error loading workflow fields. Check console.</div>';
                 }}
             }});
         </script>
-        <style>
-            .workflow-state-widget-container {{
-                border: 1px solid #ccc;
-                padding: 10px;
-                border-radius: 4px;
-                background: #f9f9f9;
-                margin-bottom: 10px;
-            }}
-        </style>
         """
         return mark_safe(html)

--- a/api/widgets.py
+++ b/api/widgets.py
@@ -63,7 +63,7 @@ class WorkflowStateWidget(forms.Widget):
         {vite_preamble}
         {css_html}
         <div id="{container_id}" class="workflow-state-widget-container"
-             style="min-height: 200px; border: 1px solid #ccc; border-radius: 4px; padding: 16px; background: #fff; margin-bottom: 20px;">
+             style="min-height: 200px; border: 1px solid var(--border-color, #ccc); border-radius: 4px; padding: 16px; background: var(--body-bg, #fff); color: var(--body-fg, #333); margin-bottom: 20px;">
             Loading custom fields...
         </div>
         <input type="hidden" name="{name}" id="id_{name}" value="">

--- a/api/widgets.py
+++ b/api/widgets.py
@@ -63,7 +63,7 @@ class WorkflowStateWidget(forms.Widget):
         {vite_preamble}
         {css_html}
         <div id="{container_id}" class="workflow-state-widget-container"
-             style="min-height: 200px; border: 1px solid var(--border-color, #ccc); border-radius: 4px; padding: 16px; background: var(--body-bg, #fff); color: var(--body-fg, #333); margin-bottom: 20px;">
+             style="min-height: 50px; background: var(--body-bg, #fff); color: var(--body-fg, #333); margin-bottom: 20px; padding-top: 10px;">
             Loading custom fields...
         </div>
         <input type="hidden" name="{name}" id="id_{name}" value="">

--- a/api/widgets.py
+++ b/api/widgets.py
@@ -85,8 +85,12 @@ class WorkflowStateWidget(forms.Widget):
                         onDirtyChange: (dirty) => {{
                             // console.log('Form dirty:', dirty);
                         }},
+                        onChange: (payload) => {{
+                            // Update hidden input on every change
+                            document.getElementById('id_{name}').value = JSON.stringify(payload);
+                        }},
                         saveStateFn: (payload) => {{
-                            // Update hidden input so main Admin "Save" sees the changes
+                            // Also update on explicit save (though autosave is disabled)
                             document.getElementById('id_{name}').value = JSON.stringify(payload);
                             return Promise.resolve({{}}); 
                         }}

--- a/api/widgets.py
+++ b/api/widgets.py
@@ -1,4 +1,5 @@
 import json
+import os
 from django import forms
 from django.conf import settings
 from django.templatetags.static import static
@@ -6,6 +7,8 @@ from django.utils.safestring import mark_safe
 
 
 class WorkflowStateWidget(forms.Widget):
+    template_name = None
+
     def __init__(self, attrs=None, piece_id=None, state_id=None, ui_schema=None):
         super().__init__(attrs)
         self.piece_id = piece_id
@@ -30,12 +33,19 @@ class WorkflowStateWidget(forms.Widget):
         ui_schema = context["widget"]["ui_schema_json"]
         piece_id = context["widget"]["piece_id"]
 
-        # Predictable asset paths from our Vite config
-        js_url = static("admin-widget.js")
-        css_url = static("assets/admin-widget.css")
+        # In development, we prefer the Vite dev server if running.
+        # gz_start sets APP_ORIGIN to the Vite URL.
+        app_origin = os.environ.get("APP_ORIGIN")
+        if settings.DEBUG and app_origin:
+            js_url = f"{app_origin}/src/admin.tsx"
+            css_html = ""  # Vite handles CSS in dev mode
+        else:
+            js_url = static("admin-widget.js")
+            css_url = static("assets/admin-widget.css")
+            css_html = f'<link rel="stylesheet" href="{css_url}">'
 
         html = f"""
-        <link rel="stylesheet" href="{css_url}">
+        {css_html}
         <div id="{container_id}" class="workflow-state-widget-container"
              style="min-height: 200px; border: 1px solid #ccc; border-radius: 4px; padding: 16px; background: #fff;">
             Loading custom fields...

--- a/api/widgets.py
+++ b/api/widgets.py
@@ -3,6 +3,7 @@ import os
 from django import forms
 from django.conf import settings
 from django.templatetags.static import static
+from django.utils.html import json_script
 from django.utils.safestring import mark_safe
 
 
@@ -19,19 +20,24 @@ class WorkflowStateWidget(forms.Widget):
         context = super().get_context(name, value, attrs)
         context["widget"]["piece_id"] = str(self.piece_id)
         context["widget"]["state_id"] = self.state_id
-        context["widget"]["ui_schema_json"] = json.dumps(self.ui_schema)
-
-        # 'value' here is the initial PieceState data as a dict
-        context["widget"]["initial_state_json"] = json.dumps(value)
+        context["widget"]["ui_schema"] = self.ui_schema
+        context["widget"]["initial_state"] = value
         return context
 
     def render(self, name, value, attrs=None, renderer=None):
         context = self.get_context(name, value, attrs)
 
         container_id = f"workflow-state-root-{name}"
-        initial_state = context["widget"]["initial_state_json"]
-        ui_schema = context["widget"]["ui_schema_json"]
+        initial_state = context["widget"]["initial_state"]
+        ui_schema = context["widget"]["ui_schema"]
         piece_id = context["widget"]["piece_id"]
+
+        # Use Django's json_script to safely embed JSON data (prevents XSS)
+        state_script_id = f"workflow-state-data-{name}"
+        schema_script_id = f"workflow-schema-data-{name}"
+        
+        html_data = json_script(initial_state, state_script_id)
+        html_data += json_script(ui_schema, schema_script_id)
 
         # In development, we prefer the Vite dev server if running.
         # gz_start sets APP_ORIGIN to the Vite URL (e.g. http://localhost:5173).
@@ -40,7 +46,6 @@ class WorkflowStateWidget(forms.Widget):
 
         if is_dev:
             # When using Vite dev server, we need the React Refresh preamble.
-            # We also load the entry point via a dynamic import inside a module script.
             vite_preamble = f"""
             <script type="module">
                 import {{ injectIntoGlobalHook }} from "{app_origin}/@react-refresh";
@@ -60,6 +65,7 @@ class WorkflowStateWidget(forms.Widget):
             css_html = f'<link rel="stylesheet" href="{css_url}">'
 
         html = f"""
+        {html_data}
         {vite_preamble}
         {css_html}
         <div id="{container_id}" class="workflow-state-widget-container"
@@ -77,16 +83,20 @@ class WorkflowStateWidget(forms.Widget):
                     if (typeof mountWorkflowStateWidget !== 'function') {{
                         throw new Error("mountWorkflowStateWidget is not a function (is: " + typeof mountWorkflowStateWidget + ")");
                     }}
+                    
+                    const initialState = JSON.parse(document.getElementById('{state_script_id}').textContent);
+                    const uiSchema = JSON.parse(document.getElementById('{schema_script_id}').textContent);
+
                     mountWorkflowStateWidget({{
                         containerId: '{container_id}',
                         pieceId: '{piece_id}',
-                        initialPieceState: {initial_state},
-                        uiSchema: {ui_schema},
+                        initialPieceState: initialState,
+                        uiSchema: uiSchema,
                         onDirtyChange: (dirty) => {{
                             // console.log('Form dirty:', dirty);
                         }},
                         onChange: (payload) => {{
-                            // Update hidden input on every change
+                            // Update hidden input so main Admin "Save" sees the changes
                             document.getElementById('id_{name}').value = JSON.stringify(payload);
                         }},
                         saveStateFn: (payload) => {{

--- a/api/widgets.py
+++ b/api/widgets.py
@@ -1,0 +1,76 @@
+import json
+from django import forms
+from django.conf import settings
+from django.utils.safestring import mark_safe
+
+class WorkflowStateWidget(forms.Widget):
+    template_name = "api/widgets/workflow_state.html"
+
+    def __init__(self, attrs=None, piece_id=None, state_id=None, ui_schema=None):
+        super().__init__(attrs)
+        self.piece_id = piece_id
+        self.state_id = state_id
+        self.ui_schema = ui_schema
+
+    def get_context(self, name, value, attrs):
+        context = super().get_context(name, value, attrs)
+        context["widget"]["piece_id"] = str(self.piece_id)
+        context["widget"]["state_id"] = self.state_id
+        context["widget"]["ui_schema_json"] = json.dumps(self.ui_schema)
+        
+        # 'value' here is the initial PieceState data as a dict
+        context["widget"]["initial_state_json"] = json.dumps(value)
+        return context
+
+    @property
+    def media(self):
+        # In a real setup, we would point to the hashed bundle in STATIC_ROOT.
+        # For development/demo, we point to the Vite output.
+        js = [
+            "admin-widget.js",
+        ]
+        return forms.Media(js=js)
+
+    def render(self, name, value, attrs=None, renderer=None):
+        context = self.get_context(name, value, attrs)
+        
+        container_id = f"workflow-state-root-{name}"
+        initial_state = context["widget"]["initial_state_json"]
+        ui_schema = context["widget"]["ui_schema_json"]
+        piece_id = context["widget"]["piece_id"]
+        
+        html = f"""
+        <div id="{container_id}" class="workflow-state-widget-container"></div>
+        <input type="hidden" name="{name}" id="id_{name}" value="">
+        <script>
+            document.addEventListener('DOMContentLoaded', function() {{
+                if (window.mountWorkflowStateWidget) {{
+                    window.mountWorkflowStateWidget({{
+                        containerId: '{container_id}',
+                        pieceId: '{piece_id}',
+                        initialPieceState: {initial_state},
+                        uiSchema: {ui_schema},
+                        onDirtyChange: function(dirty) {{
+                            // console.log('Form dirty:', dirty);
+                        }},
+                        saveStateFn: function(payload) {{
+                            // In Admin, we don't save via API immediately.
+                            // We update the hidden input so the main Admin "Save" submits it.
+                            document.getElementById('id_{name}').value = JSON.stringify(payload);
+                            return Promise.resolve({{}}); // Mock success
+                        }}
+                    }});
+                }}
+            }});
+        </script>
+        <style>
+            .workflow-state-widget-container {{
+                border: 1px solid #ccc;
+                padding: 10px;
+                border-radius: 4px;
+                background: #f9f9f9;
+                margin-bottom: 10px;
+            }}
+        </style>
+        """
+        return mark_safe(html)

--- a/api/widgets.py
+++ b/api/widgets.py
@@ -34,39 +34,59 @@ class WorkflowStateWidget(forms.Widget):
         piece_id = context["widget"]["piece_id"]
 
         # In development, we prefer the Vite dev server if running.
-        # gz_start sets APP_ORIGIN to the Vite URL.
+        # gz_start sets APP_ORIGIN to the Vite URL (e.g. http://localhost:5173).
         app_origin = os.environ.get("APP_ORIGIN")
-        if settings.DEBUG and app_origin:
+        is_dev = settings.DEBUG and app_origin
+
+        if is_dev:
+            # When using Vite dev server, we need the React Refresh preamble.
+            # We also load the entry point via a dynamic import inside a module script.
+            vite_preamble = f"""
+            <script type="module">
+                import {{ injectIntoGlobalHook }} from "{app_origin}/@react-refresh";
+                injectIntoGlobalHook(window);
+                window.$RefreshReg$ = () => {{}};
+                window.$RefreshSig$ = () => (type) => type;
+                window.__vite_plugin_react_preamble_installed__ = true;
+            </script>
+            <script type="module" src="{app_origin}/@vite/client"></script>
+            """
             js_url = f"{app_origin}/src/admin.tsx"
-            css_html = ""  # Vite handles CSS in dev mode
+            css_html = ""
         else:
+            vite_preamble = ""
             js_url = static("admin-widget.js")
             css_url = static("assets/admin-widget.css")
             css_html = f'<link rel="stylesheet" href="{css_url}">'
 
         html = f"""
+        {vite_preamble}
         {css_html}
         <div id="{container_id}" class="workflow-state-widget-container"
-             style="min-height: 200px; border: 1px solid #ccc; border-radius: 4px; padding: 16px; background: #fff;">
+             style="min-height: 200px; border: 1px solid #ccc; border-radius: 4px; padding: 16px; background: #fff; margin-bottom: 20px;">
             Loading custom fields...
         </div>
         <input type="hidden" name="{name}" id="id_{name}" value="">
         
         <script type="module">
+            // Use dynamic import to catch errors and ensure predictable execution
             import {{ mountWorkflowStateWidget }} from "{js_url}";
             
-            document.addEventListener('DOMContentLoaded', function() {{
+            const mount = () => {{
                 try {{
+                    if (typeof mountWorkflowStateWidget !== 'function') {{
+                        throw new Error("mountWorkflowStateWidget is not a function (is: " + typeof mountWorkflowStateWidget + ")");
+                    }}
                     mountWorkflowStateWidget({{
                         containerId: '{container_id}',
                         pieceId: '{piece_id}',
                         initialPieceState: {initial_state},
                         uiSchema: {ui_schema},
-                        onDirtyChange: function(dirty) {{
+                        onDirtyChange: (dirty) => {{
                             // console.log('Form dirty:', dirty);
                         }},
-                        saveStateFn: function(payload) {{
-                            // In Admin, we update the hidden input so the main Admin "Save" submits it.
+                        saveStateFn: (payload) => {{
+                            // Update hidden input so main Admin "Save" sees the changes
                             document.getElementById('id_{name}').value = JSON.stringify(payload);
                             return Promise.resolve({{}}); 
                         }}
@@ -74,9 +94,19 @@ class WorkflowStateWidget(forms.Widget):
                 }} catch (e) {{
                     console.error("Failed to mount WorkflowState widget:", e);
                     document.getElementById('{container_id}').innerHTML = 
-                        '<div style="color: red;">Error loading workflow fields. Check console.</div>';
+                        '<div style="color: red; padding: 10px;">' +
+                        '<strong>Error loading workflow fields:</strong><br>' + 
+                        e.message + 
+                        '<br><br>Check browser console for details.' +
+                        '</div>';
                 }}
-            }});
+            }};
+
+            if (document.readyState === 'loading') {{
+                document.addEventListener('DOMContentLoaded', mount);
+            }} else {{
+                mount();
+            }}
         </script>
         """
         return mark_safe(html)

--- a/api/workflow.py
+++ b/api/workflow.py
@@ -552,6 +552,9 @@ def build_ui_schema(state_id: str) -> dict:
             if field_def.get("can_create"):
                 field_schema["x-can-create"] = True
 
+        if "$ref" in field_def and not field_def["$ref"].startswith("@"):
+            field_schema["x-state-ref"] = True
+
         if "compute" in field_def:
             field_schema["x-read-only"] = True
 

--- a/api/workflow.py
+++ b/api/workflow.py
@@ -514,7 +514,56 @@ def _resolve_field_def_cached(field_def_hashable: Any) -> dict:
 
 def _resolve_field_def(field_def: dict) -> dict:
     """Resolve a DSL field_def to its JSON Schema property dict."""
-    return _resolve_field_def_cached(_make_hashable(field_def))
+    return dict(_resolve_field_def_cached(_make_hashable(field_def)))
+
+
+@lru_cache(maxsize=None)
+def build_ui_schema(state_id: str) -> dict:
+    """Return a JSON Schema that describes all fields (including global refs) for UI generation.
+
+    Adds `x-` extensions for UI-specific metadata like labels, global refs, and required status.
+    """
+    state = _STATE_MAP.get(state_id)
+    dsl_fields: dict = state.get("fields", {}) if state else {}
+
+    properties: dict = {}
+    required: list[str] = []
+
+    for field_name, field_def in dsl_fields.items():
+        # Copy to avoid mutating the cached resolve_field_def result.
+        field_schema = dict(_resolve_field_def(field_def))
+
+        # Add UI hints
+        field_schema["x-label"] = field_def.get(
+            "label", field_name.replace("_", " ").capitalize()
+        )
+        if "description" in field_def:
+            field_schema["x-description"] = field_def["description"]
+        if "display_as" in field_def:
+            field_schema["x-display-as"] = field_def["display_as"]
+        if field_def.get("required", False):
+            field_schema["x-required"] = True
+            required.append(field_name)
+
+        # Global ref detection
+        resolved_global = _resolve_to_global_ref(field_def)
+        if resolved_global:
+            field_schema["x-global-ref"] = resolved_global[0]
+            if field_def.get("can_create"):
+                field_schema["x-can-create"] = True
+
+        if "compute" in field_def:
+            field_schema["x-read-only"] = True
+
+        properties[field_name] = field_schema
+
+    schema: dict = {
+        "type": "object",
+        "properties": properties,
+        "required": required,
+        "additionalProperties": False,
+    }
+    return schema
 
 
 @lru_cache(maxsize=None)

--- a/api/workflow_views.py
+++ b/api/workflow_views.py
@@ -1,0 +1,14 @@
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from .workflow import build_ui_schema
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def workflow_state_schema(request: Request, state_id: str) -> Response:
+    """Return the UI-enhanced JSON Schema for a given workflow state."""
+    schema = build_ui_schema(state_id)
+    return Response(schema)

--- a/api/workflow_views.py
+++ b/api/workflow_views.py
@@ -1,11 +1,14 @@
+from drf_spectacular.utils import extend_schema
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
+from typing import Any
 
 from .workflow import build_ui_schema
 
 
+@extend_schema(responses={200: Any})
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def workflow_state_schema(request: Request, state_id: str) -> Response:

--- a/env-agent.sh
+++ b/env-agent.sh
@@ -118,6 +118,23 @@ _gz_is_running() {   # _gz_is_running <name>
     ps -p "$pid" -o state= 2>/dev/null | grep -qv "Z"
 }
 
+_gz_wait_for_health() {
+    local port="$1"
+    local url="http://127.0.0.1:$port/api/health/ready/"
+    local i=0
+    echo -n "Waiting for backend to be ready..."
+    until curl -s "$url" | grep -q '"status": "ready"' 2>/dev/null; do
+        echo -n "."
+        sleep 0.5
+        (( i++ ))
+        if (( i >= 40 )); then
+            echo " timed out!"
+            return 1
+        fi
+    done
+    echo " ready."
+}
+
 _gz_start() {        # _gz_start <name> <logfile> <cmd...>
     local name="$1" logfile="$2"; shift 2
     if _gz_is_running "$name"; then
@@ -559,6 +576,7 @@ gz_start() {
     gz_backend
     _gz_rotate_log web
     gz_web
+    _gz_wait_for_health "$(cat "$_GLAZE_PIDS/backend.port")"
     gz_open
     echo "Servers running — use 'gz_stop' to stop, 'gz_logs' to tail output."
     # Best-effort cleanup when this terminal tab closes normally (Ctrl-D / exit / tab X).

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -565,6 +565,16 @@ js_library(
     ],
 )
 
+js_library(
+    name = "admin_src",
+    srcs = ["src/admin.tsx"],
+    deps = [
+        ":node_modules",
+        ":util_lib",
+        ":workflow_state_src",
+    ],
+)
+
 # ── Granular web test targets ─────────────────────────────────────────────────
 # Each target runs a focused subset of tests and depends only on the components
 # it exercises.  A change to an isolated component re-runs only the relevant
@@ -898,6 +908,15 @@ vitest_test(
 )
 
 vitest_test(
+    name = "web_admin_test",
+    srcs = ["src/admin.test.tsx"],
+    tags = ["ibazel_notify_changes"],
+    deps = [
+        ":admin_src",
+    ],
+)
+
+vitest_test(
     name = "web_app_test",
     srcs = ["src/App.test.tsx"],
     tags = ["ibazel_notify_changes"],
@@ -913,6 +932,7 @@ vitest_test(
 test_suite(
     name = "web_test",
     tests = [
+        ":web_admin_test",
         ":web_analysis_test",
         ":web_analyze_page_test",
         ":web_api_test",

--- a/web/src/admin.test.tsx
+++ b/web/src/admin.test.tsx
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act } from "@testing-library/react";
+import { mountWorkflowStateWidget } from "./admin";
+import WorkflowState from "./components/WorkflowState";
+
+// Mock WorkflowState to keep the test focused on mounting and theme logic
+vi.mock("./components/WorkflowState", () => ({
+  __esModule: true,
+  default: vi.fn(() => <div data-testid="mock-workflow-state" />),
+}));
+
+describe("admin.tsx - mountWorkflowStateWidget", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    container = document.createElement("div");
+    container.id = "test-container";
+    document.body.appendChild(container);
+    vi.clearAllMocks();
+  });
+
+  const validInitialState = {
+    id: "piece-state-1",
+    state: "wheel_thrown",
+    notes: "Original notes",
+    custom_fields: { clay_weight_lbs: 1.5 },
+  };
+
+  it("attaches itself to the window object", () => {
+    expect(window.mountWorkflowStateWidget).toBeDefined();
+    expect(typeof window.mountWorkflowStateWidget).toBe("function");
+  });
+
+  it("mounts the component into the specified container", async () => {
+    await act(async () => {
+      mountWorkflowStateWidget({
+        containerId: "test-container",
+        initialPieceState: validInitialState as any,
+        pieceId: "piece-1",
+      });
+    });
+
+    expect(WorkflowState).toHaveBeenCalled();
+    expect(document.querySelector('[data-testid="mock-workflow-state"]')).toBeInTheDocument();
+  });
+
+  it("handles stringified initialPieceState", async () => {
+    await act(async () => {
+      mountWorkflowStateWidget({
+        containerId: "test-container",
+        initialPieceState: JSON.stringify(validInitialState) as any,
+        pieceId: "piece-1",
+      });
+    });
+
+    // Check last call to ignore StrictMode double-call noise
+    // We only check the first argument (props)
+    expect(vi.mocked(WorkflowState).mock.lastCall![0]).toEqual(
+      expect.objectContaining({
+        initialPieceState: expect.objectContaining({
+          id: "piece-state-1",
+          notes: "Original notes",
+        }),
+      })
+    );
+  });
+
+  it("merges global_ref_values into custom_fields", async () => {
+    const stateWithRefs = {
+      ...validInitialState,
+      global_ref_values: {
+        clay_body: { id: "cb-1", name: "Speckled Buff" },
+      },
+    };
+
+    await act(async () => {
+      mountWorkflowStateWidget({
+        containerId: "test-container",
+        initialPieceState: stateWithRefs as any,
+        pieceId: "piece-1",
+      });
+    });
+
+    expect(vi.mocked(WorkflowState).mock.lastCall![0]).toEqual(
+      expect.objectContaining({
+        initialPieceState: expect.objectContaining({
+          custom_fields: {
+            clay_weight_lbs: 1.5,
+            clay_body: { id: "cb-1", name: "Speckled Buff" },
+          },
+        }),
+      })
+    );
+  });
+
+  it("provides a cleanup function that unmounts and removes portals", async () => {
+    let unmount: () => void = () => {};
+    await act(async () => {
+      unmount = mountWorkflowStateWidget({
+        containerId: "test-container",
+        initialPieceState: validInitialState as any,
+        pieceId: "piece-1",
+      });
+    });
+
+    // Check if portal root was created
+    const portalRoot = document.getElementById("portal-root-test-container");
+    expect(portalRoot).toBeInTheDocument();
+
+    // Call cleanup
+    await act(async () => {
+      unmount();
+    });
+
+    // Verify portal root is gone
+    expect(document.getElementById("portal-root-test-container")).not.toBeInTheDocument();
+  });
+
+  it("captures changes via onChange and serializes them to the hidden input", async () => {
+    // Mock the hidden input that widgets.py creates
+    const hiddenInput = document.createElement("input");
+    hiddenInput.type = "hidden";
+    hiddenInput.id = "id_unified_custom_fields";
+    document.body.appendChild(hiddenInput);
+
+    await act(async () => {
+      mountWorkflowStateWidget({
+        containerId: "test-container",
+        initialPieceState: validInitialState as any,
+        pieceId: "piece-1",
+        onChange: (payload) => {
+          hiddenInput.value = JSON.stringify(payload);
+        }
+      });
+    });
+
+    // Extract the onChange passed to WorkflowState
+    const lastCallProps = vi.mocked(WorkflowState).mock.lastCall![0];
+    const mockPayload = { notes: "Updated", custom_fields: { foo: "bar" } };
+    
+    // Simulate a change
+    await act(async () => {
+      lastCallProps.onChange!(mockPayload as any);
+    });
+
+    expect(hiddenInput.value).toBe(JSON.stringify(mockPayload));
+  });
+});

--- a/web/src/admin.tsx
+++ b/web/src/admin.tsx
@@ -1,30 +1,45 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
+import ScopedCssBaseline from "@mui/material/ScopedCssBaseline";
 import WorkflowState from "./components/WorkflowState";
 import type { PieceDetail, PieceState, UISchema } from "./util/types";
 import type { UpdateStatePayload } from "./util/api";
 
 const getDjangoTheme = (): "light" | "dark" => {
-  return document.documentElement.dataset.theme === "dark" ? "dark" : "light";
+  // Modern Django 5.0+
+  if (document.documentElement.dataset.theme === "dark") return "dark";
+  // Fallback for custom or older setups
+  if (document.body.classList.contains("dark-mode")) return "dark";
+  // System preference fallback
+  if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) return "dark";
+  return "light";
 };
 
 const createAdminTheme = (mode: "light" | "dark") => {
+  const isDark = mode === "dark";
+  // Explicitly match Django dark/light mode background and foreground colors.
+  // Django Dark: #121212 bg, #eee fg.
+  // Django Light: #fff bg, #333 fg.
+  const bgColor = isDark ? "#121212" : "#fff";
+  const fgColor = isDark ? "#eee" : "#333";
+  const primaryColor = isDark ? "#79aec8" : "#447e9b";
+  const paperColor = isDark ? "#1e1e1e" : "#fff";
+
   return createTheme({
     palette: {
       mode,
-      primary: { main: "#1976d2" },
+      primary: { main: primaryColor },
+      background: {
+        default: bgColor,
+        paper: paperColor,
+      },
+      text: {
+        primary: fgColor,
+        secondary: isDark ? "#aaa" : "#666",
+      },
     },
     components: {
-      MuiBox: {
-        styleOverrides: {
-          root: {
-            // Apply Django colors to the container via CSS variables
-            "--body-bg": "inherit",
-            "--body-fg": "inherit",
-          },
-        },
-      },
       MuiTextField: {
         defaultProps: {
           variant: "outlined",
@@ -34,9 +49,8 @@ const createAdminTheme = (mode: "light" | "dark") => {
       MuiInputLabel: {
         styleOverrides: {
           root: {
-            // Use inherit to pick up the background color of the parent div
-            // which is set to var(--body-bg) in widgets.py
-            backgroundColor: "var(--body-bg, #fff)",
+            // Fix the 'notch' occlusion by matching the background color exactly.
+            backgroundColor: bgColor,
             padding: "0 4px",
             marginLeft: "-4px",
           },
@@ -67,11 +81,11 @@ export const mountWorkflowStateWidget = (options: MountOptions) => {
   const container = document.getElementById(options.containerId);
   if (!container) {
     console.error(`Container #${options.containerId} not found`);
-    return () => {};
+    return () => {{
+      // cleanup
+    }};
   }
 
-  // Create a dedicated container for MUI portals (Autocomplete, Dialogs, etc.)
-  // to avoid MutationObserver issues with the Admin's legacy DOM structure.
   const portalContainerId = `portal-root-${options.containerId}`;
   let portalContainer = document.getElementById(portalContainerId);
   if (!portalContainer) {
@@ -91,7 +105,6 @@ export const mountWorkflowStateWidget = (options: MountOptions) => {
     }
   }
 
-  // Ensure we have a valid state object for the component.
   const rawState = (initialPieceState || {}) as Record<string, unknown>;
   const pieceState = { ...rawState } as unknown as PieceState;
   
@@ -99,8 +112,6 @@ export const mountWorkflowStateWidget = (options: MountOptions) => {
   if (!pieceState.custom_fields) pieceState.custom_fields = {};
   if (pieceState.notes === undefined || pieceState.notes === null) pieceState.notes = "";
 
-  // Merge global_ref_values (provided by Django Admin) into custom_fields
-  // so buildDraftState can correctly resolve the initial global reference PKs.
   const globalRefValues = rawState.global_ref_values as Record<string, unknown> | undefined;
   if (globalRefValues) {
     pieceState.custom_fields = {
@@ -109,15 +120,14 @@ export const mountWorkflowStateWidget = (options: MountOptions) => {
     };
   }
 
-  const theme = createAdminTheme(getDjangoTheme());
+  const themeMode = getDjangoTheme();
+  const theme = createAdminTheme(themeMode);
 
   const wrappedSaveStateFn = async (payload: UpdateStatePayload): Promise<PieceDetail> => {
     if (options.saveStateFn) {
       await options.saveStateFn(payload);
     }
     
-    // WorkflowState expects the returned result to contain the updated state
-    // in history so it can refresh the local draft and stop the "Saving..." spinner.
     const updatedPieceState: PieceState = {
       ...pieceState,
       notes: payload.notes ?? "",
@@ -138,15 +148,21 @@ export const mountWorkflowStateWidget = (options: MountOptions) => {
   root.render(
     <React.StrictMode>
       <ThemeProvider theme={theme}>
-        <WorkflowState
-          initialPieceState={pieceState}
-          pieceId={options.pieceId}
-          onSaved={options.onSaved || (() => {})}
-          onDirtyChange={options.onDirtyChange}
-          uiSchema={options.uiSchema}
-          saveStateFn={wrappedSaveStateFn}
-          hideImageUpload // Admin has its own image inlines for now
-        />
+        {/* ScopedCssBaseline ensures the correct background/text colors are applied to children */}
+        <ScopedCssBaseline>
+          <WorkflowState
+            initialPieceState={pieceState}
+            pieceId={options.pieceId}
+            onSaved={options.onSaved || (() => {{
+              // no-op
+            }})}
+            onDirtyChange={options.onDirtyChange}
+            uiSchema={options.uiSchema}
+            saveStateFn={wrappedSaveStateFn}
+            hideImageUpload
+            disableAutosave // Disable autosave in Admin (uses main Save button)
+          />
+        </ScopedCssBaseline>
       </ThemeProvider>
     </React.StrictMode>
   );

--- a/web/src/admin.tsx
+++ b/web/src/admin.tsx
@@ -38,13 +38,33 @@ export const mountWorkflowStateWidget = (options: MountOptions) => {
   }
 
   const root = createRoot(container);
+
+  let initialPieceState = options.initialPieceState;
+  if (typeof initialPieceState === "string") {
+    try {
+      initialPieceState = JSON.parse(initialPieceState);
+    } catch (e) {
+      console.error("Failed to parse initialPieceState string:", e);
+    }
+  }
+
+  // Ensure we have a valid state object for the component.
+  const rawState = (initialPieceState || {}) as Record<string, unknown>;
+  const pieceState = { ...rawState } as unknown as PieceState;
   
-  // Ensure we have a valid state object for the component
-  const pieceState = {
-    ...options.initialPieceState,
-    custom_fields: options.initialPieceState.custom_fields || {},
-    notes: options.initialPieceState.notes || "",
-  };
+  if (!pieceState.images) pieceState.images = [];
+  if (!pieceState.custom_fields) pieceState.custom_fields = {};
+  if (pieceState.notes === undefined || pieceState.notes === null) pieceState.notes = "";
+
+  // Merge global_ref_values (provided by Django Admin) into custom_fields
+  // so buildDraftState can correctly resolve the initial global reference PKs.
+  const globalRefValues = rawState.global_ref_values as Record<string, unknown> | undefined;
+  if (globalRefValues) {
+    pieceState.custom_fields = {
+      ...pieceState.custom_fields,
+      ...globalRefValues,
+    };
+  }
 
   root.render(
     <React.StrictMode>

--- a/web/src/admin.tsx
+++ b/web/src/admin.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
-import CssBaseline from "@mui/material/CssBaseline";
 import WorkflowState from "./components/WorkflowState";
 import type { PieceDetail, PieceState, UISchema } from "./util/types";
 import type { UpdateStatePayload } from "./util/api";
@@ -11,15 +10,19 @@ const getDjangoTheme = (): "light" | "dark" => {
 };
 
 const createAdminTheme = (mode: "light" | "dark") => {
-  const bgColor = mode === "dark" ? "#121212" : "#fff";
   return createTheme({
     palette: {
       mode,
-      primary: { main: "#1976d2" },
+      primary: { main: "var(--primary, #1976d2)" },
       background: {
-        default: bgColor,
-        paper: mode === "dark" ? "#1e1e1e" : "#fff",
+        default: "var(--body-bg, #fff)",
+        paper: "var(--body-bg, #fff)",
       },
+      text: {
+        primary: "var(--body-fg, #333)",
+        secondary: "var(--body-fg, #333)",
+      },
+      divider: "var(--border-color, #ccc)",
     },
     components: {
       MuiTextField: {
@@ -27,15 +30,38 @@ const createAdminTheme = (mode: "light" | "dark") => {
           variant: "outlined",
           size: "small",
         },
+        styleOverrides: {
+          root: {
+            // Ensure inputs don't have their own backgrounds that occlude labels
+            "& .MuiInputBase-root": {
+              backgroundColor: "transparent",
+            },
+          },
+        },
       },
       MuiInputLabel: {
         styleOverrides: {
           root: {
-            // Ensure the label's background matches the theme background
-            // so the 'notch' in outlined fields works correctly.
-            backgroundColor: bgColor,
+            // Match the Django background to fix the notch occlusion
+            backgroundColor: "var(--body-bg, #fff)",
             padding: "0 4px",
             marginLeft: "-4px",
+            color: "var(--body-fg, #333)",
+            "&.Mui-focused": {
+              color: "var(--primary, #1976d2)",
+            },
+          },
+        },
+      },
+      MuiOutlinedInput: {
+        styleOverrides: {
+          root: {
+            "& .MuiOutlinedInput-notchedOutline": {
+              borderColor: "var(--border-color, #ccc)",
+            },
+            "&:hover .MuiOutlinedInput-notchedOutline": {
+              borderColor: "var(--body-fg, #333)",
+            },
           },
         },
       },
@@ -135,7 +161,6 @@ export const mountWorkflowStateWidget = (options: MountOptions) => {
   root.render(
     <React.StrictMode>
       <ThemeProvider theme={theme}>
-        <CssBaseline />
         <WorkflowState
           initialPieceState={pieceState}
           pieceId={options.pieceId}
@@ -149,7 +174,10 @@ export const mountWorkflowStateWidget = (options: MountOptions) => {
     </React.StrictMode>
   );
 
-  return () => root.unmount();
+  return () => {
+    root.unmount();
+    portalContainer?.remove();
+  };
 };
 
 window.mountWorkflowStateWidget = mountWorkflowStateWidget;

--- a/web/src/admin.tsx
+++ b/web/src/admin.tsx
@@ -13,55 +13,32 @@ const createAdminTheme = (mode: "light" | "dark") => {
   return createTheme({
     palette: {
       mode,
-      primary: { main: "var(--primary, #1976d2)" },
-      background: {
-        default: "var(--body-bg, #fff)",
-        paper: "var(--body-bg, #fff)",
-      },
-      text: {
-        primary: "var(--body-fg, #333)",
-        secondary: "var(--body-fg, #333)",
-      },
-      divider: "var(--border-color, #ccc)",
+      primary: { main: "#1976d2" },
     },
     components: {
+      MuiBox: {
+        styleOverrides: {
+          root: {
+            // Apply Django colors to the container via CSS variables
+            "--body-bg": "inherit",
+            "--body-fg": "inherit",
+          },
+        },
+      },
       MuiTextField: {
         defaultProps: {
           variant: "outlined",
           size: "small",
         },
-        styleOverrides: {
-          root: {
-            // Ensure inputs don't have their own backgrounds that occlude labels
-            "& .MuiInputBase-root": {
-              backgroundColor: "transparent",
-            },
-          },
-        },
       },
       MuiInputLabel: {
         styleOverrides: {
           root: {
-            // Match the Django background to fix the notch occlusion
+            // Use inherit to pick up the background color of the parent div
+            // which is set to var(--body-bg) in widgets.py
             backgroundColor: "var(--body-bg, #fff)",
             padding: "0 4px",
             marginLeft: "-4px",
-            color: "var(--body-fg, #333)",
-            "&.Mui-focused": {
-              color: "var(--primary, #1976d2)",
-            },
-          },
-        },
-      },
-      MuiOutlinedInput: {
-        styleOverrides: {
-          root: {
-            "& .MuiOutlinedInput-notchedOutline": {
-              borderColor: "var(--border-color, #ccc)",
-            },
-            "&:hover .MuiOutlinedInput-notchedOutline": {
-              borderColor: "var(--body-fg, #333)",
-            },
           },
         },
       },

--- a/web/src/admin.tsx
+++ b/web/src/admin.tsx
@@ -7,8 +7,9 @@ import type { PieceDetail, PieceState, UISchema } from "./util/types";
 import type { UpdateStatePayload } from "./util/api";
 
 const getDjangoTheme = (): "light" | "dark" => {
-  if (document.documentElement.dataset.theme === "dark") return "dark";
-  if (document.body.classList.contains("dark-mode")) return "dark";
+  const theme = document.documentElement.dataset.theme;
+  if (theme === "dark") return "dark";
+  if (theme === "light") return "light";
   if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) return "dark";
   return "light";
 };
@@ -36,16 +37,35 @@ const createAdminTheme = (mode: "light" | "dark") => {
     components: {
       MuiTextField: {
         defaultProps: {
-          variant: "outlined",
+          variant: "standard", // Standard variant has no box border
           size: "small",
+          fullWidth: true,
+        },
+      },
+      MuiInput: {
+        styleOverrides: {
+          root: {
+            marginTop: "16px",
+            "&::before": {
+              // Optional: remove the standard underline if a truly borderless look is desired
+              // borderBottom: '1px solid var(--border-color, #ccc)', 
+            },
+          },
         },
       },
       MuiInputLabel: {
         styleOverrides: {
           root: {
-            backgroundColor: bgColor,
-            padding: "0 4px",
-            marginLeft: "-4px",
+            backgroundColor: "transparent", // Requested transparent background
+            padding: 0,
+            marginLeft: 0,
+            transform: "translate(0, -4px) scale(0.75)", // Slightly higher
+            "&.Mui-focused": {
+              transform: "translate(0, -4px) scale(0.75)",
+            },
+          },
+          shrink: {
+            transform: "translate(0, -4px) scale(0.75)",
           },
         },
       },
@@ -70,7 +90,7 @@ declare global {
 }
 
 export const mountWorkflowStateWidget = (options: MountOptions) => {
-  console.log("Mounting WorkflowState widget...", options);
+  const themeMode = getDjangoTheme();
   const container = document.getElementById(options.containerId);
   if (!container) {
     console.error(`Container #${options.containerId} not found`);
@@ -113,7 +133,6 @@ export const mountWorkflowStateWidget = (options: MountOptions) => {
     };
   }
 
-  const themeMode = getDjangoTheme();
   const theme = createAdminTheme(themeMode);
 
   const wrappedSaveStateFn = async (payload: UpdateStatePayload): Promise<PieceDetail> => {
@@ -153,7 +172,7 @@ export const mountWorkflowStateWidget = (options: MountOptions) => {
             saveStateFn={wrappedSaveStateFn}
             hideImageUpload
             disableAutosave
-            hideNotes // Always exclude notes in Admin (redundant with parent form)
+            hideNotes
           />
         </ScopedCssBaseline>
       </ThemeProvider>

--- a/web/src/admin.tsx
+++ b/web/src/admin.tsx
@@ -29,7 +29,8 @@ declare global {
   }
 }
 
-window.mountWorkflowStateWidget = (options: MountOptions) => {
+export const mountWorkflowStateWidget = (options: MountOptions) => {
+  console.log("Mounting WorkflowState widget...", options);
   const container = document.getElementById(options.containerId);
   if (!container) {
     console.error(`Container #${options.containerId} not found`);

--- a/web/src/admin.tsx
+++ b/web/src/admin.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+import CssBaseline from "@mui/material/CssBaseline";
+import WorkflowState from "./components/WorkflowState";
+import type { PieceDetail, PieceState, UISchema } from "./util/types";
+import type { UpdateStatePayload } from "./util/api";
+
+const theme = createTheme({
+  palette: {
+    mode: "light",
+    primary: { main: "#1976d2" },
+  },
+});
+
+interface MountOptions {
+  containerId: string;
+  initialPieceState: PieceState;
+  pieceId: string;
+  uiSchema?: UISchema;
+  onSaved?: (updated: PieceDetail) => void;
+  onDirtyChange?: (dirty: boolean) => void;
+  saveStateFn?: (payload: UpdateStatePayload) => Promise<PieceDetail>;
+}
+
+declare global {
+  interface Window {
+    mountWorkflowStateWidget: (options: MountOptions) => () => void;
+  }
+}
+
+window.mountWorkflowStateWidget = (options: MountOptions) => {
+  const container = document.getElementById(options.containerId);
+  if (!container) {
+    console.error(`Container #${options.containerId} not found`);
+    return () => {};
+  }
+
+  const root = createRoot(container);
+  root.render(
+    <React.StrictMode>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <WorkflowState
+          initialPieceState={options.initialPieceState}
+          pieceId={options.pieceId}
+          onSaved={options.onSaved || (() => {})}
+          onDirtyChange={options.onDirtyChange}
+          uiSchema={options.uiSchema}
+          saveStateFn={options.saveStateFn}
+          hideImageUpload // Admin has its own image inlines for now
+        />
+      </ThemeProvider>
+    </React.StrictMode>
+  );
+
+  return () => root.unmount();
+};

--- a/web/src/admin.tsx
+++ b/web/src/admin.tsx
@@ -92,9 +92,9 @@ export const mountWorkflowStateWidget = (options: MountOptions) => {
   const container = document.getElementById(options.containerId);
   if (!container) {
     console.error(`Container #${options.containerId} not found`);
-    return () => {{
+    return () => {
       // cleanup
-    }};
+    };
   }
 
   const portalContainerId = `portal-root-${options.containerId}`;
@@ -162,9 +162,9 @@ export const mountWorkflowStateWidget = (options: MountOptions) => {
           <WorkflowState
             initialPieceState={pieceState}
             pieceId={options.pieceId}
-            onSaved={options.onSaved || (() => {{
+            onSaved={options.onSaved || (() => {
               // no-op
-            }})}
+            })}
             onDirtyChange={options.onDirtyChange}
             uiSchema={options.uiSchema}
             saveStateFn={wrappedSaveStateFn}

--- a/web/src/admin.tsx
+++ b/web/src/admin.tsx
@@ -10,6 +10,7 @@ const getDjangoTheme = (): "light" | "dark" => {
   const theme = document.documentElement.dataset.theme;
   if (theme === "dark") return "dark";
   if (theme === "light") return "light";
+  
   if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) return "dark";
   return "light";
 };
@@ -37,29 +38,23 @@ const createAdminTheme = (mode: "light" | "dark") => {
     components: {
       MuiTextField: {
         defaultProps: {
-          variant: "standard", // Standard variant has no box border
+          variant: "standard",
           size: "small",
           fullWidth: true,
         },
-      },
-      MuiInput: {
         styleOverrides: {
           root: {
-            marginTop: "16px",
-            "&::before": {
-              // Optional: remove the standard underline if a truly borderless look is desired
-              // borderBottom: '1px solid var(--border-color, #ccc)', 
-            },
+            margin: 0,
           },
         },
       },
       MuiInputLabel: {
         styleOverrides: {
           root: {
-            backgroundColor: "transparent", // Requested transparent background
+            backgroundColor: "transparent",
             padding: 0,
             marginLeft: 0,
-            transform: "translate(0, -4px) scale(0.75)", // Slightly higher
+            transform: "translate(0, -4px) scale(0.75)",
             "&.Mui-focused": {
               transform: "translate(0, -4px) scale(0.75)",
             },
@@ -81,6 +76,7 @@ interface MountOptions {
   onSaved?: (updated: PieceDetail) => void;
   onDirtyChange?: (dirty: boolean) => void;
   saveStateFn?: (payload: UpdateStatePayload) => Promise<PieceDetail>;
+  onChange?: (payload: UpdateStatePayload) => void;
 }
 
 declare global {
@@ -91,6 +87,8 @@ declare global {
 
 export const mountWorkflowStateWidget = (options: MountOptions) => {
   const themeMode = getDjangoTheme();
+  console.log(`Mounting WorkflowState widget (theme: ${themeMode})...`, options);
+  
   const container = document.getElementById(options.containerId);
   if (!container) {
     console.error(`Container #${options.containerId} not found`);
@@ -170,6 +168,7 @@ export const mountWorkflowStateWidget = (options: MountOptions) => {
             onDirtyChange={options.onDirtyChange}
             uiSchema={options.uiSchema}
             saveStateFn={wrappedSaveStateFn}
+            onChange={options.onChange}
             hideImageUpload
             disableAutosave
             hideNotes

--- a/web/src/admin.tsx
+++ b/web/src/admin.tsx
@@ -38,12 +38,20 @@ export const mountWorkflowStateWidget = (options: MountOptions) => {
   }
 
   const root = createRoot(container);
+  
+  // Ensure we have a valid state object for the component
+  const pieceState = {
+    ...options.initialPieceState,
+    custom_fields: options.initialPieceState.custom_fields || {},
+    notes: options.initialPieceState.notes || "",
+  };
+
   root.render(
     <React.StrictMode>
       <ThemeProvider theme={theme}>
         <CssBaseline />
         <WorkflowState
-          initialPieceState={options.initialPieceState}
+          initialPieceState={pieceState}
           pieceId={options.pieceId}
           onSaved={options.onSaved || (() => {})}
           onDirtyChange={options.onDirtyChange}
@@ -57,3 +65,5 @@ export const mountWorkflowStateWidget = (options: MountOptions) => {
 
   return () => root.unmount();
 };
+
+window.mountWorkflowStateWidget = mountWorkflowStateWidget;

--- a/web/src/admin.tsx
+++ b/web/src/admin.tsx
@@ -10,8 +10,13 @@ const getDjangoTheme = (): "light" | "dark" => {
   const theme = document.documentElement.dataset.theme;
   if (theme === "dark") return "dark";
   if (theme === "light") return "light";
-  
-  if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) return "dark";
+
+  if (
+    window.matchMedia &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+  ) {
+    return "dark";
+  }
   return "light";
 };
 
@@ -87,8 +92,7 @@ declare global {
 
 export const mountWorkflowStateWidget = (options: MountOptions) => {
   const themeMode = getDjangoTheme();
-  console.log(`Mounting WorkflowState widget (theme: ${themeMode})...`, options);
-  
+
   const container = document.getElementById(options.containerId);
   if (!container) {
     console.error(`Container #${options.containerId} not found`);
@@ -118,10 +122,12 @@ export const mountWorkflowStateWidget = (options: MountOptions) => {
 
   const rawState = (initialPieceState || {}) as Record<string, unknown>;
   const pieceState = { ...rawState } as unknown as PieceState;
-  
+
   if (!pieceState.images) pieceState.images = [];
   if (!pieceState.custom_fields) pieceState.custom_fields = {};
-  if (pieceState.notes === undefined || pieceState.notes === null) pieceState.notes = "";
+  if (pieceState.notes === undefined || pieceState.notes === null) {
+    pieceState.notes = "";
+  }
 
   const globalRefValues = rawState.global_ref_values as Record<string, unknown> | undefined;
   if (globalRefValues) {
@@ -137,7 +143,7 @@ export const mountWorkflowStateWidget = (options: MountOptions) => {
     if (options.saveStateFn) {
       await options.saveStateFn(payload);
     }
-    
+
     const updatedPieceState: PieceState = {
       ...pieceState,
       notes: payload.notes ?? "",
@@ -162,9 +168,7 @@ export const mountWorkflowStateWidget = (options: MountOptions) => {
           <WorkflowState
             initialPieceState={pieceState}
             pieceId={options.pieceId}
-            onSaved={options.onSaved || (() => {
-              // no-op
-            })}
+            onSaved={options.onSaved ?? (() => undefined)}
             onDirtyChange={options.onDirtyChange}
             uiSchema={options.uiSchema}
             saveStateFn={wrappedSaveStateFn}

--- a/web/src/admin.tsx
+++ b/web/src/admin.tsx
@@ -6,12 +6,42 @@ import WorkflowState from "./components/WorkflowState";
 import type { PieceDetail, PieceState, UISchema } from "./util/types";
 import type { UpdateStatePayload } from "./util/api";
 
-const theme = createTheme({
-  palette: {
-    mode: "light",
-    primary: { main: "#1976d2" },
-  },
-});
+const getDjangoTheme = (): "light" | "dark" => {
+  return document.documentElement.dataset.theme === "dark" ? "dark" : "light";
+};
+
+const createAdminTheme = (mode: "light" | "dark") => {
+  const bgColor = mode === "dark" ? "#121212" : "#fff";
+  return createTheme({
+    palette: {
+      mode,
+      primary: { main: "#1976d2" },
+      background: {
+        default: bgColor,
+        paper: mode === "dark" ? "#1e1e1e" : "#fff",
+      },
+    },
+    components: {
+      MuiTextField: {
+        defaultProps: {
+          variant: "outlined",
+          size: "small",
+        },
+      },
+      MuiInputLabel: {
+        styleOverrides: {
+          root: {
+            // Ensure the label's background matches the theme background
+            // so the 'notch' in outlined fields works correctly.
+            backgroundColor: bgColor,
+            padding: "0 4px",
+            marginLeft: "-4px",
+          },
+        },
+      },
+    },
+  });
+};
 
 interface MountOptions {
   containerId: string;
@@ -35,6 +65,16 @@ export const mountWorkflowStateWidget = (options: MountOptions) => {
   if (!container) {
     console.error(`Container #${options.containerId} not found`);
     return () => {};
+  }
+
+  // Create a dedicated container for MUI portals (Autocomplete, Dialogs, etc.)
+  // to avoid MutationObserver issues with the Admin's legacy DOM structure.
+  const portalContainerId = `portal-root-${options.containerId}`;
+  let portalContainer = document.getElementById(portalContainerId);
+  if (!portalContainer) {
+    portalContainer = document.createElement("div");
+    portalContainer.id = portalContainerId;
+    document.body.appendChild(portalContainer);
   }
 
   const root = createRoot(container);
@@ -66,6 +106,32 @@ export const mountWorkflowStateWidget = (options: MountOptions) => {
     };
   }
 
+  const theme = createAdminTheme(getDjangoTheme());
+
+  const wrappedSaveStateFn = async (payload: UpdateStatePayload): Promise<PieceDetail> => {
+    if (options.saveStateFn) {
+      await options.saveStateFn(payload);
+    }
+    
+    // WorkflowState expects the returned result to contain the updated state
+    // in history so it can refresh the local draft and stop the "Saving..." spinner.
+    const updatedPieceState: PieceState = {
+      ...pieceState,
+      notes: payload.notes ?? "",
+      images: payload.images ?? [],
+      custom_fields: payload.custom_fields ?? {},
+    };
+
+    return {
+      id: options.pieceId,
+      name: "Admin Edit",
+      current_state: updatedPieceState,
+      history: [updatedPieceState],
+      is_owner: true,
+      can_edit: true,
+    } as unknown as PieceDetail;
+  };
+
   root.render(
     <React.StrictMode>
       <ThemeProvider theme={theme}>
@@ -76,7 +142,7 @@ export const mountWorkflowStateWidget = (options: MountOptions) => {
           onSaved={options.onSaved || (() => {})}
           onDirtyChange={options.onDirtyChange}
           uiSchema={options.uiSchema}
-          saveStateFn={options.saveStateFn}
+          saveStateFn={wrappedSaveStateFn}
           hideImageUpload // Admin has its own image inlines for now
         />
       </ThemeProvider>

--- a/web/src/admin.tsx
+++ b/web/src/admin.tsx
@@ -7,20 +7,14 @@ import type { PieceDetail, PieceState, UISchema } from "./util/types";
 import type { UpdateStatePayload } from "./util/api";
 
 const getDjangoTheme = (): "light" | "dark" => {
-  // Modern Django 5.0+
   if (document.documentElement.dataset.theme === "dark") return "dark";
-  // Fallback for custom or older setups
   if (document.body.classList.contains("dark-mode")) return "dark";
-  // System preference fallback
   if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) return "dark";
   return "light";
 };
 
 const createAdminTheme = (mode: "light" | "dark") => {
   const isDark = mode === "dark";
-  // Explicitly match Django dark/light mode background and foreground colors.
-  // Django Dark: #121212 bg, #eee fg.
-  // Django Light: #fff bg, #333 fg.
   const bgColor = isDark ? "#121212" : "#fff";
   const fgColor = isDark ? "#eee" : "#333";
   const primaryColor = isDark ? "#79aec8" : "#447e9b";
@@ -49,7 +43,6 @@ const createAdminTheme = (mode: "light" | "dark") => {
       MuiInputLabel: {
         styleOverrides: {
           root: {
-            // Fix the 'notch' occlusion by matching the background color exactly.
             backgroundColor: bgColor,
             padding: "0 4px",
             marginLeft: "-4px",
@@ -148,7 +141,6 @@ export const mountWorkflowStateWidget = (options: MountOptions) => {
   root.render(
     <React.StrictMode>
       <ThemeProvider theme={theme}>
-        {/* ScopedCssBaseline ensures the correct background/text colors are applied to children */}
         <ScopedCssBaseline>
           <WorkflowState
             initialPieceState={pieceState}
@@ -160,7 +152,8 @@ export const mountWorkflowStateWidget = (options: MountOptions) => {
             uiSchema={options.uiSchema}
             saveStateFn={wrappedSaveStateFn}
             hideImageUpload
-            disableAutosave // Disable autosave in Admin (uses main Save button)
+            disableAutosave
+            hideNotes // Always exclude notes in Admin (redundant with parent form)
           />
         </ScopedCssBaseline>
       </ThemeProvider>

--- a/web/src/components/GlobalEntryField.tsx
+++ b/web/src/components/GlobalEntryField.tsx
@@ -1,5 +1,10 @@
 import { useState } from "react";
-import { Box, Button, Chip, Typography } from "@mui/material";
+import {
+  Button,
+  Chip,
+  InputAdornment,
+  TextField,
+} from "@mui/material";
 import type { SxProps, Theme } from "@mui/material";
 import GlobalEntryDialog from "./GlobalEntryDialog";
 
@@ -17,8 +22,6 @@ export interface GlobalEntryFieldProps {
   sx?: SxProps<Theme>;
 }
 
-// Keep global refs visually consistent across forms: a selected value becomes
-// a removable chip, and every edit path funnels through the shared dialog.
 export default function GlobalEntryField({
   globalName,
   label,
@@ -27,7 +30,6 @@ export default function GlobalEntryField({
   helperText,
   required = false,
   canCreate = false,
-  hideLabel = false,
   disabled = false,
   hideActionWhenDisabled = false,
   sx,
@@ -36,53 +38,57 @@ export default function GlobalEntryField({
   const showAction = !disabled || !hideActionWhenDisabled;
 
   return (
-    <Box sx={sx}>
-      <Box
-        sx={{
-          display: "flex",
-          gap: 1,
-          alignItems: "center",
-          flexWrap: "wrap",
+    <>
+      <TextField
+        label={label}
+        value={value ? "" : "None selected"}
+        helperText={helperText}
+        required={required}
+        disabled={disabled}
+        fullWidth
+        slotProps={{
+          input: {
+            readOnly: true,
+            startAdornment: value ? (
+              <InputAdornment position="start">
+                <Chip
+                  label={value}
+                  size="small"
+                  onDelete={disabled ? undefined : () => onSelect(null)}
+                />
+              </InputAdornment>
+            ) : null,
+            endAdornment: showAction ? (
+              <InputAdornment position="end">
+                <Button
+                  size="small"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setOpen(true);
+                  }}
+                  disabled={disabled}
+                  aria-label={value ? `Change ${label}` : `Browse ${label}`}
+                >
+                  {value ? "Change" : "Browse"}
+                </Button>
+              </InputAdornment>
+            ) : null,
+          },
         }}
-      >
-        {!hideLabel && (
-          <Typography
-            variant="caption"
-            color="text.secondary"
-            sx={{ flexShrink: 0 }}
-          >
-            {label}
-            {required && " *"}
-          </Typography>
-        )}
-        {value && (
-          <Chip
-            label={value}
-            onDelete={disabled ? undefined : () => onSelect(null)}
-          />
-        )}
-        {showAction && (
-          <Button
-            variant="outlined"
-            size="small"
-            onClick={() => setOpen(true)}
-            disabled={disabled}
-            aria-label={value ? `Change ${label}` : `Browse ${label}`}
-            sx={{ whiteSpace: "nowrap", flexShrink: 0 }}
-          >
-            {value ? "Change…" : "Browse…"}
-          </Button>
-        )}
-      </Box>
-      {helperText && (
-        <Typography
-          variant="caption"
-          color="text.secondary"
-          sx={{ display: "block", mt: 0.25, pl: 1, fontStyle: "italic", fontSize: "0.7rem" }}
-        >
-          {helperText}
-        </Typography>
-      )}
+        sx={[
+          {
+            "& .MuiInputBase-root": {
+              cursor: "pointer",
+              // If there's a value, the actual input text is hidden
+              "& input": {
+                display: value ? "none" : "block",
+              },
+            },
+          },
+          ...(Array.isArray(sx) ? sx : [sx]),
+        ]}
+        onClick={disabled ? undefined : () => setOpen(true)}
+      />
       <GlobalEntryDialog
         globalName={globalName}
         open={open}
@@ -90,6 +96,6 @@ export default function GlobalEntryField({
         onSelect={onSelect}
         canCreate={canCreate}
       />
-    </Box>
+    </>
   );
 }

--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -19,20 +19,23 @@ import {
   Typography,
   useMediaQuery,
 } from "@mui/material";
-import type { PieceDetail, PieceState } from "../util/types";
+import type { PieceDetail, PieceState, UISchema } from "../util/types";
 import {
+  fetchWorkflowStateSchema,
   updateCurrentState,
   type UpdateStatePayload,
 } from "../util/api";
 import { openCloudinaryUploadWidget } from "../util/cloudinaryUpload";
 import {
   getCustomFieldDefinitions,
+  getDefinitionsFromSchema,
 } from "../util/workflow";
 import { entryNameOrEmpty } from "../util/optionalValues";
 import GlobalEntryField from "./GlobalEntryField";
 import AutosaveStatus from "./AutosaveStatus";
 import { useAutosave } from "./useAutosave";
 import { usePieceDetailSaveStatus } from "./usePieceDetailSaveStatus";
+import { useAsync } from "../util/useAsync";
 import {
   type ImageEntry,
   buildDraftState,
@@ -50,6 +53,8 @@ type WorkflowStateProps = {
   hideNotes?: boolean;
   hideImageUpload?: boolean;
   saveStateFn?: (payload: UpdateStatePayload) => Promise<PieceDetail>;
+  /** Optional pre-fetched schema to avoid an extra API call. */
+  uiSchema?: UISchema;
 };
 
 
@@ -165,6 +170,7 @@ export default function WorkflowState({
   hideNotes = false,
   hideImageUpload = false,
   saveStateFn,
+  uiSchema: initialUiSchema,
 }: WorkflowStateProps) {
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [widgetLoading, setWidgetLoading] = useState(false);
@@ -174,11 +180,24 @@ export default function WorkflowState({
     buildDraftState,
   );
   const { baseState, notes, images, customFieldInputs, globalRefPks } = draft;
-  const baseDraft = useMemo(() => buildDraftState(baseState), [baseState]);
-  const customFieldDefs = useMemo(
-    () => getCustomFieldDefinitions(baseState.state),
+
+  const { data: uiSchema } = useAsync(
+    () => fetchWorkflowStateSchema(baseState.state),
     [baseState.state],
+    { enabled: !initialUiSchema },
   );
+
+  const activeSchema = initialUiSchema ?? uiSchema;
+
+  const baseDraft = useMemo(() => buildDraftState(baseState), [baseState]);
+  const customFieldDefs = useMemo(() => {
+    if (activeSchema) {
+      return getDefinitionsFromSchema(activeSchema);
+    }
+    // Fallback to build-time AST if schema is not yet loaded.
+    return getCustomFieldDefinitions(baseState.state);
+  }, [baseState.state, activeSchema]);
+
   const normalizedCustomFields = useMemo(
     () =>
       normalizeCustomFieldPayload(

--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -55,6 +55,7 @@ type WorkflowStateProps = {
   saveStateFn?: (payload: UpdateStatePayload) => Promise<PieceDetail>;
   /** Optional pre-fetched schema to avoid an extra API call. */
   uiSchema?: UISchema;
+  disableAutosave?: boolean;
 };
 
 
@@ -177,6 +178,7 @@ export default function WorkflowState({
   hideImageUpload = false,
   saveStateFn,
   uiSchema: initialUiSchema,
+  disableAutosave = false,
 }: WorkflowStateProps) {
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [widgetLoading, setWidgetLoading] = useState(false);
@@ -279,7 +281,7 @@ export default function WorkflowState({
 
 
   const autosave = useAutosave({
-    dirty: !readOnly && isDirty,
+    dirty: !readOnly && isDirty && !disableAutosave,
     saveKey: autosaveKey,
     save: saveWorkflowState,
     delayMs: autosaveDelayMs,

--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -463,15 +463,16 @@ export default function WorkflowState({
         />
       )}
       {customFieldDefs.length > 0 && (
-        <Box>
-          <Box
-            sx={{
-              display: "grid",
-              gap: 2,
-              gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
-            }}
-          >
-            {customFieldDefs.map((field) => {
+        <Box
+          sx={{
+            display: "grid",
+            gap: 2,
+            gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+            pt: 3, // Increased padding above the custom fields interior
+            alignItems: "start",
+          }}
+        >
+          {customFieldDefs.map((field) => {
               const value = customFieldInputs[field.name] ?? "";
               const helperText = field.description;
               const label = field.label;
@@ -605,7 +606,6 @@ export default function WorkflowState({
                 />
               );
             })}
-          </Box>
         </Box>
       )}
 

--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -56,6 +56,8 @@ type WorkflowStateProps = {
   /** Optional pre-fetched schema to avoid an extra API call. */
   uiSchema?: UISchema;
   disableAutosave?: boolean;
+  /** Called whenever the payload changes. */
+  onChange?: (payload: UpdateStatePayload) => void;
 };
 
 
@@ -179,6 +181,7 @@ export default function WorkflowState({
   saveStateFn,
   uiSchema: initialUiSchema,
   disableAutosave = false,
+  onChange,
 }: WorkflowStateProps) {
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [widgetLoading, setWidgetLoading] = useState(false);
@@ -238,6 +241,15 @@ export default function WorkflowState({
 
   const isDirty = notes !== baseState.notes || customFieldsDirty;
 
+  const currentPayload = useMemo(
+    () => ({
+      notes,
+      images,
+      custom_fields: normalizedCustomFields,
+    }),
+    [notes, images, normalizedCustomFields],
+  );
+
   useEffect(() => {
     latestImagesRef.current = images;
   }, [images]);
@@ -246,14 +258,15 @@ export default function WorkflowState({
     onDirtyChange?.(readOnly ? false : isDirty);
   }, [isDirty, onDirtyChange, readOnly]);
 
+  useEffect(() => {
+    if (!readOnly) {
+      onChange?.(currentPayload);
+    }
+  }, [currentPayload, onChange, readOnly]);
+
   const saveWorkflowState = useCallback(async () => {
-    const payload = {
-      notes,
-      images,
-      custom_fields: normalizedCustomFields,
-    };
     const saveFn = saveStateFn ?? ((p) => updateCurrentState(pieceId, p));
-    const result = await saveFn(payload);
+    const result = await saveFn(currentPayload);
     const savedState = saveStateFn
       ? result.history.find((ps) => ps.id === initialPieceState.id) ?? result.current_state
       : result.current_state;
@@ -261,12 +274,10 @@ export default function WorkflowState({
     onSaved(result);
   }, [
     pieceId,
-    images,
     initialPieceState.id,
-    normalizedCustomFields,
-    notes,
     onSaved,
     saveStateFn,
+    currentPayload,
   ]);
 
   const autosaveKey = useMemo(

--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -125,7 +125,13 @@ function ImageUploader({
           </Fab>
         </Portal>
       ) : (
-        <Portal container={() => document.getElementById("piece-upload-trigger")}>
+        <Portal
+          container={
+            (typeof document !== "undefined" &&
+              document.getElementById("piece-upload-trigger")) ||
+            null
+          }
+        >
           <Button
             variant="outlined"
             size="small"

--- a/web/src/components/__tests__/NewPieceDialog.test.tsx
+++ b/web/src/components/__tests__/NewPieceDialog.test.tsx
@@ -102,7 +102,7 @@ describe("NewPieceDialog", () => {
       await act(async () => {
         render(<NewPieceDialog {...defaultProps} />);
       });
-      expect(screen.getByText("Location")).toBeInTheDocument();
+      expect(screen.getByLabelText("Location")).toBeInTheDocument();
     });
 
     it("fetches location browse entries when the picker opens", async () => {

--- a/web/src/components/__tests__/WorkflowState.test.tsx
+++ b/web/src/components/__tests__/WorkflowState.test.tsx
@@ -170,6 +170,7 @@ vi.mock("../../../workflow.yml", () => ({
 vi.mock("../../util/api", () => ({
   fetchGlobalEntries: vi.fn().mockResolvedValue([]),
   fetchGlobalEntriesWithFilters: vi.fn().mockResolvedValue([]),
+  fetchWorkflowStateSchema: vi.fn().mockResolvedValue(null),
   updateCurrentState: vi.fn(),
   updatePastState: vi.fn(),
   updatePiece: vi.fn(),

--- a/web/src/components/__tests__/WorkflowState.test.tsx
+++ b/web/src/components/__tests__/WorkflowState.test.tsx
@@ -1167,10 +1167,10 @@ describe("WorkflowState", () => {
       expect(
         screen.getByRole("button", { name: "Browse Glaze Combination" }),
       ).toBeInTheDocument();
-      // No text input with the field label — free typing is not supported
-      expect(
-        screen.queryByLabelText("Glaze Combination"),
-      ).not.toBeInTheDocument();
+      // Field label exists but points to a read-only input
+      const input = screen.getByLabelText("Glaze Combination");
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveAttribute("readonly");
     });
 
     it("shows the selected value as a chip when a glaze combination is set", async () => {

--- a/web/src/components/workflowStateDraft.ts
+++ b/web/src/components/workflowStateDraft.ts
@@ -136,7 +136,7 @@ export function normalizeCustomFieldPayload(
 }
 
 function stateImages(pieceState: PieceState): ImageEntry[] {
-  return pieceState.images.map((img) => ({
+  return (pieceState.images || []).map((img) => ({
     url: img.url,
     caption: img.caption,
     cloudinary_public_id: img.cloudinary_public_id ?? null,
@@ -147,10 +147,10 @@ function stateImages(pieceState: PieceState): ImageEntry[] {
 
 export function buildDraftState(pieceState: PieceState): DraftState {
   const customFieldDefs = getCustomFieldDefinitions(pieceState.state);
-  const customFields = pieceState.custom_fields;
+  const customFields = pieceState.custom_fields || {};
   return {
     baseState: pieceState,
-    notes: pieceState.notes,
+    notes: pieceState.notes || "",
     images: stateImages(pieceState),
     customFieldInputs: buildCustomFieldInputMap(
       customFieldDefs,

--- a/web/src/util/api.ts
+++ b/web/src/util/api.ts
@@ -28,6 +28,7 @@ import type {
   TagEntry,
   Thumbnail,
   ImageCrop,
+  UISchema,
 } from "./types";
 
 export type AuthUser = {
@@ -261,6 +262,15 @@ export async function logoutUser(): Promise<void> {
 export async function fetchPiece(id: string): Promise<PieceDetail> {
   const { data } = await client.get<Wire<PieceDetail>>(`pieces/${id}/`);
   return mapPieceDetail(data);
+}
+
+export async function fetchWorkflowStateSchema(
+  stateId: string,
+): Promise<UISchema> {
+  const { data } = await client.get<UISchema>(
+    `workflow/schema/${stateId}/`,
+  );
+  return data;
 }
 
 export type CreatePiecePayload = {

--- a/web/src/util/types.ts
+++ b/web/src/util/types.ts
@@ -118,3 +118,24 @@ export interface AsyncTask {
   created: string;
   last_modified: string;
 }
+
+export interface JSONSchemaProperty {
+  type: string;
+  enum?: string[];
+  anyOf?: JSONSchemaProperty[];
+  "x-label"?: string;
+  "x-description"?: string;
+  "x-display-as"?: string;
+  "x-required"?: boolean;
+  "x-global-ref"?: string;
+  "x-can-create"?: boolean;
+  "x-read-only"?: boolean;
+  [key: string]: unknown;
+}
+
+export interface UISchema {
+  type: "object";
+  properties: Record<string, JSONSchemaProperty>;
+  required?: string[];
+  additionalProperties?: boolean;
+}

--- a/web/src/util/types.ts
+++ b/web/src/util/types.ts
@@ -128,6 +128,7 @@ export interface JSONSchemaProperty {
   "x-display-as"?: string;
   "x-required"?: boolean;
   "x-global-ref"?: string;
+  "x-state-ref"?: boolean;
   "x-can-create"?: boolean;
   "x-read-only"?: boolean;
   [key: string]: unknown;

--- a/web/src/util/workflow.test.ts
+++ b/web/src/util/workflow.test.ts
@@ -342,7 +342,67 @@ import {
   isTerminalState,
   isTaggableGlobal,
   insertableStatesBetween,
+  getDefinitionsFromSchema,
 } from "./workflow";
+
+describe("getDefinitionsFromSchema", () => {
+  it("resolves definitions from a UISchema", () => {
+    const schema: any = {
+      type: "object",
+      properties: {
+        clay_weight_lbs: {
+          type: "number",
+          "x-label": "Custom Label",
+          "x-description": "Desc",
+          "x-required": true,
+        },
+        clay_body: {
+          type: "string",
+          "x-global-ref": "clay_body",
+          "x-can-create": true,
+        },
+      },
+    };
+
+    const defs = getDefinitionsFromSchema(schema);
+    expect(defs).toHaveLength(2);
+
+    expect(defs[0]).toMatchObject({
+      name: "clay_weight_lbs",
+      label: "Custom Label",
+      type: "number",
+      description: "Desc",
+      required: true,
+      isGlobalRef: false,
+    });
+
+    expect(defs[1]).toMatchObject({
+      name: "clay_body",
+      type: "string",
+      isGlobalRef: true,
+      globalName: "clay_body",
+      canCreate: true,
+    });
+  });
+
+  it("handles missing UI extensions with fallbacks", () => {
+    const schema: any = {
+      type: "object",
+      properties: {
+        simple_field: {
+          type: "string",
+        },
+      },
+    };
+
+    const defs = getDefinitionsFromSchema(schema);
+    expect(defs[0]).toMatchObject({
+      name: "simple_field",
+      label: "Simple Field",
+      required: false,
+    });
+  });
+});
 
 describe("formatWorkflowFieldLabel", () => {
   it("converts a single snake_case word to Title Case", () => {

--- a/web/src/util/workflow.test.ts
+++ b/web/src/util/workflow.test.ts
@@ -385,6 +385,24 @@ describe("getDefinitionsFromSchema", () => {
     });
   });
 
+  it("detects state refs from UISchema", () => {
+    const schema: any = {
+      type: "object",
+      properties: {
+        inherited_field: {
+          type: "string",
+          "x-state-ref": true,
+        },
+      },
+    };
+
+    const defs = getDefinitionsFromSchema(schema);
+    expect(defs[0]).toMatchObject({
+      name: "inherited_field",
+      isStateRef: true,
+    });
+  });
+
   it("handles missing UI extensions with fallbacks", () => {
     const schema: any = {
       type: "object",

--- a/web/src/util/workflow.ts
+++ b/web/src/util/workflow.ts
@@ -417,7 +417,7 @@ export function getDefinitionsFromSchema(
     required: !!prop["x-required"],
     enum: prop.enum,
     isGlobalRef: !!prop["x-global-ref"],
-    isStateRef: false,
+    isStateRef: !!prop["x-state-ref"],
     isCalculated: !!prop["x-read-only"],
     canCreate: prop["x-can-create"],
     globalName: prop["x-global-ref"],

--- a/web/src/util/workflow.ts
+++ b/web/src/util/workflow.ts
@@ -10,6 +10,7 @@
  */
 import workflow from "../../../workflow.yml";
 import type { components } from "./generated-types";
+import type { UISchema } from "./types";
 
 type State = components["schemas"]["StateEnum"];
 
@@ -399,6 +400,29 @@ export function getCustomFieldDefinitions(
   return Object.entries(fields).map(([name, def]) =>
     buildResolvedField(name, def),
   );
+}
+
+/**
+ * Returns resolved custom field definitions derived from a UI JSON Schema.
+ * Used by the schema-driven WorkflowState component to avoid manual AST parsing.
+ */
+export function getDefinitionsFromSchema(
+  schema: UISchema,
+): ResolvedCustomField[] {
+  return Object.entries(schema.properties).map(([name, prop]) => ({
+    name,
+    label: prop["x-label"] ?? formatWorkflowFieldLabel(name),
+    type: prop.type as FieldType,
+    description: prop["x-description"],
+    required: !!prop["x-required"],
+    enum: prop.enum,
+    isGlobalRef: !!prop["x-global-ref"],
+    isStateRef: false,
+    isCalculated: !!prop["x-read-only"],
+    canCreate: prop["x-can-create"],
+    globalName: prop["x-global-ref"],
+    displayAs: prop["x-display-as"] as "percent" | undefined,
+  }));
 }
 
 /**

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -38,6 +38,8 @@ export default defineConfig({
       },
       output: {
         entryFileNames: "[name].js",
+        chunkFileNames: "chunks/[name].js",
+        assetFileNames: "assets/[name].[ext]",
         manualChunks(id) {
           if (
             id.includes("node_modules/react") ||

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -32,7 +32,12 @@ export default defineConfig({
     // sandbox CWD so Bazel's declared output tree artifact is populated.
     outDir: path.resolve(process.cwd(), "dist"),
     rollupOptions: {
+      input: {
+        main: path.resolve(root, "index.html"),
+        "admin-widget": path.resolve(root, "src/admin.tsx"),
+      },
       output: {
+        entryFileNames: "[name].js",
         manualChunks(id) {
           if (
             id.includes("node_modules/react") ||


### PR DESCRIPTION
This PR unifies the custom field logic between the React frontend and Django Admin UI by adopting a schema-driven approach.

### Changes
- **Backend (api/workflow.py, api/workflow_views.py)**: Added build_ui_schema to generate JSON schemas enhanced with x- UI extensions (labels, global refs, UI hints). Added an API endpoint to serve this schema.
- **Frontend (web/src/components/WorkflowState.tsx)**: Refactored the core workflow form component to render dynamically from the JSON schema instead of parsing the YAML AST.
- **Admin Integration (api/widgets.py, api/admin.py, web/src/admin.tsx)**: 
    - Created a standalone Vite entry point for the Admin widget.
    - Implemented WorkflowStateWidget (Django) to mount the React component inside the Admin.
    - Updated PieceStateAdmin to use the unified widget, ensuring that validation and UI are identical across the SPA and Admin.
- **Auto-fix #332**: By using the frontend API within the Admin, global entries (like Glaze Combinations) are now inherently sorted alphabetically.

### Verification
- **Backend**: Updated test_piece_state_admin_relational.py to verify the unified payload handling. All //api:api_test targets pass.
- **Frontend**: Mocked the new schema endpoint in WorkflowState.test.tsx. All //web:web_test targets pass.
- **Lint**: Clean bazel build --config=lint //... run.

Fixes #306
Fixes #332
