### PR TITLE
fix: pre-pull sidecar images and raise smoke-test wait-timeout to 300s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,13 @@ jobs:
       - name: Build OCI image and load into docker
         run: bazel run --config=ci --stamp //:load
 
+      - name: Pre-pull sidecar images
+        run: |
+          # Pull third-party images (postgres, otelcol, etc.) before starting
+          # the timed --wait block so image download doesn't eat into the
+          # healthcheck timeout budget.
+          docker compose pull --ignore-buildable
+
       - name: Smoke test via docker compose
         run: |
           set -euo pipefail
@@ -160,7 +167,9 @@ jobs:
           # `--wait` blocks until every service with a healthcheck reports
           # healthy. The web service's healthcheck (defined in
           # docker-compose.yml) is the pass criterion.
-          docker compose up -d --wait --wait-timeout 180
+          # Timeout is 300s: migrate + load_public_library (249 records) +
+          # collectstatic + gunicorn startup can exceed 120s on a cold runner.
+          docker compose up -d --wait --wait-timeout 300
           docker compose logs web | tail -50
 
       - if: failure()


### PR DESCRIPTION
## Summary

- Add a **"Pre-pull sidecar images"** step (`docker compose pull --ignore-buildable`) before the timed `--wait` block so third-party image downloads (postgres, otelcol, etc.) don't consume the healthcheck timeout budget.
- Raise `--wait-timeout` from **180s → 300s** to cover the full entrypoint startup sequence on a cold CI runner: `migrate` + `load_public_library` (249 fixture records, 249 `update_or_create` queries) + `collectstatic` + gunicorn startup can take 90–120s, leaving almost no slack at 180s.

## Why it was flaky

`docker compose up -d --wait-timeout N` starts the clock *including* image pulls. On a cold runner, pulling `otel/opentelemetry-collector-contrib` (~200MB) alone can take 30–60s, after which the web container still needs to run all four entrypoint management commands before gunicorn accepts connections. The combined worst case was pushing past 180s.

## Test plan
- [ ] CI smoke-test step completes without timeout on a cold runner
- [ ] `docker compose logs web` still captured on failure for debugging
