### PR TITLE
perf: optimize DB connections and add Nginx rate limiting

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -144,7 +144,7 @@ USE_X_FORWARDED_HOST = False
 if IS_PRODUCTION:
     DATABASES = {
         "default": dj_database_url.config(
-            conn_max_age=600,
+            conn_max_age=0,
             conn_health_checks=True,
         )
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,10 @@ services:
     restart: unless-stopped
     command: >
       postgres
-        -c shared_buffers=32MB
-        -c work_mem=4MB
-        -c maintenance_work_mem=32MB
-        -c max_connections=20
+        -c shared_buffers=256MB
+        -c work_mem=8MB
+        -c maintenance_work_mem=64MB
+        -c max_connections=60
     volumes:
       - postgres_data:/var/lib/postgresql/data
     environment:

--- a/nginx/glaze.conf
+++ b/nginx/glaze.conf
@@ -6,6 +6,9 @@
 # To update Nginx config after initial setup, edit
 # /etc/nginx/sites-available/glaze on the droplet directly.
 
+# Limit requests to 10 per second per IP, with a burst of 20.
+limit_req_zone $binary_remote_addr zone=glaze_api:10m rate=10r/s;
+
 server {
     listen 80;
     listen [::]:80;
@@ -15,6 +18,7 @@ server {
     client_max_body_size 20M;
 
     location / {
+        limit_req zone=glaze_api burst=20 nodelay;
         proxy_pass http://localhost:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Problem / Motivation
After resolving the `DisallowedHost` 500 errors, the production environment began experiencing `psycopg2.OperationalError: FATAL: sorry, too many clients already`.

Analysis of the 1GB RAM / 1 vCPU droplet revealed that the default database and connection settings were too restrictive for the traffic volume being handled by the ASGI server.

## Proposed Solution
- **DB Tuning**: Increased `max_connections` to 60 and `shared_buffers` to 256MB in `docker-compose.yml`.
- **Connection Management**: Set `conn_max_age=0` in `backend/settings.py` for production to ensure connections are not held open by idle workers.
- **Defense in Depth**: Added a `limit_req` zone to `nginx/glaze.conf` to rate-limit incoming requests at the proxy level.

## Post-Merge Instructions
The Nginx configuration must be manually synced to the droplet as it is not managed by the deployment script.

1. SSH into the droplet.
2. Update `/etc/nginx/sites-available/glaze` to include the new `limit_req_zone` (at the top level) and the `limit_req` directive inside the `location /` block.
3. Verify and reload Nginx:
   ```bash
   sudo nginx -t
   sudo systemctl reload nginx
   ```

Closes #468