### PR TITLE
chore: harden CI/CD against skip_main edge cases and stale image deploys

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -68,15 +68,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          gh release view "release-${{ env.DEPLOY_SHA }}" &>/dev/null || \
           gh release create "release-${{ env.DEPLOY_SHA }}" \
             --title "Build ${{ env.DEPLOY_SHA }}" \
             --notes "Docker image: \`ghcr.io/shaoster/glaze:${{ env.DEPLOY_SHA }}\`" \
-            --latest || true
+            --latest
 
   deploy-modal:
     name: Deploy ML Microservice to Modal
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' || github.event_name == 'push'
+    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,9 @@ jobs:
             const match = artifacts.find(
               artifact => artifact.name === artifactName && !artifact.expired
             );
+            if (match) {
+              core.notice(`skip_main: fingerprint already validated by a prior PR run — skipping lint and coverage on main.`);
+            }
             core.setOutput('skip_main', match ? 'true' : 'false');
 
   lint:
@@ -145,8 +148,13 @@ jobs:
   image:
     name: Build & smoke-test OCI image
     needs: preflight
-    if: ${{ github.event_name == 'pull_request' || needs.preflight.outputs.skip_main != 'true' }}
+    # No skip_main guard — always run on main so the image is always built and
+    # pushed. lint and coverage still skip when skip_main=true. Keeping the
+    # build and push in one job avoids the job-dependency skip-propagation
+    # problem that bit us twice when push lived in a separate job.
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - uses: actions/checkout@v5
         with:
@@ -194,32 +202,8 @@ jobs:
         if: always()
         run: docker compose down -v --remove-orphans || true
 
-  push:
-    name: Push OCI image
-    needs: [preflight, image]
-    # Always push on main merges, even when skip_main skipped the build/test
-    # job — the remote cache has the correct image layers from the PR run.
-    if: >-
-      always() && !cancelled() && github.event_name == 'push' && github.ref == 'refs/heads/main' &&
-      (needs.image.result == 'success' || needs.image.result == 'skipped')
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ github.sha }}
-
-      - uses: ./.github/actions/setup-bazel-ci
-        with:
-          cache-key-prefix: image
-          deps-key: ${{ needs.preflight.outputs.deps_key }}
-          buildbuddy-api-key: ${{ secrets.BAZEL_REMOTE_API_KEY }}
-
-      - name: Write Vite env file
-        run: printf 'VITE_GOOGLE_CLIENT_ID=%s\n' '${{ secrets.VITE_GOOGLE_CLIENT_ID }}' > web/.env.local
-
       - name: Log in to GitHub Container Registry
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -227,6 +211,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push OCI image
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           bazel run --config=ci --stamp //:push -- \
             --tag latest \

--- a/deploy.sh
+++ b/deploy.sh
@@ -35,17 +35,30 @@ cd ~/glaze
 echo "--- pulling latest images ---"
 docker compose pull
 
+echo "--- verifying image SHA ---"
+IMAGE_SHA=\$(docker inspect ghcr.io/shaoster/glaze:latest \
+    --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' 2>/dev/null || true)
+
 echo "--- syncing repo to image commit ---"
 SHA="${KNOWN_SHA}"
 if [[ -z "\$SHA" ]]; then
-    SHA=\$(docker inspect ghcr.io/shaoster/glaze:latest \
-        --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' 2>/dev/null || true)
+    SHA="\$IMAGE_SHA"
 fi
 if [[ -z "\$SHA" ]]; then
     echo "WARNING: commit SHA unknown, repo not updated"
 else
+    if [[ -n "\$IMAGE_SHA" && "\$IMAGE_SHA" != "\$SHA" ]]; then
+        echo "ERROR: pulled image was built from \$IMAGE_SHA but expected \$SHA"
+        echo "The registry may not have the image for this commit yet."
+        exit 1
+    fi
     echo "Image built from commit \$SHA"
     git fetch --quiet origin
+    DIRTY=\$(git status --short)
+    if [[ -n "\$DIRTY" ]]; then
+        echo "WARNING: discarding local modifications before checkout:"
+        echo "\$DIRTY"
+    fi
     git restore --quiet .
     git checkout --quiet "\$SHA"
 fi


### PR DESCRIPTION
Closes #486

## Summary

- **`ci.yml`**: Removes the separate `push` job — build and push now live in one `image` job. Push steps are gated on `github.event_name == 'push' && github.ref == 'refs/heads/main'`; the `image` job no longer has a `skip_main` guard (only lint and coverage skip). Adds a `core.notice` in preflight when `skip_main` fires. Removes the `always() && !cancelled()` hack from #485.
- **`cd.yml`**: Replaces `|| true` on `gh release create` with an explicit existence check (`gh release view ... || gh release create ...`) so real errors (permissions, network) are not silently swallowed. Removes dead `|| github.event_name == 'push'` from `deploy-modal`.
- **`deploy.sh`**: Aborts if the pulled image's revision label doesn't match `DEPLOY_SHA`. Logs any files discarded by `git restore .` before dropping them.

## Test plan

- [ ] On merge: CI should run `image` (not skip it), push `:latest` and SHA tag to ghcr.io
- [ ] Subsequent merge with same tree: lint/coverage skip, image still runs and pushes
- [ ] `workflow_dispatch` re-deploy of existing SHA: release creation step skips cleanly (no error)
- [ ] `deploy.sh` SHA mismatch: verify it aborts with the error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)