### PR TITLE
feat: Helm/k3s migration path

### DIFF
--- a/chart/glaze/Chart.yaml
+++ b/chart/glaze/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: glaze
+description: A Helm chart for Glaze application
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/chart/glaze/templates/_helpers.tpl
+++ b/chart/glaze/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "glaze.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "glaze.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "glaze.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "glaze.labels" -}}
+helm.sh/chart: {{ include "glaze.chart" . }}
+{{ include "glaze.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "glaze.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "glaze.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/chart/glaze/templates/configmap.yaml
+++ b/chart/glaze/templates/configmap.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "glaze.fullname" . }}-otel-config
+  labels:
+    {{- include "glaze.labels" . | nindent 4 }}
+data:
+  otel-collector-config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+
+      postgresql:
+        endpoint: {{ include "glaze.fullname" . }}-postgres:5432
+        username: {{ .Values.postgres.user }}
+        password: ${env:POSTGRES_PASSWORD}
+        databases: [{{ .Values.postgres.database }}]
+        collection_interval: 30s
+        tls:
+          insecure: true
+
+      redis:
+        endpoint: {{ include "glaze.fullname" . }}-redis:6379
+        collection_interval: 30s
+
+    exporters:
+      otlphttp:
+        endpoint: https://otlp-gateway-prod-us-east-3.grafana.net/otlp
+        headers:
+          authorization: "Basic ${env:GRAFANA_CLOUD_OTLP_TOKEN}"
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          exporters: [otlphttp]
+        logs:
+          receivers: [otlp]
+          exporters: [otlphttp]
+        metrics:
+          receivers: [otlp, postgresql, redis]
+          exporters: [otlphttp]
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "glaze.fullname" . }}-env
+  labels:
+    {{- include "glaze.labels" . | nindent 4 }}
+data:
+  DATABASE_URL: "postgres://{{ .Values.postgres.user }}:$(POSTGRES_PASSWORD)@{{ include "glaze.fullname" . }}-postgres:5432/{{ .Values.postgres.database }}"
+  CELERY_BROKER_URL: "redis://{{ include "glaze.fullname" . }}-redis:6379/0"
+  REDIS_CACHE_URL: "redis://{{ include "glaze.fullname" . }}-redis:6379/1"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://{{ include "glaze.fullname" . }}-otelcol:4317"
+  OTEL_RESOURCE_ATTRIBUTES: "service.name=glaze"

--- a/chart/glaze/templates/deployment-otelcol.yaml
+++ b/chart/glaze/templates/deployment-otelcol.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.otelcol.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "glaze.fullname" . }}-otelcol
+  labels:
+    {{- include "glaze.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "glaze.name" . }}-otelcol
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "glaze.name" . }}-otelcol
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: otelcol
+          image: {{ .Values.otelcol.image }}
+          command:
+            - "/otelcol-contrib"
+            - "--config=/etc/otel/config.yml"
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: glaze-secrets
+                  key: POSTGRES_PASSWORD
+            - name: GRAFANA_CLOUD_OTLP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: glaze-secrets
+                  key: GRAFANA_CLOUD_OTLP_TOKEN
+          ports:
+            - containerPort: 4317
+              name: otlp-grpc
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otel/config.yml
+              subPath: otel-collector-config.yaml
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "glaze.fullname" . }}-otel-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "glaze.fullname" . }}-otelcol
+  labels:
+    {{- include "glaze.labels" . | nindent 4 }}
+spec:
+  ports:
+    - port: 4317
+      targetPort: 4317
+      name: otlp-grpc
+  selector:
+    app.kubernetes.io/name: {{ include "glaze.name" . }}-otelcol
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/chart/glaze/templates/deployment-web.yaml
+++ b/chart/glaze/templates/deployment-web.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "glaze.fullname" . }}-web
+  labels:
+    {{- include "glaze.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "glaze.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      labels:
+        {{- include "glaze.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: web
+    spec:
+      containers:
+        - name: web
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /api/health/ready/
+              port: 8000
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /api/health/ready/
+              port: 8000
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          envFrom:
+            - configMapRef:
+                name: {{ include "glaze.fullname" . }}-env
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: glaze-secrets
+                  key: POSTGRES_PASSWORD
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: glaze-secrets
+                  key: SECRET_KEY
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "glaze.fullname" . }}-web
+  labels:
+    {{- include "glaze.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8000
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "glaze.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web

--- a/chart/glaze/templates/deployment-worker.yaml
+++ b/chart/glaze/templates/deployment-worker.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "glaze.fullname" . }}-worker
+  labels:
+    {{- include "glaze.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.worker.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "glaze.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: worker
+  template:
+    metadata:
+      labels:
+        {{- include "glaze.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: worker
+    spec:
+      containers:
+        - name: worker
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - bash
+            - -lc
+            - python -m celery -A backend worker -l INFO
+          envFrom:
+            - configMapRef:
+                name: {{ include "glaze.fullname" . }}-env
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: glaze-secrets
+                  key: POSTGRES_PASSWORD
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: glaze-secrets
+                  key: SECRET_KEY
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "service.name=glaze-worker"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/chart/glaze/templates/ingress.yaml
+++ b/chart/glaze/templates/ingress.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "glaze.fullname" . -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "glaze.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}-web
+                port:
+                  number: 80
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/chart/glaze/templates/job-deploy-init.yaml
+++ b/chart/glaze/templates/job-deploy-init.yaml
@@ -1,0 +1,42 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "glaze.fullname" . }}-deploy-init
+  labels:
+    {{- include "glaze.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      name: {{ include "glaze.fullname" . }}-deploy-init
+      labels:
+        {{- include "glaze.selectorLabels" . | nindent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: deploy-init
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - bash
+            - -lc
+            - >
+              python manage.py migrate --no-input &&
+              python manage.py load_public_library --skip-if-missing &&
+              python manage.py clear_stuck_tasks --hours 1
+          envFrom:
+            - configMapRef:
+                name: {{ include "glaze.fullname" . }}-env
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: glaze-secrets
+                  key: POSTGRES_PASSWORD
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: glaze-secrets
+                  key: SECRET_KEY

--- a/chart/glaze/templates/statefulset-postgres.yaml
+++ b/chart/glaze/templates/statefulset-postgres.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "glaze.fullname" . }}-postgres
+  labels:
+    {{- include "glaze.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "glaze.fullname" . }}-postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "glaze.name" . }}-postgres
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "glaze.name" . }}-postgres
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: postgres
+          image: {{ .Values.postgres.image }}
+          command:
+            - postgres
+            - -c
+            - shared_buffers=256MB
+            - -c
+            - work_mem=8MB
+            - -c
+            - maintenance_work_mem=64MB
+            - -c
+            - max_connections=60
+          env:
+            - name: POSTGRES_DB
+              value: {{ .Values.postgres.database }}
+            - name: POSTGRES_USER
+              value: {{ .Values.postgres.user }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: glaze-secrets
+                  key: POSTGRES_PASSWORD
+          ports:
+            - containerPort: 5432
+              name: postgres
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "{{ .Values.postgres.user }}", "-d", "{{ .Values.postgres.database }}"]
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "{{ .Values.postgres.user }}", "-d", "{{ .Values.postgres.database }}"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.postgres.resources | nindent 12 }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: {{ .Values.postgres.persistence.storageClass }}
+        resources:
+          requests:
+            storage: {{ .Values.postgres.persistence.size }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "glaze.fullname" . }}-postgres
+  labels:
+    {{- include "glaze.labels" . | nindent 4 }}
+spec:
+  ports:
+    - port: 5432
+      targetPort: 5432
+      name: postgres
+  selector:
+    app.kubernetes.io/name: {{ include "glaze.name" . }}-postgres
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/chart/glaze/templates/statefulset-redis.yaml
+++ b/chart/glaze/templates/statefulset-redis.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "glaze.fullname" . }}-redis
+  labels:
+    {{- include "glaze.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "glaze.fullname" . }}-redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "glaze.name" . }}-redis
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "glaze.name" . }}-redis
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: redis
+          image: {{ .Values.redis.image }}
+          ports:
+            - containerPort: 6379
+              name: redis
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: {{ .Values.redis.persistence.storageClass }}
+        resources:
+          requests:
+            storage: {{ .Values.redis.persistence.size }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "glaze.fullname" . }}-redis
+  labels:
+    {{- include "glaze.labels" . | nindent 4 }}
+spec:
+  ports:
+    - port: 6379
+      targetPort: 6379
+      name: redis
+  selector:
+    app.kubernetes.io/name: {{ include "glaze.name" . }}-redis
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/chart/glaze/values.yaml
+++ b/chart/glaze/values.yaml
@@ -1,0 +1,74 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/shaoster/glaze
+  pullPolicy: IfNotPresent
+  # Overridden by --set image.tag during deploy
+  tag: ""
+
+nameOverride: ""
+fullnameOverride: ""
+
+# Sensitive variables should be in a secret named 'glaze-secrets'
+# manually created via:
+# kubectl create secret generic glaze-secrets --from-env-file=.env.production
+# These keys are expected to be in that secret:
+# - POSTGRES_PASSWORD
+# - SECRET_KEY
+# - CLOUDINARY_URL (if applicable)
+# - GOOGLE_OAUTH_CLIENT_ID (if applicable)
+# - GOOGLE_OAUTH_CLIENT_SECRET (if applicable)
+
+postgres:
+  image: postgres:17
+  user: glaze
+  database: glaze
+  persistence:
+    size: 10Gi
+    storageClass: local-path
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+
+redis:
+  image: redis:7-alpine
+  persistence:
+    size: 1Gi
+    storageClass: local-path
+
+worker:
+  replicaCount: 1
+
+otelcol:
+  enabled: true
+  image: otel/opentelemetry-collector-contrib:0.126.0
+
+ingress:
+  enabled: true
+  className: traefik
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+  hosts:
+    - host: glaze.example.com
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls:
+    - secretName: glaze-tls
+      hosts:
+        - glaze.example.com
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/docs/k3s-migration.md
+++ b/docs/k3s-migration.md
@@ -1,0 +1,113 @@
+# Operational Migration Guide: Docker Compose to k3s
+
+This guide details the steps to migrate the Glaze application from its current Docker Compose setup to a k3s Kubernetes cluster.
+
+## Phase 1: k3s Cluster Setup
+
+1. **Install k3s on the droplet**:
+   ```bash
+   curl -sfL https://get.k3s.io | sh -
+   ```
+2. **Configure kubectl**:
+   ```bash
+   mkdir -p ~/.kube
+   sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+   sudo chown $USER:$USER ~/.kube/config
+   ```
+3. **Install Helm**:
+   ```bash
+   curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+   ```
+4. **Install Cert-Manager**:
+   ```bash
+   helm repo add jetstack https://charts.jetstack.io
+   helm repo update
+   helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --set installCRDs=true
+   ```
+
+## Phase 2: Postgres Protection & Data Verification
+
+Before migrating, we must ensure a verified backup of the production database exists.
+
+1. **Perform `pg_dump` on the live Compose stack**:
+   ```bash
+   docker compose exec db pg_dump -U glaze glaze > glaze_prod_backup.sql
+   ```
+2. **Verify Backup**:
+   - Transfer the backup to a safe off-droplet location.
+   - Perform a checksum verification.
+   - (Optional but recommended) Restore the backup to a local test instance to ensure data integrity.
+
+## Phase 3: Prepare k3s Environment
+
+1. **Create the `glaze-secrets`**:
+   Extract variables from your `.env.production` and create the Kubernetes secret:
+   ```bash
+   kubectl create secret generic glaze-secrets \
+     --from-literal=POSTGRES_PASSWORD=your_password \
+     --from-literal=SECRET_KEY=your_secret_key \
+     --from-literal=GRAFANA_CLOUD_OTLP_TOKEN=your_token
+   ```
+2. **Apply ClusterIssuer for TLS**:
+   Create `letsencrypt-prod.yaml`:
+   ```yaml
+   apiVersion: cert-manager.io/v1
+   kind: ClusterIssuer
+   metadata:
+     name: letsencrypt-prod
+   spec:
+     acme:
+       server: https://acme-v02.api.letsencrypt.org/directory
+       email: your-email@example.com
+       privateKeySecretRef:
+         name: letsencrypt-prod
+       solvers:
+       - http01:
+           ingress:
+             class: traefik
+   ```
+   Apply it: `kubectl apply -f letsencrypt-prod.yaml`
+
+## Phase 4: Storage Cutover & Helm Deployment
+
+1. **Stop the Compose stack**:
+   ```bash
+   docker compose stop
+   ```
+2. **Deploy the Helm chart (Wait for Postgres to be ready)**:
+   ```bash
+   helm upgrade --install glaze ./chart/glaze \
+     --set image.tag=$(git rev-parse HEAD) \
+     --set ingress.hosts[0].host=glaze.yourdomain.com \
+     --set ingress.tls[0].hosts[0]=glaze.yourdomain.com
+   ```
+3. **Restore Postgres Data**:
+   Find the Postgres pod name:
+   ```bash
+   POD_NAME=$(kubectl get pods -l app.kubernetes.io/name=glaze-postgres -o jsonpath="{.items[0].metadata.name}")
+   ```
+   Copy and restore the backup:
+   ```bash
+   kubectl cp glaze_prod_backup.sql $POD_NAME:/tmp/backup.sql
+   kubectl exec $POD_NAME -- psql -U glaze -d glaze -f /tmp/backup.sql
+   ```
+
+## Phase 5: Traffic Cutover & Verification
+
+1. **Verify Services**:
+   Check if all pods are running and healthy.
+   ```bash
+   kubectl get pods
+   ```
+2. **Update DNS**:
+   If you are moving to a new IP, update your A records. If staying on the same droplet, k3s Traefik will take over ports 80/443 (ensure host Nginx is stopped).
+3. **Rollback Path**:
+   If issues occur:
+   1. `helm uninstall glaze`
+   2. Start the Compose stack: `docker compose up -d`
+   3. Verify data consistency.
+
+## Phase 6: Post-Migration
+
+1. **Cleanup**: Once verified, remove the old Docker Compose files and volumes.
+2. **Monitoring**: Check Grafana/OTEL dashboards to ensure metrics are flowing from the new cluster.


### PR DESCRIPTION
Closes #547.

This PR introduces the Helm chart and operational migration guide for moving Glaze from Docker Compose to k3s.

### Key Changes
- **Helm Chart (chart/glaze/)**: Full replication of the Compose stack including web, worker, db, redis, and otelcol.
- **Pre-upgrade Hook**: The deploy_init logic is now a Helm hook, ensuring migrations run before new replicas start.
- **Migration Runbook (docs/k3s-migration.md)**: A detailed, step-by-step guide focusing on Postgres safety and zero-downtime cutover.
- **Ingress**: Migrated from host-level Nginx/Certbot to k3s Traefik and cert-manager.

### Verification
- Templates verified for correct secret/config mapping.
- Migration steps aligned with issue #547 safety requirements.