### PR TITLE
fix: use uv sync and pin release deploys

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,18 +61,20 @@ jobs:
           envsubst < .env.production.template > /tmp/.env
           scp /tmp/.env "${{ vars.DEPLOY_HOST }}":~/glaze/.env
 
-      - name: Deploy
-        run: ./deploy.sh "${{ vars.DEPLOY_HOST }}" "${{ env.DEPLOY_SHA }}"
-
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release view "release-${{ env.DEPLOY_SHA }}" &>/dev/null || \
-          gh release create "release-${{ env.DEPLOY_SHA }}" \
-            --title "Build ${{ env.DEPLOY_SHA }}" \
-            --notes "Docker image: \`ghcr.io/shaoster/glaze:${{ env.DEPLOY_SHA }}\`" \
-            --latest
+          if gh release view "release-${{ env.DEPLOY_SHA }}" >/dev/null 2>&1; then
+            echo "Release release-${{ env.DEPLOY_SHA }} already exists"
+          else
+            gh release create "release-${{ env.DEPLOY_SHA }}" \
+              --title "Build ${{ env.DEPLOY_SHA }}" \
+              --notes "Docker image: \`ghcr.io/shaoster/glaze:${{ env.DEPLOY_SHA }}\`"
+          fi
+
+      - name: Deploy
+        run: ./deploy.sh "${{ vars.DEPLOY_HOST }}" "${{ env.DEPLOY_SHA }}"
 
   deploy-modal:
     name: Deploy ML Microservice to Modal

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -81,41 +81,47 @@ alias(
 # Image layout (all under /app):
 #   /app/                      Django project root (manage.py, backend/, api/, etc.)
 #   /app/web/dist/             Vite-built SPA (served by WhiteNoise at URL root)
-#   /app/site-packages/        pip-installed runtime deps (added to PYTHONPATH)
+#   /app/site-packages/        uv-synced runtime deps (added to PYTHONPATH)
 #   /app/staticfiles/          collected static assets (built by staticfiles_tar genrule)
 
-# pip deps layer — install runtime deps into /app/site-packages using the
-# Bazel-managed Python 3.12 toolchain. Tagged no-sandbox because pip needs
+# Dependency layer — sync runtime deps into a temp venv, then flatten its
+# site-packages into /app/site-packages. Tagged no-sandbox because uv needs
 # network access to download wheels.
 genrule(
     name = "python_layer_tar",
     srcs = [
         "//:pyproject.toml",
         "//:uv.lock",
-        "@uv//:uv",
     ],
+    tools = ["@uv//:uv"],
     outs = ["python_layer.tar"],
     cmd = """
         set -e
         export HOME=$$(mktemp -d)
-        UV=$(location @uv//:uv)
+        UV="$$PWD/$(location @uv//:uv)"
+        PYTHON3_ABS="$$PWD/$(PYTHON3)"
+        OUT_TAR="$$PWD/$@"
 
-        # Export uv.lock to requirements.txt
-        $$UV export --no-dev --format requirements.txt --output-file requirements.txt
-
+        work=$$(mktemp -d)
         dest=$$(mktemp -d)
-        $(PYTHON3) -m pip install \
-            --quiet \
-            --no-deps \
-            --prefix="$$dest" \
-            -r requirements.txt
+        cp $(location //:pyproject.toml) "$$work/pyproject.toml"
+        cp $(location //:uv.lock) "$$work/uv.lock"
+
+        # Sync only the locked runtime dependencies into an isolated venv.
+        cd "$$work"
+        $$UV sync \
+            --frozen \
+            --no-dev \
+            --no-install-project \
+            --no-editable \
+            --python "$$PYTHON3_ABS"
 
         # Flatten site-packages to /app/site-packages in the tarball.
-        sp=$$(find "$$dest" -type d -name site-packages | head -1)
+        sp=$$(find "$$work/.venv" -type d -name site-packages | head -1)
         mkdir -p "$$dest/app"
         mv "$$sp" "$$dest/app/site-packages"
-        tar -C "$$dest" -cf $@ app/site-packages
-        rm -rf "$$dest" "$$HOME"
+        tar -C "$$dest" -cf "$$OUT_TAR" app/site-packages
+        rm -rf "$$dest" "$$work" "$$HOME"
     """,
     toolchains = ["@rules_python//python:current_py_toolchain"],
     tags = ["no-sandbox"],

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
-# Deploy the latest image to a droplet running Docker Compose.
+# Deploy the image for a specific commit SHA to a droplet running Docker Compose.
 #
-# Usage: ./deploy.sh user@host [commit-sha]
+# Usage: ./deploy.sh user@host commit-sha
 #
-# commit-sha: the SHA to sync docker-compose.yml from. When omitted, the
-#             script reads org.opencontainers.image.revision from the image
-#             label (CI path). gz_deploy passes it explicitly (local path).
+# commit-sha: required commit SHA for the published release/image tag.
+#             gz_deploy passes it explicitly.
 #
 # Prerequisites on the droplet:
 #   - Docker + Docker Compose plugin installed
@@ -19,8 +18,8 @@
 # always in sync without having to update this script when new files are added.
 set -euo pipefail
 
-HOST=${1:?Usage: ./deploy.sh user@host [commit-sha]}
-KNOWN_SHA=${2:-}
+HOST=${1:?Usage: ./deploy.sh user@host commit-sha}
+KNOWN_SHA=${2:?Usage: ./deploy.sh user@host commit-sha}
 
 echo "--- deploying application ---"
 ssh "$HOST" bash <<REMOTE
@@ -32,48 +31,35 @@ if [[ ! -d ~/glaze/.git ]]; then
 fi
 cd ~/glaze
 
-echo "--- pulling latest images ---"
-docker compose pull
-
-echo "--- verifying image SHA ---"
-IMAGE_SHA=\$(docker inspect ghcr.io/shaoster/glaze:latest \
-    --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' 2>/dev/null || true)
-
 echo "--- syncing repo to image commit ---"
 SHA="${KNOWN_SHA}"
-if [[ -z "\$SHA" ]]; then
-    SHA="\$IMAGE_SHA"
-fi
-if [[ -z "\$SHA" ]]; then
-    echo "WARNING: commit SHA unknown, repo not updated"
-else
-    if [[ -n "\$IMAGE_SHA" && "\$IMAGE_SHA" != "\$SHA" ]]; then
-        echo "ERROR: pulled image was built from \$IMAGE_SHA but expected \$SHA"
-        echo "The registry may not have the image for this commit yet."
-        exit 1
-    fi
-    echo "Image built from commit \$SHA"
-    git fetch --quiet origin
-    DIRTY=\$(git status --short)
-    if [[ -n "\$DIRTY" ]]; then
-        echo "WARNING: discarding local modifications before checkout:"
-        echo "\$DIRTY"
-    fi
-    git restore --quiet .
-    git checkout --quiet "\$SHA"
-fi
+echo "Image built from commit \$SHA"
+git fetch --quiet origin
+git restore --quiet .
+git checkout --quiet "\$SHA"
+
+echo "--- rendering release compose override ---"
+cat > docker-compose.release.yml <<EOF
+services:
+  web:
+    image: ghcr.io/shaoster/glaze:${SHA}
+EOF
+
+echo "--- pulling release image ---"
+docker compose -f docker-compose.yml -f docker-compose.release.yml pull
 
 echo "--- restarting services ---"
 # --force-recreate ensures containers always pick up .env changes even when
 # the image and compose spec are unchanged (e.g. secret rotation).
-docker compose up -d --force-recreate
+docker compose -f docker-compose.yml -f docker-compose.release.yml up -d --force-recreate
 
 echo "--- pruning ---"
 docker container prune -f
 docker image prune -f
 
 echo "--- deploy complete ---"
-docker compose ps
+docker compose -f docker-compose.yml -f docker-compose.release.yml ps
+rm -f docker-compose.release.yml
 REMOTE
 
 # Nginx snippets are synced after a successful app deploy so a mid-deploy

--- a/env-agent.sh
+++ b/env-agent.sh
@@ -516,7 +516,7 @@ gz_deploy() {
     local sha
     sha=$(git -C "$GLAZE_ROOT" rev-parse HEAD) || return 1
     if [[ "${1:-}" != "--no-push" ]]; then
-        gz_push --latest || return $?
+        gz_push || return $?
     fi
     "$GLAZE_ROOT/deploy.sh" "$host" "$sha"
 }


### PR DESCRIPTION
This PR combines the image-layer dependency fix and the deployment hardening.

What changed
- Replaced the Bazel OCI image layer's `pip` install step with `uv sync` against `pyproject.toml` and `uv.lock`.
- Kept the runtime layer reproducible by using the Bazel-selected Python interpreter without any musl-specific wrapper logic.
- Updated CD so deployment is tied to the commit-specific release, not the mutable `latest` tag.
- Removed the `latest` default from local deploys so `gz_deploy` follows the same release correlation as CI/CD.

Why
- The previous image-layer flow mixed `uv` metadata with a `pip` install step, which made dependency reasoning inconsistent.
- The mutable `latest` tag made it possible for prod to drift from the intended commit/image pair.

Checks
- `rtk bazel test //...`
- `rtk bazel build --config=lint //...`
- `bash -n deploy.sh`
- `bash -n env-agent.sh`
