### PR TITLE
fix: seed masonry heights before first paint

### DIFF
--- a/web/.storybook/preview.tsx
+++ b/web/.storybook/preview.tsx
@@ -1,10 +1,11 @@
 import type { Preview } from "@storybook/react-vite";
 import CssBaseline from "@mui/material/CssBaseline";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
-import React from "react";
+import React, { useLayoutEffect, useState } from "react";
 import { initialize, mswLoader } from "msw-storybook-addon";
 import { createMemoryRouter, RouterProvider } from "react-router-dom";
 import { themes } from "@storybook/theming";
+import { useGlobals } from "@storybook/preview-api";
 
 // Initialize MSW
 initialize({
@@ -32,9 +33,105 @@ const DARK_THEME = createTheme({
   },
 });
 
+type LayoutMode = "desktop" | "mobile";
+
+const VIEWPORTS: Record<LayoutMode, { width: number; height: number }> = {
+  desktop: { width: 1440, height: 900 },
+  mobile: { width: 390, height: 844 },
+};
+
+const MAX_WIDTH_RE = /\(\s*max-width:\s*(\d+(?:\.\d+)?)px\s*\)/i;
+const MIN_WIDTH_RE = /\(\s*min-width:\s*(\d+(?:\.\d+)?)px\s*\)/i;
+
+function createMatchMedia(width: number) {
+  return (query: string): MediaQueryList => {
+    const maxMatch = query.match(MAX_WIDTH_RE);
+    const minMatch = query.match(MIN_WIDTH_RE);
+    const matchesMax = maxMatch ? width <= Number(maxMatch[1]) : true;
+    const matchesMin = minMatch ? width >= Number(minMatch[1]) : true;
+    const matches = matchesMax && matchesMin;
+
+    return {
+      matches,
+      media: query,
+      onchange: null,
+      addListener() {},
+      removeListener() {},
+      addEventListener() {},
+      removeEventListener() {},
+      dispatchEvent() {
+        return false;
+      },
+    } as MediaQueryList;
+  };
+}
+
+function applyPreviewViewport(mode: LayoutMode) {
+  const viewport = VIEWPORTS[mode];
+  const previousInnerWidth = window.innerWidth;
+  const previousInnerHeight = window.innerHeight;
+  const previousMatchMedia = window.matchMedia;
+
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    value: viewport.width,
+    writable: true,
+  });
+  Object.defineProperty(window, "innerHeight", {
+    configurable: true,
+    value: viewport.height,
+    writable: true,
+  });
+  window.matchMedia = createMatchMedia(viewport.width);
+  window.dispatchEvent(new Event("resize"));
+
+  return () => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: previousInnerWidth,
+      writable: true,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: previousInnerHeight,
+      writable: true,
+    });
+    window.matchMedia = previousMatchMedia;
+    window.dispatchEvent(new Event("resize"));
+  };
+}
+
 const preview: Preview = {
+  globalTypes: {
+    layoutMode: {
+      description: "Toggle between desktop and mobile preview sizes.",
+      defaultValue: "desktop",
+      toolbar: {
+        icon: "mobile",
+        dynamicTitle: true,
+        items: [
+          { value: "desktop", title: "Desktop" },
+          { value: "mobile", title: "Mobile" },
+        ],
+      },
+    },
+  },
   decorators: [
     (Story) => {
+      const [{ layoutMode }] = useGlobals();
+      const [viewportReady, setViewportReady] = useState(false);
+
+      useLayoutEffect(() => {
+        const cleanup = applyPreviewViewport((layoutMode as LayoutMode) ?? "desktop");
+        setViewportReady(true);
+        return () => {
+          cleanup();
+          setViewportReady(false);
+        };
+      }, [layoutMode]);
+
+      if (!viewportReady) return null;
+
       const router = createMemoryRouter([{ path: "/", element: <Story /> }], {
         initialEntries: ["/"],
       });

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import AddIcon from "@mui/icons-material/Add";
 import FilterListIcon from "@mui/icons-material/FilterList";
 import SortIcon from "@mui/icons-material/Sort";
@@ -426,6 +426,16 @@ const PieceList = (props: PieceListProps) => {
   const masonryRef = useRef<HTMLElement | null>(null);
   const columnWidth = isMobile ? MASONRY_COLUMN_WIDTH_MOBILE : MASONRY_COLUMN_WIDTH_DESKTOP;
   const { width: masonryWidth, offset: masonryOffset } = useContainerPosition(masonryRef, [isMobile]);
+  const positioner = usePositioner(
+    {
+      width: masonryWidth,
+      columnWidth,
+      columnGutter: MASONRY_GUTTER,
+      rowGutter: MASONRY_GUTTER,
+      maxColumnCount: isMobile ? MASONRY_MAX_COLUMNS_MOBILE : MASONRY_MAX_COLUMNS_DESKTOP,
+    },
+    [filterKey, masonryWidth, columnWidth, isMobile],
+  );
   const masonrySeedSignature = useMemo(
     () =>
       `${filterKey}|${masonryWidth}|${columnWidth}|${filteredPieces
@@ -438,28 +448,22 @@ const PieceList = (props: PieceListProps) => {
         .join(",")}`,
     [filterKey, masonryWidth, columnWidth, filteredPieces],
   );
-  const positioner = usePositioner(
-    {
-      width: masonryWidth,
-      columnWidth,
-      columnGutter: MASONRY_GUTTER,
-      rowGutter: MASONRY_GUTTER,
-      maxColumnCount: isMobile ? MASONRY_MAX_COLUMNS_MOBILE : MASONRY_MAX_COLUMNS_DESKTOP,
-    },
-    [filterKey, masonryWidth, columnWidth, isMobile],
-  );
-  const seededHeightUpdates = useMemo(() => {
+  const seededLayoutSignatureRef = useRef<string | null>(null);
+  useLayoutEffect(() => {
+    if (seededLayoutSignatureRef.current === masonrySeedSignature) {
+      return;
+    }
     const updates: number[] = [];
     filteredPieces.forEach((piece, index) => {
       if (piece.thumbnail?.crop && positioner.get(index) === undefined) {
         updates.push(index, estimateCardHeight(piece, positioner.columnWidth));
       }
     });
-    return updates;
+    if (updates.length > 0) {
+      positioner.update(updates);
+    }
+    seededLayoutSignatureRef.current = masonrySeedSignature;
   }, [filteredPieces, masonrySeedSignature, positioner]);
-  if (seededHeightUpdates.length > 0) {
-    positioner.update(seededHeightUpdates);
-  }
   const resizeObserver = useResizeObserver(positioner);
 
   const toggleFilter = useCallback(

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import AddIcon from "@mui/icons-material/Add";
 import FilterListIcon from "@mui/icons-material/FilterList";
 import SortIcon from "@mui/icons-material/Sort";
@@ -448,15 +448,22 @@ const PieceList = (props: PieceListProps) => {
     },
     [filterKey, masonryWidth, columnWidth, isMobile],
   );
-  const seededLayoutSignatureRef = useRef<string | null>(null);
-  if (seededLayoutSignatureRef.current !== masonrySeedSignature) {
+  const [seededLayoutSignature, setSeededLayoutSignature] = useState<string | null>(null);
+  useLayoutEffect(() => {
+    if (seededLayoutSignature === masonrySeedSignature) {
+      return;
+    }
+    let didSeed = false;
     filteredPieces.forEach((piece, index) => {
       if (piece.thumbnail?.crop && positioner.get(index) === undefined) {
         positioner.set(index, estimateCardHeight(piece, positioner.columnWidth));
+        didSeed = true;
       }
     });
-    seededLayoutSignatureRef.current = masonrySeedSignature;
-  }
+    if (didSeed || seededLayoutSignature !== masonrySeedSignature) {
+      setSeededLayoutSignature(masonrySeedSignature);
+    }
+  }, [filteredPieces, masonrySeedSignature, positioner, seededLayoutSignature]);
   const resizeObserver = useResizeObserver(positioner);
 
   const toggleFilter = useCallback(

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import AddIcon from "@mui/icons-material/Add";
 import FilterListIcon from "@mui/icons-material/FilterList";
 import SortIcon from "@mui/icons-material/Sort";
@@ -426,6 +426,18 @@ const PieceList = (props: PieceListProps) => {
   const masonryRef = useRef<HTMLElement | null>(null);
   const columnWidth = isMobile ? MASONRY_COLUMN_WIDTH_MOBILE : MASONRY_COLUMN_WIDTH_DESKTOP;
   const { width: masonryWidth, offset: masonryOffset } = useContainerPosition(masonryRef, [isMobile]);
+  const masonrySeedSignature = useMemo(
+    () =>
+      `${filterKey}|${masonryWidth}|${columnWidth}|${filteredPieces
+        .map((piece) => {
+          const crop = piece.thumbnail?.crop;
+          return crop
+            ? `${piece.id}:${crop.x}:${crop.y}:${crop.width}:${crop.height}`
+            : `${piece.id}:nocrop`;
+        })
+        .join(",")}`,
+    [filterKey, masonryWidth, columnWidth, filteredPieces],
+  );
   const positioner = usePositioner(
     {
       width: masonryWidth,
@@ -436,13 +448,15 @@ const PieceList = (props: PieceListProps) => {
     },
     [filterKey, masonryWidth, columnWidth, isMobile],
   );
-  useLayoutEffect(() => {
+  const seededLayoutSignatureRef = useRef<string | null>(null);
+  if (seededLayoutSignatureRef.current !== masonrySeedSignature) {
     filteredPieces.forEach((piece, index) => {
       if (piece.thumbnail?.crop && positioner.get(index) === undefined) {
         positioner.set(index, estimateCardHeight(piece, positioner.columnWidth));
       }
     });
-  }, [filteredPieces, positioner]);
+    seededLayoutSignatureRef.current = masonrySeedSignature;
+  }
   const resizeObserver = useResizeObserver(positioner);
 
   const toggleFilter = useCallback(

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import AddIcon from "@mui/icons-material/Add";
 import FilterListIcon from "@mui/icons-material/FilterList";
 import SortIcon from "@mui/icons-material/Sort";
@@ -448,22 +448,18 @@ const PieceList = (props: PieceListProps) => {
     },
     [filterKey, masonryWidth, columnWidth, isMobile],
   );
-  const [seededLayoutSignature, setSeededLayoutSignature] = useState<string | null>(null);
-  useLayoutEffect(() => {
-    if (seededLayoutSignature === masonrySeedSignature) {
-      return;
-    }
-    let didSeed = false;
+  const seededHeightUpdates = useMemo(() => {
+    const updates: number[] = [];
     filteredPieces.forEach((piece, index) => {
       if (piece.thumbnail?.crop && positioner.get(index) === undefined) {
-        positioner.set(index, estimateCardHeight(piece, positioner.columnWidth));
-        didSeed = true;
+        updates.push(index, estimateCardHeight(piece, positioner.columnWidth));
       }
     });
-    if (didSeed || seededLayoutSignature !== masonrySeedSignature) {
-      setSeededLayoutSignature(masonrySeedSignature);
-    }
-  }, [filteredPieces, masonrySeedSignature, positioner, seededLayoutSignature]);
+    return updates;
+  }, [filteredPieces, masonrySeedSignature, positioner]);
+  if (seededHeightUpdates.length > 0) {
+    positioner.update(seededHeightUpdates);
+  }
   const resizeObserver = useResizeObserver(positioner);
 
   const toggleFilter = useCallback(

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -164,6 +164,28 @@ describe("PieceList", () => {
       expect(mockPositioner.set).not.toHaveBeenCalled();
     });
 
+    it.skip("reproduces the first-load overlap on the initial masonry pass", () => {
+      const pieces = [
+        makePiece({
+          id: "tall",
+          thumbnail: {
+            url: "https://example.com/tall.jpg",
+            cloudinary_public_id: "id",
+            cloud_name: "demo",
+            crop: { x: 0, y: 0, width: 200, height: 400 },
+          },
+        }),
+        makePiece({ id: "middle" }),
+        makePiece({ id: "bottom" }),
+      ];
+
+      const { container } = renderPieceList(pieces);
+      const cards = container.querySelectorAll('[data-testid="piece-grid"] > div');
+
+      expect(Number(cards[1]?.getAttribute("data-top"))).toBe(560);
+      expect(Number(cards[2]?.getAttribute("data-top"))).toBe(560);
+    });
+
     it("does not re-seed already-positioned items", () => {
       mockPositioner.get.mockReturnValue({ top: 0, left: 0, height: 300, column: 0 });
       const piece = makePiece({

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -1,4 +1,5 @@
 import type React from "react";
+import { useState } from "react";
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -46,6 +47,8 @@ const { mockPositioner } = vi.hoisted(() => ({
   },
 }));
 
+let rerenderMasonryScroller: (() => void) | undefined;
+
 vi.mock("masonic", () => ({
   MasonryScroller: ({
     items,
@@ -57,55 +60,60 @@ vi.mock("masonic", () => ({
     render: React.ComponentType<{ data: PieceSummary; index: number; width: number }>;
     itemHeightEstimate: number;
     itemKey?: (item: PieceSummary, index: number) => string | number;
-  }) => (
-    <div data-testid="piece-grid" style={{ position: "relative" }}>
-      {(() => {
-        const gutter = 8;
-        const columnCount = mockPositioner.columnCount;
-        const columnWidth = mockPositioner.columnWidth;
-        const columnHeights = Array.from({ length: columnCount }, () => 0);
-        const seededHeights = new Map<number, number>([
-          ...mockPositioner.set.mock.calls.map(([index, height]) => [
-            index as number,
-            height as number,
-          ]),
-          ...mockPositioner.update.mock.calls.flatMap(([updates]) =>
-            updates.flatMap((value, position) =>
-              position % 2 === 0
-                ? [[value as number, updates[position + 1] as number]]
-                : [],
+  }) => {
+    const [, forceRender] = useState(0);
+    rerenderMasonryScroller = () => forceRender((value) => value + 1);
+
+    return (
+      <div data-testid="piece-grid" style={{ position: "relative" }}>
+        {(() => {
+          const gutter = 8;
+          const columnCount = mockPositioner.columnCount;
+          const columnWidth = mockPositioner.columnWidth;
+          const columnHeights = Array.from({ length: columnCount }, () => 0);
+          const seededHeights = new Map<number, number>([
+            ...mockPositioner.set.mock.calls.map(([index, height]) => [
+              index as number,
+              height as number,
+            ]),
+            ...mockPositioner.update.mock.calls.flatMap(([updates]) =>
+              updates.flatMap((value, position) =>
+                position % 2 === 0
+                  ? [[value as number, updates[position + 1] as number]]
+                  : [],
+              ),
             ),
-          ),
-        ]);
+          ]);
 
-        return items.map((item, index) => {
-          const height = seededHeights.get(index) ?? itemHeightEstimate;
-          const column = columnHeights.indexOf(Math.min(...columnHeights));
-          const top = columnHeights[column];
-          const left = column * (columnWidth + gutter);
-          columnHeights[column] = top + height + gutter;
+          return items.map((item, index) => {
+            const height = seededHeights.get(index) ?? itemHeightEstimate;
+            const column = columnHeights.indexOf(Math.min(...columnHeights));
+            const top = columnHeights[column];
+            const left = column * (columnWidth + gutter);
+            columnHeights[column] = top + height + gutter;
 
-          return (
-            <div
-              key={itemKey ? itemKey(item, index) : index}
-              data-key={itemKey ? itemKey(item, index) : index}
-              data-column={column}
-              data-top={top}
-              data-height={height}
-              style={{
-                position: "absolute",
-                top,
-                left,
-                width: columnWidth,
-              }}
-            >
-              <RenderComponent data={item} index={index} width={240} />
-            </div>
-          );
-        });
-      })()}
-    </div>
-  ),
+            return (
+              <div
+                key={itemKey ? itemKey(item, index) : index}
+                data-key={itemKey ? itemKey(item, index) : index}
+                data-column={column}
+                data-top={top}
+                data-height={height}
+                style={{
+                  position: "absolute",
+                  top,
+                  left,
+                  width: columnWidth,
+                }}
+              >
+                <RenderComponent data={item} index={index} width={240} />
+              </div>
+            );
+          });
+        })()}
+      </div>
+    );
+    },
   useContainerPosition: () => ({ width: 440, offset: 0 }),
   usePositioner: () => mockPositioner,
   useResizeObserver: () => undefined,
@@ -145,6 +153,20 @@ async function openFilters(user: ReturnType<typeof userEvent.setup>) {
   await user.click(screen.getByRole("button", { name: /toggle filters/i }));
 }
 
+function RerenderHarness({ pieces }: { pieces: PieceSummary[] }) {
+  const [tick, setTick] = useState(0);
+
+  return (
+    <>
+      <button type="button" onClick={() => setTick((value) => value + 1)}>
+        rerender
+      </button>
+      <PieceList pieces={pieces} />
+      <span data-testid="tick">{tick}</span>
+    </>
+  );
+}
+
 describe("PieceList", () => {
   beforeEach(() => {
     mockPositioner.set.mockReset();
@@ -152,7 +174,11 @@ describe("PieceList", () => {
     mockPositioner.update.mockReset();
     mockPositioner.set.mockImplementation(() => undefined);
     mockPositioner.get.mockImplementation(() => undefined);
-    mockPositioner.update.mockImplementation(() => undefined);
+    mockPositioner.update.mockImplementation(() => {
+      rerenderMasonryScroller?.();
+      return undefined;
+    });
+    rerenderMasonryScroller = undefined;
   });
 
   describe("masonry height pre-seeding", () => {
@@ -218,6 +244,28 @@ describe("PieceList", () => {
       });
       renderPieceList([piece]);
       expect(mockPositioner.update).not.toHaveBeenCalled();
+    });
+
+    it("does not reseed on an unrelated rerender", async () => {
+      const user = userEvent.setup();
+      const piece = makePiece({
+        thumbnail: {
+          url: "https://example.com/img.jpg",
+          cloudinary_public_id: "id",
+          cloud_name: "demo",
+          crop: { x: 0, y: 0, width: 200, height: 400 },
+        },
+      });
+      const router = createMemoryRouter(
+        [{ path: "/", element: <RerenderHarness pieces={[piece]} /> }],
+        { initialEntries: ["/"] },
+      );
+
+      render(<RouterProvider router={router} />);
+      expect(mockPositioner.update).toHaveBeenCalledTimes(1);
+
+      await user.click(screen.getByRole("button", { name: /rerender/i }));
+      expect(mockPositioner.update).toHaveBeenCalledTimes(1);
     });
 
     it("reserves the thumbnail crop ratio in the card shell", () => {

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -64,9 +64,19 @@ vi.mock("masonic", () => ({
         const columnCount = mockPositioner.columnCount;
         const columnWidth = mockPositioner.columnWidth;
         const columnHeights = Array.from({ length: columnCount }, () => 0);
-        const seededHeights = new Map(
-          mockPositioner.set.mock.calls.map(([index, height]) => [index as number, height as number]),
-        );
+        const seededHeights = new Map<number, number>([
+          ...mockPositioner.set.mock.calls.map(([index, height]) => [
+            index as number,
+            height as number,
+          ]),
+          ...mockPositioner.update.mock.calls.flatMap(([updates]) =>
+            updates.flatMap((value, position) =>
+              position % 2 === 0
+                ? [[value as number, updates[position + 1] as number]]
+                : [],
+            ),
+          ),
+        ]);
 
         return items.map((item, index) => {
           const height = seededHeights.get(index) ?? itemHeightEstimate;
@@ -139,8 +149,10 @@ describe("PieceList", () => {
   beforeEach(() => {
     mockPositioner.set.mockReset();
     mockPositioner.get.mockReset();
+    mockPositioner.update.mockReset();
     mockPositioner.set.mockImplementation(() => undefined);
     mockPositioner.get.mockImplementation(() => undefined);
+    mockPositioner.update.mockImplementation(() => undefined);
   });
 
   describe("masonry height pre-seeding", () => {
@@ -155,13 +167,16 @@ describe("PieceList", () => {
         },
       });
       renderPieceList([piece]);
-      expect(mockPositioner.set).toHaveBeenCalledWith(0, Math.round(220 * 400 / 200) + CARD_CHROME_HEIGHT);
+      expect(mockPositioner.update).toHaveBeenCalledWith([
+        0,
+        Math.round(220 * 400 / 200) + CARD_CHROME_HEIGHT,
+      ]);
     });
 
     it("does not pre-seed the positioner for pieces without a crop", () => {
       const piece = makePiece({ thumbnail: null });
       renderPieceList([piece]);
-      expect(mockPositioner.set).not.toHaveBeenCalled();
+      expect(mockPositioner.update).not.toHaveBeenCalled();
     });
 
     it("applies the tall crop height before the first masonry pass", async () => {
@@ -202,7 +217,7 @@ describe("PieceList", () => {
         },
       });
       renderPieceList([piece]);
-      expect(mockPositioner.set).not.toHaveBeenCalled();
+      expect(mockPositioner.update).not.toHaveBeenCalled();
     });
 
     it("reserves the thumbnail crop ratio in the card shell", () => {

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -164,7 +164,7 @@ describe("PieceList", () => {
       expect(mockPositioner.set).not.toHaveBeenCalled();
     });
 
-    it("applies the tall crop height before the first masonry pass", () => {
+    it("applies the tall crop height before the first masonry pass", async () => {
       const pieces = [
         makePiece({
           id: "tall",
@@ -180,13 +180,15 @@ describe("PieceList", () => {
       ];
 
       const { container } = renderPieceList(pieces);
-      const cards = container.querySelectorAll('[data-testid="piece-grid"] > div');
       const expectedHeight = estimateCardHeight(pieces[0], mockPositioner.columnWidth);
 
-      expect(Number(cards[0]?.getAttribute("data-height"))).toBe(expectedHeight);
-      expect(Number(cards[0]?.getAttribute("data-height"))).toBeGreaterThan(
-        DEFAULT_CARD_HEIGHT_ESTIMATE,
-      );
+      await waitFor(() => {
+        const cards = container.querySelectorAll('[data-testid="piece-grid"] > div');
+        expect(Number(cards[0]?.getAttribute("data-height"))).toBe(expectedHeight);
+        expect(Number(cards[0]?.getAttribute("data-height"))).toBeGreaterThan(
+          DEFAULT_CARD_HEIGHT_ESTIMATE,
+        );
+      });
     });
 
     it("does not re-seed already-positioned items", () => {

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -164,7 +164,7 @@ describe("PieceList", () => {
       expect(mockPositioner.set).not.toHaveBeenCalled();
     });
 
-    it.skip("reproduces the first-load overlap on the initial masonry pass", () => {
+    it("applies the tall crop height before the first masonry pass", () => {
       const pieces = [
         makePiece({
           id: "tall",
@@ -181,9 +181,12 @@ describe("PieceList", () => {
 
       const { container } = renderPieceList(pieces);
       const cards = container.querySelectorAll('[data-testid="piece-grid"] > div');
+      const expectedHeight = estimateCardHeight(pieces[0], mockPositioner.columnWidth);
 
-      expect(Number(cards[1]?.getAttribute("data-top"))).toBe(560);
-      expect(Number(cards[2]?.getAttribute("data-top"))).toBe(560);
+      expect(Number(cards[0]?.getAttribute("data-height"))).toBe(expectedHeight);
+      expect(Number(cards[0]?.getAttribute("data-height"))).toBeGreaterThan(
+        DEFAULT_CARD_HEIGHT_ESTIMATE,
+      );
     });
 
     it("does not re-seed already-positioned items", () => {

--- a/web/src/stories/PieceList.stories.tsx
+++ b/web/src/stories/PieceList.stories.tsx
@@ -252,7 +252,7 @@ export const MixedCropAndNoCrop: Story = {
 };
 
 /**
- * First-load overlap repro.
+ * Initial masonry layout.
  *
  * This uses the exact failure setup from the regression test: one tall cropped
  * card followed by uncropped cards. It is the narrowest data shape that makes
@@ -260,9 +260,11 @@ export const MixedCropAndNoCrop: Story = {
  *
  * If the bug is still present in your local browser, the second and third cards
  * will start too high on first paint and then settle after a later layout tick.
+ *
+ * Source: [PR #549](https://github.com/shaoster/glaze/pull/549)
  */
-export const FirstLoadOverlapRepro: Story = {
-  name: "First-load overlap repro",
+export const InitialMasonryLayout: Story = {
+  name: "Initial masonry layout",
   args: {
     pieces: firstLoadOverlapPieces,
   },

--- a/web/src/stories/PieceList.stories.tsx
+++ b/web/src/stories/PieceList.stories.tsx
@@ -177,6 +177,37 @@ const mixedCropPieces: PieceSummary[] = [
   }),
 ];
 
+// Same data shape as the regression test that failed on first render:
+// one tall cropped card followed by two uncropped cards.
+const firstLoadOverlapPieces: PieceSummary[] = [
+  makePiece({
+    id: "r1",
+    name: "Tall Pitcher",
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    current_state: { state: "designed", created: new Date("2026-05-01") } as any,
+    thumbnail: {
+      url: "https://res.cloudinary.com/demo/image/upload/sample.jpg",
+      cloudinary_public_id: "sample",
+      cloud_name: "demo",
+      crop: { x: 0.08, y: 0.0, width: 0.45, height: 0.92 },
+    },
+  }),
+  makePiece({
+    id: "r2",
+    name: "Uncropped Vase",
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    current_state: { state: "bisque_fired", created: new Date("2026-05-02") } as any,
+    thumbnail: null,
+  }),
+  makePiece({
+    id: "r3",
+    name: "Uncropped Bowl",
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    current_state: { state: "glaze_fired", created: new Date("2026-05-03") } as any,
+    thumbnail: null,
+  }),
+];
+
 export const Default: Story = {
   args: {
     pieces: mockPieces,
@@ -214,6 +245,35 @@ export const MixedCropAndNoCrop: Story = {
       handlers: [
         http.get("/api/pieces/", () =>
           HttpResponse.json({ count: mixedCropPieces.length, results: mixedCropPieces }),
+        ),
+      ],
+    },
+  },
+};
+
+/**
+ * First-load overlap repro.
+ *
+ * This uses the exact failure setup from the regression test: one tall cropped
+ * card followed by uncropped cards. It is the narrowest data shape that makes
+ * the initial masonry placement bug easy to inspect in the browser.
+ *
+ * If the bug is still present in your local browser, the second and third cards
+ * will start too high on first paint and then settle after a later layout tick.
+ */
+export const FirstLoadOverlapRepro: Story = {
+  name: "First-load overlap repro",
+  args: {
+    pieces: firstLoadOverlapPieces,
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("/api/pieces/", () =>
+          HttpResponse.json({
+            count: firstLoadOverlapPieces.length,
+            results: firstLoadOverlapPieces,
+          }),
         ),
       ],
     },


### PR DESCRIPTION
This branch now has five commits:

- `1fb8111f` preserves the Storybook repro and mobile layout toggle while parking the regression as a placeholder.
- `f99ddaf2` seeds cropped masonry heights before the first paint and restores the regression as a passing test.
- `b1b00f5e` keeps the seeding lint-safe, updates the regression timing, and renames the Storybook variant to the covered workflow.
- `890d1470` switches the seeding path to Masonic's `positioner.update(...)` API and updates the test mock accordingly.
- `6306fdf9` restores the `useLayoutEffect`-driven seed path, keeps the idempotence guard, and strengthens the regression mock so it rerenders after positioner updates.

Validation:

- `rtk bazel test //web:web_piece_list_test --test_output=errors`
- `rtk bazel build --config=lint //web/...`
