### PR TITLE
fix: sync config files via git checkout instead of per-file curl

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -39,6 +39,9 @@ else
     curl -fsSL \
         "https://raw.githubusercontent.com/shaoster/glaze/\${SHA}/docker-compose.yml" \
         -o docker-compose.yml
+    curl -fsSL \
+        "https://raw.githubusercontent.com/shaoster/glaze/\${SHA}/otel-collector-config.yml" \
+        -o otel-collector-config.yml
 fi
 
 echo "--- restarting services ---"

--- a/deploy.sh
+++ b/deploy.sh
@@ -9,10 +9,14 @@
 #
 # Prerequisites on the droplet:
 #   - Docker + Docker Compose plugin installed
-#   - ~/glaze/docker-compose.yml present (bootstrapped once; kept in sync by this script)
 #   - ~/glaze/.env present (copy from .env.production.example)
 #   - Authenticated with ghcr.io (one-time):
 #       docker login ghcr.io -u shaoster -p <PAT with read:packages>
+#
+# On first run this script clones the repo to ~/glaze (public repo, no key needed).
+# Subsequent deploys fetch the commit matching the deployed image so config files
+# (docker-compose.yml, otel-collector-config.yml, nginx/snippets/, etc.) are
+# always in sync without having to update this script when new files are added.
 set -euo pipefail
 
 HOST=${1:?Usage: ./deploy.sh user@host [commit-sha]}
@@ -21,27 +25,28 @@ KNOWN_SHA=${2:-}
 echo "--- deploying application ---"
 ssh "$HOST" bash <<REMOTE
 set -euo pipefail
+
+echo "--- bootstrapping repo (no-op if already cloned) ---"
+if [[ ! -d ~/glaze/.git ]]; then
+    git clone https://github.com/shaoster/glaze.git ~/glaze
+fi
 cd ~/glaze
 
 echo "--- pulling latest images ---"
 docker compose pull
 
-echo "--- syncing docker-compose.yml ---"
+echo "--- syncing repo to image commit ---"
 SHA="${KNOWN_SHA}"
 if [[ -z "\$SHA" ]]; then
     SHA=\$(docker inspect ghcr.io/shaoster/glaze:latest \
         --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' 2>/dev/null || true)
 fi
 if [[ -z "\$SHA" ]]; then
-    echo "WARNING: commit SHA unknown, docker-compose.yml not updated"
+    echo "WARNING: commit SHA unknown, repo not updated"
 else
     echo "Image built from commit \$SHA"
-    curl -fsSL \
-        "https://raw.githubusercontent.com/shaoster/glaze/\${SHA}/docker-compose.yml" \
-        -o docker-compose.yml
-    curl -fsSL \
-        "https://raw.githubusercontent.com/shaoster/glaze/\${SHA}/otel-collector-config.yml" \
-        -o otel-collector-config.yml
+    git fetch --quiet origin
+    git checkout --quiet "\$SHA"
 fi
 
 echo "--- restarting services ---"


### PR DESCRIPTION
## Summary

- Replaces the per-file `curl` approach with a `git clone` + `git checkout` on the droplet. On first deploy the repo is cloned; subsequent deploys fetch and checkout the exact commit SHA that matches the deployed image.
- Any config file committed to the repo (e.g. `otel-collector-config.yml`, future additions) is automatically present on the droplet without needing to update `deploy.sh`.
- Fixes the root cause that prevented `otelcol` from starting after https://github.com/shaoster/glaze/pull/475: the collector config was never copied to the host.

## Test plan
- [ ] First deploy on a fresh droplet: `~/glaze` should be cloned automatically
- [ ] Subsequent deploy: `git checkout <sha>` brings `docker-compose.yml`, `otel-collector-config.yml`, and `nginx/snippets/` in sync with the image
- [ ] `docker compose ps` shows `otelcol` running after deploy
