### PR TITLE
fix: resolve DisallowedHost 500 error in production

### DIFF
--- a/api/tests/test_health.py
+++ b/api/tests/test_health.py
@@ -53,3 +53,13 @@ class TestHealthReady:
             response = self._get()
         assert response.status_code == 503
         assert response.json()["checks"]["async_tasks"] is False
+
+    def test_ignores_untrusted_forwarded_host_header(self):
+        # Regression test for production DisallowedHost error.
+        # With USE_X_FORWARDED_HOST = False, Django should ignore this header
+        # and rely on the Host header (which defaults to 'testserver' in DRF tests).
+        client = APIClient()
+        response = client.get(
+            "/api/health/ready/", HTTP_X_FORWARDED_HOST="159.223.154.68"
+        )
+        assert response.status_code == 200

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -132,7 +132,7 @@ ASGI_APPLICATION = "backend.asgi.application"
 # plain HTTP. Trust only the proxy's X-Forwarded-Proto value so Django still
 # treats external HTTPS requests as secure.
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
-USE_X_FORWARDED_HOST = True
+USE_X_FORWARDED_HOST = False
 
 
 # Database


### PR DESCRIPTION
## Problem / Motivation
Production logs showed frequent `django.core.exceptions.DisallowedHost` errors for `159.223.154.68`. This IP is likely the origin server or an upstream proxy being passed in the `X-Forwarded-Host` header.

The setting `USE_X_FORWARDED_HOST = True` was added in `a1e09bb` for Cloudinary cleanup archive streaming but introduced this vulnerability by trusting unvalidated upstream headers.

## Proposed Solution
Set `USE_X_FORWARDED_HOST = False`. Django will now ignore the `X-Forwarded-Host` header and rely on the `Host` header, which is correctly set and validated by Nginx.

## Verification Results
- **Manual Reproduction**: Sending `X-Forwarded-Host: <IP>` with the setting enabled triggered a `400 Bad Request`. Request succeeds with the setting disabled.
- **Regression Test**: Added `test_ignores_untrusted_forwarded_host_header` to `api/tests/test_health.py` which verifies that the health check succeeds even with a spoofed forwarded host header.
- **Automated Tests**: `rtk bazel test //api:api_admin_test` passes.

Closes #468