### PR TITLE
Fix coverage audit native bindings and worktree support

### DIFF
--- a/.agents/skills/cover/SKILL.md
+++ b/.agents/skills/cover/SKILL.md
@@ -9,16 +9,29 @@ Use this skill to assess test coverage and create actionable tasks to improve it
 
 ## Automated Analysis
 
-Use the new coverage-analysis tool to turn LCOV output into a temporary `.gitignored` SQLite database, then query the database instead of scraping raw LCOV by hand. The sparse schema should make the common questions cheap to ask:
+The coverage-analysis tool ingests raw LCOV output from `bazel-testlogs` into a temporary SQLite database. This enables high-performance queries that track:
+- **Per-test `CoverageLine` rows**: identify which specific tests hit which lines.
+- **Aggregated coverage**: view project-wide health.
+- **Redundancy & Overlap**: find lines exercised by too many tests or tests with identical footprints.
 
-- Build and query the database with `bazel run //web:coverage_audit -- summary`
+**Step 1: Generate Raw Coverage Data**
+Run this from the repo root (works in worktrees). It generates individual `coverage.dat` files for every test in `bazel-testlogs`:
+```bash
+rtk bazel coverage --combined_report=lcov --cache_test_results=false //...
+```
 
-- source files
-- source lines
-- per-test `CoverageLine` rows
-- a combined coverage view for aggregate queries
+**Step 2: Ingest and Analyze**
+Run the audit tool. It automatically scans `bazel-testlogs`, builds the database, and performs cross-test analysis:
+```bash
+bazel run //web:coverage_audit -- summary
+```
 
-Generate the raw coverage data with `rtk bazel coverage --combined_report=lcov --cache_test_results=false //...`, then load the per-test reports into the coverage-analysis tool. Avoid `genhtml` and other interactive report-generation tools; they add noise without improving the analysis.
+The sparse schema makes common questions cheap to ask via the following commands:
+- `bazel run //web:coverage_audit -- gaps`: Largest uncovered contiguous ranges.
+- `bazel run //web:coverage_audit -- redundant`: Lines hit by many tests; candidates for simplification.
+- `bazel run //web:coverage_audit -- unexpected`: Tests reaching outside their feature area.
+
+Native dependencies like `better-sqlite3` are managed via Bazel lifecycle hooks in `MODULE.bazel`. Do NOT attempt to manually run `pnpm install` or debug missing `.node` bindings; if they are missing, ensure `MODULE.bazel` has the correct `lifecycle_hooks` configured and run `bazel run //web:coverage_audit` to trigger the build.
 
 ## Common Query Recipes
 
@@ -32,7 +45,7 @@ Generate the raw coverage data with `rtk bazel coverage --combined_report=lcov -
 
 1. **Generate Coverage Data**
    - Run `rtk bazel coverage --combined_report=lcov --cache_test_results=false //...`.
-   - Load the per-test LCOV into the coverage-analysis tool and use the database for all follow-up queries.
+   - Run `bazel run //web:coverage_audit -- summary` to build the SQLite database.
 2. **Analyze**
    - Do not ask the developer for information that can be inferred from the coverage data.
    - If the data is insufficient to support a concrete recommendation, do not create an issue yet.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -64,7 +64,7 @@ npm.npm_translate_lock(
     name = "npm",
     data = ["//web:package.json"],
     pnpm_lock = "//web:pnpm-lock.yaml",
-    lifecycle_hooks_exclude = ["*"],
+    lifecycle_hooks = {"better-sqlite3": ["install"]},
     update_pnpm_lock = True,
     verify_node_modules_ignored = "//:.bazelignore",
 )

--- a/web/package.json
+++ b/web/package.json
@@ -70,6 +70,8 @@
     "glob": "^13"
   },
   "pnpm": {
-    "onlyBuiltDependencies": []
+    "onlyBuiltDependencies": [
+      "better-sqlite3"
+    ]
   }
 }

--- a/web/scripts/coverage-audit.mjs
+++ b/web/scripts/coverage-audit.mjs
@@ -23,7 +23,7 @@ import lcovParse from "lcov-parse";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const WEB_DIR = resolve(SCRIPT_DIR, "..");
-const REPO_ROOT = resolve(WEB_DIR, "..");
+const REPO_ROOT = process.env.BUILD_WORKSPACE_DIRECTORY || resolve(WEB_DIR, "..");
 const DEFAULT_REPORT_ROOT = resolve(REPO_ROOT, "bazel-testlogs");
 const DEFAULT_INTEGRATION_REGEX = /(?:^|[/_.-])integration(?:$|[/_.-])/i;
 


### PR DESCRIPTION
## Description
This PR fixes the `coverage_audit` tool, which was failing due to missing `better-sqlite3` native bindings and incorrect path resolution in worktree environments.

### Key Changes
- **Native Bindings**: Updated `MODULE.bazel` to explicitly enable lifecycle hooks for `better-sqlite3`.
- **pnpm v10 Compliance**: Added `better-sqlite3` to `pnpm.onlyBuiltDependencies` in `web/package.json` to allow its build scripts to run.
- **Worktree Path Resolution**: Patched `web/scripts/coverage-audit.mjs` to respect `BUILD_WORKSPACE_DIRECTORY` when resolving the repository root. This allows the tool to correctly find `bazel-testlogs` when executed via `bazel run` from a worktree.
- **Documentation**: Updated `.agents/skills/cover/SKILL.md` with the verified two-step Bazel workflow while maintaining technical context for per-test redundancy analysis.

### Verification Results
Verified in a dedicated worktree using:
```bash
rtk bazel coverage --combined_report=lcov --cache_test_results=false //...
bazel run //web:coverage_audit -- summary
```
The tool now correctly builds its dependencies and ingests per-test coverage data without manual NPM intervention.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>