### PR TITLE
fix: otelcol startup failures and nginx metrics scraping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -167,6 +167,11 @@ services:
     # and setting OTEL_ENABLED=false can save ~50-100MB+.
     image: otel/opentelemetry-collector-contrib:0.126.0
     restart: unless-stopped
+    # docker_stats receiver needs read access to the Docker socket.
+    # group_add adds the host docker group (GID 112 on this droplet) so the
+    # otelcol process can open /var/run/docker.sock without running as root.
+    group_add:
+      - "112"
     volumes:
       - ./otel-collector-config.yml:/etc/otel/config.yml:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -179,6 +179,9 @@ services:
     environment:
       GRAFANA_CLOUD_OTLP_TOKEN: ${GRAFANA_CLOUD_OTLP_TOKEN:-}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      # otelcol's Docker SDK defaults to negotiating API 1.25, which Docker
+      # 27+ daemons reject (minimum 1.44). Pin explicitly to 1.44.
+      DOCKER_API_VERSION: "1.44"
 
   mailpit:
     image: axllent/mailpit:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -167,21 +167,12 @@ services:
     # and setting OTEL_ENABLED=false can save ~50-100MB+.
     image: otel/opentelemetry-collector-contrib:0.126.0
     restart: unless-stopped
-    # docker_stats receiver needs read access to the Docker socket.
-    # group_add adds the host docker group (GID 112 on this droplet) so the
-    # otelcol process can open /var/run/docker.sock without running as root.
-    group_add:
-      - "112"
     volumes:
       - ./otel-collector-config.yml:/etc/otel/config.yml:ro
-      - /var/run/docker.sock:/var/run/docker.sock:ro
     command: ["--config=/etc/otel/config.yml"]
     environment:
       GRAFANA_CLOUD_OTLP_TOKEN: ${GRAFANA_CLOUD_OTLP_TOKEN:-}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      # otelcol's Docker SDK defaults to negotiating API 1.25, which Docker
-      # 27+ daemons reject (minimum 1.44). Pin explicitly to 1.44.
-      DOCKER_API_VERSION: "1.44"
 
   mailpit:
     image: axllent/mailpit:latest

--- a/nginx/conf.d/glaze.conf
+++ b/nginx/conf.d/glaze.conf
@@ -38,6 +38,13 @@ server {
         root /var/www/certbot;
     }
 
+    # otelcol scrapes this over HTTP on the internal Docker network.
+    location /nginx_status {
+        stub_status;
+        allow 172.16.0.0/12;
+        deny  all;
+    }
+
     location / {
         return 301 https://potterdoc.com$request_uri;
     }

--- a/nginx/conf.d/glaze.conf
+++ b/nginx/conf.d/glaze.conf
@@ -19,13 +19,23 @@ ssl_session_timeout       1d;
 # Drop connections whose Host header matches no server_name (raw-IP scanners,
 # health probers hitting the droplet directly). Must be first so nginx selects
 # it as default_server before the named vhosts below.
+# /nginx_status is carved out for the otelcol scraper on the internal network.
 server {
     listen 80  default_server;
     listen [::]:80  default_server;
     listen 443 ssl default_server;
     listen [::]:443 ssl default_server;
     server_name _;
-    return 444;
+
+    location /nginx_status {
+        stub_status;
+        allow 172.16.0.0/12;
+        deny  all;
+    }
+
+    location / {
+        return 444;
+    }
 }
 
 # HTTP: serve ACME challenge for both apex and www; redirect everything else.

--- a/otel-collector-config.yml
+++ b/otel-collector-config.yml
@@ -17,13 +17,6 @@ receivers:
     endpoint: redis:6379
     collection_interval: 30s
 
-  docker_stats:
-    endpoint: unix:///var/run/docker.sock
-    collection_interval: 30s
-    excluded_images:
-      - postgres
-      - redis
-
   nginx:
     endpoint: http://nginx/nginx_status
     collection_interval: 30s
@@ -43,5 +36,5 @@ service:
       receivers: [otlp]
       exporters: [otlphttp]
     metrics:
-      receivers: [otlp, postgresql, redis, docker_stats, nginx]
+      receivers: [otlp, postgresql, redis, nginx]
       exporters: [otlphttp]

--- a/otel-collector-config.yml
+++ b/otel-collector-config.yml
@@ -20,7 +20,6 @@ receivers:
   docker_stats:
     endpoint: unix:///var/run/docker.sock
     collection_interval: 30s
-    container_labels_as_resource_attributes: true
     excluded_images:
       - postgres
       - redis


### PR DESCRIPTION
## Summary

Post-merge fixes discovered while debugging missing Grafana metrics after deploying #527:

- **`docker_stats` receiver crashes otelcol**: `container_labels_as_resource_attributes` is not a valid key in otelcol 0.126.0; removed it. Then found the receiver hardcodes Docker API version 1.25, which Docker 27+ daemons reject (minimum 1.44) — removed the receiver entirely.
- **nginx metrics not flowing**: `stub_status` was only in the HTTPS server block, but otelcol scrapes `http://nginx/nginx_status` (port 80) with `Host: nginx`. That host doesn't match the named server blocks, hitting the `default_server` which returns 444. Moved `stub_status` into the `default_server` block (still IP-restricted to `172.16.0.0/12`).

## Test plan

- [ ] `docker compose logs otelcol` shows "Everything is ready. Begin running and processing data." with no crash loop
- [ ] nginx metrics (`nginx.connections_accepted`, etc.) appear in Grafana within 30s of deploy
- [ ] External requests to raw IP still get connection-closed (444), not nginx_status data