### PR TITLE
Optimize piece list/detail queries

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import datetime
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
 from django.apps import apps
@@ -58,6 +59,15 @@ from .workflow import (
 from .workflow import (
     get_state_ref_fields as get_state_ref_fields,
 )
+
+
+@lru_cache(maxsize=None)
+def _piece_state_global_ref_related_name(global_name: str) -> str:
+    config = get_global_config(global_name)
+    ref_model = apps.get_model("api", f"PieceState{config['model']}Ref")
+    related_name = ref_model._meta.get_field("piece_state").remote_field.related_name
+    assert related_name is not None
+    return related_name
 
 
 class AllowedEmail(models.Model):
@@ -327,6 +337,20 @@ class PieceState(models.Model):
     def images(self, value: list[dict]) -> None:
         self._pending_images = value
 
+    def _prefetched_global_ref(self, field_name: str) -> Any | None:
+        global_ref_map = get_global_ref_fields_for_state(self.state)
+        global_name = global_ref_map.get(field_name)
+        if global_name is None:
+            return None
+        related_name = _piece_state_global_ref_related_name(global_name)
+        refs = getattr(self, "_prefetched_objects_cache", {}).get(related_name)
+        if refs is None:
+            return None
+        for ref_row in refs:
+            if ref_row.field_name == field_name:
+                return getattr(ref_row, global_name)
+        return None
+
     def save(self, *args, allow_sealed_edit: bool = False, **kwargs):
         """
         Validates inline custom_fields against the workflow DSL for this state,
@@ -417,6 +441,9 @@ class PieceState(models.Model):
         # Not in custom_fields or calculated. Check junction tables for global refs.
         global_ref_map = get_global_ref_fields_for_state(self.state)
         if field_name in global_ref_map:
+            prefetched_global_ref = self._prefetched_global_ref(field_name)
+            if prefetched_global_ref is not None:
+                return prefetched_global_ref
             global_name = global_ref_map[field_name]
             config = get_global_config(global_name)
             ref_model = apps.get_model("api", f"PieceState{config['model']}Ref")

--- a/api/models.py
+++ b/api/models.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from django.apps import apps
@@ -242,8 +243,26 @@ class Piece(models.Model):
     class Meta:
         ordering = ["-fields_last_modified"]
 
+    def _prefetched_states(self) -> list["PieceState"] | None:
+        """Return prefetched states when the relation is already cached."""
+        states = getattr(self, "_prefetched_objects_cache", {}).get("states")
+        if states is None:
+            return None
+        return list(states)
+
+    @staticmethod
+    def _state_sort_key(state: "PieceState") -> tuple[bool, int, datetime]:
+        order = state.order if state.order is not None else -1
+        return (state.order is not None, order, state.created)
+
     @property
     def current_state(self) -> "PieceState | None":
+        prefetched_states = self._prefetched_states()
+        if prefetched_states is not None:
+            if not prefetched_states:
+                return None
+            return max(prefetched_states, key=self._state_sort_key)
+
         from django.db.models import F
 
         return self.states.order_by(

--- a/api/piece_views.py
+++ b/api/piece_views.py
@@ -73,18 +73,28 @@ _DEFAULT_PAGE_SIZE = 24
 
 
 def _piece_queryset(request: Request):
-    return Piece.objects.prefetch_related("states", "tag_links__tag").filter(
-        user=request.user
-    )  # type: ignore[misc]
+    user_id = request.user.id
+    assert user_id is not None
+    return (
+        Piece.objects.select_related("current_location", "thumbnail")
+        .prefetch_related("states", "tag_links__tag")
+        .filter(user_id=user_id)
+    )
 
 
 def _piece_read_queryset(request: Request):
-    qs = Piece.objects.prefetch_related("states", "tag_links__tag")
+    qs = Piece.objects.select_related("current_location", "thumbnail").prefetch_related(
+        "states", "tag_links__tag"
+    )
     if request.user.is_authenticated:
         # Editable pieces are inaccessible to non-owners even when shared=True,
         # without altering the shared flag itself.
         return qs.filter(Q(user=request.user) | Q(shared=True, is_editable=False))
     return qs.filter(shared=True, is_editable=False)
+
+
+def _piece_detail_queryset(request: Request):
+    return _piece_read_queryset(request).prefetch_related("states__image_links__image")
 
 
 def _serialize_piece_detail(piece: Piece, request: Request):
@@ -206,7 +216,7 @@ def pieces(request: Request) -> Response:
 @permission_classes([AllowAny])
 def piece_detail(request: Request, piece_id: str) -> Response:
     if request.method == "GET":
-        piece = get_object_or_404(_piece_read_queryset(request), pk=piece_id)
+        piece = get_object_or_404(_piece_detail_queryset(request), pk=piece_id)
         return Response(_serialize_piece_detail(piece, request))
 
     if not request.user.is_authenticated:
@@ -236,8 +246,7 @@ def piece_states(request: Request, piece_id: str) -> Response:
     serializer = PieceStateCreateSerializer(data=request.data, context={"piece": piece})
     serializer.is_valid(raise_exception=True)
     serializer.save()
-    # Reload to pick up updated last_modified on current_state
-    piece.refresh_from_db()
+    piece = get_object_or_404(_piece_detail_queryset(request), pk=piece_id)
     return Response(
         _serialize_piece_detail(piece, request), status=status.HTTP_201_CREATED
     )
@@ -250,7 +259,7 @@ def piece_states(request: Request, piece_id: str) -> Response:
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def piece_current_state_detail(request: Request, piece_id: str) -> Response:
-    piece = get_object_or_404(_piece_queryset(request), pk=piece_id)
+    piece = get_object_or_404(_piece_detail_queryset(request), pk=piece_id)
     current = piece.current_state
     if current is None:
         return Response(
@@ -276,7 +285,7 @@ def piece_current_state(request: Request, piece_id: str) -> Response:
     serializer = PieceStateUpdateSerializer(data=request.data)
     serializer.is_valid(raise_exception=True)
     serializer.update(current, serializer.validated_data)
-    piece.refresh_from_db()
+    piece = get_object_or_404(_piece_detail_queryset(request), pk=piece_id)
     return Response(_serialize_piece_detail(piece, request))
 
 
@@ -311,10 +320,10 @@ def piece_past_state(request: Request, piece_id: str, state_id: str) -> Response
                 status=status.HTTP_403_FORBIDDEN,
             )
         ps.delete()
-        piece.refresh_from_db()
+        piece = get_object_or_404(_piece_detail_queryset(request), pk=piece_id)
         return Response(_serialize_piece_detail(piece, request))
     serializer = PieceStateUpdateSerializer(data=request.data)
     serializer.is_valid(raise_exception=True)
     serializer.update(ps, serializer.validated_data)
-    piece.refresh_from_db()
+    piece = get_object_or_404(_piece_detail_queryset(request), pk=piece_id)
     return Response(_serialize_piece_detail(piece, request))

--- a/api/piece_views.py
+++ b/api/piece_views.py
@@ -9,7 +9,7 @@ from typing import Callable
 from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model, login, logout
-from django.db.models import DateTimeField, OuterRef, Q, Subquery
+from django.db.models import DateTimeField, OuterRef, Prefetch, Q, Subquery
 from django.db.models.functions import Coalesce, Greatest
 from django.http import StreamingHttpResponse
 from django.shortcuts import get_object_or_404
@@ -55,7 +55,9 @@ from .serializers import (
 from .utils import bootstrap_dev_user
 from .workflow import (
     get_glaze_image_qualifying_states,
+    get_global_config,
     get_global_model_and_field,
+    get_state_global_ref_map,
     is_private_global,
     is_public_global,
 )
@@ -94,7 +96,25 @@ def _piece_read_queryset(request: Request):
 
 
 def _piece_detail_queryset(request: Request):
-    return _piece_read_queryset(request).prefetch_related("states__image_links__image")
+    return _piece_read_queryset(request).prefetch_related(
+        "states__image_links__image", *_piece_state_ref_prefetches()
+    )
+
+
+def _piece_state_ref_prefetches() -> list[Prefetch]:
+    prefetches: list[Prefetch] = []
+    for global_name in get_state_global_ref_map():
+        config = get_global_config(global_name)
+        ref_model = apps.get_model("api", f"PieceState{config['model']}Ref")
+        related_name = ref_model._meta.get_field("piece_state").remote_field.related_name
+        assert related_name is not None
+        prefetches.append(
+            Prefetch(
+                f"states__{related_name}",
+                queryset=ref_model.objects.select_related(global_name),
+            )
+        )
+    return prefetches
 
 
 def _serialize_piece_detail(piece: Piece, request: Request):

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -288,10 +288,16 @@ class PieceStateSerializer(serializers.ModelSerializer):
 
     @extend_schema_field(serializers.CharField(allow_null=True))
     def get_previous_state(self, obj: PieceState) -> str | None:
+        prefetched_states = obj.piece._prefetched_states()
+        if prefetched_states is not None:
+            for index, state in enumerate(prefetched_states):
+                if state.pk == obj.pk:
+                    prev = prefetched_states[index - 1] if index > 0 else None
+                    return prev.state if prev else None
+            return None
+
         if obj.order is not None:
-            prev = (
-                obj.piece.states.filter(order__lt=obj.order).order_by("-order").first()
-            )
+            prev = obj.piece.states.filter(order__lt=obj.order).order_by("-order").first()
         else:
             prev = (
                 obj.piece.states.filter(created__lt=obj.created)
@@ -302,6 +308,18 @@ class PieceStateSerializer(serializers.ModelSerializer):
 
     @extend_schema_field(serializers.CharField(allow_null=True))
     def get_next_state(self, obj: PieceState) -> str | None:
+        prefetched_states = obj.piece._prefetched_states()
+        if prefetched_states is not None:
+            for index, state in enumerate(prefetched_states):
+                if state.pk == obj.pk:
+                    nxt = (
+                        prefetched_states[index + 1]
+                        if index < len(prefetched_states) - 1
+                        else None
+                    )
+                    return nxt.state if nxt else None
+            return None
+
         if obj.order is not None:
             nxt = obj.piece.states.filter(order__gt=obj.order).order_by("order").first()
         else:

--- a/api/tests/test_piece_detail.py
+++ b/api/tests/test_piece_detail.py
@@ -1,6 +1,8 @@
 import uuid
 
 import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from rest_framework.exceptions import ValidationError
 from rest_framework.test import APIClient
 
@@ -14,6 +16,23 @@ from api.serializers import _replace_piece_tags
 
 @pytest.mark.django_db
 class TestPieceDetail:
+    def test_get_uses_a_small_number_of_queries(self, client, piece, user):
+        piece.current_location = Location.objects.create(user=user, name="Studio")
+        piece.thumbnail = {
+            "url": "https://example.com/piece-thumb.jpg",
+            "cloudinary_public_id": None,
+            "cloud_name": None,
+        }
+        piece.save()
+        PieceState.objects.create(piece=piece, state="designed")
+        PieceState.objects.create(piece=piece, state="designed")
+
+        with CaptureQueriesContext(connection) as ctx:
+            response = client.get(f"/api/pieces/{piece.id}/")
+
+        assert response.status_code == 200
+        assert len(ctx) <= 6
+
     def test_get(self, client, piece):
         response = client.get(f"/api/pieces/{piece.id}/")
         assert response.status_code == 200

--- a/api/tests/test_piece_detail.py
+++ b/api/tests/test_piece_detail.py
@@ -6,7 +6,14 @@ from django.test.utils import CaptureQueriesContext
 from rest_framework.exceptions import ValidationError
 from rest_framework.test import APIClient
 
-from api.models import Location, PieceState, Tag
+from api.models import (
+    ClayBody,
+    Location,
+    PieceState,
+    PieceStateClayBodyRef,
+    PieceStateLocationRef,
+    Tag,
+)
 from api.serializers import _replace_piece_tags
 
 # ---------------------------------------------------------------------------
@@ -31,7 +38,51 @@ class TestPieceDetail:
             response = client.get(f"/api/pieces/{piece.id}/")
 
         assert response.status_code == 200
-        assert len(ctx) <= 6
+        assert len(ctx) <= 7
+
+    def test_get_prefetches_state_global_refs(self, client, piece, user):
+        clay_body = ClayBody.objects.create(user=user, name="Stoneware")
+        kiln_location = Location.objects.create(user=user, name="Kiln Shelf")
+
+        clay_state = PieceState.objects.create(
+            piece=piece,
+            user=piece.user,
+            state="handbuilt",
+            order=2,
+        )
+        PieceStateClayBodyRef.objects.create(
+            piece_state=clay_state,
+            field_name="clay_body",
+            clay_body=clay_body,
+        )
+
+        kiln_state = PieceState.objects.create(
+            piece=piece,
+            user=piece.user,
+            state="submitted_to_bisque_fire",
+            order=3,
+        )
+        PieceStateLocationRef.objects.create(
+            piece_state=kiln_state,
+            field_name="kiln_location",
+            location=kiln_location,
+        )
+
+        with CaptureQueriesContext(connection) as ctx:
+            response = client.get(f"/api/pieces/{piece.id}/")
+
+        assert response.status_code == 200
+        sql = "\n".join(query["sql"] for query in ctx)
+        assert "api_piecestateclaybodyref" in sql
+        assert "api_piecestatelocationref" in sql
+        assert "WHERE (\"api_piecestateclaybodyref\".\"field_name\"" not in sql
+        assert "WHERE (\"api_piecestatelocationref\".\"field_name\"" not in sql
+        assert response.json()["current_state"]["custom_fields"]["kiln_location"][
+            "name"
+        ] == "Kiln Shelf"
+        assert response.json()["history"][1]["custom_fields"]["clay_body"]["name"] == (
+            "Stoneware"
+        )
 
     def test_get(self, client, piece):
         response = client.get(f"/api/pieces/{piece.id}/")

--- a/api/tests/test_pieces_list.py
+++ b/api/tests/test_pieces_list.py
@@ -1,6 +1,8 @@
 import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 
-from api.models import ENTRY_STATE, Piece, PieceState, Tag
+from api.models import ENTRY_STATE, Location, Piece, PieceState, Tag
 
 # ---------------------------------------------------------------------------
 # GET /api/pieces/
@@ -9,6 +11,31 @@ from api.models import ENTRY_STATE, Piece, PieceState, Tag
 
 @pytest.mark.django_db
 class TestPiecesList:
+    def test_list_uses_a_small_number_of_queries(self, client, user):
+        location = Location.objects.create(user=user, name="Bench")
+        pieces = []
+        for i in range(3):
+            pieces.append(
+                Piece.objects.create(
+                    user=user,
+                    name=f"Piece {i}",
+                    thumbnail={
+                        "url": f"https://example.com/thumb-{i}.jpg",
+                        "cloudinary_public_id": None,
+                        "cloud_name": None,
+                    },
+                    current_location=location,
+                )
+            )
+        for piece in pieces:
+            PieceState.objects.create(piece=piece, state=ENTRY_STATE)
+
+        with CaptureQueriesContext(connection) as ctx:
+            response = client.get("/api/pieces/")
+
+        assert response.status_code == 200
+        assert len(ctx) <= 5
+
     def test_empty(self, client):
         response = client.get("/api/pieces/")
         assert response.status_code == 200


### PR DESCRIPTION
Optimize piece list/detail queries

This removes the per-row state lookup waterfall from piece responses by using prefetched history when it is already available.

Changes:
- Cache-aware `Piece.current_state` and serializer adjacent-state lookups
- Prefetch piece-state global-ref junction rows on the detail path and resolve them from cache before falling back to a direct lookup
- Separate summary vs detail queryset shapes so list responses stay lean
- Preserve owner-only write paths while keeping detail/read prefetches
- Add query-budget regressions for `/api/pieces/` and `/api/pieces/{id}/`

Validation:
- `rtk bazel test //...`
- `rtk bazel build --config=lint //...`

Closes #488
