### PR TITLE
chore: migrate Django logs from Logtail to Grafana Cloud via OTLP

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -44,7 +44,6 @@ jobs:
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
           CLOUDINARY_API_KEY: ${{ secrets.CLOUDINARY_API_KEY }}
           CLOUDINARY_API_SECRET: ${{ secrets.CLOUDINARY_API_SECRET }}
-          LOGTAIL_SOURCE_TOKEN: ${{ secrets.LOGTAIL_SOURCE_TOKEN }}
           MODAL_AUTH_TOKEN: ${{ secrets.MODAL_AUTH_TOKEN }}
           GRAFANA_CLOUD_OTLP_TOKEN: ${{ secrets.GRAFANA_CLOUD_OTLP_TOKEN }}
           ALLOWED_HOST: ${{ vars.ALLOWED_HOST }}

--- a/api/BUILD.bazel
+++ b/api/BUILD.bazel
@@ -40,7 +40,6 @@ py_library(
     deps = [
         ":api_workflow_lib",
         "//backend:backend_lib",
-        "@pypi//logtail_python",
     ],
 )
 

--- a/api/logging.py
+++ b/api/logging.py
@@ -27,8 +27,7 @@ def task_context(task_id: str) -> Generator[None, None, None]:
 class TaskCorrelationFilter(logging.Filter):
     """Logging filter that injects the current task_id into LogRecords.
 
-    This allows log formatters (and external aggregators like Logtail)
-    to group logs by background task.
+    This allows log aggregators to group logs by background task.
     """
 
     def filter(self, record: logging.LogRecord) -> bool:

--- a/api/tests/test_otel.py
+++ b/api/tests/test_otel.py
@@ -1,6 +1,11 @@
 import asyncio
+import importlib
+import logging
 import os
+import sys
 import tempfile
+import types
+import unittest.mock as mock
 
 from opentelemetry import trace
 from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware
@@ -82,13 +87,8 @@ def test_open_telemetry_middleware_creates_request_span_from_traceparent():
     assert sent_messages[0]["status"] == 204
 
 
-def _make_otel_mocks(monkeypatch, version_file_data):
+def _make_otel_mocks(monkeypatch, version_file_data=None):
     """Patch configure_otel's lazy imports to avoid real gRPC/Django/psycopg2 setup."""
-    import sys
-    import types
-    import unittest.mock as mock
-
-    # Stub the OTLP gRPC exporter module so it doesn't need grpcio at import time.
     fake_exporter_mod = types.ModuleType(
         "opentelemetry.exporter.otlp.proto.grpc.trace_exporter"
     )
@@ -99,22 +99,32 @@ def _make_otel_mocks(monkeypatch, version_file_data):
         fake_exporter_mod,
     )
 
-    # Stub DjangoInstrumentor and Psycopg2Instrumentor.
+    log_exporter_mod = types.ModuleType(
+        "opentelemetry.exporter.otlp.proto.grpc._log_exporter"
+    )
+    log_exporter_mod.OTLPLogExporter = mock.MagicMock()
+    monkeypatch.setitem(
+        sys.modules,
+        "opentelemetry.exporter.otlp.proto.grpc._log_exporter",
+        log_exporter_mod,
+    )
+
     django_instr_mod = types.ModuleType("opentelemetry.instrumentation.django")
     django_instr_mod.DjangoInstrumentor = mock.MagicMock()
     monkeypatch.setitem(
         sys.modules, "opentelemetry.instrumentation.django", django_instr_mod
     )
+
     psycopg2_instr_mod = types.ModuleType("opentelemetry.instrumentation.psycopg2")
     psycopg2_instr_mod.Psycopg2Instrumentor = mock.MagicMock()
     monkeypatch.setitem(
         sys.modules, "opentelemetry.instrumentation.psycopg2", psycopg2_instr_mod
     )
 
-    # Stub the async-patch imports.
     asgiref_mod = types.ModuleType("asgiref.sync")
     asgiref_mod.markcoroutinefunction = mock.MagicMock()
     monkeypatch.setitem(sys.modules, "asgiref.sync", asgiref_mod)
+
     otel_mw_mod = types.ModuleType(
         "opentelemetry.instrumentation.django.middleware.otel_middleware"
     )
@@ -125,23 +135,20 @@ def _make_otel_mocks(monkeypatch, version_file_data):
         otel_mw_mod,
     )
 
-    open_mock = mock.mock_open(read_data=version_file_data)
     if version_file_data is None:
         open_mock = mock.MagicMock(side_effect=FileNotFoundError)
+    else:
+        open_mock = mock.mock_open(read_data=version_file_data)
     return mock.patch("builtins.open", open_mock)
 
 
 def test_configure_otel_stamps_version_from_file(monkeypatch):
-    import importlib
-
     import backend.otel as otel_mod
 
     monkeypatch.setenv("OTEL_ENABLED", "1")
     open_patch = _make_otel_mocks(monkeypatch, "abc1234\n")
 
     captured = []
-
-    import unittest.mock as mock
 
     original_TracerProvider = __import__(
         "opentelemetry.sdk.trace", fromlist=["TracerProvider"]
@@ -165,16 +172,12 @@ def test_configure_otel_stamps_version_from_file(monkeypatch):
 
 
 def test_configure_otel_uses_dev_version_when_file_missing(monkeypatch):
-    import importlib
-
     import backend.otel as otel_mod
 
     monkeypatch.setenv("OTEL_ENABLED", "1")
     open_patch = _make_otel_mocks(monkeypatch, None)
 
     captured = []
-
-    import unittest.mock as mock
 
     original_TracerProvider = __import__(
         "opentelemetry.sdk.trace", fromlist=["TracerProvider"]
@@ -195,3 +198,35 @@ def test_configure_otel_uses_dev_version_when_file_missing(monkeypatch):
     assert result is True
     assert len(captured) == 1
     assert captured[0].resource.attributes[SERVICE_VERSION] == "dev"
+
+
+def test_configure_otel_registers_logging_handler(monkeypatch):
+    import backend.otel as otel_mod
+
+    monkeypatch.setenv("OTEL_ENABLED", "1")
+    open_patch = _make_otel_mocks(monkeypatch)
+
+    root = logging.getLogger()
+    handlers_before = list(root.handlers)
+
+    with open_patch:
+        importlib.reload(otel_mod)
+        result = otel_mod.configure_otel()
+
+    assert result is True
+    from opentelemetry.sdk._logs import LoggingHandler
+
+    new_handlers = [h for h in root.handlers if h not in handlers_before]
+    assert any(isinstance(h, LoggingHandler) for h in new_handlers)
+
+    # Remove handlers added during the test to avoid polluting other tests.
+    for h in new_handlers:
+        root.removeHandler(h)
+
+
+def test_configure_otel_returns_false_when_disabled(monkeypatch):
+    import backend.otel as otel_mod
+
+    monkeypatch.delenv("OTEL_ENABLED", raising=False)
+    importlib.reload(otel_mod)
+    assert otel_mod.configure_otel() is False

--- a/backend/otel.py
+++ b/backend/otel.py
@@ -1,4 +1,5 @@
 import functools
+import logging
 import os
 
 
@@ -115,6 +116,21 @@ def configure_otel() -> bool:
     )
     provider.add_span_processor(BatchSpanProcessor(exporter))
     trace.set_tracer_provider(provider)
+
+    from opentelemetry import _logs as otel_logs
+    from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
+    from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+    from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+
+    log_exporter = OTLPLogExporter(
+        endpoint=os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317"),
+        insecure=True,
+    )
+    log_provider = LoggerProvider(resource=resource)
+    log_provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter))
+    otel_logs.set_logger_provider(log_provider)
+    logging.getLogger().addHandler(LoggingHandler(level=logging.INFO, logger_provider=log_provider))
+
     DjangoInstrumentor().instrument()
     Psycopg2Instrumentor().instrument()
 

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -276,17 +276,6 @@ LOGGING = {
     },
 }
 
-LOGTAIL_SOURCE_TOKEN = os.environ.get("LOGTAIL_SOURCE_TOKEN")
-if LOGTAIL_SOURCE_TOKEN:
-    LOGGING["handlers"]["logtail"] = {
-        "class": "logtail.LogtailHandler",
-        "source_token": LOGTAIL_SOURCE_TOKEN,
-    }
-    LOGGING["root"]["handlers"].append("logtail")
-    LOGGING["loggers"]["django"]["handlers"].append("logtail")
-    LOGGING["loggers"]["django.request"]["handlers"].append("logtail")
-    LOGGING["loggers"]["api"]["handlers"].append("logtail")
-
 # Security settings
 SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
 SECURE_CROSS_ORIGIN_OPENER_POLICY = "same-origin-allow-popups"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ dependencies = [
     "lazy-loader==0.5",
     "librt==0.8.1",
     "llvmlite==0.47.0",
-    "logtail-python==0.3.4",
     "msgpack==1.1.2",
     "mypy==1.20.0",
     "mypy-extensions==1.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -481,7 +481,6 @@ dependencies = [
     { name = "lazy-loader" },
     { name = "librt" },
     { name = "llvmlite" },
-    { name = "logtail-python" },
     { name = "msgpack" },
     { name = "mypy" },
     { name = "mypy-extensions" },
@@ -586,7 +585,6 @@ requires-dist = [
     { name = "lazy-loader", specifier = "==0.5" },
     { name = "librt", specifier = "==0.8.1" },
     { name = "llvmlite", specifier = "==0.47.0" },
-    { name = "logtail-python", specifier = "==0.3.4" },
     { name = "msgpack", specifier = "==1.1.2" },
     { name = "mypy", specifier = "==1.20.0" },
     { name = "mypy-extensions", specifier = "==1.1.0" },
@@ -883,19 +881,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/4b/e3f2cd17822cf772a4a51a0a8080b0032e6d37b2dbe8cfb724eac4e31c52/llvmlite-0.47.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5853bf26160857c0c2573415ff4efe01c4c651e59e2c55c2a088740acfee51cd", size = 56275178, upload-time = "2026-03-31T18:28:48.342Z" },
     { url = "https://files.pythonhosted.org/packages/b6/55/a3b4a543185305a9bdf3d9759d53646ed96e55e7dfd43f53e7a421b8fbae/llvmlite-0.47.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:003bcf7fa579e14db59c1a1e113f93ab8a06b56a4be31c7f08264d1d4072d077", size = 55128632, upload-time = "2026-03-31T18:28:52.901Z" },
     { url = "https://files.pythonhosted.org/packages/2f/f5/d281ae0f79378a5a91f308ea9fdb9f9cc068fddd09629edc0725a5a8fde1/llvmlite-0.47.0-cp312-cp312-win_amd64.whl", hash = "sha256:f3079f25bdc24cd9d27c4b2b5e68f5f60c4fdb7e8ad5ee2b9b006007558f9df7", size = 38138692, upload-time = "2026-03-31T18:28:57.147Z" },
-]
-
-[[package]]
-name = "logtail-python"
-version = "0.3.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "msgpack" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/9a/15e146007507d6baddaf34d915e16bbd2d424a8722e8ffa9a41d31d6c92f/logtail_python-0.3.4.tar.gz", hash = "sha256:284fffda6b54892ce9a2d0cade04cd61b7a1900c01d583abbdfe0dfee366e1c3", size = 29517, upload-time = "2025-09-01T14:39:52.986Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/4a/c98428c52a92b9347c15b6ad987a76205112edea5bbb5d3223873e12e9d9/logtail_python-0.3.4-py2.py3-none-any.whl", hash = "sha256:db5cf6b93f8de2352904519d9502021d3af3a81e6a27336b45a62358b35bbc16", size = 8897, upload-time = "2025-09-01T14:39:51.694Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Removes `logtail-python` and all `LOGTAIL_SOURCE_TOKEN` references — BetterStack is no longer needed.
- In `configure_otel()`, stands up a `LoggerProvider` backed by `OTLPLogExporter` on the same gRPC endpoint already used for traces, and attaches a `LoggingHandler` to the root Python logger at INFO level. All Django/api logs now flow to Grafana Loki correlated with the active trace context via the existing `OtelTraceFilter`.
- No new dependencies — `opentelemetry-sdk==1.41.1` already ships `opentelemetry.sdk._logs` and the pinned grpc exporter already includes `OTLPLogExporter`.

Closes #493

## Test plan

- [ ] `bazel test //api:api_test //api:api_mypy` — all pass
- [ ] `bazel build --config=lint //...` — clean
- [ ] With `OTEL_ENABLED=1`, Django INFO logs appear in Grafana Loki correlated with `trace_id` from active spans
