### PR TITLE
fix: patch Django OTel middleware for ASGI and fix collector endpoint

### DIFF
--- a/backend/otel.py
+++ b/backend/otel.py
@@ -28,3 +28,17 @@ def configure_otel() -> None:
     trace.set_tracer_provider(provider)
     DjangoInstrumentor().instrument()
     Psycopg2Instrumentor().instrument()
+
+    # opentelemetry-instrumentation-django 0.62b1's _DjangoMiddleware has no
+    # __acall__, so under ASGI/uvicorn it runs in a thread executor and loses
+    # the OTel context — Django HTTP spans never appear. Patch it async-capable.
+    from asgiref.sync import markcoroutinefunction
+    from opentelemetry.instrumentation.django.middleware.otel_middleware import _DjangoMiddleware
+
+    async def __acall__(self, request):
+        self.process_request(request)
+        response = await self.get_response(request)
+        return self.process_response(request, response)
+
+    _DjangoMiddleware.__acall__ = __acall__
+    markcoroutinefunction(_DjangoMiddleware)

--- a/otel-collector-config.yml
+++ b/otel-collector-config.yml
@@ -6,7 +6,7 @@ receivers:
 
 exporters:
   otlphttp:
-    endpoint: https://otlp-gateway-prod-us-east-0.grafana.net/otlp
+    endpoint: https://otlp-gateway-prod-us-east-3.grafana.net/otlp
     headers:
       authorization: "Basic ${env:GRAFANA_CLOUD_OTLP_TOKEN}"
 


### PR DESCRIPTION
## Summary

- **`backend/otel.py`**: Monkey-patches `_DjangoMiddleware.__acall__` after `DjangoInstrumentor().instrument()`. The upstream middleware (v0.62b1) is sync-only — under ASGI/uvicorn it gets dispatched to a thread executor, dropping the OTel context and producing orphaned psycopg2 spans with no parent HTTP span. The patch adds an async path so Django HTTP spans appear in Tempo.
- **`otel-collector-config.yml`**: Fixes the OTLP gateway endpoint from `prod-us-east-0` to `prod-us-east-3` (our Grafana Cloud stack region). This was already patched on prod via SSH; now aligned in the repo.

## Test plan

- [ ] CI passes (no backend changes that affect tests)
- [ ] Deploy to prod; otelcol restarts with correct endpoint (no more 401s from stale endpoint)
- [ ] New image deployed; make a few API requests
- [ ] In Grafana Tempo, query `{resource.service.name="glaze"}` — HTTP request spans should now appear alongside the SELECT spans

🤖 Generated with [Claude Code](https://claude.com/claude-code)