### PR TITLE
docs: clarify gz_setup and gz_reload contract

### DIFF
--- a/.agents/skills/dev-environment/SKILL.md
+++ b/.agents/skills/dev-environment/SKILL.md
@@ -29,16 +29,16 @@ rtk bazel run @nodejs_linux_amd64//:npm -- install
 ```
 
 In a new environment, always run `gz_setup` before doing anything else.
-`gz_setup` reuses the main checkout's `.venv` and `web/node_modules` by default from a
-repo-local worktree. Use `gz_setup --isolated` (or `GLAZE_SETUP_ISOLATED=1 gz_setup`)
-when a branch needs its own dependency environment (changing Python or Node packages).
+`gz_setup` materializes the isolated worktree-local developer environment. Re-run it
+after changing Python or Node packages so the current shell and future shells pick up
+the refreshed `PATH` and activated environment.
 
 ## Shell Bootstrap
 
 | Script | Purpose |
 |---|---|
 | `env.sh` | Interactive shells: sources `~/.bashrc`, delegates to `env-agent.sh`, defines all `gz_*` helpers |
-| `env-agent.sh` | Lightweight, silent bootstrap for non-interactive shells: activates `.venv` if present, loads `.env.local` vars, exports `BASH_ENV` |
+| `env-agent.sh` | Lightweight, silent bootstrap for non-interactive shells: activates `.manage.venv` if present, loads `.env.local` vars, prepends repo-local dev bins, exports `BASH_ENV` |
 
 `env.sh` sources `env-agent.sh` — venv activation and env-var loading logic live in one place.
 
@@ -110,11 +110,11 @@ Always run `git` commands from the repo root. Wrap subdirectory commands in a su
 
 ```bash
 # ✅ correct — shell stays at repo root
-(cd web && rtk bazel run @nodejs_linux_amd64//:npx -- pnpm install)
+(cd web && pnpm install)
 git add web/pnpm-lock.yaml
 
 # ❌ incorrect — shell is now inside web/
-cd web && rtk bazel run @nodejs_linux_amd64//:npx -- pnpm install
+cd web && pnpm install
 git add web/pnpm-lock.yaml   # fails: no web/web/pnpm-lock.yaml
 ```
 
@@ -150,15 +150,22 @@ under `/home/phil/.cache/bazel`. It is large, slow to traverse, and not a source
 truth for anything in the repo. To inspect a Python package, read it from
 `.manage.venv/lib/python3.12/site-packages/` instead.
 
-## Symlinking `.env.local` into a Worktree
+## Copying `.env.local` into a Worktree
 
-When working in an agent worktree, symlink the untracked root `.env.local` into the
+When working in an agent worktree, copy the untracked root `.env.local` into the
 worktree so servers load Cloudinary and OAuth credentials:
 
 ```bash
-ln -s /home/phil/code/glaze/.env.local .env.local
-ln -s /home/phil/code/glaze/web/.env.local web/.env.local
+cp /home/phil/code/glaze/.env.local .env.local
 ```
+
+If the worktree also needs web-only overrides, copy `web/.env.local` separately
+afterward; do not symlink either file.
+
+`env.sh` and `env-agent.sh` only read `.env` / `.env.local` files from the current
+checkout. If a worktree does not have a valid env file, bootstrap fails fast and
+prints guidance for either copying the root checkout's env file or creating one
+from `.env.example`.
 
 **Avoid copying `.env.local` from prod** — prod env files often contain keys set to
 empty strings (e.g. `EMAIL_PORT=`) that are valid in shell but cause Django startup

--- a/.agents/skills/dev-packages/SKILL.md
+++ b/.agents/skills/dev-packages/SKILL.md
@@ -55,6 +55,11 @@ rtk bazel test //api:api_test //api:api_mypy
 Commit `pyproject.toml`, `uv.lock`, `MODULE.bazel.lock` (updated automatically
 by Bazel), and the `BUILD.bazel` change together.
 
+If the package update introduced new executables or changed the materialized
+worktree environment, run `gz_reload` in the current shell so `PATH` refreshes
+immediately. If the worktree’s dependency environment itself needs to be
+re-materialized, rerun `gz_setup`.
+
 ## Adding a New npm Package
 
 Bazel resolves npm packages from `web/pnpm-lock.yaml`. After any `npm install`:
@@ -67,7 +72,7 @@ Prefer Python for standalone dev tooling when the dependency graph allows it. Us
 
 # Regenerate the pnpm lockfile from the updated package-lock.json
 # pnpm must run from web/ where package.json and pnpm-lock.yaml live
-(cd web && rtk bazel run @nodejs_linux_amd64//:npx -- pnpm import)
+(cd web && pnpm import)
 ```
 
 `pnpm` is available at `~/.nvm/versions/node/*/bin/pnpm` when nvm is active. If
@@ -85,3 +90,8 @@ Add the package to the appropriate `BUILD.bazel` entry if Bazel tests fail with 
 missing module error.
 
 Commit `web/package.json`, `web/package-lock.json`, and `web/pnpm-lock.yaml` together.
+
+If the package update introduced new executables or changed the materialized
+worktree environment, run `gz_reload` in the current shell so `PATH` refreshes
+immediately. If the worktree’s dependency environment itself needs to be
+re-materialized, rerun `gz_setup`.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This section is for folks who just want to fire up the whole stack quickly and s
 
 ```bash
 source env.sh
-gz_setup    # first-time only: creates venv, installs deps, runs migrations
+gz_setup    # materializes the worktree environment; rerun after dependency changes
 gz_start    # starts backend + web via the Bazel-run launcher
 ```
 
@@ -77,7 +77,7 @@ source env.sh
 
 **VS Code / Cursor:** the repo ships terminal profiles in [`.vscode/settings.json`](.vscode/settings.json) for Linux and macOS that automatically source `env.sh` in every new integrated terminal. Linux uses `bash`; macOS uses `zsh` with a repo-owned [`.vscode/.zshrc`](.vscode/.zshrc). The venv is activated and `gz_*` helpers are available from the moment the terminal opens.
 
-**AI coding agents (Claude Code, Codex, Cursor agent):** a companion script [`env-agent.sh`](env-agent.sh) provides a silent, lightweight bootstrap (venv activation + `.env.local` loading) for non-interactive shells. Claude Code picks it up via `.claude/settings.json`; Codex and other agents inherit it through `BASH_ENV` when launched from an `env.sh`-sourced terminal. Prefer repo-local worktrees under `.agent-worktrees/...` instead of `/tmp`; the bootstrap detects the active git worktree root automatically and falls back to the main checkout's `.env.local` and `.venv` when the worktree does not have its own yet. `gz_setup` reuses the shared `.venv` and `web/node_modules` by default, and `gz_setup --isolated` creates worktree-local dependency installs when a branch is changing Python or Node packages. Keep repo-local Codex-specific config in `.agent-config/codex/` rather than `.codex`, which may be reserved by the local Codex installation. See [`docs/agents/dev.md`](docs/agents/dev.md) for details.
+**AI coding agents (Claude Code, Codex, Cursor agent):** a companion script [`env-agent.sh`](env-agent.sh) provides a silent, lightweight bootstrap (venv activation + current-checkout `.env`/`.env.local` loading) for non-interactive shells. Claude Code picks it up via `.claude/settings.json`; Codex and other agents inherit it through `BASH_ENV` when launched from an `env.sh`-sourced terminal. Prefer repo-local worktrees under `.agent-worktrees/...` instead of `/tmp`; the bootstrap detects the active git worktree root automatically and expects the worktree to own its `.env`/`.env.local` files and materialized dependency environment after `gz_setup` has run. `gz_setup` materializes the isolated worktree-local developer environment, and `gz_reload` refreshes the current shell after setup so the new `PATH` is visible immediately. Keep repo-local Codex-specific config in `.agent-config/codex/` rather than `.codex`, which may be reserved by the local Codex installation. See [`docs/agents/dev.md`](docs/agents/dev.md) for details.
 
 ### Vibe Coding With Agents
 
@@ -152,7 +152,8 @@ Each variable in `.env.example` has an inline comment explaining what it enables
 
 | Command    | Description                                                                                                                                                                                                             |
 | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `gz_setup` | Setup helper: reuses shared deps by default in repo-local worktrees, or use `gz_setup --isolated` for fresh worktree-local `.venv` and `web/node_modules`. Also runs DB migrations and installs Node via nvm if needed. |
+| `gz_setup` | Setup helper: materializes the isolated worktree-local developer environment, refreshes the current shell with the new PATH, and runs DB migrations. Re-run after changing Python or Node dependencies. |
+| `gz_reload` | Re-source `env.sh` in the current shell after changing shell bootstrap, env files, or freshly materialized tools that should appear on `PATH` right now. |
 
 ### Servers
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,26 @@ source env.sh
 
 **AI coding agents (Claude Code, Codex, Cursor agent):** a companion script [`env-agent.sh`](env-agent.sh) provides a silent, lightweight bootstrap (venv activation + current-checkout `.env`/`.env.local` loading) for non-interactive shells. Claude Code picks it up via `.claude/settings.json`; Codex and other agents inherit it through `BASH_ENV` when launched from an `env.sh`-sourced terminal. Prefer repo-local worktrees under `.agent-worktrees/...` instead of `/tmp`; the bootstrap detects the active git worktree root automatically and expects the worktree to own its `.env`/`.env.local` files and materialized dependency environment after `gz_setup` has run. `gz_setup` materializes the isolated worktree-local developer environment, and `gz_reload` refreshes the current shell after setup so the new `PATH` is visible immediately. Keep repo-local Codex-specific config in `.agent-config/codex/` rather than `.codex`, which may be reserved by the local Codex installation. See [`docs/agents/dev.md`](docs/agents/dev.md) for details.
 
+### Managing Package Dependencies
+
+Use the package managers you already know to edit dependency manifests, then hand the result back to the repo’s Bazel-aware workflow.
+
+**Python**
+- Use the Bazel-managed `uv` entrypoint from the repo root to edit Python dependencies.
+- Typical commands: `uv add`, `uv remove`, `uv lock`, `uv sync`.
+- After changing Python packages, run `gz_sync` so the materialized environment and Bazel view stay aligned.
+
+**Web**
+- Use `npm` inside [`web/`](web/) to edit JavaScript dependencies.
+- After `npm install`, regenerate `web/pnpm-lock.yaml` from `web/package-lock.json` with `pnpm import`.
+- The reconciliation step should use the repo’s Bazel-aware Node toolchain so the `pnpm` side stays aligned with CI and Bazel.
+- After changing web packages, run `gz_sync` so the current shell and repo locks stay in sync.
+
+**When to use which helper**
+- Run `gz_setup` when the worktree’s materialized dependency environment itself needs to be rebuilt.
+- Run `gz_sync` after native `uv` or `npm` dependency changes.
+- Run `gz_reload` when shell bootstrap files or env files changed and you only need the current terminal to pick up the new `PATH` immediately.
+
 ### Vibe Coding With Agents
 
 Glaze uses a high-level orchestration workflow inspired by the [Get Shit Done (GSD)](https://github.com/gsd-build/get-shit-done) philosophy, but adapted for non-developer QoL and safety with non-frontier models:
@@ -152,7 +172,8 @@ Each variable in `.env.example` has an inline comment explaining what it enables
 
 | Command    | Description                                                                                                                                                                                                             |
 | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `gz_setup` | Setup helper: materializes the isolated worktree-local developer environment, refreshes the current shell with the new PATH, and runs DB migrations. Re-run after changing Python or Node dependencies. |
+| `gz_setup` | Setup helper: materializes the isolated worktree-local developer environment, refreshes the current shell with the new PATH, and runs DB migrations. Re-run after the dependency environment itself changes. |
+| `gz_sync` | Reconcile native package-manager edits with the Bazel-aware workflow and refresh the current shell. Use this after `uv` or `npm` dependency changes. |
 | `gz_reload` | Re-source `env.sh` in the current shell after changing shell bootstrap, env files, or freshly materialized tools that should appear on `PATH` right now. |
 
 ### Servers

--- a/docs/agents/dev.md
+++ b/docs/agents/dev.md
@@ -26,7 +26,13 @@ to stream a Postgres dump from the droplet and restore it into a disposable
 `postgres:17` container locally to verify the backup contains real data.
 
 See [`env.sh`](../../env.sh) for shell helpers (`gz_setup`, `gz_start`, etc.) that wrap these commands.
-In a new environment, run `source env.sh` once so the helpers are available. After that, `gz_start` will start the dev stack directly. Use `gz_setup` only when you want to repair a broken local environment or explicitly create isolated worktree-local dependencies with `--isolated`.
+In a new environment, run `source env.sh` once so the helpers are available. After that:
+
+- run `gz_setup` once per checkout or worktree to materialize the isolated developer environment
+- rerun `gz_setup` after changing Python or Node dependencies, because it rebuilds the materialized env and refreshes the current shell
+- run `gz_reload` when the env files or shell bootstrap changed and you want the current terminal to pick up the new PATH immediately
+
+`gz_start` then starts the dev stack directly once the environment is in place.
 
 ---
 
@@ -37,7 +43,7 @@ Two scripts handle environment bootstrap:
 | Script                               | Purpose                                                                                                                                                                        |
 | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | [`env.sh`](../../env.sh)             | Interactive Bash shells: sources `~/.bashrc`, delegates to `env-agent.sh`, then defines all `gz_*` helpers. Used as `bash --rcfile` by the VS Code/Cursor terminal profile. |
-| [`env-agent.sh`](../../env-agent.sh) | Lightweight, silent bootstrap for non-interactive shells: activates `.venv` if present, loads `.env.local` vars, exports `BASH_ENV` so child processes inherit the same setup. |
+| [`env-agent.sh`](../../env-agent.sh) | Lightweight, silent bootstrap for non-interactive shells: activates `.manage.venv` if present, loads the current checkout's `.env`/`.env.local` vars, prepends repo-local dev bins, exports `BASH_ENV` so child processes inherit the same setup. |
 
 `env.sh` sources `env-agent.sh` — the venv activation and env-var loading logic live in exactly one place.
 
@@ -45,17 +51,17 @@ For CI/CD workflow details, deployment variables, and GitHub Actions behavior, s
 
 ### VS Code / Cursor integrated terminal
 
-[`.vscode/settings.json`](../../.vscode/settings.json) configures `glaze` terminal profiles for Linux and macOS that automatically source `env.sh`. Linux uses `bash`; macOS uses `zsh` with repo-owned startup in [`.vscode/.zshrc`](../../.vscode/.zshrc). New terminals automatically get the full interactive environment (venv active, `gz_*` functions, `.env.local` loaded) without any manual `source` step.
+[`.vscode/settings.json`](../../.vscode/settings.json) configures `glaze` terminal profiles for Linux and macOS that automatically source `env.sh`. Linux uses `bash`; macOS uses `zsh` with repo-owned startup in [`.vscode/.zshrc`](../../.vscode/.zshrc). New terminals automatically get the full interactive environment (venv active, web `.bin` on `PATH`, `gz_*` functions, current-checkout `.env`/`.env.local` loaded) without any manual `source` step.
 
 `python.terminal.activateEnvironment` is disabled so VS Code does not double-activate the venv on top of what `env.sh` already did.
 
 ### Claude Code
 
-[`.claude/settings.json`](../../.claude/settings.json) sets `BASH_ENV=/path/to/env-agent.sh`. Every `bash -c "..."` command Claude Code runs sources `env-agent.sh` first, so `python`, `pytest`, `npm`, and `.env.local` vars are all available without a manual activation step.
+[`.claude/settings.json`](../../.claude/settings.json) sets `BASH_ENV=/path/to/env-agent.sh`. Every `bash -c "..."` command Claude Code runs sources `env-agent.sh` first, so `python`, `pytest`, `npm`, the workspace venv bin entry points, and `.env`/`.env.local` vars from the current checkout are all available without a manual activation step.
 
 ### Codex and other agents
 
-`env-agent.sh` exports `BASH_ENV` pointing at itself, so any agent process spawned from a shell that has already sourced `env.sh` (e.g. a VS Code terminal) automatically propagates the bootstrap to its own subshells. No per-tool config is needed for Codex or similar CLI agents launched from the integrated terminal.
+`env-agent.sh` exports `BASH_ENV` pointing at itself, so any agent process spawned from a shell that has already sourced `env.sh` (e.g. a VS Code terminal) automatically propagates the bootstrap to its own subshells. No per-tool config is needed for Codex or similar CLI agents launched from the integrated terminal, and each checkout must supply its own `.env`/`.env.local` files rather than borrowing them from another checkout.
 
 ### Agent worktree location
 
@@ -70,7 +76,7 @@ Keep repo-local agent configuration out of `.codex`, which may be reserved by th
 - Codex-specific local config: `.agent-config/codex/`
 - Shared agent assets and instructions: `.agents/`
 
-This keeps worktrees close to the repo-local bootstrap, makes cleanup easier, and avoids temp-directory permission/path surprises. `env-agent.sh` resolves the active git worktree root from the current working directory, then falls back to the main checkout's `.env.local` files and `.venv` when the worktree does not have its own copies yet.
+This keeps worktrees close to the repo-local bootstrap, makes cleanup easier, and avoids temp-directory permission/path surprises. `env-agent.sh` resolves the active git worktree root from the current working directory and expects that checkout to own its `.env`/`.env.local` files and materialized dependency environment after `gz_setup` has run.
 
 ### One terminal per worktree
 
@@ -209,21 +215,20 @@ Commit `requirements.txt`, `requirements.lock`, `MODULE.bazel.lock` (updated aut
 
 ### Updating pnpm-lock.yaml after npm installs
 
-Bazel resolves npm packages from `web/pnpm-lock.yaml`. After any `npm install` that adds or removes packages, regenerate the lockfile with `pnpm import` so Bazel picks up the change:
+Bazel resolves npm packages from `web/pnpm-lock.yaml`. After any native `npm install` that adds or removes packages, regenerate the lockfile with `pnpm import` so Bazel picks up the change:
 
 # Install the package normally (from the repo root or web/ — npm resolves via web/package.json)
 (cd web && rtk bazel run @nodejs_linux_amd64//:npm -- install react-swipeable)
 
 # Regenerate the pnpm lockfile from the updated package-lock.json
 # pnpm must be run from web/ where package.json and pnpm-lock.yaml live
-(cd web && rtk bazel run @nodejs_linux_amd64//:npx -- pnpm import)
 (cd web && pnpm import)
 
 # Commit both the updated package files
 git add web/package.json web/package-lock.json web/pnpm-lock.yaml
 ```
 
-`pnpm` is available at `~/.nvm/versions/node/*/bin/pnpm` when nvm is active. If `env-agent.sh` has sourced `.nvm/nvm.sh`, the `pnpm` binary is on `$PATH` and the `(cd web && pnpm import)` subshell inherits it.
+`pnpm` is available at `~/.nvm/versions/node/*/bin/pnpm` when nvm is active. If `env-agent.sh` has sourced `.nvm/nvm.sh`, the `pnpm` binary is on `$PATH` and the `(cd web && pnpm import)` subshell inherits it. If the current shell does not yet see the freshly changed PATH after a package update, run `gz_reload`; if the worktree needs the materialized env rebuilt, run `gz_setup` again.
 
 After updating the lockfile, check whether the new package needs to be added to a `js_library` `srcs` or `deps` in the relevant `BUILD.bazel`. Use `rtk bazel query 'labels(srcs, <library-target>)'` to inspect what a target currently includes, and add the package to the appropriate `BUILD.bazel` entry if Bazel tests fail with a missing module error.
 
@@ -250,11 +255,11 @@ Always run `git` commands from the repo root. When a command must run from a sub
 
 ```bash
 # ✅ correct — shell stays at repo root after this line
-(cd web && npx pnpm install)
+(cd web && pnpm install)
 git add web/pnpm-lock.yaml
 
 # ❌ incorrect — shell is now inside web/, breaking the git add
-cd web && npx pnpm install
+cd web && pnpm install
 git add web/pnpm-lock.yaml   # fails: no web/web/pnpm-lock.yaml
 ```
 
@@ -353,7 +358,7 @@ response is probably being buffered or retained.
 
 All vars are optional. The app runs without any of them; each missing group degrades gracefully.
 
-**`.env.local`** (loaded by `source env.sh`, read by Django):
+**`.env.local`** (loaded by `source env.sh` from the current checkout, read by Django):
 
 | Variable                   | Absent behavior                                                                       |
 | -------------------------- | ------------------------------------------------------------------------------------- |

--- a/docs/agents/worktrees.md
+++ b/docs/agents/worktrees.md
@@ -79,6 +79,16 @@ git worktree add .agent-worktrees/codex/issue-47-fix-auth -b issue/47-fix-auth m
 git worktree add .agent-worktrees/codex/issue-49-add-export -b issue/49-add-export main
 git worktree add .agent-worktrees/codex/issue-50-clean-tags -b issue/50-clean-tags main
 
+# Copy local env files into each worktree (do not symlink)
+cp .env.local .agent-worktrees/codex/issue-47-fix-auth/.env.local
+cp .env.local .agent-worktrees/codex/issue-49-add-export/.env.local
+cp .env.local .agent-worktrees/codex/issue-50-clean-tags/.env.local
+
+# Copy web-only overrides separately if needed
+# cp web/.env.local .agent-worktrees/codex/issue-47-fix-auth/web/.env.local
+# cp web/.env.local .agent-worktrees/codex/issue-49-add-export/web/.env.local
+# cp web/.env.local .agent-worktrees/codex/issue-50-clean-tags/web/.env.local
+
 # List all worktrees
 git worktree list
 
@@ -96,7 +106,8 @@ git worktree list
 
 **Why `.agent-worktrees/`**: Keeping worktrees inside the project directory means
 agents already have file permissions, share the repo-local bootstrap, and avoid
-tool-reserved paths like `.codex`.
+tool-reserved paths like `.codex`. Each new worktree should own its own copied
+`.env.local` files rather than symlinking them from another checkout.
 
 ### Step 3: Apply existing work
 

--- a/env-agent.sh
+++ b/env-agent.sh
@@ -20,6 +20,16 @@ _gz_detect_shared_root() {
     cd "$common_dir/.." 2>/dev/null && pwd
 }
 
+_gz_prepend_path_once() {
+    local dir="$1"
+    [[ -d "$dir" ]] || return 0
+    case ":$PATH:" in
+        *":$dir:"*) return 0 ;;
+    esac
+    PATH="$dir:$PATH"
+    export PATH
+}
+
 _detected_root="$(_gz_detect_git_root)"
 _detected_root="${_detected_root:-$_GLAZE_SCRIPT_DIR}"
 
@@ -39,22 +49,49 @@ if [[ -z "$_GLAZE_AGENT_ENV_LOADED" || "${GLAZE_ROOT:-}" != "$_detected_root" ]]
     _GLAZE_LOGS="$GLAZE_ROOT/.dev-logs"
     mkdir -p "$_GLAZE_PIDS" "$_GLAZE_LOGS"
 
-    _gz_preferred_root_for() {
-        local rel="$1"
-        if [[ -e "$GLAZE_ROOT/$rel" ]]; then
-            printf '%s\n' "$GLAZE_ROOT"
-            return 0
-        fi
-        if [[ "$GLAZE_SHARED_ROOT" != "$GLAZE_ROOT" && -e "$GLAZE_SHARED_ROOT/$rel" ]]; then
-            printf '%s\n' "$GLAZE_SHARED_ROOT"
-            return 0
-        fi
-        printf '%s\n' "$GLAZE_ROOT"
+    _gz_env_rel_paths=(
+        ".env"
+        ".env.local"
+        "web/.env"
+        "web/.env.local"
+        "mobile/.env"
+        "mobile/.env.local"
+    )
+
+    _gz_has_env_files() {
+        local root="$1"
+        local rel
+        for rel in "${_gz_env_rel_paths[@]}"; do
+            [[ -f "$root/$rel" ]] && return 0
+        done
+        return 1
     }
 
-    # Activate Bazel-managed venv if present (built by `bazel run //:manage.venv`)
-    _GLAZE_VENV_ROOT="$(_gz_preferred_root_for ".manage.venv/bin/activate")"
-    [[ -f "$_GLAZE_VENV_ROOT/.manage.venv/bin/activate" ]] && source "$_GLAZE_VENV_ROOT/.manage.venv/bin/activate"
+    _gz_missing_env_error() {
+        local shared_has_env=0
+        if [[ "$GLAZE_SHARED_ROOT" != "$GLAZE_ROOT" ]] && _gz_has_env_files "$GLAZE_SHARED_ROOT"; then
+            shared_has_env=1
+        fi
+
+        if (( shared_has_env )); then
+            cat >&2 <<EOF
+This worktree has no valid .env or .env.local file.
+Copy the root checkout's .env.local into this worktree, then run \`source env.sh\`.
+EOF
+        else
+            if [[ "$GLAZE_SHARED_ROOT" == "$GLAZE_ROOT" ]]; then
+                cat >&2 <<EOF
+This repo checkout has no valid .env or .env.local file.
+Run \`cp .env.example .env.local && source env.sh\` to initialize it.
+EOF
+            else
+                cat >&2 <<EOF
+This worktree has no valid .env or .env.local file.
+Run \`cp .env.example .env.local\` in the root checkout, then copy or symlink it into this worktree and run \`source env.sh\` again.
+EOF
+            fi
+        fi
+    }
 
     # Load local env vars
     _gz_load_env_file() {
@@ -66,16 +103,17 @@ if [[ -z "$_GLAZE_AGENT_ENV_LOADED" || "${GLAZE_ROOT:-}" != "$_detected_root" ]]
         set +a
     }
 
-    _gz_load_preferred_env_file() {
-        local rel="$1"
-        local preferred_root
-        preferred_root="$(_gz_preferred_root_for "$rel")"
-        _gz_load_env_file "$preferred_root/$rel"
-    }
+    if ! _gz_has_env_files "$GLAZE_ROOT"; then
+        _gz_missing_env_error
+        return 1
+    fi
 
-    _gz_load_preferred_env_file ".env.local"
-    _gz_load_preferred_env_file "web/.env.local"
-    _gz_load_preferred_env_file "mobile/.env.local"
+    for _gz_env_rel in "${_gz_env_rel_paths[@]}"; do
+        _gz_load_env_file "$GLAZE_ROOT/$_gz_env_rel"
+    done
+    unset _gz_env_rel
+
+    _gz_prepend_path_once "$GLAZE_ROOT/web/node_modules/.bin"
 
     # Prevent Rust/rtk stack overflows from crashing the WSL2 VM
     ulimit -s unlimited 2>/dev/null || true
@@ -92,7 +130,7 @@ unset _detected_root
 # ---------------------------------------------------------------------------
 
 _gz_venv_root() {
-    _gz_preferred_root_for ".manage.venv/bin/activate"
+    printf '%s\n' "$GLAZE_ROOT"
 }
 
 _gz_port_is_free() {  # _gz_port_is_free <port>
@@ -260,26 +298,10 @@ gz_install_mcp_tools() {
 }
 
 gz_setup() {
-    local setup_mode="shared"
-    if [[ "${GLAZE_SETUP_ISOLATED:-0}" == "1" ]]; then
-        setup_mode="isolated"
+    if [[ $# -gt 0 ]]; then
+        echo "Usage: gz_setup"
+        return 2
     fi
-
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --isolated)
-                setup_mode="isolated"
-                ;;
-            --shared)
-                setup_mode="shared"
-                ;;
-            *)
-                echo "Usage: gz_setup [--shared|--isolated]"
-                return 2
-                ;;
-        esac
-        shift
-    done
 
     echo "=== Glaze: setting up development environment ==="
     # RTK
@@ -305,9 +327,9 @@ gz_setup() {
     echo "--- Syncing web dependencies via Bazel (@npm//:sync)..."
     (cd "$GLAZE_ROOT" && ${GLAZE_AGENT:+rtk }bazel run @npm//:sync)
 
-    # Activate the venv in the current shell — it may not have been active at
-    # source time if the repo was freshly cloned and the venv didn't exist yet.
-    [[ -f "$GLAZE_ROOT/.manage.venv/bin/activate" ]] && source "$GLAZE_ROOT/.manage.venv/bin/activate"
+    echo "--- Reloading shell bootstrap..."
+    gz_reload
+    unset GLAZE_AGENT
 
     echo "=== Setup complete ==="
     echo "    Run 'gz_gentypes' to regenerate TypeScript types via Bazel (no backend)."
@@ -853,11 +875,11 @@ gz_logs() {    # gz_logs [backend|web|all]  — defaults to running servers
 # ---------------------------------------------------------------------------
 
 gz_reload() {
-    # Re-source this file, bypassing the double-source guard so edits take
-    # effect in the current shell.
+    # Re-source the interactive bootstrap so edits and newly materialized
+    # dependencies take effect in the current shell.
     unset _GLAZE_AGENT_ENV_LOADED
     # shellcheck disable=SC1091
-    source "$_GLAZE_SCRIPT_DIR/env-agent.sh"
+    source "$_GLAZE_SCRIPT_DIR/env.sh"
 }
 
 gz_gentypes() {
@@ -872,9 +894,9 @@ gz_gentypes() {
 
 _GZ_SHORTCUTS=(
     "gz_help           — show this list of shortcuts"
-    "gz_reload         — re-source env.sh in the current shell (picks up env-agent.sh edits)"
+    "gz_reload         — re-source env.sh in the current shell (picks up env/bootstrap edits)"
     "gz_install_mcp_tools — install MCP tool dependencies (jq, curl, git, gh)"
-    "gz_setup [--isolated] — setup (shared reuse by default; --isolated for per-worktree deps)"
+    "gz_setup          — setup the isolated worktree environment"
     "gz_manage <cmd>   — run any manage.py subcommand"
     "gz_migrate        — migrate"
     "gz_makemigrations — makemigrations"

--- a/env.sh
+++ b/env.sh
@@ -13,9 +13,15 @@ fi
 
 # Bootstrap: everything (helpers, venv, env vars) defined in env-agent.sh.
 source "$_GLAZE_SCRIPT_DIR/env-agent.sh"
+_env_agent_rc=$?
+if [[ $_env_agent_rc -ne 0 ]]; then
+    return $_env_agent_rc
+fi
 
 # If we're in an interactive shell OR CI, we're likely a developer/bot, not an agent.
 # This unsets the rtk prefix for all tool invocations.
 unset GLAZE_AGENT
 
-echo "Glaze ready — run 'gz_help' for shortcuts, 'gz_setup' for first-time install."
+if [[ -n "${PS1:-}" ]]; then
+    echo "Glaze ready — run 'gz_help' for shortcuts, 'gz_setup' for first-time install."
+fi


### PR DESCRIPTION
Clarify the `gz_setup` and `gz_reload` contract for worktrees.

### What changed
- `gz_setup` now reads as the one-time materialization step for a checkout/worktree.
- `gz_reload` is documented as the shell refresh step after env/bootstrap changes or newly materialized tools.
- The package docs now say to rerun `gz_setup` after dependency updates and use direct `pnpm`/`uv`-style flows before Bazel sync/import steps.
- Worktree guidance now says to copy the root `.env.local` into each new worktree rather than symlinking it.

### Verification
- `bash -n env-agent.sh && bash -n env.sh`
