### PR TITLE
feat: use thumbnail crop dimensions for masonry height pre-seeding

### DIFF
--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -429,7 +429,10 @@ js_library(
 
 js_library(
     name = "piece_list_src",
-    srcs = ["src/components/PieceList.tsx"],
+    srcs = [
+        "src/components/PieceList.tsx",
+        "src/components/pieceCardHeight.ts",
+    ],
     deps = [
         ":cloudinary_image_src",
         ":generated_types",

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -17,7 +17,7 @@ import { formatState, isTerminalState, SUCCESSORS } from "../util/workflow";
 import type { PieceSortOrder } from "../util/api";
 import { DEFAULT_PIECE_SORT, PIECE_SORT_OPTIONS } from "../util/api";
 import { MasonryScroller, useContainerPosition, usePositioner, useResizeObserver } from "masonic";
-import { estimateCardHeight } from "./pieceCardHeight";
+import { DEFAULT_CARD_HEIGHT_ESTIMATE, estimateCardHeight } from "./pieceCardHeight";
 import { Link, useSearchParams } from "react-router-dom";
 import CloudinaryImage from "./CloudinaryImage";
 import TagAutocomplete from "./TagAutocomplete";
@@ -25,9 +25,17 @@ import TagChip from "./TagChip";
 import { DEFAULT_THUMBNAIL } from "./thumbnailConstants";
 
 // Kiln-glow amber used for stale indicator
+const SSR_FALLBACK_HEIGHT = 768; // standard portrait tablet height; only used before first paint
+
+const MASONRY_COLUMN_WIDTH_MOBILE = 160;
+const MASONRY_COLUMN_WIDTH_DESKTOP = 220;
+const MASONRY_GUTTER = 8;
+const MASONRY_MAX_COLUMNS_MOBILE = 2;
+const MASONRY_MAX_COLUMNS_DESKTOP = 4;
+
 function useWindowHeight(): number {
   const [height, setHeight] = useState(() =>
-    typeof window !== "undefined" ? window.innerHeight : 768,
+    typeof window !== "undefined" ? window.innerHeight : SSR_FALLBACK_HEIGHT,
   );
   useEffect(() => {
     const update = () => setHeight(window.innerHeight);
@@ -405,10 +413,16 @@ const PieceList = (props: PieceListProps) => {
 
   const windowHeight = useWindowHeight();
   const masonryRef = useRef<HTMLElement | null>(null);
-  const columnWidth = isMobile ? 160 : 220;
+  const columnWidth = isMobile ? MASONRY_COLUMN_WIDTH_MOBILE : MASONRY_COLUMN_WIDTH_DESKTOP;
   const { width: masonryWidth, offset: masonryOffset } = useContainerPosition(masonryRef, [isMobile]);
   const positioner = usePositioner(
-    { width: masonryWidth, columnWidth, columnGutter: 8, rowGutter: 8, maxColumnCount: isMobile ? 2 : 4 },
+    {
+      width: masonryWidth,
+      columnWidth,
+      columnGutter: MASONRY_GUTTER,
+      rowGutter: MASONRY_GUTTER,
+      maxColumnCount: isMobile ? MASONRY_MAX_COLUMNS_MOBILE : MASONRY_MAX_COLUMNS_DESKTOP,
+    },
     [filterKey],
   );
   // Pre-seed per-item height estimates from crop aspect ratios before masonic places items,
@@ -814,7 +828,7 @@ const PieceList = (props: PieceListProps) => {
               items={filteredPieces}
               render={MasonryPieceCard}
               itemKey={(piece) => piece.id}
-              itemHeightEstimate={260}
+              itemHeightEstimate={DEFAULT_CARD_HEIGHT_ESTIMATE}
               offset={masonryOffset}
               height={windowHeight}
             />

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import AddIcon from "@mui/icons-material/Add";
 import FilterListIcon from "@mui/icons-material/FilterList";
 import SortIcon from "@mui/icons-material/Sort";
@@ -16,7 +16,8 @@ import type { PieceSummary, TagEntry } from "../util/types";
 import { formatState, isTerminalState, SUCCESSORS } from "../util/workflow";
 import type { PieceSortOrder } from "../util/api";
 import { DEFAULT_PIECE_SORT, PIECE_SORT_OPTIONS } from "../util/api";
-import { Masonry } from "masonic";
+import { MasonryScroller, useContainerPosition, usePositioner, useResizeObserver } from "masonic";
+import { estimateCardHeight } from "./pieceCardHeight";
 import { Link, useSearchParams } from "react-router-dom";
 import CloudinaryImage from "./CloudinaryImage";
 import TagAutocomplete from "./TagAutocomplete";
@@ -389,6 +390,22 @@ const PieceList = (props: PieceListProps) => {
     const tags = [...activeTagIds].sort().join(",");
     return `${filters}|${tags}|${sortOrder}`;
   }, [activeFilters, activeTagIds, sortOrder]);
+
+  const masonryRef = useRef<HTMLElement | null>(null);
+  const columnWidth = isMobile ? 160 : 220;
+  const { width: masonryWidth, offset: masonryOffset } = useContainerPosition(masonryRef, [isMobile]);
+  const positioner = usePositioner(
+    { width: masonryWidth, columnWidth, columnGutter: 8, rowGutter: 8, maxColumnCount: isMobile ? 2 : 4 },
+    [filterKey],
+  );
+  // Pre-seed per-item height estimates from crop aspect ratios before masonic places items,
+  // so initial column distribution reflects each card's actual proportions.
+  filteredPieces.forEach((piece, index) => {
+    if (piece.thumbnail?.crop && positioner.get(index) === undefined) {
+      positioner.set(index, estimateCardHeight(piece, positioner.columnWidth));
+    }
+  });
+  const resizeObserver = useResizeObserver(positioner);
 
   const toggleFilter = useCallback(
     (filter: FilterCategory) => {
@@ -777,17 +794,18 @@ const PieceList = (props: PieceListProps) => {
             pointerEvents: showOverlay ? "none" : "auto",
           }}
         >
-          <Masonry
-            key={filterKey}
-            items={filteredPieces}
-            render={MasonryPieceCard}
-            itemKey={(piece) => piece.id}
-            itemHeightEstimate={260}
-            columnWidth={isMobile ? 160 : 220}
-            maxColumnCount={isMobile ? 2 : 4}
-            columnGutter={8}
-            rowGutter={8}
-          />
+          <Box ref={masonryRef as React.RefObject<HTMLDivElement>}>
+            <MasonryScroller
+              positioner={positioner}
+              resizeObserver={resizeObserver}
+              items={filteredPieces}
+              render={MasonryPieceCard}
+              itemKey={(piece) => piece.id}
+              itemHeightEstimate={260}
+              offset={masonryOffset}
+              height={typeof window !== "undefined" ? window.innerHeight : 768}
+            />
+          </Box>
         </Box>
 
         {/* Centered spinner overlay while fetching the next page */}

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -25,6 +25,18 @@ import TagChip from "./TagChip";
 import { DEFAULT_THUMBNAIL } from "./thumbnailConstants";
 
 // Kiln-glow amber used for stale indicator
+function useWindowHeight(): number {
+  const [height, setHeight] = useState(() =>
+    typeof window !== "undefined" ? window.innerHeight : 768,
+  );
+  useEffect(() => {
+    const update = () => setHeight(window.innerHeight);
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, []);
+  return height;
+}
+
 const KILN_COLOR = "oklch(0.72 0.13 55)";
 
 type FilterCategory = "wip" | "completed" | "discarded" | "shared";
@@ -391,6 +403,7 @@ const PieceList = (props: PieceListProps) => {
     return `${filters}|${tags}|${sortOrder}`;
   }, [activeFilters, activeTagIds, sortOrder]);
 
+  const windowHeight = useWindowHeight();
   const masonryRef = useRef<HTMLElement | null>(null);
   const columnWidth = isMobile ? 160 : 220;
   const { width: masonryWidth, offset: masonryOffset } = useContainerPosition(masonryRef, [isMobile]);
@@ -803,7 +816,7 @@ const PieceList = (props: PieceListProps) => {
               itemKey={(piece) => piece.id}
               itemHeightEstimate={260}
               offset={masonryOffset}
-              height={typeof window !== "undefined" ? window.innerHeight : 768}
+              height={windowHeight}
             />
           </Box>
         </Box>

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -4,7 +4,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createMemoryRouter, RouterProvider } from "react-router-dom";
 import PieceList from "../PieceList";
-import { estimateCardHeight } from "../pieceCardHeight";
+import { CARD_CHROME_HEIGHT, DEFAULT_CARD_HEIGHT_ESTIMATE, estimateCardHeight } from "../pieceCardHeight";
 import type { PieceSummary } from "../../util/types";
 
 vi.mock("../CloudinaryImage", () => ({
@@ -107,45 +107,43 @@ async function openFilters(user: ReturnType<typeof userEvent.setup>) {
 }
 
 describe("estimateCardHeight", () => {
-  const CHROME = 60;
-
-  it("returns 260 when thumbnail is null", () => {
-    expect(estimateCardHeight({ thumbnail: null } as PieceSummary, 220)).toBe(260);
+  it("returns DEFAULT_CARD_HEIGHT_ESTIMATE when thumbnail is null", () => {
+    expect(estimateCardHeight({ thumbnail: null } as PieceSummary, 220)).toBe(DEFAULT_CARD_HEIGHT_ESTIMATE);
   });
 
-  it("returns 260 when crop is null", () => {
+  it("returns DEFAULT_CARD_HEIGHT_ESTIMATE when crop is null", () => {
     expect(
       estimateCardHeight({ thumbnail: { crop: null } } as PieceSummary, 220),
-    ).toBe(260);
+    ).toBe(DEFAULT_CARD_HEIGHT_ESTIMATE);
   });
 
-  it("returns 260 when crop is absent", () => {
+  it("returns DEFAULT_CARD_HEIGHT_ESTIMATE when crop is absent", () => {
     expect(
       estimateCardHeight({ thumbnail: {} } as PieceSummary, 220),
-    ).toBe(260);
+    ).toBe(DEFAULT_CARD_HEIGHT_ESTIMATE);
   });
 
   it("computes height from landscape crop aspect ratio", () => {
-    // 400×200 crop → ratio 0.5 → at width 220 → image height 110 + CHROME
+    // 400×200 crop → ratio 0.5 → at width 220 → image height 110 + CARD_CHROME_HEIGHT
     const piece = {
       thumbnail: { crop: { x: 0, y: 0, width: 400, height: 200 } },
     } as PieceSummary;
-    expect(estimateCardHeight(piece, 220)).toBe(Math.round(220 * 0.5) + CHROME);
+    expect(estimateCardHeight(piece, 220)).toBe(Math.round(220 * 0.5) + CARD_CHROME_HEIGHT);
   });
 
   it("computes height from portrait crop aspect ratio", () => {
-    // 200×400 crop → ratio 2 → at width 220 → image height 440 + CHROME
+    // 200×400 crop → ratio 2 → at width 220 → image height 440 + CARD_CHROME_HEIGHT
     const piece = {
       thumbnail: { crop: { x: 0, y: 0, width: 200, height: 400 } },
     } as PieceSummary;
-    expect(estimateCardHeight(piece, 220)).toBe(Math.round(220 * 2) + CHROME);
+    expect(estimateCardHeight(piece, 220)).toBe(Math.round(220 * 2) + CARD_CHROME_HEIGHT);
   });
 
-  it("returns 260 when crop.width is 0 (guard against division by zero)", () => {
+  it("returns DEFAULT_CARD_HEIGHT_ESTIMATE when crop.width is 0 (guard against division by zero)", () => {
     const piece = {
       thumbnail: { crop: { x: 0, y: 0, width: 0, height: 200 } },
     } as PieceSummary;
-    expect(estimateCardHeight(piece, 220)).toBe(260);
+    expect(estimateCardHeight(piece, 220)).toBe(DEFAULT_CARD_HEIGHT_ESTIMATE);
   });
 });
 
@@ -157,7 +155,7 @@ describe("PieceList", () => {
 
   describe("masonry height pre-seeding", () => {
     it("pre-seeds the positioner with crop-derived height for pieces with a crop", () => {
-      // 200×400 crop at columnWidth 220 → image height = 220*400/200 = 440 → + 60 chrome = 500
+      // 200×400 crop at columnWidth 220 → image height = 220*400/200 = 440 → + CARD_CHROME_HEIGHT
       const piece = makePiece({
         thumbnail: {
           url: "https://example.com/img.jpg",
@@ -167,7 +165,7 @@ describe("PieceList", () => {
         },
       });
       renderPieceList([piece]);
-      expect(mockPositioner.set).toHaveBeenCalledWith(0, 500);
+      expect(mockPositioner.set).toHaveBeenCalledWith(0, Math.round(220 * 400 / 200) + CARD_CHROME_HEIGHT);
     });
 
     it("does not pre-seed the positioner for pieces without a crop", () => {

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createMemoryRouter, RouterProvider } from "react-router-dom";
 import PieceList from "../PieceList";
+import { estimateCardHeight } from "../pieceCardHeight";
 import type { PieceSummary } from "../../util/types";
 
 vi.mock("../CloudinaryImage", () => ({
@@ -30,8 +31,23 @@ vi.mock("../CloudinaryImage", () => ({
   ),
 }));
 
+const { mockPositioner } = vi.hoisted(() => ({
+  mockPositioner: {
+    get: vi.fn().mockReturnValue(undefined),
+    set: vi.fn(),
+    columnWidth: 220,
+    columnCount: 2,
+    update: vi.fn(),
+    range: vi.fn(),
+    size: vi.fn().mockReturnValue(0),
+    estimateHeight: vi.fn().mockReturnValue(0),
+    shortestColumn: vi.fn().mockReturnValue(0),
+    all: vi.fn().mockReturnValue([]),
+  },
+}));
+
 vi.mock("masonic", () => ({
-  Masonry: ({
+  MasonryScroller: ({
     items,
     render: RenderComponent,
     itemKey,
@@ -51,6 +67,9 @@ vi.mock("masonic", () => ({
       ))}
     </div>
   ),
+  useContainerPosition: () => ({ width: 440, offset: 0 }),
+  usePositioner: () => mockPositioner,
+  useResizeObserver: () => undefined,
 }));
 
 function makePiece(overrides: Partial<PieceSummary> = {}): PieceSummary {
@@ -87,7 +106,91 @@ async function openFilters(user: ReturnType<typeof userEvent.setup>) {
   await user.click(screen.getByRole("button", { name: /toggle filters/i }));
 }
 
+describe("estimateCardHeight", () => {
+  const CHROME = 60;
+
+  it("returns 260 when thumbnail is null", () => {
+    expect(estimateCardHeight({ thumbnail: null } as PieceSummary, 220)).toBe(260);
+  });
+
+  it("returns 260 when crop is null", () => {
+    expect(
+      estimateCardHeight({ thumbnail: { crop: null } } as PieceSummary, 220),
+    ).toBe(260);
+  });
+
+  it("returns 260 when crop is absent", () => {
+    expect(
+      estimateCardHeight({ thumbnail: {} } as PieceSummary, 220),
+    ).toBe(260);
+  });
+
+  it("computes height from landscape crop aspect ratio", () => {
+    // 400×200 crop → ratio 0.5 → at width 220 → image height 110 + CHROME
+    const piece = {
+      thumbnail: { crop: { x: 0, y: 0, width: 400, height: 200 } },
+    } as PieceSummary;
+    expect(estimateCardHeight(piece, 220)).toBe(Math.round(220 * 0.5) + CHROME);
+  });
+
+  it("computes height from portrait crop aspect ratio", () => {
+    // 200×400 crop → ratio 2 → at width 220 → image height 440 + CHROME
+    const piece = {
+      thumbnail: { crop: { x: 0, y: 0, width: 200, height: 400 } },
+    } as PieceSummary;
+    expect(estimateCardHeight(piece, 220)).toBe(Math.round(220 * 2) + CHROME);
+  });
+
+  it("returns 260 when crop.width is 0 (guard against division by zero)", () => {
+    const piece = {
+      thumbnail: { crop: { x: 0, y: 0, width: 0, height: 200 } },
+    } as PieceSummary;
+    expect(estimateCardHeight(piece, 220)).toBe(260);
+  });
+});
+
 describe("PieceList", () => {
+  beforeEach(() => {
+    mockPositioner.set.mockClear();
+    mockPositioner.get.mockReturnValue(undefined);
+  });
+
+  describe("masonry height pre-seeding", () => {
+    it("pre-seeds the positioner with crop-derived height for pieces with a crop", () => {
+      // 200×400 crop at columnWidth 220 → image height = 220*400/200 = 440 → + 60 chrome = 500
+      const piece = makePiece({
+        thumbnail: {
+          url: "https://example.com/img.jpg",
+          cloudinary_public_id: "id",
+          cloud_name: "demo",
+          crop: { x: 0, y: 0, width: 200, height: 400 },
+        },
+      });
+      renderPieceList([piece]);
+      expect(mockPositioner.set).toHaveBeenCalledWith(0, 500);
+    });
+
+    it("does not pre-seed the positioner for pieces without a crop", () => {
+      const piece = makePiece({ thumbnail: null });
+      renderPieceList([piece]);
+      expect(mockPositioner.set).not.toHaveBeenCalled();
+    });
+
+    it("does not re-seed already-positioned items", () => {
+      mockPositioner.get.mockReturnValue({ top: 0, left: 0, height: 300, column: 0 });
+      const piece = makePiece({
+        thumbnail: {
+          url: "https://example.com/img.jpg",
+          cloudinary_public_id: "id",
+          cloud_name: "demo",
+          crop: { x: 0, y: 0, width: 200, height: 400 },
+        },
+      });
+      renderPieceList([piece]);
+      expect(mockPositioner.set).not.toHaveBeenCalled();
+    });
+  });
+
   describe("with no pieces", () => {
     it("renders the piece count as 0", () => {
       renderPieceList([]);

--- a/web/src/components/pieceCardHeight.ts
+++ b/web/src/components/pieceCardHeight.ts
@@ -1,15 +1,16 @@
 import type { PieceSummary } from "../util/types";
 
 export const CARD_CHROME_HEIGHT = 60; // border (2) + body padding (18) + title (~20) + caption (~20)
+export const DEFAULT_CARD_HEIGHT_ESTIMATE = 260;
 
 /**
  * Estimates the rendered card height from the thumbnail crop aspect ratio.
- * Falls back to 260 when no crop is available.
+ * Falls back to DEFAULT_CARD_HEIGHT_ESTIMATE when no crop is available.
  */
 export function estimateCardHeight(piece: PieceSummary, columnWidth: number): number {
   const crop = piece.thumbnail?.crop;
   if (crop && crop.width > 0) {
     return Math.round((columnWidth * crop.height) / crop.width) + CARD_CHROME_HEIGHT;
   }
-  return 260;
+  return DEFAULT_CARD_HEIGHT_ESTIMATE;
 }

--- a/web/src/components/pieceCardHeight.ts
+++ b/web/src/components/pieceCardHeight.ts
@@ -1,0 +1,15 @@
+import type { PieceSummary } from "../util/types";
+
+export const CARD_CHROME_HEIGHT = 60; // border (2) + body padding (18) + title (~20) + caption (~20)
+
+/**
+ * Estimates the rendered card height from the thumbnail crop aspect ratio.
+ * Falls back to 260 when no crop is available.
+ */
+export function estimateCardHeight(piece: PieceSummary, columnWidth: number): number {
+  const crop = piece.thumbnail?.crop;
+  if (crop && crop.width > 0) {
+    return Math.round((columnWidth * crop.height) / crop.width) + CARD_CHROME_HEIGHT;
+  }
+  return 260;
+}


### PR DESCRIPTION
## Summary

- Replaces the static `itemHeightEstimate={260}` on `<Masonry>` with per-item height pre-seeding via masonic's lower-level API (`usePositioner` + `MasonryScroller`)
- For each piece whose thumbnail has a crop, the positioner is seeded with `Math.round(columnWidth × crop.height / crop.width) + 60` before masonic distributes items to columns
- Pieces without crops fall back to the `260` default
- Extracts `estimateCardHeight()` to `web/src/components/pieceCardHeight.ts` to avoid the `react-refresh/only-export-components` lint rule

## Why the lower-level masonic API

masonic's `<Masonry>` component only accepts `itemHeightEstimate: number` (a single static value). Per-item estimates require using `usePositioner` directly and calling `positioner.set(index, height)` before masonic renders — which is exactly what the library does internally for measured items.

## Test plan

- [x] Unit tests for `estimateCardHeight`: landscape, portrait, null thumbnail, null crop, zero crop width
- [x] Tests confirm `positioner.set` is called with the crop-derived height for pieces with crops
- [x] Tests confirm `positioner.set` is NOT called for pieces without crops or already-positioned items
- [x] `rtk bazel test //web:web_piece_list_test` — passes
- [x] `rtk bazel build --config=lint //web/...` — passes

Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)
