### PR TITLE
[codex] stabilize masonry crop layout

### DIFF
--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -17,7 +17,7 @@ import { formatState, isTerminalState, SUCCESSORS } from "../util/workflow";
 import type { PieceSortOrder } from "../util/api";
 import { DEFAULT_PIECE_SORT, PIECE_SORT_OPTIONS } from "../util/api";
 import { MasonryScroller, useContainerPosition, usePositioner, useResizeObserver } from "masonic";
-import { DEFAULT_CARD_HEIGHT_ESTIMATE, estimateCardHeight } from "./pieceCardHeight";
+import { DEFAULT_CARD_HEIGHT_ESTIMATE, estimateCardHeight, getThumbnailAspectRatio } from "./pieceCardHeight";
 import { Link, useSearchParams } from "react-router-dom";
 import CloudinaryImage from "./CloudinaryImage";
 import TagAutocomplete from "./TagAutocomplete";
@@ -114,6 +114,7 @@ const PieceCard = ({ piece, width }: PieceCardProps) => {
   const isStale = days >= 14 && !isTerminal;
   const label = formatState(piece.current_state.state);
   const detailPath = `/pieces/${piece.id}`;
+  const estimatedHeight = estimateCardHeight(piece, width);
 
   // Tags: show 2 visible + dashed overflow chip (non-expandable in card)
   const tags = piece.tags ?? [];
@@ -129,6 +130,8 @@ const PieceCard = ({ piece, width }: PieceCardProps) => {
     <Box
       component={Link}
       to={detailPath}
+      style={{ minHeight: estimatedHeight }}
+      data-estimated-height={estimatedHeight}
       sx={{
         display: "block",
         borderRadius: 2,
@@ -147,7 +150,14 @@ const PieceCard = ({ piece, width }: PieceCardProps) => {
       }}
     >
       {/* Thumbnail area */}
-      <Box sx={{ position: "relative", overflow: "hidden" }}>
+      <Box
+        data-testid="piece-thumbnail-shell"
+        sx={{
+          position: "relative",
+          overflow: "hidden",
+          aspectRatio: getThumbnailAspectRatio(piece),
+        }}
+      >
         <CloudinaryImage
           url={piece.thumbnail?.url ?? DEFAULT_THUMBNAIL}
           cloud_name={piece.thumbnail?.cloud_name}

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -50,21 +50,50 @@ vi.mock("masonic", () => ({
   MasonryScroller: ({
     items,
     render: RenderComponent,
+    itemHeightEstimate,
     itemKey,
   }: {
     items: PieceSummary[];
     render: React.ComponentType<{ data: PieceSummary; index: number; width: number }>;
+    itemHeightEstimate: number;
     itemKey?: (item: PieceSummary, index: number) => string | number;
   }) => (
-    <div data-testid="piece-grid">
-      {items.map((item, index) => (
-        <div
-          key={itemKey ? itemKey(item, index) : index}
-          data-key={itemKey ? itemKey(item, index) : index}
-        >
-          <RenderComponent data={item} index={index} width={240} />
-        </div>
-      ))}
+    <div data-testid="piece-grid" style={{ position: "relative" }}>
+      {(() => {
+        const gutter = 8;
+        const columnCount = mockPositioner.columnCount;
+        const columnWidth = mockPositioner.columnWidth;
+        const columnHeights = Array.from({ length: columnCount }, () => 0);
+        const seededHeights = new Map(
+          mockPositioner.set.mock.calls.map(([index, height]) => [index as number, height as number]),
+        );
+
+        return items.map((item, index) => {
+          const height = seededHeights.get(index) ?? itemHeightEstimate;
+          const column = columnHeights.indexOf(Math.min(...columnHeights));
+          const top = columnHeights[column];
+          const left = column * (columnWidth + gutter);
+          columnHeights[column] = top + height + gutter;
+
+          return (
+            <div
+              key={itemKey ? itemKey(item, index) : index}
+              data-key={itemKey ? itemKey(item, index) : index}
+              data-column={column}
+              data-top={top}
+              data-height={height}
+              style={{
+                position: "absolute",
+                top,
+                left,
+                width: columnWidth,
+              }}
+            >
+              <RenderComponent data={item} index={index} width={240} />
+            </div>
+          );
+        });
+      })()}
     </div>
   ),
   useContainerPosition: () => ({ width: 440, offset: 0 }),
@@ -149,8 +178,10 @@ describe("estimateCardHeight", () => {
 
 describe("PieceList", () => {
   beforeEach(() => {
-    mockPositioner.set.mockClear();
-    mockPositioner.get.mockReturnValue(undefined);
+    mockPositioner.set.mockReset();
+    mockPositioner.get.mockReset();
+    mockPositioner.set.mockImplementation(() => undefined);
+    mockPositioner.get.mockImplementation(() => undefined);
   });
 
   describe("masonry height pre-seeding", () => {
@@ -186,6 +217,77 @@ describe("PieceList", () => {
       });
       renderPieceList([piece]);
       expect(mockPositioner.set).not.toHaveBeenCalled();
+    });
+
+    it("reserves the thumbnail crop ratio in the card shell", () => {
+      renderPieceList([
+        makePiece({
+          thumbnail: {
+            url: "https://example.com/img.jpg",
+            cloudinary_public_id: "id",
+            cloud_name: "demo",
+            crop: { x: 0, y: 0, width: 200, height: 400 },
+          },
+        }),
+      ]);
+
+      expect(screen.getByTestId("piece-thumbnail-shell")).toHaveStyle({
+        aspectRatio: "200 / 400",
+      });
+    });
+
+    it("reserves the crop-derived card height for mocked image payloads", () => {
+      const pieces = [
+        makePiece({
+          id: "portrait",
+          name: "Tall Pitcher",
+          thumbnail: {
+            url: "https://example.com/tall.jpg",
+            cloudinary_public_id: "pieces/tall",
+            cloud_name: "demo",
+            crop: { x: 0, y: 0, width: 200, height: 400 },
+          },
+        }),
+        makePiece({
+          id: "landscape",
+          name: "Low Tray",
+          thumbnail: {
+            url: "https://example.com/wide.jpg",
+            cloudinary_public_id: "pieces/wide",
+            cloud_name: "demo",
+            crop: { x: 0, y: 0, width: 400, height: 200 },
+          },
+        }),
+        makePiece({
+          id: "square",
+          name: "Small Cup",
+          thumbnail: {
+            url: "https://example.com/square.jpg",
+            cloudinary_public_id: "pieces/square",
+            cloud_name: "demo",
+            crop: { x: 0, y: 0, width: 200, height: 200 },
+          },
+        }),
+      ];
+
+      renderPieceList(pieces);
+
+      const cards = screen.getAllByRole("link");
+      expect(cards[0]).toHaveAttribute(
+        "data-estimated-height",
+        `${estimateCardHeight(pieces[0], 240)}`,
+      );
+      expect(cards[1]).toHaveAttribute(
+        "data-estimated-height",
+        `${estimateCardHeight(pieces[1], 240)}`,
+      );
+      expect(cards[2]).toHaveAttribute(
+        "data-estimated-height",
+        `${estimateCardHeight(pieces[2], 240)}`,
+      );
+      expect(Number(cards[0].getAttribute("data-estimated-height"))).toBeGreaterThan(
+        DEFAULT_CARD_HEIGHT_ESTIMATE,
+      );
     });
   });
 

--- a/web/src/components/pieceCardHeight.ts
+++ b/web/src/components/pieceCardHeight.ts
@@ -3,6 +3,14 @@ import type { PieceSummary } from "../util/types";
 export const CARD_CHROME_HEIGHT = 60; // border (2) + body padding (18) + title (~20) + caption (~20)
 export const DEFAULT_CARD_HEIGHT_ESTIMATE = 260;
 
+export function getThumbnailAspectRatio(piece: PieceSummary): string | undefined {
+  const crop = piece.thumbnail?.crop;
+  if (crop && crop.width > 0 && crop.height > 0) {
+    return `${crop.width} / ${crop.height}`;
+  }
+  return undefined;
+}
+
 /**
  * Estimates the rendered card height from the thumbnail crop aspect ratio.
  * Falls back to DEFAULT_CARD_HEIGHT_ESTIMATE when no crop is available.


### PR DESCRIPTION
## What changed
- Reserved crop-backed thumbnail aspect ratios in the piece card shell so masonry has a real height before the image loads.
- Put the crop-derived total height on the card root as an explicit layout contract, which the masonry grid can measure consistently.
- Expanded the `PieceList` regression coverage with mocked crop payloads and a deterministic layout check that verifies the rendered height estimate for tall, wide, and square crops.

## Why
- We saw two failure modes in the masonry list: crop height estimates being ignored entirely, or positioner placement drifting into overlapping cards.
- The regression test now asserts the rendered card height contract directly, which gives us a stable signal when tuning the masonry strategy.

## Validation
- `rtk bazel test //web:web_piece_list_test`
- `rtk bazel test //...`
- `rtk bazel build --config=lint //web/...`

Closes #533
