### PR TITLE
fix OTel tracing with upstream ASGI middleware

### DIFF
--- a/api/BUILD.bazel
+++ b/api/BUILD.bazel
@@ -180,6 +180,21 @@ py_test(
 )
 
 py_test(
+    name = "api_otel_test",
+    size = "small",
+    srcs = _CONFTEST + [
+        "tests/test_otel.py",
+    ],
+    args = [
+        "api/tests/test_otel.py",
+    ],
+    data = _TEST_DATA,
+    env = _TEST_ENV,
+    main = "//tools:pytest_main.py",
+    deps = _TEST_DEPS,
+)
+
+py_test(
     name = "api_piece_test",
     size = "medium",
     srcs = _CONFTEST + [
@@ -357,6 +372,7 @@ test_suite(
         ":api_invitation_test",
         ":api_migration_test",
         ":api_model_test",
+        ":api_otel_test",
         ":api_piece_test",
         ":api_workflow_test",
     ],

--- a/api/tests/test_otel.py
+++ b/api/tests/test_otel.py
@@ -1,0 +1,80 @@
+import asyncio
+
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware
+from opentelemetry.trace import SpanKind
+
+
+def test_open_telemetry_middleware_creates_request_span_from_traceparent():
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider(
+        resource=Resource.create({"service.name": "glaze-test"}),
+    )
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    current_span_ids: list[int] = []
+
+    async def app(scope, receive, send):
+        current_span = trace.get_current_span()
+        current_span_ids.append(current_span.get_span_context().span_id)
+        assert current_span.get_span_context().is_valid
+
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 204,
+                "headers": [],
+            }
+        )
+        await send(
+            {
+                "type": "http.response.body",
+                "body": b"",
+                "more_body": False,
+            }
+        )
+
+    wrapped = OpenTelemetryMiddleware(
+        app,
+        tracer_provider=provider,
+        exclude_spans=["receive", "send"],
+    )
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/pieces/123",
+        "raw_path": b"/pieces/123",
+        "scheme": "https",
+        "server": ("example.com", 443),
+        "headers": [
+            (
+                b"traceparent",
+                b"00-11111111111111111111111111111111-2222222222222222-01",
+            )
+        ],
+    }
+    sent_messages = []
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message):
+        sent_messages.append(message)
+
+    asyncio.run(wrapped(scope, receive, send))
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+
+    request_span = spans[0]
+    assert request_span.name == "GET /pieces/123"
+    assert request_span.kind == SpanKind.SERVER
+    assert request_span.parent.span_id == int("2222222222222222", 16)
+    assert current_span_ids == [request_span.context.span_id]
+    assert request_span.attributes["http.method"] == "GET"
+    assert request_span.attributes["http.status_code"] == 204
+    assert sent_messages[0]["status"] == 204

--- a/backend/BUILD.bazel
+++ b/backend/BUILD.bazel
@@ -35,7 +35,7 @@ py_library(
         "@pypi//aiofiles",
         "@pypi//opentelemetry_api",
         "@pypi//opentelemetry_sdk",
-        "@pypi//opentelemetry_instrumentation_django",
+        "@pypi//opentelemetry_instrumentation_asgi",
         "@pypi//opentelemetry_instrumentation_psycopg2",
         "@pypi//opentelemetry_exporter_otlp_proto_grpc",
     ],

--- a/backend/asgi.py
+++ b/backend/asgi.py
@@ -14,6 +14,8 @@ from django.core.asgi import get_asgi_application
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "backend.settings")
 
 from backend.otel import configure_otel
+from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware
 
-configure_otel()
 application = get_asgi_application()  # noqa: E402
+if configure_otel():
+    application = OpenTelemetryMiddleware(application)

--- a/backend/otel.py
+++ b/backend/otel.py
@@ -1,44 +1,38 @@
 import os
 
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
 
-def configure_otel() -> None:
+
+def configure_otel() -> bool:
     if not os.environ.get("OTEL_ENABLED"):
-        return
+        return False
 
     # The OTel gRPC exporter bundles _pb2.py files generated for protobuf<7.
     # protobuf>=4 rejects old generated descriptors unless the pure-Python
     # runtime is used. Set this before importing any opentelemetry.proto module.
     os.environ.setdefault("PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION", "python")
 
-    from opentelemetry import trace
     from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-    from opentelemetry.instrumentation.django import DjangoInstrumentor
     from opentelemetry.instrumentation.psycopg2 import Psycopg2Instrumentor
-    from opentelemetry.sdk.trace import TracerProvider
-    from opentelemetry.sdk.trace.export import BatchSpanProcessor
-    from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
 
     sample_rate = float(os.environ.get("OTEL_SAMPLE_RATE", "1.0"))
-    provider = TracerProvider(sampler=TraceIdRatioBased(sample_rate))
+    provider = TracerProvider(
+        resource=Resource.create(
+            {
+                "service.name": os.environ.get("OTEL_SERVICE_NAME", "glaze"),
+            }
+        ),
+        sampler=TraceIdRatioBased(sample_rate),
+    )
     exporter = OTLPSpanExporter(
         endpoint=os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317"),
         insecure=True,
     )
     provider.add_span_processor(BatchSpanProcessor(exporter))
     trace.set_tracer_provider(provider)
-    DjangoInstrumentor().instrument()
     Psycopg2Instrumentor().instrument()
-
-    # opentelemetry-instrumentation-django 0.62b1's _DjangoMiddleware has no
-    # __acall__, so under ASGI/uvicorn it runs in a thread executor and loses
-    # the OTel context — Django HTTP spans never appear. Patch it async-capable.
-    from asgiref.sync import markcoroutinefunction
-    from opentelemetry.instrumentation.django.middleware.otel_middleware import _DjangoMiddleware
-
-    async def __acall__(self, request):
-        self.process_request(request)
-        response = await self.get_response(request)
-        return self.process_response(request, response)
-
-    _DjangoMiddleware.__acall__ = __acall__
-    markcoroutinefunction(_DjangoMiddleware)
+    return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
     "onnxruntime==1.26.0",
     "opencv-python-headless==4.13.0.92",
     "opentelemetry-exporter-otlp-proto-grpc>=1.11.1",
-    "opentelemetry-instrumentation-django>=0.62b1",
+    "opentelemetry-instrumentation-asgi>=0.62b1",
     "opentelemetry-instrumentation-psycopg2>=0.62b1",
     "opentelemetry-sdk>=1.41.1",
     "packaging==26.2",

--- a/uv.lock
+++ b/uv.lock
@@ -491,7 +491,7 @@ dependencies = [
     { name = "onnxruntime" },
     { name = "opencv-python-headless" },
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
-    { name = "opentelemetry-instrumentation-django" },
+    { name = "opentelemetry-instrumentation-asgi" },
     { name = "opentelemetry-instrumentation-psycopg2" },
     { name = "opentelemetry-sdk" },
     { name = "packaging" },
@@ -596,7 +596,7 @@ requires-dist = [
     { name = "onnxruntime", specifier = "==1.26.0" },
     { name = "opencv-python-headless", specifier = "==4.13.0.92" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.11.1" },
-    { name = "opentelemetry-instrumentation-django", specifier = ">=0.62b1" },
+    { name = "opentelemetry-instrumentation-asgi", specifier = ">=0.62b1" },
     { name = "opentelemetry-instrumentation-psycopg2", specifier = ">=0.62b1" },
     { name = "opentelemetry-sdk", specifier = ">=1.41.1" },
     { name = "packaging", specifier = "==26.2" },
@@ -1072,6 +1072,22 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-instrumentation-asgi"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/43/b2f0703ff46718ff7b17d7fbf8e9d7f20e26a23c7c325092dd762d09cf9d/opentelemetry_instrumentation_asgi-0.62b1.tar.gz", hash = "sha256:7cf5f5d5c493bbb1edd2bd6d51fa879d964e94048904017258a32ffa47329310", size = 26781, upload-time = "2026-04-24T13:22:37.158Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/41/968c1fe12fb90abffca6620e65d4af91451c02ecca8f74a17a62cac490de/opentelemetry_instrumentation_asgi-0.62b1-py3-none-any.whl", hash = "sha256:b7f89be48528512619bd54fa2459f72afb1695ba71d7024d382ad96d467e7fa8", size = 17011, upload-time = "2026-04-24T13:21:38.006Z" },
+]
+
+[[package]]
 name = "opentelemetry-instrumentation-dbapi"
 version = "0.62b1"
 source = { registry = "https://pypi.org/simple" }
@@ -1087,22 +1103,6 @@ wheels = [
 ]
 
 [[package]]
-name = "opentelemetry-instrumentation-django"
-version = "0.62b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-instrumentation-wsgi" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/82/659d2192cb076bc836639c23876f67cc9afc85629694666479c189975cd4/opentelemetry_instrumentation_django-0.62b1.tar.gz", hash = "sha256:268c9b3d234510ab835acea0524ba65361389f6e2c291b495ba8072c7bb59003", size = 26022, upload-time = "2026-04-24T13:22:48.392Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/7c/306249a95e88ce4de1491d7bf49280c72e297b207c1da6967d0ec0078d9a/opentelemetry_instrumentation_django-0.62b1-py3-none-any.whl", hash = "sha256:5ac96ef25019fbea5e2739c9b4b7ce17e4379e2b1ec9fdce6b696a5c09ceabbe", size = 20782, upload-time = "2026-04-24T13:21:51.153Z" },
-]
-
-[[package]]
 name = "opentelemetry-instrumentation-psycopg2"
 version = "0.62b1"
 source = { registry = "https://pypi.org/simple" }
@@ -1114,21 +1114,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/45/14/302c4c96bd4ec97656217e715f20e69f61dc79e3478c95e883ed50cd8100/opentelemetry_instrumentation_psycopg2-0.62b1.tar.gz", hash = "sha256:0f756c7e00babb04429c528e8cd0054b348a8458a7a986a6807c0d413222f45c", size = 12077, upload-time = "2026-04-24T13:22:57.343Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/da/e650b7077ad57048cd765d91d7c4f002bd3ec6101fc7920b14e956f73404/opentelemetry_instrumentation_psycopg2-0.62b1-py3-none-any.whl", hash = "sha256:b1de5da4b300504dbe52145d3098092b5caab2b50373809cf11506e0adddd0eb", size = 11585, upload-time = "2026-04-24T13:22:05.857Z" },
-]
-
-[[package]]
-name = "opentelemetry-instrumentation-wsgi"
-version = "0.62b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/36/db/19f1d66cead56e52291fccaa235b07ad45a5c24be1c740301a840c68235a/opentelemetry_instrumentation_wsgi-0.62b1.tar.gz", hash = "sha256:02a364fd9c940a46b19c825c5bfe386b007d5292ef91573894164836953fe831", size = 19919, upload-time = "2026-04-24T13:23:09.796Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/0e/60fec0780e16929c821df7c55c4f0bea45d6ef562e662c5f27f47d0ff195/opentelemetry_instrumentation_wsgi-0.62b1-py3-none-any.whl", hash = "sha256:a2df11de0113f504043e2b0fa0288238a93ee49ff607bd5100cb2d3a75bc771f", size = 14629, upload-time = "2026-04-24T13:22:23.951Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Switch OTel tracing to the upstream ASGI middleware

- Replace the custom ASGI request-span wrapper with `opentelemetry.instrumentation.asgi.OpenTelemetryMiddleware`.
- Drop the Django instrumentor path and the monkey-patch workaround.
- Keep psycopg2 instrumentation and the exporter setup intact.
- Update Bazel and package metadata to depend on `opentelemetry-instrumentation-asgi`.
- Add a focused integration test that verifies the ASGI middleware creates the top-level request span and preserves incoming trace context.

Validation:
- `rtk bazel test //...`
- `rtk bazel build --config=lint //...`
