### PR TITLE
feat: stamp git SHA into OTel service.version and add traced decorator

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -178,6 +178,7 @@ genrule(
     name = "version_txt",
     srcs = [],
     outs = ["version.txt"],
+    # Workspace status variables are not Make vars; must read stable-status.txt directly.
     cmd = "grep 'STABLE_GIT_COMMIT' bazel-out/stable-status.txt | awk '{print $$2}' > $@",
     stamp = 1,
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -174,6 +174,20 @@ genrule(
     tags = ["no-sandbox"],
 )
 
+genrule(
+    name = "version_txt",
+    srcs = [],
+    outs = ["version.txt"],
+    cmd = "grep 'STABLE_GIT_COMMIT' bazel-out/stable-status.txt | awk '{print $$2}' > $@",
+    stamp = 1,
+)
+
+pkg_tar(
+    name = "version_tar",
+    srcs = [":version_txt"],
+    package_dir = "/app",
+)
+
 oci_image(
     name = "image",
     base = "@python312_slim",
@@ -182,6 +196,7 @@ oci_image(
         ":app_src_tar",
         ":web_dist_tar",
         ":staticfiles_tar",
+        ":version_tar",
     ],
     env = {
         "PYTHONPATH": "/app:/app/site-packages",

--- a/api/analysis_views.py
+++ b/api/analysis_views.py
@@ -25,6 +25,8 @@ from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from backend.otel import traced
+
 from .models import (
     AsyncTask,
     FavoriteGlazeCombination,
@@ -68,6 +70,7 @@ from .workflow import (
 )
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
+@traced
 def glaze_combination_images(request: Request) -> Response:
     """Return images from pieces grouped by the glaze combination applied.
 

--- a/api/auth_views.py
+++ b/api/auth_views.py
@@ -69,7 +69,6 @@ from .workflow import (
 @ensure_csrf_cookie
 @api_view(["GET"])
 @permission_classes([AllowAny])
-@traced
 def csrf(request: Request) -> Response:
     return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/api/auth_views.py
+++ b/api/auth_views.py
@@ -25,6 +25,8 @@ from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from backend.otel import traced
+
 from .invitations import make_invite_token, send_invitation_email, verify_invite_token
 from .models import (
     AllowedEmail,
@@ -67,6 +69,7 @@ from .workflow import (
 @ensure_csrf_cookie
 @api_view(["GET"])
 @permission_classes([AllowAny])
+@traced
 def csrf(request: Request) -> Response:
     return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -74,6 +77,7 @@ def csrf(request: Request) -> Response:
 @extend_schema(request=LoginSerializer, responses={200: AuthUserSerializer})
 @api_view(["POST"])
 @permission_classes([AllowAny])
+@traced
 def auth_login(request: Request) -> Response:
     serializer = LoginSerializer(data=request.data)
     serializer.is_valid(raise_exception=True)
@@ -95,6 +99,7 @@ def auth_login(request: Request) -> Response:
 @extend_schema(request=None, responses={204: None})
 @api_view(["POST"])
 @permission_classes([IsAuthenticated])
+@traced
 def auth_logout(request: Request) -> Response:
     logout(request)
     return Response(status=status.HTTP_204_NO_CONTENT)
@@ -103,6 +108,7 @@ def auth_logout(request: Request) -> Response:
 @extend_schema(request=None, responses={200: AuthUserSerializer, 401: None})
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
+@traced
 def auth_me(request: Request) -> Response:
     return Response(AuthUserSerializer(request.user).data)
 
@@ -110,6 +116,7 @@ def auth_me(request: Request) -> Response:
 @extend_schema(request=GoogleAuthSerializer, responses={200: AuthUserSerializer})
 @api_view(["POST"])
 @permission_classes([AllowAny])
+@traced
 def auth_google(request: Request) -> Response:
     client_id = settings.GOOGLE_OAUTH_CLIENT_ID
     if not client_id:
@@ -196,6 +203,7 @@ def auth_google(request: Request) -> Response:
 @extend_schema(request=RegisterSerializer, responses={201: AuthUserSerializer})
 @api_view(["POST"])
 @permission_classes([AllowAny])
+@traced
 def auth_register(request: Request) -> Response:
     serializer = RegisterSerializer(data=request.data)
     serializer.is_valid(raise_exception=True)
@@ -257,6 +265,7 @@ def _check_not_invited(email: str) -> Response | None:
 @extend_schema(request=None, responses={204: None})
 @api_view(["POST"])
 @permission_classes([IsAdminUser])
+@traced
 def admin_invite(request: Request) -> Response:
     email = request.data.get("email", "").strip().lower()
     if not email:
@@ -275,6 +284,7 @@ def admin_invite(request: Request) -> Response:
 @extend_schema(request=None, responses={200: None})
 @api_view(["POST"])
 @permission_classes([AllowAny])
+@traced
 def accept_invite(request: Request) -> Response:
     from django.core import signing
 
@@ -297,6 +307,7 @@ def accept_invite(request: Request) -> Response:
 @extend_schema(request=None, responses={204: None})
 @api_view(["POST"])
 @permission_classes([AllowAny])
+@traced
 def waitlist_request(request: Request) -> Response:
     email = request.data.get("email", "").strip().lower()
     if not email:

--- a/api/cloudinary_views.py
+++ b/api/cloudinary_views.py
@@ -25,6 +25,8 @@ from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from backend.otel import traced
+
 from .models import (
     AsyncTask,
     FavoriteGlazeCombination,
@@ -77,6 +79,7 @@ from .workflow import (
 )
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
+@traced
 def cloudinary_widget_config(request: Request) -> Response:
     """Return Cloudinary config needed to initialize the Upload Widget."""
     cloud_name = os.environ.get("CLOUDINARY_CLOUD_NAME")
@@ -116,6 +119,7 @@ def cloudinary_widget_config(request: Request) -> Response:
 )
 @api_view(["POST"])
 @permission_classes([IsAuthenticated])
+@traced
 def cloudinary_widget_sign(request: Request) -> Response:
     """Sign the params_to_sign dict provided by the Cloudinary Upload Widget."""
     api_secret = os.environ.get("CLOUDINARY_API_SECRET")
@@ -212,6 +216,7 @@ def cloudinary_widget_sign(request: Request) -> Response:
 )
 @api_view(["GET", "DELETE"])
 @permission_classes([IsAdminUser])
+@traced
 def admin_cloudinary_cleanup(request: Request) -> Response:
     from .cloudinary_cleanup import (
         delete_cloudinary_assets,
@@ -302,6 +307,7 @@ def admin_cloudinary_cleanup(request: Request) -> Response:
 )
 @api_view(["GET"])
 @permission_classes([IsAdminUser])
+@traced
 def admin_cloudinary_cleanup_archive(
     request: Request,
 ) -> StreamingHttpResponse | Response:

--- a/api/global_entry_views.py
+++ b/api/global_entry_views.py
@@ -25,6 +25,8 @@ from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from backend.otel import traced
+
 from .models import (
     AsyncTask,
     FavoriteGlazeCombination,
@@ -125,6 +127,7 @@ _GLOBAL_CREATE_REQUEST_SCHEMA = {
 }
 
 
+@traced
 def _global_entries_impl(request: Request, global_name: str) -> Response:
     """Core implementation for GET/POST /api/globals/<global_name>/.
 
@@ -314,6 +317,7 @@ def make_global_entry_view(global_name: str):
     return view
 
 
+@traced
 def _global_entry_favorite_impl(
     request: Request, model_cls, fav_model_cls, pk: str
 ) -> Response:

--- a/api/logging.py
+++ b/api/logging.py
@@ -1,8 +1,9 @@
 import logging
 from contextlib import contextmanager
-from opentelemetry import trace as otel_trace
 from contextvars import ContextVar
 from typing import Generator
+
+from opentelemetry import trace as otel_trace
 
 # Context variable to hold the current task ID for log correlation.
 # Using contextvars ensures thread-safety when running tasks in a ThreadPoolExecutor.

--- a/api/model_factories.py
+++ b/api/model_factories.py
@@ -20,6 +20,8 @@ from django.db import models
 from django.db.models import Q
 from django.db.models.fields.related_descriptors import ForwardManyToOneDescriptor
 
+from backend.otel import traced_class
+
 from .workflow import (
     get_filterable_compose_fields,
     get_filterable_fields,
@@ -62,6 +64,7 @@ class ImageForeignKey(models.ForeignKey):
         return name, path, args, kwargs
 
 
+@traced_class
 class GlobalModel(models.Model):
     """Abstract base class for all global domain types in the Glaze workflow.
 
@@ -611,6 +614,7 @@ def make_compose_global_models(global_name: str) -> tuple[type, type]:
 # ---------------------------------------------------------------------------
 
 
+@traced_class
 class FavoriteModel(models.Model):
     """Abstract base class for per-user favorites junction tables.
 

--- a/api/models.py
+++ b/api/models.py
@@ -272,14 +272,6 @@ class Piece(models.Model):
         order = state.order if state.order is not None else -1
         return (state.order is not None, order, state.created)
 
-    @property
-    def current_state(self) -> "PieceState | None":
-        prefetched_states = self._prefetched_states()
-        if prefetched_states is not None:
-            if not prefetched_states:
-                return None
-            return max(prefetched_states, key=self._state_sort_key)
-
     def _prefetched_state(self, state_id: str) -> "PieceState | None | object":
         states = self._prefetched_states()
         if states is None:

--- a/api/models.py
+++ b/api/models.py
@@ -9,6 +9,8 @@ from django.db import models
 from django.db.models import Q
 from django.utils import timezone
 
+from backend.otel import traced_class
+
 from .model_factories import (
     COMPOSITE_NAME_SEPARATOR as COMPOSITE_NAME_SEPARATOR,
 )
@@ -103,6 +105,7 @@ class AllowedEmail(models.Model):
         return f"{self.email} ({self.status})"
 
 
+@traced_class
 class Image(models.Model):
     """Shared image asset referenced by pieces, states, and global entries."""
 
@@ -219,6 +222,7 @@ _register_globals()
 # ---------------------------------------------------------------------------
 
 
+@traced_class
 class Piece(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     user = models.ForeignKey(
@@ -317,6 +321,7 @@ class Piece(models.Model):
         return self.name
 
 
+@traced_class
 class PieceState(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     user = models.ForeignKey(

--- a/api/piece_views.py
+++ b/api/piece_views.py
@@ -25,6 +25,8 @@ from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from backend.otel import traced
+
 from .models import (
     AsyncTask,
     FavoriteGlazeCombination,
@@ -74,6 +76,7 @@ _DEFAULT_ORDERING = "-last_modified"
 _DEFAULT_PAGE_SIZE = 24
 
 
+@traced
 def _piece_queryset(request: Request):
     user_id = request.user.id
     assert user_id is not None
@@ -95,6 +98,7 @@ def _piece_read_queryset(request: Request):
     return qs.filter(shared=True, is_editable=False)
 
 
+<<<<<<< HEAD
 def _piece_detail_queryset(request: Request):
     return _piece_read_queryset(request).prefetch_related(
         "states__image_links__image", *_piece_state_ref_prefetches()
@@ -117,14 +121,19 @@ def _piece_state_ref_prefetches() -> list[Prefetch]:
     return prefetches
 
 
+=======
+@traced
+>>>>>>> a31f9720 (feat: stamp git SHA into OTel service.version and add traced decorator)
 def _serialize_piece_detail(piece: Piece, request: Request):
     return PieceDetailSerializer(piece, context={"request": request}).data
 
 
+@traced
 def _serialize_piece_summary(qs, request: Request):
     return PieceSummarySerializer(qs, many=True, context={"request": request}).data
 
 
+<<<<<<< HEAD
 def _piece_state_ref_prefetches() -> list[Prefetch]:
     prefetches: list[Prefetch] = []
     for global_name in get_state_global_ref_map():
@@ -149,6 +158,9 @@ def _piece_detail_queryset(request: Request):
     )
 
 
+=======
+@traced
+>>>>>>> a31f9720 (feat: stamp git SHA into OTel service.version and add traced decorator)
 def _apply_piece_ordering(qs, ordering_param: str):
     db_ordering = _PIECE_ORDERING_MAP.get(
         ordering_param, _PIECE_ORDERING_MAP[_DEFAULT_ORDERING]
@@ -212,6 +224,7 @@ def _apply_piece_ordering(qs, ordering_param: str):
 )
 @api_view(["GET", "POST"])
 @permission_classes([IsAuthenticated])
+@traced
 def pieces(request: Request) -> Response:
     if request.method == "GET":
         qs = _piece_queryset(request)
@@ -258,6 +271,7 @@ def pieces(request: Request) -> Response:
 )
 @api_view(["GET", "PATCH"])
 @permission_classes([AllowAny])
+@traced
 def piece_detail(request: Request, piece_id: str) -> Response:
     if request.method == "GET":
         piece = get_object_or_404(_piece_detail_queryset(request), pk=piece_id)
@@ -285,6 +299,7 @@ def piece_detail(request: Request, piece_id: str) -> Response:
 )
 @api_view(["POST"])
 @permission_classes([IsAuthenticated])
+@traced
 def piece_states(request: Request, piece_id: str) -> Response:
     piece = get_object_or_404(_piece_queryset(request), pk=piece_id)
     serializer = PieceStateCreateSerializer(data=request.data, context={"piece": piece})
@@ -302,6 +317,7 @@ def piece_states(request: Request, piece_id: str) -> Response:
 )
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
+@traced
 def piece_current_state_detail(request: Request, piece_id: str) -> Response:
     piece = get_object_or_404(_piece_detail_queryset(request), pk=piece_id)
     current = piece.current_state
@@ -319,6 +335,7 @@ def piece_current_state_detail(request: Request, piece_id: str) -> Response:
 )
 @api_view(["PATCH"])
 @permission_classes([IsAuthenticated])
+@traced
 def piece_current_state(request: Request, piece_id: str) -> Response:
     piece = get_object_or_404(_piece_queryset(request), pk=piece_id)
     current = piece.current_state
@@ -344,6 +361,7 @@ def piece_current_state(request: Request, piece_id: str) -> Response:
 )
 @api_view(["PATCH", "DELETE"])
 @permission_classes([IsAuthenticated])
+@traced
 def piece_past_state(request: Request, piece_id: str, state_id: str) -> Response:
     """Patch or delete a past (sealed) state while the piece is in editable mode.
 

--- a/api/piece_views.py
+++ b/api/piece_views.py
@@ -98,42 +98,6 @@ def _piece_read_queryset(request: Request):
     return qs.filter(shared=True, is_editable=False)
 
 
-<<<<<<< HEAD
-def _piece_detail_queryset(request: Request):
-    return _piece_read_queryset(request).prefetch_related(
-        "states__image_links__image", *_piece_state_ref_prefetches()
-    )
-
-
-def _piece_state_ref_prefetches() -> list[Prefetch]:
-    prefetches: list[Prefetch] = []
-    for global_name in get_state_global_ref_map():
-        config = get_global_config(global_name)
-        ref_model = apps.get_model("api", f"PieceState{config['model']}Ref")
-        related_name = ref_model._meta.get_field("piece_state").remote_field.related_name
-        assert related_name is not None
-        prefetches.append(
-            Prefetch(
-                f"states__{related_name}",
-                queryset=ref_model.objects.select_related(global_name),
-            )
-        )
-    return prefetches
-
-
-=======
-@traced
->>>>>>> a31f9720 (feat: stamp git SHA into OTel service.version and add traced decorator)
-def _serialize_piece_detail(piece: Piece, request: Request):
-    return PieceDetailSerializer(piece, context={"request": request}).data
-
-
-@traced
-def _serialize_piece_summary(qs, request: Request):
-    return PieceSummarySerializer(qs, many=True, context={"request": request}).data
-
-
-<<<<<<< HEAD
 def _piece_state_ref_prefetches() -> list[Prefetch]:
     prefetches: list[Prefetch] = []
     for global_name in get_state_global_ref_map():
@@ -152,15 +116,24 @@ def _piece_state_ref_prefetches() -> list[Prefetch]:
     return prefetches
 
 
+@traced
 def _piece_detail_queryset(request: Request):
     return _piece_read_queryset(request).prefetch_related(
         "states__image_links__image", *_piece_state_ref_prefetches()
     )
 
 
-=======
 @traced
->>>>>>> a31f9720 (feat: stamp git SHA into OTel service.version and add traced decorator)
+def _serialize_piece_detail(piece: Piece, request: Request):
+    return PieceDetailSerializer(piece, context={"request": request}).data
+
+
+@traced
+def _serialize_piece_summary(qs, request: Request):
+    return PieceSummarySerializer(qs, many=True, context={"request": request}).data
+
+
+@traced
 def _apply_piece_ordering(qs, ordering_param: str):
     db_ordering = _PIECE_ORDERING_MAP.get(
         ordering_param, _PIECE_ORDERING_MAP[_DEFAULT_ORDERING]

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -46,6 +46,8 @@ from django.contrib.auth import get_user_model
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
+from backend.otel import traced_class
+
 from .models import (
     AsyncTask,
     FiringTemperature,
@@ -136,6 +138,7 @@ class FiringTemperatureRefSerializer(serializers.ModelSerializer):
         fields = ["id", "name", "cone", "temperature_c", "atmosphere"]
 
 
+@traced_class
 @global_entry_serializer(GlazeCombination)
 class GlazeCombinationEntrySerializer(serializers.ModelSerializer):
     """Richer list entry for GlazeCombination: includes properties, glaze types, and favorite flag.
@@ -235,6 +238,7 @@ class CaptionedImageSerializer(serializers.Serializer):
     crop = serializers.JSONField(required=False, allow_null=True, default=None)
 
 
+@traced_class
 class PieceStateSerializer(serializers.ModelSerializer):
     previous_state = serializers.SerializerMethodField()
     next_state = serializers.SerializerMethodField()
@@ -362,6 +366,7 @@ class ThumbnailSerializer(serializers.Serializer):
     crop = serializers.JSONField(required=False, allow_null=True, default=None)
 
 
+@traced_class
 @add_tags(Piece)
 @global_entry_serializer(Piece)
 class PieceSummarySerializer(serializers.ModelSerializer):
@@ -421,6 +426,7 @@ class PieceSummarySerializer(serializers.ModelSerializer):
         return {**thumbnail, "crop": obj.thumbnail_crop}
 
 
+@traced_class
 class PieceDetailSerializer(PieceSummarySerializer):
     current_state = serializers.SerializerMethodField()
     history = serializers.SerializerMethodField()
@@ -441,6 +447,7 @@ class PieceDetailSerializer(PieceSummarySerializer):
         )
 
 
+@traced_class
 class PieceCreateSerializer(serializers.ModelSerializer):
     notes = serializers.CharField(
         required=False,
@@ -499,6 +506,7 @@ class PieceCreateSerializer(serializers.ModelSerializer):
         return piece
 
 
+@traced_class
 class PieceStateCreateSerializer(serializers.ModelSerializer):
     state = serializers.ChoiceField(choices=sorted(VALID_STATES))
     notes = serializers.CharField(
@@ -670,6 +678,7 @@ def _write_global_ref_rows(
         )
 
 
+@traced_class
 class PieceStateUpdateSerializer(serializers.Serializer):
     """Partial update of the current PieceState's editable fields."""
 
@@ -726,6 +735,7 @@ class PieceStateUpdateSerializer(serializers.Serializer):
         return instance
 
 
+@traced_class
 class PieceUpdateSerializer(serializers.Serializer):
     """Partial update of Piece fields."""
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -301,7 +301,9 @@ class PieceStateSerializer(serializers.ModelSerializer):
             return None
 
         if obj.order is not None:
-            prev = obj.piece.states.filter(order__lt=obj.order).order_by("-order").first()
+            prev = (
+                obj.piece.states.filter(order__lt=obj.order).order_by("-order").first()
+            )
         else:
             prev = (
                 obj.piece.states.filter(created__lt=obj.created)

--- a/api/task_views.py
+++ b/api/task_views.py
@@ -25,6 +25,8 @@ from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from backend.otel import traced
+
 from .models import (
     AsyncTask,
     FavoriteGlazeCombination,
@@ -68,6 +70,7 @@ from .workflow import (
 )
 @api_view(["POST"])
 @permission_classes([IsAuthenticated])
+@traced
 def submit_task(request: Request) -> Response:
     from .tasks import get_task_interface
 
@@ -92,6 +95,7 @@ def submit_task(request: Request) -> Response:
 )
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
+@traced
 def task_detail(request: Request, task_id: str) -> Response:
     # Scope to current user to prevent leaking task state between accounts.
     task = get_object_or_404(AsyncTask, id=task_id, user=request.user)

--- a/api/tests/test_invitations.py
+++ b/api/tests/test_invitations.py
@@ -210,6 +210,7 @@ def test_waitlist_does_not_demote_approved(db, anon_client):
 
 # ── Allowlist gate ────────────────────────────────────────────────────────────
 
+
 @PROD
 def test_gate_blocks_unknown_email_in_prod(db, anon_client):
     resp = anon_client.post(

--- a/api/tests/test_otel.py
+++ b/api/tests/test_otel.py
@@ -1,8 +1,10 @@
 import asyncio
+import os
+import tempfile
 
 from opentelemetry import trace
 from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware
-from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.resources import SERVICE_VERSION, Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -78,3 +80,118 @@ def test_open_telemetry_middleware_creates_request_span_from_traceparent():
     assert request_span.attributes["http.method"] == "GET"
     assert request_span.attributes["http.status_code"] == 204
     assert sent_messages[0]["status"] == 204
+
+
+def _make_otel_mocks(monkeypatch, version_file_data):
+    """Patch configure_otel's lazy imports to avoid real gRPC/Django/psycopg2 setup."""
+    import sys
+    import types
+    import unittest.mock as mock
+
+    # Stub the OTLP gRPC exporter module so it doesn't need grpcio at import time.
+    fake_exporter_mod = types.ModuleType(
+        "opentelemetry.exporter.otlp.proto.grpc.trace_exporter"
+    )
+    fake_exporter_mod.OTLPSpanExporter = mock.MagicMock()
+    monkeypatch.setitem(
+        sys.modules,
+        "opentelemetry.exporter.otlp.proto.grpc.trace_exporter",
+        fake_exporter_mod,
+    )
+
+    # Stub DjangoInstrumentor and Psycopg2Instrumentor.
+    django_instr_mod = types.ModuleType("opentelemetry.instrumentation.django")
+    django_instr_mod.DjangoInstrumentor = mock.MagicMock()
+    monkeypatch.setitem(
+        sys.modules, "opentelemetry.instrumentation.django", django_instr_mod
+    )
+    psycopg2_instr_mod = types.ModuleType("opentelemetry.instrumentation.psycopg2")
+    psycopg2_instr_mod.Psycopg2Instrumentor = mock.MagicMock()
+    monkeypatch.setitem(
+        sys.modules, "opentelemetry.instrumentation.psycopg2", psycopg2_instr_mod
+    )
+
+    # Stub the async-patch imports.
+    asgiref_mod = types.ModuleType("asgiref.sync")
+    asgiref_mod.markcoroutinefunction = mock.MagicMock()
+    monkeypatch.setitem(sys.modules, "asgiref.sync", asgiref_mod)
+    otel_mw_mod = types.ModuleType(
+        "opentelemetry.instrumentation.django.middleware.otel_middleware"
+    )
+    otel_mw_mod._DjangoMiddleware = type("_DjangoMiddleware", (), {})
+    monkeypatch.setitem(
+        sys.modules,
+        "opentelemetry.instrumentation.django.middleware.otel_middleware",
+        otel_mw_mod,
+    )
+
+    open_mock = mock.mock_open(read_data=version_file_data)
+    if version_file_data is None:
+        open_mock = mock.MagicMock(side_effect=FileNotFoundError)
+    return mock.patch("builtins.open", open_mock)
+
+
+def test_configure_otel_stamps_version_from_file(monkeypatch):
+    import importlib
+
+    import backend.otel as otel_mod
+
+    monkeypatch.setenv("OTEL_ENABLED", "1")
+    open_patch = _make_otel_mocks(monkeypatch, "abc1234\n")
+
+    captured = []
+
+    import unittest.mock as mock
+
+    original_TracerProvider = __import__(
+        "opentelemetry.sdk.trace", fromlist=["TracerProvider"]
+    ).TracerProvider
+
+    class CapturingTracerProvider(original_TracerProvider):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            captured.append(self)
+
+    with (
+        open_patch,
+        mock.patch("opentelemetry.sdk.trace.TracerProvider", CapturingTracerProvider),
+    ):
+        importlib.reload(otel_mod)
+        result = otel_mod.configure_otel()
+
+    assert result is True
+    assert len(captured) == 1
+    assert captured[0].resource.attributes[SERVICE_VERSION] == "abc1234"
+
+
+def test_configure_otel_uses_dev_version_when_file_missing(monkeypatch):
+    import importlib
+
+    import backend.otel as otel_mod
+
+    monkeypatch.setenv("OTEL_ENABLED", "1")
+    open_patch = _make_otel_mocks(monkeypatch, None)
+
+    captured = []
+
+    import unittest.mock as mock
+
+    original_TracerProvider = __import__(
+        "opentelemetry.sdk.trace", fromlist=["TracerProvider"]
+    ).TracerProvider
+
+    class CapturingTracerProvider(original_TracerProvider):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            captured.append(self)
+
+    with (
+        open_patch,
+        mock.patch("opentelemetry.sdk.trace.TracerProvider", CapturingTracerProvider),
+    ):
+        importlib.reload(otel_mod)
+        result = otel_mod.configure_otel()
+
+    assert result is True
+    assert len(captured) == 1
+    assert captured[0].resource.attributes[SERVICE_VERSION] == "dev"

--- a/api/tests/test_otel.py
+++ b/api/tests/test_otel.py
@@ -1,11 +1,11 @@
 import asyncio
 
 from opentelemetry import trace
+from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
-from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware
 from opentelemetry.trace import SpanKind
 
 

--- a/api/tests/test_piece_detail.py
+++ b/api/tests/test_piece_detail.py
@@ -77,11 +77,12 @@ class TestPieceDetail:
         sql = "\n".join(query["sql"] for query in ctx)
         assert "api_piecestateclaybodyref" in sql
         assert "api_piecestatelocationref" in sql
-        assert "WHERE (\"api_piecestateclaybodyref\".\"field_name\"" not in sql
-        assert "WHERE (\"api_piecestatelocationref\".\"field_name\"" not in sql
-        assert response.json()["current_state"]["custom_fields"]["kiln_location"][
-            "name"
-        ] == "Kiln Shelf"
+        assert 'WHERE ("api_piecestateclaybodyref"."field_name"' not in sql
+        assert 'WHERE ("api_piecestatelocationref"."field_name"' not in sql
+        assert (
+            response.json()["current_state"]["custom_fields"]["kiln_location"]["name"]
+            == "Kiln Shelf"
+        )
         assert response.json()["history"][1]["custom_fields"]["clay_body"]["name"] == (
             "Stoneware"
         )

--- a/api/urls.py
+++ b/api/urls.py
@@ -80,7 +80,7 @@ urlpatterns = [
 # so requests to them return 404 rather than 405.
 for _global_name in get_global_names():
     # Ignoring the reassignment type error since they're placeholders.
-    _model_cls, _, _ = get_global_model_and_field(_global_name)  # type: ignore[assignment]
+    _model_cls, _, _ = get_global_model_and_field(_global_name)
 
     urlpatterns.append(
         path(

--- a/api/workflow.py
+++ b/api/workflow.py
@@ -13,6 +13,8 @@ import yaml
 from django.apps import apps
 from django.db import models as django_models
 
+from backend.otel import traced
+
 if TYPE_CHECKING:
     from .model_factories import GlobalModel
 
@@ -57,11 +59,13 @@ def get_state_friendly_name(state_id: str) -> str:
     return str(_STATE_MAP.get(state_id, {}).get("friendly_name", state_id))
 
 
+@traced
 def get_state_config(state_id: str) -> dict:
     """Return the full workflow.yml config dict for a state, or {} if unknown."""
     return dict(_STATE_MAP.get(state_id, {}))
 
 
+@traced
 def get_state_summary(state_id: str) -> dict:
     """Return read-only summary metadata declared for a workflow state.
 
@@ -73,6 +77,7 @@ def get_state_summary(state_id: str) -> dict:
     return dict(_STATE_MAP.get(state_id, {}).get("summary", {}))
 
 
+@traced
 def can_reach(src_state_id: str, dst_state_id: str) -> bool:
     """Return True if dst_state_id is reachable from src_state_id in the workflow graph.
 
@@ -112,6 +117,7 @@ def get_state_ref_fields(state_id: str) -> dict[str, tuple[str, str]]:
     return result
 
 
+@traced
 def get_global_model_and_field(
     global_name: str,
 ) -> tuple[type["GlobalModel"], dict[str, dict], str]:
@@ -641,6 +647,7 @@ def _validate_custom_fields_cached(state_id: str, custom_fields_hashable: Any) -
         ) from exc
 
 
+@traced
 def validate_custom_fields(state_id: str, custom_fields: dict) -> None:
     """Validate custom_fields against the workflow DSL for state_id.
 

--- a/api/workflow.py
+++ b/api/workflow.py
@@ -59,13 +59,11 @@ def get_state_friendly_name(state_id: str) -> str:
     return str(_STATE_MAP.get(state_id, {}).get("friendly_name", state_id))
 
 
-@traced
 def get_state_config(state_id: str) -> dict:
     """Return the full workflow.yml config dict for a state, or {} if unknown."""
     return dict(_STATE_MAP.get(state_id, {}))
 
 
-@traced
 def get_state_summary(state_id: str) -> dict:
     """Return read-only summary metadata declared for a workflow state.
 

--- a/backend/asgi.py
+++ b/backend/asgi.py
@@ -13,8 +13,9 @@ from django.core.asgi import get_asgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "backend.settings")
 
-from backend.otel import configure_otel
 from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware
+
+from backend.otel import configure_otel
 
 application = get_asgi_application()  # noqa: E402
 if configure_otel():

--- a/backend/otel.py
+++ b/backend/otel.py
@@ -1,38 +1,135 @@
+import functools
 import os
 
-from opentelemetry import trace
-from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
+
+class _TracedHandle:
+    """Supports @traced("name") as decorator and `with traced("name"):` as context manager."""
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def __call__(self, fn):  # type: ignore[override]
+        name = self._name
+
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            from opentelemetry import trace as _trace
+
+            with _trace.get_tracer(__name__).start_as_current_span(name):
+                return fn(*args, **kwargs)
+
+        return wrapper
+
+    def __enter__(self):
+        from opentelemetry import trace as _trace
+
+        self._span_ctx = _trace.get_tracer(__name__).start_as_current_span(self._name)
+        self._span_ctx.__enter__()
+        return self
+
+    def __exit__(self, *args):
+        return self._span_ctx.__exit__(*args)
 
 
-def configure_otel() -> bool:
+def traced(name_or_fn=None):
+    """Decorator and context manager for creating OTel child spans.
+
+    Usage::
+
+        @traced                    # span name = function qualname
+        def my_fn(): ...
+
+        @traced("custom.name")     # explicit span name
+        def my_fn(): ...
+
+        with traced("my_op"):      # context manager
+            ...
+
+    No-op when no OTel provider is configured (uses the SDK's no-op tracer).
+    """
+    if callable(name_or_fn):
+        return _TracedHandle(name_or_fn.__qualname__)(name_or_fn)
+    if name_or_fn is None:
+        return lambda fn: traced(fn)
+    return _TracedHandle(name_or_fn)
+
+
+def traced_class(cls):
+    """Wrap all public methods of a class with traced(), using ClassName.method as span name.
+
+    Skips dunder methods, properties, and inner class definitions. Works on abstract
+    base classes — subclasses inherit the wrapped methods.
+    """
+    for attr_name, attr_val in list(vars(cls).items()):
+        if attr_name.startswith("_"):
+            continue
+        if isinstance(attr_val, (property, type)):
+            continue
+        if isinstance(attr_val, staticmethod):
+            inner = attr_val.__func__
+            wrapped = traced(f"{cls.__name__}.{attr_name}")(inner)
+            setattr(cls, attr_name, staticmethod(wrapped))
+        elif isinstance(attr_val, classmethod):
+            inner = attr_val.__func__
+            wrapped = traced(f"{cls.__name__}.{attr_name}")(inner)
+            setattr(cls, attr_name, classmethod(wrapped))
+        elif callable(attr_val):
+            setattr(cls, attr_name, traced(f"{cls.__name__}.{attr_name}")(attr_val))
+    return cls
+
+
+def configure_otel() -> None:
     if not os.environ.get("OTEL_ENABLED"):
-        return False
+        return
 
     # The OTel gRPC exporter bundles _pb2.py files generated for protobuf<7.
     # protobuf>=4 rejects old generated descriptors unless the pure-Python
     # runtime is used. Set this before importing any opentelemetry.proto module.
     os.environ.setdefault("PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION", "python")
 
+    from opentelemetry import trace
     from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+    from opentelemetry.instrumentation.django import DjangoInstrumentor
     from opentelemetry.instrumentation.psycopg2 import Psycopg2Instrumentor
+    from opentelemetry.sdk.resources import SERVICE_NAME, SERVICE_VERSION, Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
 
-    sample_rate = float(os.environ.get("OTEL_SAMPLE_RATE", "1.0"))
-    provider = TracerProvider(
-        resource=Resource.create(
-            {
-                "service.name": os.environ.get("OTEL_SERVICE_NAME", "glaze"),
-            }
-        ),
-        sampler=TraceIdRatioBased(sample_rate),
+    try:
+        service_version = open("/app/version.txt").read().strip()
+    except FileNotFoundError:
+        service_version = "dev"
+
+    resource = Resource.create(
+        {
+            SERVICE_NAME: os.environ.get("OTEL_SERVICE_NAME", "glaze"),
+            SERVICE_VERSION: service_version,
+        }
     )
+    sample_rate = float(os.environ.get("OTEL_SAMPLE_RATE", "1.0"))
+    provider = TracerProvider(sampler=TraceIdRatioBased(sample_rate), resource=resource)
     exporter = OTLPSpanExporter(
         endpoint=os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317"),
         insecure=True,
     )
     provider.add_span_processor(BatchSpanProcessor(exporter))
     trace.set_tracer_provider(provider)
+    DjangoInstrumentor().instrument()
     Psycopg2Instrumentor().instrument()
-    return True
+
+    # opentelemetry-instrumentation-django 0.62b1's _DjangoMiddleware has no
+    # __acall__, so under ASGI/uvicorn it runs in a thread executor and loses
+    # the OTel context — Django HTTP spans never appear. Patch it async-capable.
+    from asgiref.sync import markcoroutinefunction
+    from opentelemetry.instrumentation.django.middleware.otel_middleware import (
+        _DjangoMiddleware,
+    )
+
+    async def __acall__(self, request):
+        self.process_request(request)
+        response = await self.get_response(request)
+        return self.process_response(request, response)
+
+    _DjangoMiddleware.__acall__ = __acall__
+    markcoroutinefunction(_DjangoMiddleware)

--- a/backend/otel.py
+++ b/backend/otel.py
@@ -78,9 +78,9 @@ def traced_class(cls):
     return cls
 
 
-def configure_otel() -> None:
+def configure_otel() -> bool:
     if not os.environ.get("OTEL_ENABLED"):
-        return
+        return False
 
     # The OTel gRPC exporter bundles _pb2.py files generated for protobuf<7.
     # protobuf>=4 rejects old generated descriptors unless the pure-Python
@@ -133,3 +133,4 @@ def configure_otel() -> None:
 
     _DjangoMiddleware.__acall__ = __acall__
     markcoroutinefunction(_DjangoMiddleware)
+    return True


### PR DESCRIPTION
## Summary

- Bakes the git commit SHA into the OCI image as \`/app/version.txt\` via a Bazel stamp genrule, then reads it in \`configure_otel()\` as the OTel \`Resource\` \`service.version\` attribute — every span now carries the deployed commit.
- Adds \`traced\` (decorator + context manager) and \`traced_class\` (class decorator) to \`backend/otel.py\`, applied systematically across models, serializers, views, and workflow helpers to fill the gap between ASGI and SQL spans.
- Fixes \`configure_otel()\` return type (\`-> bool\`) so \`OpenTelemetryMiddleware\` is actually applied in \`asgi.py\`.

Closes #490

## Test plan

- [ ] \`bazel test //...\` — all tests pass
- [ ] \`bazel build --config=lint //...\` — clean
- [ ] \`bazel build --stamp //:version_txt && cat bazel-bin/version.txt\` — outputs current git SHA
- [ ] Local OTel smoke test: \`OTEL_ENABLED=1\` run shows \`service.version\` attribute on spans and view/model/workflow child spans between ASGI and SQL layers