### PR TITLE
[codex] fix piece list thumbnail sizing

### DIFF
--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -171,7 +171,8 @@ const PieceCard = ({ piece, width }: PieceCardProps) => {
           requestedHeight={getThumbnailRequestedHeight(piece, Math.round(width))}
           style={{
             width: "100%",
-            height: "auto",
+            height: "100%",
+            objectFit: "cover",
             display: "block",
           }}
           onLoad={(e) => {

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -13,12 +13,14 @@ vi.mock("../CloudinaryImage", () => ({
     crop,
     requestedHeight,
     requestedWidth,
+    style,
     url,
     alt,
   }: {
     crop?: unknown;
     requestedHeight?: number;
     requestedWidth?: number;
+    style?: React.CSSProperties;
     url: string;
     alt?: string;
   }) => (
@@ -28,6 +30,7 @@ vi.mock("../CloudinaryImage", () => ({
       data-crop={crop ? "yes" : "no"}
       data-requested-height={requestedHeight}
       data-requested-width={requestedWidth}
+      style={style}
     />
   ),
 }));
@@ -628,6 +631,26 @@ describe("PieceList", () => {
       expect(image.getAttribute("data-crop")).toBe("yes");
       expect(image.getAttribute("data-requested-width")).toBe("240");
       expect(image.hasAttribute("data-requested-height")).toBe(false);
+    });
+
+    it("fills the thumbnail shell so cropped images do not leave a visible gap", () => {
+      const { container } = renderPieceList([
+        makePiece({
+          thumbnail: {
+            url: "https://example.com/tall.jpg",
+            cloudinary_public_id: "pieces/tall",
+            cloud_name: "demo",
+            crop: { x: 0, y: 0, width: 200, height: 400 },
+          },
+        }),
+      ]);
+
+      const image = container.querySelector("img")!;
+      expect(image).toHaveStyle({
+        width: "100%",
+        height: "100%",
+        objectFit: "cover",
+      });
     });
 
     it("card links to piece detail page", () => {


### PR DESCRIPTION
## What changed
- Adjusted PieceList thumbnail images to fill the shell and crop with object-fit: cover so the masonry cards no longer show the black gap under cropped images.
- Added a regression test that asserts cropped thumbnails receive the fill styles.

## Why
- The local repro showed the shell height was correct, but the rendered image was shorter than the shell because the card was using height: auto for cropped thumbnails.

## Validation
- rtk bazel test //web:web_piece_list_test --test_output=errors
