### PR TITLE
fix: suppress MasonryScroller until container width is known

### DIFF
--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -854,16 +854,26 @@ const PieceList = (props: PieceListProps) => {
           }}
         >
           <Box ref={masonryRef as React.RefObject<HTMLDivElement>}>
-            <MasonryScroller
-              positioner={positioner}
-              resizeObserver={resizeObserver}
-              items={filteredPieces}
-              render={MasonryPieceCard}
-              itemKey={(piece) => piece.id}
-              itemHeightEstimate={DEFAULT_CARD_HEIGHT_ESTIMATE}
-              offset={masonryOffset}
-              height={windowHeight}
-            />
+            {/* Guard: masonic must not render until the container width is
+                known. On the first React commit useContainerPosition still
+                returns width=0, so masonic's Phase-1 items are laid out at
+                columnWidth=0, the thumbnail shell collapses to 0 px, and
+                offsetHeight measurements are chrome-only (~112 px). Those
+                contaminated heights are copied into the next positioner when
+                the real width arrives, causing the initial overlap that only
+                resolves on the next ResizeObserver tick (i.e. first scroll). */}
+            {masonryWidth > 0 && (
+              <MasonryScroller
+                positioner={positioner}
+                resizeObserver={resizeObserver}
+                items={filteredPieces}
+                render={MasonryPieceCard}
+                itemKey={(piece) => piece.id}
+                itemHeightEstimate={DEFAULT_CARD_HEIGHT_ESTIMATE}
+                offset={masonryOffset}
+                height={windowHeight}
+              />
+            )}
           </Box>
         </Box>
 

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -854,14 +854,8 @@ const PieceList = (props: PieceListProps) => {
           }}
         >
           <Box ref={masonryRef as React.RefObject<HTMLDivElement>}>
-            {/* Guard: masonic must not render until the container width is
-                known. On the first React commit useContainerPosition still
-                returns width=0, so masonic's Phase-1 items are laid out at
-                columnWidth=0, the thumbnail shell collapses to 0 px, and
-                offsetHeight measurements are chrome-only (~112 px). Those
-                contaminated heights are copied into the next positioner when
-                the real width arrives, causing the initial overlap that only
-                resolves on the next ResizeObserver tick (i.e. first scroll). */}
+            {/* Suppress until width is known — rendering at width=0 contaminates
+                the positioner with chrome-only heights. See PR #551. */}
             {masonryWidth > 0 && (
               <MasonryScroller
                 positioner={positioner}

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -200,8 +200,11 @@ describe("PieceList", () => {
       expect(screen.queryByTestId("piece-grid")).not.toBeInTheDocument();
     });
 
-    it("renders the masonry grid once container width is known", () => {
-      mockContainerPosition.width = 440;
+    it("renders the masonry grid when container width is exactly 1 (boundary)", () => {
+      // Verifies the guard is `> 0` not `>= some threshold`. A wrong condition
+      // like `> 1` would let width=0 contaminate the positioner for narrow
+      // containers.
+      mockContainerPosition.width = 1;
       renderPieceList([makePiece()]);
       expect(screen.getByTestId("piece-grid")).toBeInTheDocument();
     });

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -32,20 +32,24 @@ vi.mock("../CloudinaryImage", () => ({
   ),
 }));
 
-const { mockPositioner } = vi.hoisted(() => ({
-  mockPositioner: {
-    get: vi.fn().mockReturnValue(undefined),
-    set: vi.fn(),
-    columnWidth: 220,
-    columnCount: 2,
-    update: vi.fn(),
-    range: vi.fn(),
-    size: vi.fn().mockReturnValue(0),
-    estimateHeight: vi.fn().mockReturnValue(0),
-    shortestColumn: vi.fn().mockReturnValue(0),
-    all: vi.fn().mockReturnValue([]),
-  },
-}));
+const { mockPositioner, mockContainerPosition } = vi.hoisted(() => {
+  const mockContainerPosition = { width: 440, offset: 0 };
+  return {
+    mockPositioner: {
+      get: vi.fn().mockReturnValue(undefined),
+      set: vi.fn(),
+      columnWidth: 220,
+      columnCount: 2,
+      update: vi.fn(),
+      range: vi.fn(),
+      size: vi.fn().mockReturnValue(0),
+      estimateHeight: vi.fn().mockReturnValue(0),
+      shortestColumn: vi.fn().mockReturnValue(0),
+      all: vi.fn().mockReturnValue([]),
+    },
+    mockContainerPosition,
+  };
+});
 
 let rerenderMasonryScroller: (() => void) | undefined;
 
@@ -114,7 +118,7 @@ vi.mock("masonic", () => ({
       </div>
     );
     },
-  useContainerPosition: () => ({ width: 440, offset: 0 }),
+  useContainerPosition: () => ({ width: mockContainerPosition.width, offset: mockContainerPosition.offset }),
   usePositioner: () => mockPositioner,
   useResizeObserver: () => undefined,
 }));
@@ -179,6 +183,28 @@ describe("PieceList", () => {
       return undefined;
     });
     rerenderMasonryScroller = undefined;
+    mockContainerPosition.width = 440;
+    mockContainerPosition.offset = 0;
+  });
+
+  describe("MasonryScroller container-width guard", () => {
+    it("does not render the masonry grid when container width is zero", () => {
+      // Root cause of the prod-only initial-overlap bug: useContainerPosition
+      // returns width=0 on the first React commit. If MasonryScroller renders
+      // then, masonic lays out Phase-1 items at columnWidth=0, the thumbnail
+      // shell collapses, and offsetHeight measurements are chrome-only (~112 px).
+      // Those heights are copied into the next positioner when the real width
+      // arrives, causing items to be placed too close and overlap.
+      mockContainerPosition.width = 0;
+      renderPieceList([makePiece()]);
+      expect(screen.queryByTestId("piece-grid")).not.toBeInTheDocument();
+    });
+
+    it("renders the masonry grid once container width is known", () => {
+      mockContainerPosition.width = 440;
+      renderPieceList([makePiece()]);
+      expect(screen.getByTestId("piece-grid")).toBeInTheDocument();
+    });
   });
 
   describe("masonry height pre-seeding", () => {

--- a/web/src/stories/PieceList.stories.tsx
+++ b/web/src/stories/PieceList.stories.tsx
@@ -183,9 +183,11 @@ const mixedCropPieces: PieceSummary[] = [
 // useContainerPosition still returned width=0, so masonic measured Phase-1
 // items at columnWidth=0 and the thumbnail shell collapsed to 0 px.
 // This dataset exercises that path at realistic scale.
+type ThumbnailCrop = { x: number; y: number; width: number; height: number } | null;
+
 const largePieceDataset: PieceSummary[] = Array.from({ length: 24 }, (_, i) => {
   const states = ["designed", "bisque_fired", "glazed", "glaze_fired", "completed", "touching_up"] as const;
-  const crops: (PieceSummary["thumbnail"] & object)["crop"][] = [
+  const crops: ThumbnailCrop[] = [
     { x: 0.05, y: 0.0, width: 0.45, height: 0.92 }, // portrait
     null,
     { x: 0.0, y: 0.1, width: 0.8, height: 0.8 }, // near-square

--- a/web/src/stories/PieceList.stories.tsx
+++ b/web/src/stories/PieceList.stories.tsx
@@ -177,6 +177,51 @@ const mixedCropPieces: PieceSummary[] = [
   }),
 ];
 
+// Matches the prod scale shown in the screenshot that reproduced the overlap:
+// 24+ pieces with mixed crops, no-crops, and tag counts. The root cause was
+// that MasonryScroller rendered on the first React commit when
+// useContainerPosition still returned width=0, so masonic measured Phase-1
+// items at columnWidth=0 and the thumbnail shell collapsed to 0 px.
+// This dataset exercises that path at realistic scale.
+const largePieceDataset: PieceSummary[] = Array.from({ length: 24 }, (_, i) => {
+  const states = ["designed", "bisque_fired", "glazed", "glaze_fired", "completed", "touching_up"] as const;
+  const crops: (PieceSummary["thumbnail"] & object)["crop"][] = [
+    { x: 0.05, y: 0.0, width: 0.45, height: 0.92 }, // portrait
+    null,
+    { x: 0.0, y: 0.1, width: 0.8, height: 0.8 }, // near-square
+    null,
+    { x: 0.0, y: 0.2, width: 0.9, height: 0.4 }, // landscape
+    null,
+  ];
+  const tagSets = [
+    [],
+    [{ id: "t1", name: "functional", color: "#E76F51", is_public: false }],
+    [
+      { id: "t2", name: "decorative", color: "#2A9D8F", is_public: true },
+      { id: "t3", name: "handle", color: "#264653", is_public: true },
+    ],
+    [
+      { id: "t4", name: "cup", color: "#E9C46A", is_public: true },
+      { id: "t5", name: "fluted", color: "#F4A261", is_public: false },
+      { id: "t6", name: "slip", color: "#E76F51", is_public: false },
+    ],
+  ];
+  const crop = crops[i % crops.length];
+  return makePiece({
+    id: `lp${i}`,
+    name: `Piece ${i + 1}`,
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+    current_state: { state: states[i % states.length], created: new Date("2026-05-01") } as any,
+    thumbnail: {
+      url: "https://res.cloudinary.com/demo/image/upload/sample.jpg",
+      cloudinary_public_id: "sample",
+      cloud_name: "demo",
+      crop: crop ?? null,
+    },
+    tags: tagSets[i % tagSets.length],
+  });
+});
+
 // Same data shape as the regression test that failed on first render:
 // one tall cropped card followed by two uncropped cards.
 const firstLoadOverlapPieces: PieceSummary[] = [
@@ -275,6 +320,42 @@ export const InitialMasonryLayout: Story = {
           HttpResponse.json({
             count: firstLoadOverlapPieces.length,
             results: firstLoadOverlapPieces,
+          }),
+        ),
+      ],
+    },
+  },
+};
+
+/**
+ * Prod-scale dataset: 24 pieces with mixed crops, no-crops, and tag counts.
+ *
+ * This matches the real-world scale visible in the prod screenshot that showed
+ * overlapping cards. The root cause was MasonryScroller rendering on the first
+ * React commit before `useContainerPosition` had measured the container — at
+ * that point masonic laid out Phase-1 items at `columnWidth=0`, the thumbnail
+ * shell collapsed to 0 px, and the resulting chrome-only heights were copied
+ * into the next positioner, causing all cards to be placed too close together.
+ *
+ * After the fix (`{masonryWidth > 0 && <MasonryScroller />}`), the grid is
+ * suppressed until the container width is known, so the first masonic render
+ * always uses the correct column width and measures card heights accurately.
+ *
+ * If you see cards overlapping on first paint in this story, the
+ * `masonryWidth > 0` guard in `PieceList.tsx` has been removed or bypassed.
+ */
+export const LargeDataset: Story = {
+  name: "Large dataset (24 pieces, prod scale)",
+  args: {
+    pieces: largePieceDataset,
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("/api/pieces/", () =>
+          HttpResponse.json({
+            count: largePieceDataset.length,
+            results: largePieceDataset,
           }),
         ),
       ],


### PR DESCRIPTION
## Root cause

`useContainerPosition` (masonic) initialises its state as `{ width: 0 }` and
fires a `useLayoutEffect` to measure the real container width. During the
**first** React commit — before that effect updates state — `MasonryScroller`
was already rendering. Masonic laid out its hidden Phase-1 measurement items
with `columnWidth: 0`, so the thumbnail shell (`aspect-ratio` × 0 = 0 px)
collapsed and `el.offsetHeight` was chrome-only (~112 px).

When the real width arrived, `usePositioner` detected `optsChanged`, created
a fresh positioner, and **copied** those contaminated heights into it. Masonic
then absolutely positioned every card using chrome-only heights, placing each
subsequent card too close to the previous one — producing the visible overlap.
Because `useResizeObserver` fires on the next ResizeObserver tick (first
scroll), positions corrected themselves, giving the "fine after first scroll"
behaviour.

## Fix

Wrap `MasonryScroller` in `{masonryWidth > 0 && ...}`. The `masonryRef`
container `Box` is always rendered so `useContainerPosition` can still measure
it. Because `useContainerPosition` uses `useLayoutEffect`, React 18 processes
the resulting state update synchronously before the browser paints — users
never see an empty grid.

```tsx
{/* Suppress until width is known — rendering at width=0 contaminates
    the positioner with chrome-only heights. See PR #551. */}
{masonryWidth > 0 && (
  <MasonryScroller ... />
)}
```

## Tests

- **Regression test** (`does not render the masonry grid when container width is zero`): confirmed it fails on the unfixed baseline and passes with the fix.
- **Boundary test** (`renders the masonry grid when container width is exactly 1`): verifies the guard is `> 0`, not some higher threshold that would mishandle narrow containers.
- `mockContainerPosition` is now mutable and reset in `beforeEach`, allowing per-test width overrides without polluting other tests.

## Storybook

Added **"Large dataset (24 pieces, prod scale)"** story matching the prod
screenshot that showed the overlap. Documents the root cause and what to look
for if the guard is ever removed.

## Checklist

- [x] All tests pass: `rtk bazel test //...` (49/49)
- [x] All linters pass: `rtk bazel build --config=lint //...`
- [x] Regression test verified to fail on unfixed baseline
- [x] Boundary test (width=1) complements the zero-width regression test
- [x] No debug code or stray console statements
- [x] `Co-Authored-By` tag in commits
