### PR TITLE
fix: restore working tree before checkout in deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -46,6 +46,7 @@ if [[ -z "\$SHA" ]]; then
 else
     echo "Image built from commit \$SHA"
     git fetch --quiet origin
+    git restore --quiet .
     git checkout --quiet "\$SHA"
 fi
 


### PR DESCRIPTION
## Summary

- `git restore .` added before `git checkout` in the deploy script so manual hotfixes on the server (e.g. patching `otel-collector-config.yml` via SSH) don't block future deploys with an "overwritten by checkout" error.

## Test plan

- [ ] Re-run deploy — should no longer abort on modified tracked files

🤖 Generated with [Claude Code](https://claude.com/claude-code)