### PR TITLE
fix: add always() to push job so skip_main doesn't block registry push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
     # Always push on main merges, even when skip_main skipped the build/test
     # job — the remote cache has the correct image layers from the PR run.
     if: >-
-      always() && github.event_name == 'push' && github.ref == 'refs/heads/main' &&
+      always() && !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main' &&
       (needs.image.result == 'success' || needs.image.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
     # Always push on main merges, even when skip_main skipped the build/test
     # job — the remote cache has the correct image layers from the PR run.
     if: >-
-      github.event_name == 'push' && github.ref == 'refs/heads/main' &&
+      always() && github.event_name == 'push' && github.ref == 'refs/heads/main' &&
       (needs.image.result == 'success' || needs.image.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

GitHub automatically skips a job when any required dependency is skipped — the job's own `if` condition is not evaluated. The `push` job depends on `image`, which gets skipped when `skip_main` is `true`. Without `always()`, the push job is silently skipped on every merge whose tree fingerprint was already validated by a PR.

Added `always()` to the `push` job's `if` so GitHub evaluates the condition rather than auto-skipping.

## Test plan

- [ ] Merge this PR; CI on main should skip lint/coverage/image but the push job should run and push `:latest` to ghcr.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)