### PR TITLE
chore: add devcontainer, prerequisites docs, remove dead nvm fallback

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    curl \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Bazelisk as `bazel`
+ARG BAZELISK_VERSION=1.25.0
+RUN curl -fsSL \
+    "https://github.com/bazelbuild/bazelisk/releases/download/v${BAZELISK_VERSION}/bazelisk-linux-amd64" \
+    -o /usr/local/bin/bazel \
+    && chmod +x /usr/local/bin/bazel

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "Glaze",
+  "build": { "dockerfile": "Dockerfile" },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode-remote.remote-containers",
+        "ms-python.python",
+        "ms-python.vscode-pylance"
+      ],
+      "settings": {
+        "terminal.integrated.profiles.linux": {
+          "glaze": {
+            "path": "bash",
+            "args": ["--rcfile", "${containerWorkspaceFolder}/env.sh"]
+          }
+        },
+        "terminal.integrated.defaultProfile.linux": "glaze"
+      }
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,13 @@
 {
   "name": "Glaze",
   "build": { "dockerfile": "Dockerfile" },
-  "forwardPorts": [8080, 5173],
+  "forwardPorts": [
+    8080, 8081, 8082, 8083, 8084, 8085, 8086, 8087,
+    5173, 5174, 5175, 5176, 5177, 5178, 5179, 5180
+  ],
   "portsAttributes": {
-    "8080": { "label": "Django backend" },
-    "5173": { "label": "Vite dev server" }
+    "8080-8087": { "label": "Django backend" },
+    "5173-5180": { "label": "Vite dev server" }
   },
   "customizations": {
     "vscode": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,11 @@
 {
   "name": "Glaze",
   "build": { "dockerfile": "Dockerfile" },
+  "forwardPorts": [8080, 5173],
+  "portsAttributes": {
+    "8080": { "label": "Django backend" },
+    "5173": { "label": "Vite dev server" }
+  },
   "customizations": {
     "vscode": {
       "extensions": [

--- a/README.md
+++ b/README.md
@@ -90,13 +90,28 @@ The web UI is organized around a small set of React components in [`web/src/comp
 - [`PieceShareControls.tsx`](web/src/components/PieceShareControls.tsx): Owner-only sharing controls shown on terminal pieces — toggles the public sharing flag and provides a copyable share link.
 - [`PublicPieceShell.tsx`](web/src/components/PublicPieceShell.tsx): Thin unauthenticated route wrapper that renders `PieceDetailPage` for publicly shared terminal pieces, without the main app shell.
 
+## Prerequisites
+
+Before cloning, ensure the following are installed on your system:
+
+| Tool | Required | Install |
+|---|---|---|
+| OS | Ubuntu 22.04+ or Debian 12+ (WSL2 on Windows works; macOS untested) | — |
+| [Bazelisk](https://github.com/bazelbuild/bazelisk) | Yes — aliased as `bazel`; downloads Bazel 8.5.1 automatically via `.bazelversion` | [Bazelisk releases](https://github.com/bazelbuild/bazelisk/releases) or `brew install bazelisk` |
+| `curl` | Yes — used by `gz_setup` to bootstrap RTK | `apt install curl` |
+| `git` | Yes | `apt install git` |
+
+Python (3.12) and Node (22) are managed hermetically by Bazel — no manual installs needed once Bazelisk is present.
+
+**VS Code users:** install [Docker Desktop](https://www.docker.com/products/docker-desktop/) (Windows/macOS) or Docker Engine (Linux) and the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers), then open the repo and choose **Reopen in Container** — the devcontainer pre-installs all prerequisites automatically.
+
 ## Quick start
 
 This section is for folks who just want to fire up the whole stack quickly and start poking around the app.
 
 ```bash
 source env.sh
-gz_setup    # first-time only: creates venv, installs deps, runs migrations, installs Node
+gz_setup    # first-time only: creates venv, installs deps, runs migrations
 gz_start    # starts backend (port 8080) and web (Vite port), press Ctrl+C to stop
 ```
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Python (3.12) and Node (22) are managed hermetically by Bazel — no manual inst
 
 **VS Code users:** install [Docker Desktop](https://www.docker.com/products/docker-desktop/) (Windows/macOS) or Docker Engine (Linux) and the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers), then open the repo and choose **Reopen in Container** — the devcontainer pre-installs all prerequisites automatically.
 
+The devcontainer pre-forwards backend ports `8080–8087` and Vite ports `5173–5180`. These ranges match the authorized origins registered in the Google OAuth client, and support up to 8 simultaneous worktree dev stacks. Running more than 8 concurrent `gz_start` instances inside the container is not supported — use the host environment instead if you need more.
+
 ## Quick start
 
 This section is for folks who just want to fire up the whole stack quickly and start poking around the app.

--- a/env-agent.sh
+++ b/env-agent.sh
@@ -274,6 +274,7 @@ gz_setup() {
     if ! command -v rtk &>/dev/null; then
         echo "--- Installing RTK (for test optimizations and type generation)..."
         curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
+        export PATH="$HOME/.local/bin:$PATH"
         mkdir -p ~/.claude
         rtk init -g --auto-patch
     fi
@@ -291,6 +292,10 @@ gz_setup() {
     # normal pnpm tree at web/node_modules/ that both Bazel and the IDE read.
     echo "--- Syncing web dependencies via Bazel (@npm//:sync)..."
     (cd "$GLAZE_ROOT" && ${GLAZE_AGENT:+rtk }bazel run @npm//:sync)
+
+    # Activate the venv in the current shell — it may not have been active at
+    # source time if the repo was freshly cloned and the venv didn't exist yet.
+    [[ -f "$GLAZE_ROOT/.manage.venv/bin/activate" ]] && source "$GLAZE_ROOT/.manage.venv/bin/activate"
 
     echo "=== Setup complete ==="
     echo "    Run 'gz_gentypes' to regenerate TypeScript types via Bazel (no backend)."

--- a/env-agent.sh
+++ b/env-agent.sh
@@ -289,7 +289,6 @@ gz_setup() {
     # Node + web deps — pnpm install via aspect_rules_js's @npm//:sync. This
     # runs pnpm under the Bazel-managed node toolchain and materializes a
     # normal pnpm tree at web/node_modules/ that both Bazel and the IDE read.
-    _gz_ensure_node
     echo "--- Syncing web dependencies via Bazel (@npm//:sync)..."
     (cd "$GLAZE_ROOT" && ${GLAZE_AGENT:+rtk }bazel run @npm//:sync)
 


### PR DESCRIPTION
## Summary

- Add `.devcontainer/` (Ubuntu 24.04 base, pre-installs Bazelisk + curl) so VS Code "Reopen in Container" produces a working dev environment without any manual host setup
- Add Prerequisites section to README.md documenting the two host dependencies (Bazelisk, curl) and the Docker Desktop + Dev Containers extension requirement for the devcontainer workflow
- Remove dead `_gz_ensure_node` call from `gz_setup` — `@npm//:sync` uses Bazel's hermetic Node toolchain and never needed a host `node` binary; the call was triggering a wasteful nvm install attempt on clean hosts

## Test plan

- [x] `docker build` of `.devcontainer/` succeeds cleanly
- [x] `docker run` smoke test: `source env.sh && gz_setup` on the devcontainer image completes all steps (RTK installs, Bazel 8.5.1 downloads, Python venv builds, migrations run, web deps sync) with no `command not found` errors for `bazel` or `curl`
- [x] No nvm / "Node not found" output in `gz_setup` — `_gz_ensure_node` call removed
- [ ] VS Code "Reopen in Container" opens a terminal that auto-sources `env.sh`

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)
