### PR TITLE
fix: pin deploy image tag in compose

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -60,20 +60,17 @@ jobs:
           envsubst < .env.production.template > /tmp/.env
           scp /tmp/.env "${{ vars.DEPLOY_HOST }}":~/glaze/.env
 
+      - name: Deploy
+        run: ./deploy.sh "${{ vars.DEPLOY_HOST }}" "${{ env.DEPLOY_SHA }}"
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if gh release view "release-${{ env.DEPLOY_SHA }}" >/dev/null 2>&1; then
-            echo "Release release-${{ env.DEPLOY_SHA }} already exists"
-          else
-            gh release create "release-${{ env.DEPLOY_SHA }}" \
-              --title "Build ${{ env.DEPLOY_SHA }}" \
-              --notes "Docker image: \`ghcr.io/shaoster/glaze:${{ env.DEPLOY_SHA }}\`"
-          fi
-
-      - name: Deploy
-        run: ./deploy.sh "${{ vars.DEPLOY_HOST }}" "${{ env.DEPLOY_SHA }}"
+          gh release view "release-${{ env.DEPLOY_SHA }}" >/dev/null 2>&1 || \
+          gh release create "release-${{ env.DEPLOY_SHA }}" \
+            --title "Build ${{ env.DEPLOY_SHA }}" \
+            --notes "Docker image: \`ghcr.io/shaoster/glaze:${{ env.DEPLOY_SHA }}\`"
 
   deploy-modal:
     name: Deploy ML Microservice to Modal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,8 @@ jobs:
         run: bazel run --config=ci --stamp //:load
 
       - name: Pre-pull sidecar images
+        env:
+          IMAGE_TAG: latest
         run: |
           # Pull third-party sidecar images (postgres, otelcol) before starting
           # the timed --wait block so image download doesn't eat into the
@@ -181,6 +183,8 @@ jobs:
           docker compose pull db otelcol
 
       - name: Smoke test via docker compose
+        env:
+          IMAGE_TAG: latest
         run: |
           set -euo pipefail
           export POSTGRES_PASSWORD=ci
@@ -200,6 +204,8 @@ jobs:
 
       - name: Tear down compose
         if: always()
+        env:
+          IMAGE_TAG: latest
         run: docker compose down -v --remove-orphans || true
 
       - name: Log in to GitHub Container Registry

--- a/deploy.sh
+++ b/deploy.sh
@@ -13,16 +13,16 @@
 #       docker login ghcr.io -u shaoster -p <PAT with read:packages>
 #
 # On first run this script clones the repo to ~/glaze (public repo, no key needed).
-# Subsequent deploys fetch the commit matching the deployed image so config files
-# (docker-compose.yml, otel-collector-config.yml, nginx/snippets/, etc.) are
-# always in sync without having to update this script when new files are added.
+# Subsequent deploys fetch the commit matching the deployed image, persist that
+# tag in ~/glaze/.env, and then restart Compose so later restarts keep using the
+# exact release image instead of drifting to a moving tag.
 set -euo pipefail
 
 HOST=${1:?Usage: ./deploy.sh user@host commit-sha}
 KNOWN_SHA=${2:?Usage: ./deploy.sh user@host commit-sha}
 
 echo "--- deploying application ---"
-ssh "$HOST" bash <<REMOTE
+ssh "$HOST" env KNOWN_SHA="$KNOWN_SHA" bash <<'REMOTE'
 set -euo pipefail
 
 echo "--- bootstrapping repo (no-op if already cloned) ---"
@@ -32,34 +32,36 @@ fi
 cd ~/glaze
 
 echo "--- syncing repo to image commit ---"
-SHA="${KNOWN_SHA}"
-echo "Image built from commit \$SHA"
+SHA="$KNOWN_SHA"
+echo "Image built from commit $SHA"
 git fetch --quiet origin
 git restore --quiet .
-git checkout --quiet "\$SHA"
+git checkout --quiet "$SHA"
 
-echo "--- rendering release compose override ---"
-cat > docker-compose.release.yml <<EOF
-services:
-  web:
-    image: ghcr.io/shaoster/glaze:${SHA}
-EOF
+echo "--- recording release tag in .env ---"
+env_tmp=$(mktemp .env.tmp.XXXXXX)
+trap 'rm -f "$env_tmp"' EXIT
+if [[ -f .env ]]; then
+    grep -v '^IMAGE_TAG=' .env > "$env_tmp" || true
+fi
+printf 'IMAGE_TAG=%s\n' "$SHA" >> "$env_tmp"
+mv "$env_tmp" .env
+trap - EXIT
 
 echo "--- pulling release image ---"
-docker compose -f docker-compose.yml -f docker-compose.release.yml pull
+docker compose pull
 
 echo "--- restarting services ---"
 # --force-recreate ensures containers always pick up .env changes even when
 # the image and compose spec are unchanged (e.g. secret rotation).
-docker compose -f docker-compose.yml -f docker-compose.release.yml up -d --force-recreate
+docker compose up -d --force-recreate
 
 echo "--- pruning ---"
 docker container prune -f
 docker image prune -f
 
 echo "--- deploy complete ---"
-docker compose -f docker-compose.yml -f docker-compose.release.yml ps
-rm -f docker-compose.release.yml
+docker compose ps
 REMOTE
 
 # Nginx snippets are synced after a successful app deploy so a mid-deploy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       retries: 10
 
   web:
-    image: ghcr.io/shaoster/glaze:latest
+    image: ghcr.io/shaoster/glaze:${IMAGE_TAG:?Set IMAGE_TAG in .env}
     restart: unless-stopped
     ports:
       - "127.0.0.1:8000:8000"


### PR DESCRIPTION
This PR fixes the deploy-tag drift and the compose interpolation failures.

What changed
- `docker-compose.yml` resolves the web image tag from `IMAGE_TAG` instead of hardcoding `latest`.
- `deploy.sh` is the single writer for `IMAGE_TAG` on the droplet and updates `~/glaze/.env` atomically before `docker compose up`.
- The CI image job sets `IMAGE_TAG=latest` for the sidecar pre-pull, smoke test, and teardown steps, which matches the locally loaded image from `bazel run //:load`.
- CD no longer writes `IMAGE_TAG` into the shipped `.env`, avoiding the duplicate write path.
- GitHub release creation remains after a successful deploy.

Why
- The previous version duplicated the `IMAGE_TAG` write in CD and in `deploy.sh`, which made the deploy state harder to reason about.
- The `.env` rewrite is now a single atomic update, which avoids temp-file collisions and partial writes.
- The CI compose lifecycle needs the locally loaded image tag, not the unreleased commit SHA.

Checks
- `rtk bazel test //...`
- `rtk bazel build --config=lint //...`
- `bash -n deploy.sh`
