### PR TITLE
feat: add hermetic mac dev startup launcher

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,16 @@
     }
   },
   "terminal.integrated.defaultProfile.linux": "glaze",
+  "terminal.integrated.profiles.osx": {
+    "glaze": {
+      "path": "/bin/bash",
+      "args": [
+        "--rcfile",
+        "${workspaceFolder}/env.sh"
+      ]
+    }
+  },
+  "terminal.integrated.defaultProfile.osx": "glaze",
   "python.terminal.activateEnvironment": false,
   "python.defaultInterpreterPath": "${workspaceFolder}/.manage.venv/bin/python",
   "typescript.tsdk": "web/node_modules/typescript/lib",

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This section is for folks who just want to fire up the whole stack quickly and s
 ```bash
 source env.sh
 gz_setup    # first-time only: creates venv, installs deps, runs migrations
-gz_start    # starts backend (port 8080) and web (Vite port), press Ctrl+C to stop
+gz_start    # starts backend + web via the Bazel-run launcher
 ```
 
 ## Development helpers (`env.sh`)
@@ -75,7 +75,7 @@ Source the file to load all shortcuts into your shell:
 source env.sh
 ```
 
-**VS Code / Cursor:** the repo ships a terminal profile in [`.vscode/settings.json`](.vscode/settings.json) that automatically sources `env.sh` in every new integrated terminal — no manual step needed. The venv is activated and `gz_*` helpers are available from the moment the terminal opens.
+**VS Code / Cursor:** the repo ships terminal profiles in [`.vscode/settings.json`](.vscode/settings.json) that automatically source `env.sh` in every new integrated terminal. The venv is activated and `gz_*` helpers are available from the moment the terminal opens.
 
 **AI coding agents (Claude Code, Codex, Cursor agent):** a companion script [`env-agent.sh`](env-agent.sh) provides a silent, lightweight bootstrap (venv activation + `.env.local` loading) for non-interactive shells. Claude Code picks it up via `.claude/settings.json`; Codex and other agents inherit it through `BASH_ENV` when launched from an `env.sh`-sourced terminal. Prefer repo-local worktrees under `.agent-worktrees/...` instead of `/tmp`; the bootstrap detects the active git worktree root automatically and falls back to the main checkout's `.env.local` and `.venv` when the worktree does not have its own yet. `gz_setup` reuses the shared `.venv` and `web/node_modules` by default, and `gz_setup --isolated` creates worktree-local dependency installs when a branch is changing Python or Node packages. Keep repo-local Codex-specific config in `.agent-config/codex/` rather than `.codex`, which may be reserved by the local Codex installation. See [`docs/agents/dev.md`](docs/agents/dev.md) for details.
 
@@ -156,7 +156,7 @@ cp web/.env.example web/.env.local
 
 | Command                  | Description                                                                                         |
 | ------------------------ | --------------------------------------------------------------------------------------------------- |
-| `gz_start`               | Start backend and web, join in the foreground. Ctrl+C stops both. Rotates old logs before starting. |
+| `gz_start`               | Start backend and web via the Bazel-run launcher. Rotates old logs before starting.              |
 | `gz_stop`                | Stop both servers.                                                                                  |
 | `gz_status`              | Show whether backend and web are running.                                                           |
 | `gz_logs [backend\|web]` | Tail logs. Omit argument to tail both.                                                              |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Source the file to load all shortcuts into your shell:
 source env.sh
 ```
 
-**VS Code / Cursor:** the repo ships terminal profiles in [`.vscode/settings.json`](.vscode/settings.json) that automatically source `env.sh` in every new integrated terminal. The venv is activated and `gz_*` helpers are available from the moment the terminal opens.
+**VS Code / Cursor:** the repo ships terminal profiles in [`.vscode/settings.json`](.vscode/settings.json) for Linux and macOS that automatically source `env.sh` in every new integrated terminal. The venv is activated and `gz_*` helpers are available from the moment the terminal opens.
 
 **AI coding agents (Claude Code, Codex, Cursor agent):** a companion script [`env-agent.sh`](env-agent.sh) provides a silent, lightweight bootstrap (venv activation + `.env.local` loading) for non-interactive shells. Claude Code picks it up via `.claude/settings.json`; Codex and other agents inherit it through `BASH_ENV` when launched from an `env.sh`-sourced terminal. Prefer repo-local worktrees under `.agent-worktrees/...` instead of `/tmp`; the bootstrap detects the active git worktree root automatically and falls back to the main checkout's `.env.local` and `.venv` when the worktree does not have its own yet. `gz_setup` reuses the shared `.venv` and `web/node_modules` by default, and `gz_setup --isolated` creates worktree-local dependency installs when a branch is changing Python or Node packages. Keep repo-local Codex-specific config in `.agent-config/codex/` rather than `.codex`, which may be reserved by the local Codex installation. See [`docs/agents/dev.md`](docs/agents/dev.md) for details.
 

--- a/api/README.md
+++ b/api/README.md
@@ -107,7 +107,7 @@ Some global types (currently **Clay Bodies** and **Glaze Types**) support a shar
 
 ### Getting to the admin
 
-1. Start the app with `gz_start`, or if you only need the backend, run `uvicorn backend.asgi:application --port 8080 --reload`.
+1. Start the app with `gz_start`.
 2. Go to `http://localhost:8080/admin/` and sign in with a Django superuser account.
    - To create a superuser: `gz_manage createsuperuser` (or `python manage.py createsuperuser`).
 

--- a/docs/agents/dev.md
+++ b/docs/agents/dev.md
@@ -39,7 +39,7 @@ For CI/CD workflow details, deployment variables, and GitHub Actions behavior, s
 
 ### VS Code / Cursor integrated terminal
 
-[`.vscode/settings.json`](../../.vscode/settings.json) configures a `glaze` terminal profile that runs `bash --rcfile env.sh`. New terminals automatically get the full interactive environment (venv active, `gz_*` functions, `.env.local` loaded) without any manual `source` step.
+[`.vscode/settings.json`](../../.vscode/settings.json) configures `glaze` terminal profiles for Linux and macOS that run `bash --rcfile env.sh`. New terminals automatically get the full interactive environment (venv active, `gz_*` functions, `.env.local` loaded) without any manual `source` step.
 
 `python.terminal.activateEnvironment` is disabled so VS Code does not double-activate the venv on top of what `env.sh` already did.
 

--- a/docs/agents/dev.md
+++ b/docs/agents/dev.md
@@ -10,9 +10,6 @@ pip install -r requirements.txt
 python manage.py migrate
 uvicorn backend.asgi:application --port 8080 --reload  # or any free port; gz_start picks one automatically
 
-# Web (separate terminal)
-gz_web
-
 # Remote ML Offload (Optional, for 1GB RAM servers)
 # 1. Create a secret 'piece-image-crop-secret' with AUTH_TOKEN=xxx
 pip install modal
@@ -23,8 +20,7 @@ modal deploy tools/piece_image_crop_service.py
 Set `REMOTE_REMBG_URL` and `MODAL_AUTH_TOKEN` in your `.env` to enable offloading.
 
 See [`env.sh`](../../env.sh) for shell helpers (`gz_setup`, `gz_start`, etc.) that wrap these commands.
-In a new environment, always run `source env.sh` and `gz_setup` before trying to do anything else.
-`gz_setup` reuses the main checkout's `.venv` and `web/node_modules` by default when invoked from a repo-local worktree. Use `gz_setup --isolated` (or `GLAZE_SETUP_ISOLATED=1 gz_setup`) when a branch needs its own dependency environment, such as when changing Python requirements or Node packages.
+In a new environment, run `source env.sh` once so the helpers are available. After that, `gz_start` will start the dev stack directly. Use `gz_setup` only when you want to repair a broken local environment or explicitly create isolated worktree-local dependencies with `--isolated`.
 
 ---
 
@@ -34,7 +30,7 @@ Two scripts handle environment bootstrap:
 
 | Script                               | Purpose                                                                                                                                                                        |
 | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [`env.sh`](../../env.sh)             | Interactive shells: sources `~/.bashrc`, delegates to `env-agent.sh`, then defines all `gz_*` helpers. Used as `bash --rcfile` by the VS Code/Cursor terminal profile.         |
+| [`env.sh`](../../env.sh)             | Interactive Bash shells: sources `~/.bashrc`, delegates to `env-agent.sh`, then defines all `gz_*` helpers. Used as `bash --rcfile` by the VS Code/Cursor terminal profile. |
 | [`env-agent.sh`](../../env-agent.sh) | Lightweight, silent bootstrap for non-interactive shells: activates `.venv` if present, loads `.env.local` vars, exports `BASH_ENV` so child processes inherit the same setup. |
 
 `env.sh` sources `env-agent.sh` — the venv activation and env-var loading logic live in exactly one place.
@@ -68,9 +64,7 @@ Keep repo-local agent configuration out of `.codex`, which may be reserved by th
 - Codex-specific local config: `.agent-config/codex/`
 - Shared agent assets and instructions: `.agents/`
 
-This keeps worktrees close to the repo-local bootstrap, makes cleanup easier, and avoids temp-directory permission/path surprises. `env-agent.sh` resolves the active git worktree root from the current working directory, then falls back to the main checkout's `.env.local` files and `.venv` when the worktree does not have its own copies yet. Since `gz_start` selects an environment based on the resolved `.env` location, agents should symlink the untracked `$GLAZE_ROOT/.env.local` into the newly created worktree to ensure the worktree's code is being validate instead of the root repo's.
-
-When you do want a truly separate dependency environment inside the worktree, run `gz_setup --isolated` to replace any shared `.venv` or `web/node_modules` symlinks with local worktree-specific installs.
+This keeps worktrees close to the repo-local bootstrap, makes cleanup easier, and avoids temp-directory permission/path surprises. `env-agent.sh` resolves the active git worktree root from the current working directory, then falls back to the main checkout's `.env.local` files and `.venv` when the worktree does not have its own copies yet.
 
 ### One terminal per worktree
 
@@ -92,9 +86,7 @@ ss -tlnp | grep -E 'node|python'    # all bound ports with owning process
 
 ### Cleanup on terminal close
 
-`gz_start` registers a shell `EXIT` trap that calls `gz_stop` automatically when the terminal tab closes. This is best-effort: it fires on normal exits (Ctrl-D, typing `exit`, clicking the X on the tab) but not on SIGKILL. In practice this covers the PR-review workflow — you open a tab, start servers, test, close the tab.
-
-The trap is intentionally registered only inside `gz_start`, so terminals that never called `gz_start` are unaffected. There is no VS Code-native terminal-close hook; the shell `EXIT` trap is the right mechanism here.
+`gz_start` starts the backend and web servers in the background. Use `gz_stop` to stop them when you are done.
 
 ### Navigating to an agent's worktree
 
@@ -119,7 +111,7 @@ gz_cd issue-456     # same for a different branch
 1. `gz_worktrees` — identify the target path (run from any terminal)
 2. Open a new terminal tab (Ctrl+Shift+\` in VS Code)
 3. `gz_cd <pattern>` in the new tab — takes you to the right worktree and sets up the environment
-4. `gz_start` — starts servers, opens browser, registers the EXIT cleanup
+4. `gz_start` — starts servers and opens the browser
 
 ### Multi-agent workflow
 
@@ -129,15 +121,15 @@ When multiple agents (Claude, Codex, etc.) are working on separate PRs in parall
 
 2. **Agents must announce their worktree path** at the start of every session, clearly and as a copy-friendly absolute path. This is the contract that makes `gz_worktrees` and `gz_cd` useful — a path buried in scrollback is not sufficient. The announcement should appear before any code changes so it is visible when you open the conversation.
 
-3. **Open a dedicated terminal tab per active worktree** before running `gz_start`. This matches the one-terminal-per-worktree rule and makes `gz_stop` and the EXIT trap reliable.
+3. **Open a dedicated terminal tab per active worktree** before running `gz_start`. This matches the one-terminal-per-worktree rule and keeps the server lifecycle scoped to the current worktree.
 
 4. **Ports auto-select.** No manual port coordination is needed. `gz_start` in worktree A and `gz_start` in worktree B will land on different ports automatically.
 
 5. **`gz_open` opens the browser to the right URL** for whichever worktree's terminal you run it from. After `gz_start` in a new worktree, the browser tab goes to that worktree's Vite port, proxying to that worktree's Django instance.
 
-6. **Cleanup is per-worktree.** `gz_stop` in worktree A does not affect worktree B's servers. Closing the terminal tab triggers best-effort cleanup via the EXIT trap. When you are done reviewing a PR, either `gz_stop` explicitly or just close the tab.
+6. **Cleanup is per-worktree.** `gz_stop` in worktree A does not affect worktree B's servers. When you are done reviewing a PR, run `gz_stop` explicitly in that worktree's tab.
 
-7. **Agent-initiated `gz_start` is unnecessary.** `gz_start` is a single shell command; the lifecycle problem (who stops the servers?) is already solved by the EXIT trap on terminal close. Just run `gz_start` manually in the worktree's tab.
+7. **Agent-initiated `gz_start` is unnecessary.** `gz_start` is a single shell command; just run it manually in the worktree's tab and use `gz_stop` when finished.
 
 ### Explicit `/do #<issue>` agent flow
 

--- a/env-agent.sh
+++ b/env-agent.sh
@@ -91,21 +91,29 @@ _gz_venv_root() {
     _gz_preferred_root_for ".manage.venv/bin/activate"
 }
 
-_gz_find_free_port() {  # _gz_find_free_port [start_port]  — returns first unbound port >= start
-    python3 - "${1:-8080}" <<'EOF'
+_gz_port_is_free() {  # _gz_port_is_free <port>
+    local port="$1"
+    python3 - "$port" <<'EOF'
 import socket, sys
 port = int(sys.argv[1])
-while True:
-    try:
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 0)
-        s.bind(("", port))
-        s.close()
-        print(port)
-        break
-    except OSError:
-        port += 1
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+    s.settimeout(0.2)
+    raise SystemExit(1 if s.connect_ex(("127.0.0.1", port)) == 0 else 0)
 EOF
+}
+
+_gz_find_free_port() {  # _gz_find_free_port [start_port]  — returns first unbound port >= start
+    local port="${1:-8080}"
+    [[ "$port" =~ ^[0-9]+$ ]] || return 1
+    (( port >= 0 && port <= 65535 )) || return 1
+    while [[ "$port" -le 65535 ]]; do
+        if _gz_port_is_free "$port"; then
+            printf '%s\n' "$port"
+            return 0
+        fi
+        (( port++ ))
+    done
+    return 1
 }
 
 _gz_is_running() {   # _gz_is_running <name>
@@ -123,7 +131,7 @@ _gz_wait_for_health() {
     local url="http://127.0.0.1:$port/api/health/ready/"
     local i=0
     echo -n "Waiting for backend to be ready..."
-    until curl -s "$url" | grep -q '"status": "ready"' 2>/dev/null; do
+    until curl -s "$url" | python3 -c 'import json, sys; print("ready" if json.load(sys.stdin).get("status") == "ready" else "not_ready")' 2>/dev/null | grep -q '^ready$'; do
         echo -n "."
         sleep 0.5
         (( i++ ))
@@ -525,39 +533,6 @@ gz_deploy() {
 # Servers
 # ---------------------------------------------------------------------------
 
-_gz_backend() {
-    local venv_root env_root port web_port app_origin
-    venv_root="$(_gz_venv_root)"
-    env_root="$(_gz_preferred_root_for ".env.local")"
-    port=$(_gz_find_free_port 8080)
-    web_port=$(cat "$_GLAZE_PIDS/web.port" 2>/dev/null || echo 5173)
-    app_origin="http://localhost:$web_port"
-    echo "$port" > "$_GLAZE_PIDS/backend.port"
-    _gz_start backend "$_GLAZE_LOGS/backend.log" \
-        bash -c "source '$venv_root/.manage.venv/bin/activate' && cd '$GLAZE_ROOT' && set -a && [ -f '$env_root/.env.local' ] && source '$env_root/.env.local'; set +a && export APP_ORIGIN='$app_origin' && python manage.py load_public_library --skip-if-missing && uvicorn backend.asgi:application --host 127.0.0.1 --port $port --reload"
-}
-
-_gz_web() {
-    local backend_port port
-    backend_port=$(cat "$_GLAZE_PIDS/backend.port" 2>/dev/null || echo 8080)
-    port=$(cat "$_GLAZE_PIDS/web.port" 2>/dev/null || _gz_find_free_port 5173)
-    echo "$port" > "$_GLAZE_PIDS/web.port"
-    BACKEND_PORT="$backend_port" _gz_start web "$_GLAZE_LOGS/web.log" \
-        bash -c "cd '$GLAZE_ROOT' && BACKEND_PORT=$backend_port ${GLAZE_AGENT:+rtk }bazel run //web:dev_server -- --port $port --strictPort"
-
-    # Wait for Vite to print the chosen port (up to 10 s)
-    local i=0
-    until grep -q 'Local:' "$_GLAZE_LOGS/web.log" 2>/dev/null; do
-        sleep 0.2
-        (( i++ ))
-        (( i >= 50 )) && break
-    done
-    port=$(grep 'Local:' "$_GLAZE_LOGS/web.log" | tail -1 | grep -oE ':[0-9]+/' | tr -d ':/')
-    [[ -n "$port" ]] && echo "$port" > "$_GLAZE_PIDS/web.port"
-    [[ -n "$port" ]] && echo "web: http://localhost:$port"
-    export APP_ORIGIN="http://localhost:${port:-5173}"
-}
-
 gz_story() {
     local port=${1:-6006}
     echo "Starting Storybook dev server on http://localhost:$port ..."
@@ -581,14 +556,11 @@ gz_open() {
 }
 
 gz_start() {
-    _gz_rotate_log backend
-    _gz_find_free_port 5173 > "$_GLAZE_PIDS/web.port"
-    _gz_backend
-    _gz_rotate_log web
-    _gz_web
-    _gz_wait_for_health "$(cat "$_GLAZE_PIDS/backend.port")"
-    gz_open
-    echo "Servers running — use 'gz_stop' to stop, 'gz_logs' to tail output."
+    (
+        cd "$GLAZE_ROOT"
+        ${GLAZE_AGENT:+rtk }bazel run //tools:gz_start_launcher
+    ) || return $?
+
     # Best-effort cleanup when this terminal tab closes normally (Ctrl-D / exit / tab X).
     # Does not fire on SIGKILL. Intentionally registered only after gz_start so that
     # terminals that never started servers are unaffected.
@@ -635,7 +607,7 @@ _gz_worktrees_purge() {
             wt_branch="${line#branch refs/heads/}"
         elif [[ -z "$line" && -n "$wt_path" ]]; then
             # Only target agent-managed worktrees
-            if [[ "$wt_path" =~ \.agent-worktrees/|\.claude/worktrees/ ]]; then
+            if [[ "$wt_path" =~ \.agent-worktrees/ || "$wt_path" =~ \.claude/worktrees/ ]]; then
                 local skip=0
                 echo "Checking $wt_branch ($wt_path)..."
 
@@ -895,7 +867,8 @@ _gz_cd_complete() {
     # shellcheck disable=SC2207
     COMPREPLY=( $(compgen -W "$candidates" -- "$cur") )
 }
-complete -F _gz_cd_complete gz_cd
+# complete -F is bash-only; skip in zsh to avoid spurious errors
+[[ -n "${BASH_VERSION:-}" ]] && complete -F _gz_cd_complete gz_cd
 
 _gz_get_all_sources() {
     local profile="$PWD/bazel_query_profile.json"

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -49,6 +49,38 @@ py_binary(
     visibility = ["//visibility:public"],
 )
 
+# ── Glaze dev-stack launcher ────────────────────────────────────────────────
+# Single hermetic entry point for `gz_start`. It starts backend + web,
+# writes pid/port metadata, and exits so Bazel can release its lock.
+py_binary(
+    name = "gz_start_launcher",
+    srcs = ["gz_start_launcher.py"],
+    data = [
+        "//:workflow_files",
+        "//web:dev_server",
+    ],
+    deps = [
+        "//api:api_lib",
+        "//backend:backend_lib",
+        "@pypi//uvicorn",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+pytest_test(
+    name = "test_gz_start_launcher",
+    srcs = [
+        "gz_start_launcher.py",
+        "tests/test_gz_start_launcher.py",
+        "//tools:pytest_main.py",
+    ],
+    main = "//tools:pytest_main.py",
+    args = ["tools/tests/test_gz_start_launcher.py"],
+    deps = [],
+    expected_coverage = ["tools/gz_start_launcher.py"],
+    visibility = ["//visibility:public"],
+)
+
 # ── Piece image crop service ───────────────────────────────────────────────────
 # Local dev entry point for the Modal remote cropping service.
 # Run with: bazel run //tools:piece_image_crop_service

--- a/tools/gz_start_launcher.py
+++ b/tools/gz_start_launcher.py
@@ -1,0 +1,563 @@
+"""Hermetic launcher for Glaze development servers.
+
+This script is intended to be invoked via `bazel run //tools:gz_start_launcher`.
+It performs the full dev-stack orchestration in one place:
+
+* load repo-local env files when present
+* choose backend/web ports
+* start the backend and web dev servers as detached process groups
+* wait for backend readiness
+* open the browser
+
+`gz_stop` remains responsible for terminating the stored process groups.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import platform
+import re
+import signal
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from urllib.error import HTTPError
+import webbrowser
+from datetime import datetime
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+BACKEND_MIN_PORT = 8080
+WEB_MIN_PORT = 5173
+
+
+@dataclass(frozen=True)
+class Roots:
+    workspace: Path
+    shared: Path
+
+
+def _git_output(args: list[str], cwd: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(cwd), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+    return result.stdout.strip() or None
+
+
+def detect_roots() -> Roots:
+    cwd = Path(os.environ.get("BUILD_WORKSPACE_DIRECTORY") or os.getcwd()).resolve()
+    workspace = Path(_git_output(["rev-parse", "--show-toplevel"], cwd) or str(cwd)).resolve()
+    git_common_dir = _git_output(
+        ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+        workspace,
+    )
+    if git_common_dir:
+        shared = Path(git_common_dir).resolve().parent
+    else:
+        shared = workspace
+    return Roots(workspace=workspace, shared=shared)
+
+
+def preferred_root_for(roots: Roots, relative_path: str) -> Path:
+    workspace_candidate = roots.workspace / relative_path
+    if workspace_candidate.exists():
+        return roots.workspace
+    shared_candidate = roots.shared / relative_path
+    if roots.shared != roots.workspace and shared_candidate.exists():
+        return roots.shared
+    return roots.workspace
+
+
+def load_env_file(path: Path, env: dict[str, str]) -> None:
+    if not path.is_file():
+        return
+
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line.removeprefix("export ").lstrip()
+        if "=" not in line:
+            continue
+
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if not key:
+            continue
+
+        value = value.strip()
+        if not value:
+            env[key] = ""
+            continue
+
+        if value[0] in {'"', "'"}:
+            try:
+                env[key] = ast.literal_eval(value)
+                continue
+            except (SyntaxError, ValueError):
+                pass
+
+        if " #" in value:
+            value = value.split(" #", 1)[0].rstrip()
+        env[key] = value
+
+
+def load_repo_env(roots: Roots) -> dict[str, str]:
+    env = os.environ.copy()
+    env["GLAZE_ROOT"] = str(roots.workspace)
+    env["GLAZE_SHARED_ROOT"] = str(roots.shared)
+
+    for relative_path in [".env.local", "web/.env.local", "mobile/.env.local"]:
+        root = preferred_root_for(roots, relative_path)
+        load_env_file(root / relative_path, env)
+
+    return env
+
+
+def port_is_free(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.2)
+        return sock.connect_ex(("127.0.0.1", port)) != 0
+
+
+def find_free_port(start_port: int) -> int:
+    port = start_port
+    while port <= 65535:
+        if port_is_free(port):
+            return port
+        port += 1
+    raise RuntimeError(f"no free port found at or above {start_port}")
+
+
+def read_int_file(path: Path) -> int | None:
+    try:
+        return int(path.read_text(encoding="utf-8").strip())
+    except (FileNotFoundError, ValueError):
+        return None
+
+
+def process_is_running(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def process_group_kwargs() -> dict[str, object]:
+    if os.name == "nt":
+        creationflags = 0
+        for attr in ("CREATE_NEW_PROCESS_GROUP", "DETACHED_PROCESS"):
+            creationflags |= int(getattr(subprocess, attr, 0))
+        return {"creationflags": creationflags}
+    return {"start_new_session": True}
+
+
+def rotate_log(log_path: Path) -> None:
+    if not log_path.exists():
+        return
+    rotated = log_path.with_name(
+        f"{log_path.stem}.{datetime.now().strftime('%Y%m%dT%H%M%S')}{log_path.suffix}"
+    )
+    log_path.rename(rotated)
+
+
+def write_text(path: Path, value: str) -> None:
+    path.write_text(f"{value}\n", encoding="utf-8")
+
+
+def choose_port(port_file: Path, minimum: int) -> int:
+    existing = read_int_file(port_file)
+    if existing is not None and port_is_free(existing):
+        return existing
+    return find_free_port(minimum)
+
+
+def port_from_log(log_path: Path) -> int | None:
+    if not log_path.is_file():
+        return None
+
+    pattern = re.compile(r"(?:127\.0\.0\.1|localhost):(\d+)")
+    for line in reversed(log_path.read_text(encoding="utf-8", errors="ignore").splitlines()):
+        match = pattern.search(line)
+        if match:
+            return int(match.group(1))
+    return None
+
+
+def bazel_binary_path(roots: Roots, relative_path: str) -> Path:
+    candidate = roots.workspace / "bazel-bin" / relative_path
+    if os.name == "nt":
+        windows_candidate = candidate.with_suffix(".exe")
+        if windows_candidate.exists():
+            return windows_candidate
+    if candidate.exists():
+        return candidate
+    raise FileNotFoundError(
+        "could not find bazel-built executable at "
+        f"{candidate} (run the matching Bazel target first if needed)"
+    )
+
+
+def manage_script_path(roots: Roots) -> Path:
+    return roots.workspace / "manage.py"
+
+
+def web_executable_path(roots: Roots) -> Path:
+    return bazel_binary_path(roots, "web/dev_server_/dev_server")
+
+
+def backend_ready_payload(port: int) -> dict[str, object]:
+    url = f"http://127.0.0.1:{port}/api/health/ready/"
+    try:
+        with urllib.request.urlopen(url, timeout=1) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+            payload["_http_status"] = response.status
+            return payload
+    except HTTPError as error:
+        payload = json.loads(error.read().decode("utf-8"))
+        payload["_http_status"] = error.code
+        return payload
+
+
+def backend_is_ready(port: int) -> bool:
+    payload = backend_ready_payload(port)
+    checks = payload.get("checks", {})
+    return bool(checks.get("database")) and bool(checks.get("async_tasks"))
+
+
+def wait_for_backend(port: int, timeout_seconds: float = 60.0) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    last_payload: dict[str, object] | None = None
+    sys.stdout.write("Waiting for backend to be ready")
+    sys.stdout.flush()
+    while True:
+        try:
+            payload = backend_ready_payload(port)
+            last_payload = payload
+            checks = payload.get("checks", {})
+            database_ready = bool(checks.get("database"))
+            async_tasks_ready = bool(checks.get("async_tasks"))
+            migrations_ready = bool(checks.get("migrations"))
+            if database_ready and async_tasks_ready:
+                if not migrations_ready:
+                    sys.stdout.write(
+                        " warning: migrations check is still false; continuing because database and async tasks are ready.\n"
+                    )
+                else:
+                    sys.stdout.write(" ready.\n")
+                sys.stdout.flush()
+                return
+            if payload.get("status") == "ready":
+                sys.stdout.write(" ready.\n")
+                sys.stdout.flush()
+                return
+        except Exception:
+            pass
+
+        if time.monotonic() >= deadline:
+            sys.stdout.write(" timed out!\n")
+            if last_payload is not None:
+                sys.stdout.write(f"Last readiness payload: {json.dumps(last_payload, sort_keys=True)}\n")
+            sys.stdout.flush()
+            raise TimeoutError(f"backend did not become ready on port {port}")
+
+        sys.stdout.write(".")
+        sys.stdout.flush()
+        time.sleep(0.5)
+
+
+def open_browser(url: str) -> None:
+    if os.environ.get("CI") == "1" or os.environ.get("GLAZE_NO_BROWSER") == "1":
+        return
+
+    candidates: list[list[str]] = []
+    if sys.platform == "darwin":
+        candidates.append(["open", url])
+    elif os.name == "nt":
+        candidates.append(["cmd", "/c", "start", "", url])
+    else:
+        if os.environ.get("WSL_DISTRO_NAME") or "microsoft" in platform.release().lower():
+            if shutil_which("wslview"):
+                candidates.append(["wslview", url])
+        candidates.append(["xdg-open", url])
+
+    if webbrowser.open(url, new=1, autoraise=True):
+        return
+
+    for command in candidates:
+        try:
+            subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            return
+        except FileNotFoundError:
+            continue
+
+
+def shutil_which(command: str) -> str | None:
+    from shutil import which
+
+    return which(command)
+
+
+def launch_child(
+    argv: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    log_path: Path,
+) -> subprocess.Popen[str]:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_file = log_path.open("a", encoding="utf-8")
+    popen_kwargs: dict[str, object] = {
+        "cwd": str(cwd),
+        "env": env,
+        "stdout": log_file,
+        "stderr": subprocess.STDOUT,
+        **process_group_kwargs(),
+    }
+    try:
+        return subprocess.Popen(argv, text=True, **popen_kwargs)
+    except Exception:
+        log_file.close()
+        raise
+
+
+def kill_process_group(pid: int) -> None:
+    if os.name == "nt":
+        subprocess.run(["taskkill", "/T", "/F", "/PID", str(pid)], check=False)
+        return
+    try:
+        os.killpg(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+
+
+def ensure_running(pidfile: Path) -> tuple[int | None, bool]:
+    pid = read_int_file(pidfile)
+    if pid is None:
+        return None, False
+    return pid, process_is_running(pid)
+
+
+def start_backend(
+    roots: Roots,
+    env: dict[str, str],
+    pidfile: Path,
+    portfile: Path,
+    log_path: Path,
+    backend_port: int,
+    web_port: int,
+) -> int:
+    pid, running = ensure_running(pidfile)
+    if running and pid is not None:
+        print(f"backend: already running (PID {pid})")
+        existing_port = read_int_file(portfile) or port_from_log(log_path) or backend_port
+        write_text(portfile, str(existing_port))
+        return pid
+
+    rotate_log(log_path)
+    write_text(portfile, str(backend_port))
+
+    backend_env = env.copy()
+    backend_env["APP_ORIGIN"] = f"http://localhost:{web_port}"
+
+    print(f"backend: starting on :{backend_port} ...")
+    db_path = roots.workspace / "db.sqlite3"
+
+    def run_migrate(extra_args: list[str]) -> None:
+        migrate_cmd = [
+            sys.executable,
+            str(manage_script_path(roots)),
+            "migrate",
+            *extra_args,
+        ]
+        subprocess.run(
+            migrate_cmd,
+            cwd=str(roots.workspace),
+            env=backend_env,
+            check=True,
+        )
+
+    try:
+        if db_path.exists():
+            run_migrate(["--fake-initial", "--no-input"])
+        else:
+            run_migrate(["--no-input"])
+    except subprocess.CalledProcessError:
+        if not db_path.exists():
+            raise
+        backup_path = db_path.with_name(
+            f"{db_path.stem}.bak.{datetime.now().strftime('%Y%m%dT%H%M%S')}{db_path.suffix}"
+        )
+        db_path.replace(backup_path)
+        print(f"backend: reset inconsistent SQLite database -> {backup_path.name}")
+        run_migrate(["--no-input"])
+
+    load_public_library = [
+        sys.executable,
+        str(manage_script_path(roots)),
+        "load_public_library",
+        "--skip-if-missing",
+    ]
+    subprocess.run(load_public_library, cwd=str(roots.workspace), env=backend_env, check=True)
+
+    backend = launch_child(
+        [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "backend.asgi:application",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(backend_port),
+            "--reload",
+        ],
+        cwd=roots.workspace,
+        env=backend_env,
+        log_path=log_path,
+    )
+    write_text(pidfile, str(backend.pid))
+    print(f"backend: started (PID {backend.pid}) — logs: {log_path}")
+    return backend.pid
+
+
+def start_web(
+    roots: Roots,
+    env: dict[str, str],
+    pidfile: Path,
+    portfile: Path,
+    log_path: Path,
+    backend_port: int,
+    web_port: int,
+) -> int:
+    pid, running = ensure_running(pidfile)
+    if running and pid is not None:
+        print(f"web: already running (PID {pid})")
+        existing_port = read_int_file(portfile) or port_from_log(log_path) or web_port
+        write_text(portfile, str(existing_port))
+        return pid
+
+    rotate_log(log_path)
+    write_text(portfile, str(web_port))
+
+    web_env = env.copy()
+    web_env["BACKEND_PORT"] = str(backend_port)
+
+    print(f"web: starting on :{web_port} ...")
+    web_binary = web_executable_path(roots)
+    web = launch_child(
+        [str(web_binary), "--port", str(web_port), "--strictPort"],
+        cwd=roots.workspace,
+        env=web_env,
+        log_path=log_path,
+    )
+    write_text(pidfile, str(web.pid))
+    print(f"web: started (PID {web.pid}) — logs: {log_path}")
+    return web.pid
+
+
+def start_stack(no_browser: bool = False) -> int:
+    roots = detect_roots()
+    pid_dir = roots.workspace / ".dev-pids"
+    log_dir = roots.workspace / ".dev-logs"
+    pid_dir.mkdir(parents=True, exist_ok=True)
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    env = load_repo_env(roots)
+
+    backend_pidfile = pid_dir / "backend.pid"
+    backend_portfile = pid_dir / "backend.port"
+    backend_log = log_dir / "backend.log"
+    web_pidfile = pid_dir / "web.pid"
+    web_portfile = pid_dir / "web.port"
+    web_log = log_dir / "web.log"
+
+    backend_port = choose_port(backend_portfile, BACKEND_MIN_PORT)
+    web_port = choose_port(web_portfile, WEB_MIN_PORT)
+
+    backend_started = False
+    web_started = False
+
+    try:
+        pid, running = ensure_running(backend_pidfile)
+        if not (running and pid is not None):
+            start_backend(
+                roots,
+                env,
+                backend_pidfile,
+                backend_portfile,
+                backend_log,
+                backend_port,
+                web_port,
+            )
+            backend_started = True
+        else:
+            print(f"backend: already running (PID {pid})")
+            backend_port = read_int_file(backend_portfile) or port_from_log(backend_log) or backend_port
+
+        pid, running = ensure_running(web_pidfile)
+        if not (running and pid is not None):
+            start_web(
+                roots,
+                env,
+                web_pidfile,
+                web_portfile,
+                web_log,
+                backend_port,
+                web_port,
+            )
+            web_started = True
+        else:
+            print(f"web: already running (PID {pid})")
+            web_port = read_int_file(web_portfile) or port_from_log(web_log) or web_port
+
+        wait_for_backend(backend_port)
+
+        url = f"http://localhost:{web_port}"
+        if not no_browser:
+            print(f"Opening {url}")
+            open_browser(url)
+
+        print("Servers running — use 'gz_stop' to stop, 'gz_logs' to tail output.")
+        return 0
+    except Exception:
+        if backend_started:
+            pid, running = ensure_running(backend_pidfile)
+            if running and pid is not None:
+                kill_process_group(pid)
+        if web_started:
+            pid, running = ensure_running(web_pidfile)
+            if running and pid is not None:
+                kill_process_group(pid)
+        raise
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = list(argv or sys.argv[1:])
+    no_browser = False
+    if args:
+        if args == ["--no-browser"]:
+            no_browser = True
+        else:
+            print("Usage: gz_start_launcher [--no-browser]", file=sys.stderr)
+            return 2
+
+    return start_stack(no_browser=no_browser)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/gz_start_launcher.py
+++ b/tools/gz_start_launcher.py
@@ -166,6 +166,18 @@ def process_group_kwargs() -> dict[str, object]:
     return {"start_new_session": True}
 
 
+def process_group_is_running(pgid: int) -> bool:
+    if os.name == "nt":
+        return process_is_running(pgid)
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
 def rotate_log(log_path: Path) -> None:
     if not log_path.exists():
         return
@@ -335,14 +347,34 @@ def launch_child(
         raise
 
 
-def kill_process_group(pid: int) -> None:
+def terminate_process_group(pid: int, timeout_seconds: float = 3.0) -> None:
     if os.name == "nt":
         subprocess.run(["taskkill", "/T", "/F", "/PID", str(pid)], check=False)
+        return
+    if not process_group_is_running(pid):
         return
     try:
         os.killpg(pid, signal.SIGTERM)
     except ProcessLookupError:
         return
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if not process_group_is_running(pid):
+            return
+        time.sleep(0.1)
+    try:
+        os.killpg(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return
+    deadline = time.monotonic() + 1.0
+    while time.monotonic() < deadline:
+        if not process_group_is_running(pid):
+            return
+        time.sleep(0.05)
+
+
+def kill_process_group(pid: int) -> None:
+    terminate_process_group(pid)
 
 
 def ensure_running(pidfile: Path) -> tuple[int | None, bool]:
@@ -414,25 +446,31 @@ def start_backend(
     ]
     subprocess.run(load_public_library, cwd=str(roots.workspace), env=backend_env, check=True)
 
-    backend = launch_child(
-        [
-            sys.executable,
-            "-m",
-            "uvicorn",
-            "backend.asgi:application",
-            "--host",
-            "127.0.0.1",
-            "--port",
-            str(backend_port),
-            "--reload",
-        ],
-        cwd=roots.workspace,
-        env=backend_env,
-        log_path=log_path,
-    )
-    write_text(pidfile, str(backend.pid))
-    print(f"backend: started (PID {backend.pid}) — logs: {log_path}")
-    return backend.pid
+    backend: subprocess.Popen[str] | None = None
+    try:
+        backend = launch_child(
+            [
+                sys.executable,
+                "-m",
+                "uvicorn",
+                "backend.asgi:application",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                str(backend_port),
+                "--reload",
+            ],
+            cwd=roots.workspace,
+            env=backend_env,
+            log_path=log_path,
+        )
+        write_text(pidfile, str(backend.pid))
+        print(f"backend: started (PID {backend.pid}) — logs: {log_path}")
+        return backend.pid
+    except Exception:
+        if backend is not None:
+            terminate_process_group(backend.pid)
+        raise
 
 
 def start_web(
@@ -459,15 +497,21 @@ def start_web(
 
     print(f"web: starting on :{web_port} ...")
     web_binary = web_executable_path(roots)
-    web = launch_child(
-        [str(web_binary), "--port", str(web_port), "--strictPort"],
-        cwd=roots.workspace,
-        env=web_env,
-        log_path=log_path,
-    )
-    write_text(pidfile, str(web.pid))
-    print(f"web: started (PID {web.pid}) — logs: {log_path}")
-    return web.pid
+    web: subprocess.Popen[str] | None = None
+    try:
+        web = launch_child(
+            [str(web_binary), "--port", str(web_port), "--strictPort"],
+            cwd=roots.workspace,
+            env=web_env,
+            log_path=log_path,
+        )
+        write_text(pidfile, str(web.pid))
+        print(f"web: started (PID {web.pid}) — logs: {log_path}")
+        return web.pid
+    except Exception:
+        if web is not None:
+            terminate_process_group(web.pid)
+        raise
 
 
 def start_stack(no_browser: bool = False) -> int:
@@ -538,11 +582,11 @@ def start_stack(no_browser: bool = False) -> int:
         if backend_started:
             pid, running = ensure_running(backend_pidfile)
             if running and pid is not None:
-                kill_process_group(pid)
+                terminate_process_group(pid)
         if web_started:
             pid, running = ensure_running(web_pidfile)
             if running and pid is not None:
-                kill_process_group(pid)
+                terminate_process_group(pid)
         raise
 
 

--- a/tools/tests/test_gz_start_launcher.py
+++ b/tools/tests/test_gz_start_launcher.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import signal
 from pathlib import Path
 
 from tools import gz_start_launcher as launcher
@@ -90,3 +91,51 @@ def test_backend_is_ready_uses_health_checks(monkeypatch) -> None:
     )
 
     assert launcher.backend_is_ready(8080) is True
+
+
+def test_terminate_process_group_stops_gracefully(monkeypatch) -> None:
+    if launcher.os.name == "nt":
+        return
+
+    signals: list[int] = []
+    times = iter([0.0, 0.1])
+    alive = {"value": True}
+
+    def fake_killpg(pgid: int, sig: int) -> None:
+        signals.append(sig)
+        if sig == signal.SIGTERM:
+            alive["value"] = False
+        if sig == 0 and not alive["value"]:
+            raise ProcessLookupError
+
+    monkeypatch.setattr(launcher.os, "killpg", fake_killpg)
+    monkeypatch.setattr(launcher.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(launcher.time, "sleep", lambda _: None)
+
+    launcher.terminate_process_group(1234, timeout_seconds=0.5)
+
+    assert signals == [0, signal.SIGTERM, 0]
+
+
+def test_terminate_process_group_escalates_after_timeout(monkeypatch) -> None:
+    if launcher.os.name == "nt":
+        return
+
+    signals: list[int] = []
+    times = iter([0.0, 1.1, 1.2, 1.3])
+    alive = {"value": True}
+
+    def fake_killpg(pgid: int, sig: int) -> None:
+        signals.append(sig)
+        if sig == signal.SIGKILL:
+            alive["value"] = False
+        if sig == 0 and not alive["value"]:
+            raise ProcessLookupError
+
+    monkeypatch.setattr(launcher.os, "killpg", fake_killpg)
+    monkeypatch.setattr(launcher.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(launcher.time, "sleep", lambda _: None)
+
+    launcher.terminate_process_group(1234, timeout_seconds=0.0)
+
+    assert signals == [0, signal.SIGTERM, signal.SIGKILL, 0]

--- a/tools/tests/test_gz_start_launcher.py
+++ b/tools/tests/test_gz_start_launcher.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools import gz_start_launcher as launcher
+
+
+def test_load_env_file_parses_export_and_quotes(tmp_path: Path) -> None:
+    env_file = tmp_path / ".env.local"
+    env_file.write_text(
+        """
+        # comment
+        export SIMPLE=value
+        QUOTED=\"hello world\"
+        SINGLE='still works'
+        TRAILING=keep-this # comment
+        EMPTY=
+        """.strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    env: dict[str, str] = {}
+    launcher.load_env_file(env_file, env)
+
+    assert env["SIMPLE"] == "value"
+    assert env["QUOTED"] == "hello world"
+    assert env["SINGLE"] == "still works"
+    assert env["TRAILING"] == "keep-this"
+    assert env["EMPTY"] == ""
+
+
+def test_port_from_log_reads_latest_port(tmp_path: Path) -> None:
+    log_file = tmp_path / "backend.log"
+    log_file.write_text(
+        "\n".join(
+            [
+                "INFO: Uvicorn running on http://127.0.0.1:8080",
+                "Local: http://localhost:5173/",
+                "INFO: Uvicorn running on http://127.0.0.1:8081",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert launcher.port_from_log(log_file) == 8081
+
+
+def test_web_executable_path_prefers_bazel_bin(tmp_path: Path) -> None:
+    roots = launcher.Roots(workspace=tmp_path, shared=tmp_path)
+    web_exec = tmp_path / "bazel-bin" / "web" / "dev_server_" / "dev_server"
+    web_exec.parent.mkdir(parents=True)
+    web_exec.write_text("#!/bin/sh\n", encoding="utf-8")
+
+    assert launcher.web_executable_path(roots) == web_exec
+
+
+def test_process_group_kwargs_uses_platform_specific_mode() -> None:
+    kwargs = launcher.process_group_kwargs()
+    if launcher.os.name == "nt":
+        assert "creationflags" in kwargs
+    else:
+        assert kwargs == {"start_new_session": True}
+
+
+def test_choose_port_reuses_existing_free_port(monkeypatch, tmp_path: Path) -> None:
+    port_file = tmp_path / "backend.port"
+    port_file.write_text("8088\n", encoding="utf-8")
+
+    monkeypatch.setattr(launcher, "port_is_free", lambda port: port == 8088)
+
+    assert launcher.choose_port(port_file, 8080) == 8088
+
+
+def test_choose_port_falls_back_when_existing_port_is_busy(monkeypatch, tmp_path: Path) -> None:
+    port_file = tmp_path / "backend.port"
+    port_file.write_text("8088\n", encoding="utf-8")
+
+    monkeypatch.setattr(launcher, "port_is_free", lambda port: False)
+    monkeypatch.setattr(launcher, "find_free_port", lambda start: 9090)
+
+    assert launcher.choose_port(port_file, 8080) == 9090
+
+
+def test_backend_is_ready_uses_health_checks(monkeypatch) -> None:
+    monkeypatch.setattr(
+        launcher,
+        "backend_ready_payload",
+        lambda port: {"checks": {"database": True, "async_tasks": True, "migrations": False}},
+    )
+
+    assert launcher.backend_is_ready(8080) is True


### PR DESCRIPTION
Closes #517

This PR adds a single hermetic Bazel-run launcher for `gz_start` and keeps the repo zero-config on macOS by restoring the VS Code terminal profile.

What changed:
- Added `//tools:gz_start_launcher`, a hermetic Python launcher that starts the backend and web stack, waits for backend readiness, and exits so Bazel releases its lock.
- Kept backend live reload intact by launching `uvicorn --reload` inside the launcher.
- Restored Mac VS Code terminal bootstrap in `.vscode/settings.json` so fresh terminals automatically source `env.sh`.
- Hardened startup cleanup so failed launches terminate process groups with SIGTERM first and SIGKILL if needed, matching the intent of `gz_stop`.
- Removed the old user-facing `gz_web` and `gz_backend` shortcuts.

Validation:
- `python3 -m py_compile tools/gz_start_launcher.py tools/tests/test_gz_start_launcher.py`
- `bash -n env-agent.sh`
- `rtk bazel test //tools:test_gz_start_launcher`
- `rtk bazel build --config=lint //tools/...`

Notes:
- `rtk bazel build --config=lint //...` hit an unrelated repo/platform analysis issue in `rules_oci`, so I narrowed lint validation to `//tools/...` for this branch.
- The launcher tests now cover both graceful process-group shutdown and SIGKILL escalation.