### PR TITLE
feat: move collectstatic to Bazel build time (#481)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,10 +168,11 @@ jobs:
 
       - name: Pre-pull sidecar images
         run: |
-          # Pull third-party images (postgres, otelcol, etc.) before starting
+          # Pull third-party sidecar images (postgres, otelcol) before starting
           # the timed --wait block so image download doesn't eat into the
-          # healthcheck timeout budget.
-          docker compose pull --ignore-buildable
+          # healthcheck timeout budget. Explicitly name services to avoid pulling
+          # the web service and overwriting the locally-built Bazel image.
+          docker compose pull db otelcol
 
       - name: Smoke test via docker compose
         run: |

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -82,10 +82,7 @@ alias(
 #   /app/                      Django project root (manage.py, backend/, api/, etc.)
 #   /app/web/dist/             Vite-built SPA (served by WhiteNoise at URL root)
 #   /app/site-packages/        pip-installed runtime deps (added to PYTHONPATH)
-#
-# collectstatic runs at container startup (docker-entrypoint.sh) because it
-# needs files from pip-installed packages (e.g. DRF browsable API assets) that
-# land in site-packages, not in the image layers we control at build time.
+#   /app/staticfiles/          collected static assets (built by staticfiles_tar genrule)
 
 # pip deps layer — install runtime deps into /app/site-packages using the
 # Bazel-managed Python 3.12 toolchain. Tagged no-sandbox because pip needs
@@ -147,6 +144,36 @@ pkg_tar(
     package_dir = "/app/web/dist",
 )
 
+# Static files layer — run collectstatic at build time so container startup
+# doesn't block on it. Needs site-packages (DRF assets) + app source.
+genrule(
+    name = "staticfiles_tar",
+    srcs = [
+        ":python_layer_tar",
+        ":app_src_tar",
+        ":web_dist_tar",
+    ],
+    outs = ["staticfiles.tar"],
+    cmd = """
+        set -e
+        tmp=$$(mktemp -d)
+        tar -xf $(location :python_layer_tar) -C "$$tmp"
+        tar -xf $(location :app_src_tar) -C "$$tmp"
+        tar -xf $(location :web_dist_tar) -C "$$tmp"
+        PYTHON3="$$PWD/$(PYTHON3)"
+        OUT_TAR="$$PWD/$@"
+        export PYTHONPATH="$$tmp/app:$$tmp/app/site-packages"
+        export DJANGO_SETTINGS_MODULE=backend.settings
+        export SECRET_KEY=buildtime-placeholder
+        cd "$$tmp/app"
+        "$$PYTHON3" manage.py collectstatic --no-input
+        tar -C "$$tmp" -cf "$$OUT_TAR" app/staticfiles
+        rm -rf "$$tmp"
+    """,
+    toolchains = ["@rules_python//python:current_py_toolchain"],
+    tags = ["no-sandbox"],
+)
+
 oci_image(
     name = "image",
     base = "@python312_slim",
@@ -154,6 +181,7 @@ oci_image(
         ":python_layer_tar",
         ":app_src_tar",
         ":web_dist_tar",
+        ":staticfiles_tar",
     ],
     env = {
         "PYTHONPATH": "/app:/app/site-packages",

--- a/backend/BUILD.bazel
+++ b/backend/BUILD.bazel
@@ -48,6 +48,7 @@ filegroup(
         "__init__.py",
         "asgi.py",
         "middleware.py",
+        "otel.py",
         "settings.py",
         "test_settings.py",
         "urls.py",

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,7 +2,6 @@
 set -e
 
 python manage.py migrate --no-input
-python manage.py collectstatic --no-input
 python manage.py load_public_library --skip-if-missing
 # On startup, fail all tasks marked as RUNNING or PENDING because in an
 # InMemoryTaskInterface setup, no tasks can survive a process restart.


### PR DESCRIPTION
## Summary

- Adds `staticfiles_tar` Bazel genrule that runs `collectstatic` at image build time, extracting pip deps + app source + web dist into a temp dir, running the command, and packaging the output as an OCI layer
- Removes `collectstatic` from `docker-entrypoint.sh` — it no longer runs on every container start
- Fixes `backend/BUILD.bazel`: adds `otel.py` to `backend_runtime_files` so it is included in the OCI image (was missing, causing `ModuleNotFoundError` in production)

Closes #481

## Test plan

- [x] `bazel build //:staticfiles_tar` — 211 files collected, 69 DRF files confirmed via `tar -tf`
- [x] `bazel run //:load` — full image built with `staticfiles_tar` layer
- [x] `docker compose up -d --wait --wait-timeout 180` — all services healthy
- [x] `/app/staticfiles` present in container
- [x] No `collectstatic` line in startup logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)