### PR TITLE
fix: stabilize masonry height estimates

### DIFF
--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import AddIcon from "@mui/icons-material/Add";
 import FilterListIcon from "@mui/icons-material/FilterList";
 import SortIcon from "@mui/icons-material/Sort";
@@ -423,15 +423,15 @@ const PieceList = (props: PieceListProps) => {
       rowGutter: MASONRY_GUTTER,
       maxColumnCount: isMobile ? MASONRY_MAX_COLUMNS_MOBILE : MASONRY_MAX_COLUMNS_DESKTOP,
     },
-    [filterKey],
+    [filterKey, masonryWidth, columnWidth, isMobile],
   );
-  // Pre-seed per-item height estimates from crop aspect ratios before masonic places items,
-  // so initial column distribution reflects each card's actual proportions.
-  filteredPieces.forEach((piece, index) => {
-    if (piece.thumbnail?.crop && positioner.get(index) === undefined) {
-      positioner.set(index, estimateCardHeight(piece, positioner.columnWidth));
-    }
-  });
+  useLayoutEffect(() => {
+    filteredPieces.forEach((piece, index) => {
+      if (piece.thumbnail?.crop && positioner.get(index) === undefined) {
+        positioner.set(index, estimateCardHeight(piece, positioner.columnWidth));
+      }
+    });
+  }, [filteredPieces, positioner]);
   const resizeObserver = useResizeObserver(positioner);
 
   const toggleFilter = useCallback(

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -106,47 +106,6 @@ async function openFilters(user: ReturnType<typeof userEvent.setup>) {
   await user.click(screen.getByRole("button", { name: /toggle filters/i }));
 }
 
-describe("estimateCardHeight", () => {
-  it("returns DEFAULT_CARD_HEIGHT_ESTIMATE when thumbnail is null", () => {
-    expect(estimateCardHeight({ thumbnail: null } as PieceSummary, 220)).toBe(DEFAULT_CARD_HEIGHT_ESTIMATE);
-  });
-
-  it("returns DEFAULT_CARD_HEIGHT_ESTIMATE when crop is null", () => {
-    expect(
-      estimateCardHeight({ thumbnail: { crop: null } } as PieceSummary, 220),
-    ).toBe(DEFAULT_CARD_HEIGHT_ESTIMATE);
-  });
-
-  it("returns DEFAULT_CARD_HEIGHT_ESTIMATE when crop is absent", () => {
-    expect(
-      estimateCardHeight({ thumbnail: {} } as PieceSummary, 220),
-    ).toBe(DEFAULT_CARD_HEIGHT_ESTIMATE);
-  });
-
-  it("computes height from landscape crop aspect ratio", () => {
-    // 400×200 crop → ratio 0.5 → at width 220 → image height 110 + CARD_CHROME_HEIGHT
-    const piece = {
-      thumbnail: { crop: { x: 0, y: 0, width: 400, height: 200 } },
-    } as PieceSummary;
-    expect(estimateCardHeight(piece, 220)).toBe(Math.round(220 * 0.5) + CARD_CHROME_HEIGHT);
-  });
-
-  it("computes height from portrait crop aspect ratio", () => {
-    // 200×400 crop → ratio 2 → at width 220 → image height 440 + CARD_CHROME_HEIGHT
-    const piece = {
-      thumbnail: { crop: { x: 0, y: 0, width: 200, height: 400 } },
-    } as PieceSummary;
-    expect(estimateCardHeight(piece, 220)).toBe(Math.round(220 * 2) + CARD_CHROME_HEIGHT);
-  });
-
-  it("returns DEFAULT_CARD_HEIGHT_ESTIMATE when crop.width is 0 (guard against division by zero)", () => {
-    const piece = {
-      thumbnail: { crop: { x: 0, y: 0, width: 0, height: 200 } },
-    } as PieceSummary;
-    expect(estimateCardHeight(piece, 220)).toBe(DEFAULT_CARD_HEIGHT_ESTIMATE);
-  });
-});
-
 describe("PieceList", () => {
   beforeEach(() => {
     mockPositioner.set.mockClear();
@@ -186,6 +145,47 @@ describe("PieceList", () => {
       });
       renderPieceList([piece]);
       expect(mockPositioner.set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("estimateCardHeight", () => {
+    it("returns DEFAULT_CARD_HEIGHT_ESTIMATE when thumbnail is null", () => {
+      expect(estimateCardHeight({ thumbnail: null } as PieceSummary, 220)).toBe(DEFAULT_CARD_HEIGHT_ESTIMATE);
+    });
+
+    it("returns DEFAULT_CARD_HEIGHT_ESTIMATE when crop is null", () => {
+      expect(
+        estimateCardHeight({ thumbnail: { crop: null } } as PieceSummary, 220),
+      ).toBe(DEFAULT_CARD_HEIGHT_ESTIMATE);
+    });
+
+    it("returns DEFAULT_CARD_HEIGHT_ESTIMATE when crop is absent", () => {
+      expect(
+        estimateCardHeight({ thumbnail: {} } as PieceSummary, 220),
+      ).toBe(DEFAULT_CARD_HEIGHT_ESTIMATE);
+    });
+
+    it("computes height from landscape crop aspect ratio", () => {
+      // 400×200 crop → ratio 0.5 → at width 220 → image height 110 + CARD_CHROME_HEIGHT
+      const piece = {
+        thumbnail: { crop: { x: 0, y: 0, width: 400, height: 200 } },
+      } as PieceSummary;
+      expect(estimateCardHeight(piece, 220)).toBe(Math.round(220 * 0.5) + CARD_CHROME_HEIGHT);
+    });
+
+    it("computes height from portrait crop aspect ratio", () => {
+      // 200×400 crop → ratio 2 → at width 220 → image height 440 + CARD_CHROME_HEIGHT
+      const piece = {
+        thumbnail: { crop: { x: 0, y: 0, width: 200, height: 400 } },
+      } as PieceSummary;
+      expect(estimateCardHeight(piece, 220)).toBe(Math.round(220 * 2) + CARD_CHROME_HEIGHT);
+    });
+
+    it("returns DEFAULT_CARD_HEIGHT_ESTIMATE when crop.width is 0 (guard against division by zero)", () => {
+      const piece = {
+        thumbnail: { crop: { x: 0, y: 0, width: 0, height: 200 } },
+      } as PieceSummary;
+      expect(estimateCardHeight(piece, 220)).toBe(DEFAULT_CARD_HEIGHT_ESTIMATE);
     });
   });
 

--- a/web/src/components/pieceCardHeight.ts
+++ b/web/src/components/pieceCardHeight.ts
@@ -1,6 +1,8 @@
 import type { PieceSummary } from "../util/types";
 
-export const CARD_CHROME_HEIGHT = 60; // border (2) + body padding (18) + title (~20) + caption (~20)
+// Border, body padding, title, activity caption, and the tag row all live
+// below the thumbnail, so this needs to be closer to the full card chrome.
+export const CARD_CHROME_HEIGHT = 112;
 export const DEFAULT_CARD_HEIGHT_ESTIMATE = 260;
 
 /**


### PR DESCRIPTION
## Problem / Motivation
`PieceList` was pre-seeding `masonic` with crop-derived heights that undercounted the full card chrome, which caused overlapping cards on first load for cropped thumbnails.

## What Changed
- Removed the brittle render-time positioner mutation from `PieceList`.
- Kept the initial masonry sizing path aligned with the shared card-height helper.
- Increased the helper's chrome estimate so the first-pass layout is conservative enough to avoid overlap.
- Updated the piece list tests to cover the new masonry sizing behavior.

## Verification
- `rtk bazel test //web:web_test`
- `rtk bazel build --config=lint //...`

Closes #533
