### PR TITLE
fix: move Nginx sync out of remote shell block in deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -47,11 +47,11 @@ echo "--- pruning stopped containers and unused images ---"
 docker container prune -f
 docker image prune -f
 
+echo "--- deploy complete ---"
+docker compose ps
+REMOTE
+
 echo "--- syncing Nginx snippets ---"
 ssh "$HOST" "mkdir -p /etc/nginx/snippets"
 scp -r nginx/snippets/*.conf "$HOST":/etc/nginx/snippets/
 ssh "$HOST" "nginx -t && systemctl reload nginx"
-
-echo "--- deploy complete ---"
-docker compose ps
-REMOTE


### PR DESCRIPTION
## Problem / Motivation
The Nginx snippet refactor merged in #471 contained a bug in `deploy.sh`. The synchronization logic was placed inside the heredoc that executes on the remote host, causing the production server to attempt to SSH into itself. This resulted in a `Permission denied (publickey)` error in the CD pipeline.

## Proposed Solution
Move the `ssh` and `scp` commands for Nginx snippets outside of the `ssh <<REMOTE` block. They now execute on the local runner, correctly using the available SSH keys and local source files.

## Verification Results
- **Manual Verification**: Verified the command sequence correctly targets the remote host from a local context.
- **CD Fix**: This addresses the failure seen in the most recent production deployment run.