### PR TITLE
Fix Modal deploy workflow for services

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -149,4 +149,19 @@ jobs:
         env:
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-        run: modal deploy -m services
+        run: |
+          shopt -s nullglob
+          deployed=0
+          for service in services/*.py; do
+            if [ "$(basename "$service")" = "__init__.py" ]; then
+              continue
+            fi
+
+            modal deploy "$service"
+            deployed=1
+          done
+
+          if [ "$deployed" -eq 0 ]; then
+            echo "No Modal service modules found under services/." >&2
+            exit 1
+          fi

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -57,7 +57,7 @@ Runs automatically after CI completes successfully on `main`, or manually via `w
 | Job | What it does |
 |---|---|
 | **Deploy to droplet** | Renders `.env.production.template` with secrets and variables into `/tmp/.env`, SCPs it to the droplet, then runs `deploy.sh` to pull the new image, run the one-shot `deploy_init` bootstrap, and perform the rolling restart. Creates a GitHub Release tagged `release-<sha>` on success. Runs in the `glaze-droplet` environment with `concurrency: deploy-production` (never cancels in-progress deploys). |
-| **Deploy Services to Modal** | Deploys the `services/` directory to Modal using `modal deploy -m services`. Runs in parallel with the droplet deploy. |
+| **Deploy Services to Modal** | Deploys each deployable Python module under `services/` individually. Runs in parallel with the droplet deploy. |
 
 #### Required secrets / variables
 
@@ -112,7 +112,7 @@ PR merged to main
        └─ image job always runs -> pushes ghcr.io/shaoster/glaze:latest + :<sha>
             └─ CD triggered by workflow_run on success
                  ├─ deploy job: SCP .env -> deploy.sh -> pull image -> run deploy_init -> rolling restart -> GitHub Release
-                 └─ deploy-modal job: modal deploy -m services
+                 └─ deploy-modal job: iterate over services/*.py and run modal deploy on each module
 ```
 
 nginx config changes (in `nginx/conf.d/`) are deployed automatically with every release — `docker compose up -d --force-recreate` mounts the config at the checked-out SHA with no separate sync step.

--- a/services/piece_image_segment_service.py
+++ b/services/piece_image_segment_service.py
@@ -5,7 +5,7 @@ Can be deployed to Modal.com or run locally.
 
 Deployment (Modal):
     1. Set up a secret named 'piece-image-segment-secret' with 'AUTH_TOKEN'
-    2. modal deploy -m services
+    2. modal deploy services/piece_image_segment_service.py
 
 Usage (Local):
     pip install fastapi uvicorn rembg onnxruntime pillow pillow-heif

--- a/tools/README.md
+++ b/tools/README.md
@@ -14,7 +14,7 @@ To maintain stability on hardware with <1GB RAM, Glaze supports offloading the h
 1.  **Set up Auth Token**: Create a Modal secret named `piece-image-segment-secret` with an `AUTH_TOKEN` key.
 2.  **Install Modal**: `bazel run @uv//:uv -- tool install modal`
 3.  **Authenticate**: `modal setup`
-4.  **Deploy**: `modal deploy -m services`
+4.  **Deploy**: `modal deploy services/piece_image_segment_service.py`
 5.  **Capture the URL**: The output will provide a permanent URL, e.g., `https://your-workspace-name--crop.modal.run`.
 
 #### Step 2: Configure the Backend (Run on the PRODUCTION host / Droplet)


### PR DESCRIPTION
## Summary
- Update the CD workflow to deploy each deployable `services/*.py` Modal app individually instead of targeting the `services/` package as one unit.
- Align the service module note and CI/CD docs with the file-based Modal deploy command.
- Leave `services/__init__.py` in place for now so the current import and test setup stays stable.

## Validation
- `rtk bazel test //...`
- `rtk bazel build --config=lint //...`
