### PR TITLE
feat: move image to state affordance in lightbox

### DIFF
--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -278,6 +278,7 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
       return state.images.map((image, imageIndex) => ({
         ...image,
         stateLabel: formatState(state.state),
+        stateId: state.id,
         editableCurrentStateIndex:
           canEdit && isCurrentState ? imageIndex : null,
       }));
@@ -396,6 +397,10 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
     onPieceUpdated,
     updatePieceFn: canEdit ? updatePiece : undefined,
     updateCurrentStateFn: canEdit ? updateCurrentState : undefined,
+    pieceStates: piece.history.map((s) => ({ id: s.id, state: s.state, label: formatState(s.state) })),
+    currentStateId: currentState.id,
+    isEditable: piece.is_editable,
+    updatePastStateFn: canEdit ? updatePastState : undefined,
   } satisfies ComponentProps<typeof PiecePhotoGallery>;
 
   return (

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -397,7 +397,10 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
     onPieceUpdated,
     updatePieceFn: canEdit ? updatePiece : undefined,
     updateCurrentStateFn: canEdit ? updateCurrentState : undefined,
-    pieceStates: piece.history.map((s) => ({ id: s.id, label: formatState(s.state) })),
+    pieceStates: [
+      { id: currentState.id, label: formatState(currentState.state) },
+      ...piece.history.map((s) => ({ id: s.id, label: formatState(s.state) })),
+    ],
     currentStateId: currentState.id,
     isEditable: piece.is_editable,
     updatePastStateFn: canEdit ? updatePastState : undefined,

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -397,7 +397,7 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
     onPieceUpdated,
     updatePieceFn: canEdit ? updatePiece : undefined,
     updateCurrentStateFn: canEdit ? updateCurrentState : undefined,
-    pieceStates: piece.history.map((s) => ({ id: s.id, state: s.state, label: formatState(s.state) })),
+    pieceStates: piece.history.map((s) => ({ id: s.id, label: formatState(s.state) })),
     currentStateId: currentState.id,
     isEditable: piece.is_editable,
     updatePastStateFn: canEdit ? updatePastState : undefined,

--- a/web/src/components/PiecePhotoGallery.tsx
+++ b/web/src/components/PiecePhotoGallery.tsx
@@ -407,7 +407,7 @@ export default function PiecePhotoGallery({
         >
           Move to state
         </Button>
-      ) : canMutateCurrentStateImages && !isEditable ? (
+      ) : canMutateCurrentStateImages && !isEditable && updatePastStateFn !== undefined && (pieceStates?.length ?? 0) > 1 ? (
         <Tooltip title="Piece must be editable to move images.">
           <span>
             <Button

--- a/web/src/components/PiecePhotoGallery.tsx
+++ b/web/src/components/PiecePhotoGallery.tsx
@@ -494,6 +494,7 @@ export default function PiecePhotoGallery({
       {moveDialogImageIndex !== null && (
         <Dialog
           open
+          // Intentionally swallow backdrop/escape close while a save is in flight.
           onClose={() => !moveSaving && setMoveDialogImageIndex(null)}
           maxWidth="xs"
           fullWidth

--- a/web/src/components/PiecePhotoGallery.tsx
+++ b/web/src/components/PiecePhotoGallery.tsx
@@ -8,14 +8,18 @@ import {
   Dialog,
   DialogActions,
   DialogContent,
+  DialogTitle,
   IconButton,
+  List,
+  ListItemButton,
+  ListItemText,
   TextField,
   Tooltip,
   Typography,
   useTheme,
 } from "@mui/material";
-import type { CaptionedImage, PieceDetail } from "../util/types";
-import { updateCurrentState, updatePiece } from "../util/api";
+import type { CaptionedImage, PieceDetail, State } from "../util/types";
+import { updateCurrentState, updatePastState, updatePiece } from "../util/api";
 import DeletePiecePhotoDialog from "./DeletePiecePhotoDialog";
 import ImageLightbox from "./ImageLightbox";
 import PiecePhotoGalleryGrid from "./PiecePhotoGalleryGrid";
@@ -23,6 +27,7 @@ import { normalizeFields } from "../util/normalizeWorkflowFields";
 
 export type PiecePhotoGalleryImage = CaptionedImage & {
   stateLabel: string;
+  stateId: string;
   editableCurrentStateIndex: number | null;
 };
 
@@ -30,6 +35,12 @@ export type EditablePiecePhoto = Pick<
   CaptionedImage,
   "url" | "caption" | "cloudinary_public_id" | "cloud_name" | "crop"
 >;
+
+type PieceStateRef = {
+  id: string;
+  state: State;
+  label: string;
+};
 
 type PiecePhotoGalleryProps = {
   images: PiecePhotoGalleryImage[];
@@ -40,12 +51,26 @@ type PiecePhotoGalleryProps = {
   onPieceUpdated?: (updated: PieceDetail) => void;
   updatePieceFn?: typeof updatePiece;
   updateCurrentStateFn?: typeof updateCurrentState;
+  pieceStates?: PieceStateRef[];
+  currentStateId?: string;
+  isEditable?: boolean;
+  updatePastStateFn?: typeof updatePastState;
 };
 
 function isEditableImage(
   image: PiecePhotoGalleryImage,
 ): image is PiecePhotoGalleryImage & { editableCurrentStateIndex: number } {
   return image.editableCurrentStateIndex !== null;
+}
+
+function toEditablePhoto(image: CaptionedImage): EditablePiecePhoto {
+  return {
+    url: image.url,
+    caption: image.caption,
+    cloudinary_public_id: image.cloudinary_public_id ?? null,
+    cloud_name: image.cloud_name ?? null,
+    crop: image.crop ?? null,
+  };
 }
 
 export default function PiecePhotoGallery({
@@ -57,6 +82,10 @@ export default function PiecePhotoGallery({
   onPieceUpdated,
   updatePieceFn,
   updateCurrentStateFn,
+  pieceStates,
+  currentStateId,
+  isEditable,
+  updatePastStateFn,
 }: PiecePhotoGalleryProps) {
   const theme = useTheme();
   const [galleryOpen, setGalleryOpen] = useState(false);
@@ -67,6 +96,9 @@ export default function PiecePhotoGallery({
   const [captionSaveError, setCaptionSaveError] = useState<string | null>(null);
   const [deleteDialogIndex, setDeleteDialogIndex] = useState<number | null>(null);
   const [deleteSaving, setDeleteSaving] = useState(false);
+  const [moveDialogImageIndex, setMoveDialogImageIndex] = useState<number | null>(null);
+  const [moveSaving, setMoveSaving] = useState(false);
+  const [moveError, setMoveError] = useState<string | null>(null);
 
   useEffect(() => {
     if (lightboxIndex === null) return;
@@ -185,6 +217,68 @@ export default function PiecePhotoGallery({
     }
   }
 
+  async function handleMoveImage(targetStateId: string) {
+    if (
+      moveDialogImageIndex === null ||
+      !pieceId ||
+      !onPieceUpdated ||
+      !updateCurrentStateFn ||
+      !updatePastStateFn
+    ) {
+      return;
+    }
+    const image = images[moveDialogImageIndex];
+    const sourceStateId = image.stateId;
+
+    const nextSourceImages = images
+      .filter((img) => img.stateId === sourceStateId && img !== image)
+      .map(toEditablePhoto);
+
+    setMoveSaving(true);
+    setMoveError(null);
+    try {
+      let updatedAfterSource: PieceDetail;
+      if (sourceStateId === currentStateId) {
+        updatedAfterSource = await updateCurrentStateFn(pieceId, {
+          notes: currentStateNotes!,
+          images: nextSourceImages,
+          custom_fields: normalizeFields(currentStateCustomFields ?? {}),
+        });
+      } else {
+        updatedAfterSource = await updatePastStateFn(pieceId, sourceStateId, {
+          images: nextSourceImages,
+        });
+      }
+
+      const allStates = [updatedAfterSource.current_state, ...updatedAfterSource.history];
+      const targetState = allStates.find((s) => s.id === targetStateId);
+      if (!targetState) {
+        throw new Error("Target state not found.");
+      }
+      const nextTargetImages = [...targetState.images.map(toEditablePhoto), toEditablePhoto(image)];
+
+      let finalPiece: PieceDetail;
+      if (targetStateId === currentStateId) {
+        finalPiece = await updateCurrentStateFn(pieceId, {
+          notes: updatedAfterSource.current_state.notes,
+          images: nextTargetImages,
+          custom_fields: normalizeFields(updatedAfterSource.current_state.custom_fields ?? {}),
+        });
+      } else {
+        finalPiece = await updatePastStateFn(pieceId, targetStateId, {
+          images: nextTargetImages,
+        });
+      }
+      onPieceUpdated(finalPiece);
+      setMoveDialogImageIndex(null);
+      setLightboxIndex(null);
+    } catch {
+      setMoveError("Failed to move image. Please try again.");
+    } finally {
+      setMoveSaving(false);
+    }
+  }
+
   const triggerLabel = `${photoCount} photo${photoCount === 1 ? "" : "s"}`;
 
   const canMutateCurrentStateImages =
@@ -199,6 +293,11 @@ export default function PiecePhotoGallery({
   const canEditCaption =
     editableCurrentStateIndex !== null &&
     canMutateCurrentStateImages;
+  const canMove =
+    canMutateCurrentStateImages &&
+    isEditable === true &&
+    updatePastStateFn !== undefined &&
+    (pieceStates?.length ?? 0) > 1;
 
   const footer = activeImage ? (
     <Box sx={{ display: "grid", gap: 0.75, justifyItems: "center" }}>
@@ -299,6 +398,29 @@ export default function PiecePhotoGallery({
           ? "Added in current state"
           : `Added in ${activeImage.stateLabel}`}
       </Typography>
+      {canMove ? (
+        <Button
+          size="small"
+          variant="outlined"
+          onClick={() => setMoveDialogImageIndex(lightboxIndex)}
+          sx={{ color: "white", borderColor: "rgba(255,255,255,0.35)" }}
+        >
+          Move to state
+        </Button>
+      ) : canMutateCurrentStateImages && !isEditable ? (
+        <Tooltip title="Piece must be editable to move images.">
+          <span>
+            <Button
+              size="small"
+              variant="outlined"
+              disabled
+              sx={{ color: "rgba(255,255,255,0.35)", borderColor: "rgba(255,255,255,0.2)" }}
+            >
+              Move to state
+            </Button>
+          </span>
+        </Tooltip>
+      ) : null}
     </Box>
   ) : null;
 
@@ -369,6 +491,48 @@ export default function PiecePhotoGallery({
         onCancel={() => setDeleteDialogIndex(null)}
         onConfirm={() => void handleDeleteImage()}
       />
+
+      {moveDialogImageIndex !== null && (
+        <Dialog
+          open
+          onClose={() => !moveSaving && setMoveDialogImageIndex(null)}
+          maxWidth="xs"
+          fullWidth
+        >
+          <DialogTitle>Move image to state</DialogTitle>
+          <DialogContent>
+            <List disablePadding>
+              {(pieceStates ?? [])
+                .filter((s) => s.id !== images[moveDialogImageIndex]?.stateId)
+                .map((s) => (
+                  <ListItemButton
+                    key={s.id}
+                    onClick={() => void handleMoveImage(s.id)}
+                    disabled={moveSaving}
+                  >
+                    <ListItemText primary={s.label} />
+                  </ListItemButton>
+                ))}
+            </List>
+            {moveError && (
+              <Typography variant="body2" color="error" sx={{ mt: 1 }}>
+                {moveError}
+              </Typography>
+            )}
+          </DialogContent>
+          <DialogActions>
+            <Button
+              onClick={() => {
+                setMoveDialogImageIndex(null);
+                setMoveError(null);
+              }}
+              disabled={moveSaving}
+            >
+              Cancel
+            </Button>
+          </DialogActions>
+        </Dialog>
+      )}
     </>
   );
 }

--- a/web/src/components/PiecePhotoGallery.tsx
+++ b/web/src/components/PiecePhotoGallery.tsx
@@ -18,7 +18,7 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
-import type { CaptionedImage, PieceDetail, State } from "../util/types";
+import type { CaptionedImage, PieceDetail } from "../util/types";
 import { updateCurrentState, updatePastState, updatePiece } from "../util/api";
 import DeletePiecePhotoDialog from "./DeletePiecePhotoDialog";
 import ImageLightbox from "./ImageLightbox";
@@ -38,7 +38,6 @@ export type EditablePiecePhoto = Pick<
 
 type PieceStateRef = {
   id: string;
-  state: State;
   label: string;
 };
 

--- a/web/src/components/__tests__/PiecePhotoGallery.test.tsx
+++ b/web/src/components/__tests__/PiecePhotoGallery.test.tsx
@@ -615,7 +615,7 @@ describe("PiecePhotoGallery", () => {
 
       // Image at index 0 has stateId "state-current"; dialog should only show "state-past"
       expect(screen.getByText("Move image to state")).toBeInTheDocument();
-      expect(screen.getByRole("option") || screen.getByText("Designed")).toBeInTheDocument();
+      expect(screen.getByText("Designed")).toBeInTheDocument();
       expect(screen.queryByText("Wheel Thrown")).not.toBeInTheDocument();
     });
 

--- a/web/src/components/__tests__/PiecePhotoGallery.test.tsx
+++ b/web/src/components/__tests__/PiecePhotoGallery.test.tsx
@@ -74,6 +74,7 @@ function makeImages(): PiecePhotoGalleryImage[] {
       cloudinary_public_id: "piece/a",
       cloud_name: null,
       stateLabel: "Throwing",
+      stateId: "state-current",
       editableCurrentStateIndex: 0,
     },
     {
@@ -83,6 +84,7 @@ function makeImages(): PiecePhotoGalleryImage[] {
       cloudinary_public_id: "piece/b",
       cloud_name: null,
       stateLabel: "Trimming",
+      stateId: "state-past",
       editableCurrentStateIndex: null,
     },
   ];
@@ -99,11 +101,17 @@ function makeSingleImage(
       cloudinary_public_id: "piece/solo",
       cloud_name: null,
       stateLabel: "Throwing",
+      stateId: "state-current",
       editableCurrentStateIndex: 0,
       ...overrides,
     },
   ];
 }
+
+const DEFAULT_PIECE_STATES = [
+  { id: "state-current", state: "wheel_thrown" as const, label: "Wheel Thrown" },
+  { id: "state-past", state: "designed" as const, label: "Designed" },
+];
 
 function makeUpdatedPiece(overrides: Partial<PieceDetail> = {}): PieceDetail {
   const state = {
@@ -519,6 +527,224 @@ describe("PiecePhotoGallery", () => {
     await waitFor(() =>
       expect(screen.queryByLabelText("Mock lightbox")).not.toBeInTheDocument(),
     );
+  });
+
+  describe("move image to state", () => {
+    it("does not show 'Move to state' button when pieceStates is not provided", async () => {
+      render(
+        <PiecePhotoGallery
+          images={makeImages()}
+          pieceId="piece-1"
+          currentStateNotes="Current notes"
+          onPieceUpdated={vi.fn()}
+          updateCurrentStateFn={vi.fn()}
+        />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "2 photos" }));
+      await userEvent.click(screen.getByRole("button", { name: "Open piece photo 1" }));
+
+      expect(screen.queryByRole("button", { name: /move to state/i })).not.toBeInTheDocument();
+    });
+
+    it("shows 'Move to state' button disabled with tooltip when !isEditable", async () => {
+      render(
+        <PiecePhotoGallery
+          images={makeImages()}
+          pieceId="piece-1"
+          currentStateNotes="Current notes"
+          onPieceUpdated={vi.fn()}
+          updateCurrentStateFn={vi.fn()}
+          updatePastStateFn={vi.fn()}
+          pieceStates={DEFAULT_PIECE_STATES}
+          currentStateId="state-current"
+          isEditable={false}
+        />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "2 photos" }));
+      await userEvent.click(screen.getByRole("button", { name: "Open piece photo 1" }));
+      const lightbox = screen.getByLabelText("Mock lightbox");
+      const moveBtn = within(lightbox).getByRole("button", { name: /move to state/i });
+
+      expect(moveBtn).toBeDisabled();
+    });
+
+    it("shows 'Move to state' button enabled when isEditable", async () => {
+      render(
+        <PiecePhotoGallery
+          images={makeImages()}
+          pieceId="piece-1"
+          currentStateNotes="Current notes"
+          onPieceUpdated={vi.fn()}
+          updateCurrentStateFn={vi.fn()}
+          updatePastStateFn={vi.fn()}
+          pieceStates={DEFAULT_PIECE_STATES}
+          currentStateId="state-current"
+          isEditable={true}
+        />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "2 photos" }));
+      await userEvent.click(screen.getByRole("button", { name: "Open piece photo 1" }));
+      const lightbox = screen.getByLabelText("Mock lightbox");
+      const moveBtn = within(lightbox).getByRole("button", { name: /move to state/i });
+
+      expect(moveBtn).not.toBeDisabled();
+    });
+
+    it("opens state picker dialog showing only other states", async () => {
+      render(
+        <PiecePhotoGallery
+          images={makeImages()}
+          pieceId="piece-1"
+          currentStateNotes="Current notes"
+          onPieceUpdated={vi.fn()}
+          updateCurrentStateFn={vi.fn()}
+          updatePastStateFn={vi.fn()}
+          pieceStates={DEFAULT_PIECE_STATES}
+          currentStateId="state-current"
+          isEditable={true}
+        />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "2 photos" }));
+      await userEvent.click(screen.getByRole("button", { name: "Open piece photo 1" }));
+      const lightbox = screen.getByLabelText("Mock lightbox");
+      await userEvent.click(within(lightbox).getByRole("button", { name: /move to state/i }));
+
+      // Image at index 0 has stateId "state-current"; dialog should only show "state-past"
+      expect(screen.getByText("Move image to state")).toBeInTheDocument();
+      expect(screen.getByRole("option") || screen.getByText("Designed")).toBeInTheDocument();
+      expect(screen.queryByText("Wheel Thrown")).not.toBeInTheDocument();
+    });
+
+    it("moves a current-state image to a past state via two sequential API calls", async () => {
+      const pastStateAfterRemove = {
+        id: "state-past",
+        state: "designed" as const,
+        notes: "",
+        created: new Date("2024-01-14T10:00:00Z"),
+        last_modified: new Date("2024-01-14T10:00:00Z"),
+        images: [],
+        previous_state: null,
+        next_state: "wheel_thrown" as const,
+        custom_fields: {},
+        has_been_edited: false,
+      };
+      const currentStateAfterRemove = {
+        id: "state-current",
+        state: "wheel_thrown" as const,
+        notes: "Current notes",
+        created: new Date("2024-01-16T10:00:00Z"),
+        last_modified: new Date("2024-01-16T10:00:00Z"),
+        images: [],
+        previous_state: "designed" as const,
+        next_state: null,
+        custom_fields: {},
+        has_been_edited: false,
+      };
+      const pieceAfterRemove = makeUpdatedPiece({
+        current_state: currentStateAfterRemove,
+        history: [currentStateAfterRemove, pastStateAfterRemove],
+      });
+      const finalPiece = makeUpdatedPiece();
+
+      const updateCurrentStateFn = vi.fn().mockResolvedValue(pieceAfterRemove);
+      const updatePastStateFn = vi.fn().mockResolvedValue(finalPiece);
+      const onPieceUpdated = vi.fn();
+
+      render(
+        <PiecePhotoGallery
+          images={makeImages()}
+          pieceId="piece-1"
+          currentStateNotes="Current notes"
+          currentStateCustomFields={{}}
+          onPieceUpdated={onPieceUpdated}
+          updateCurrentStateFn={updateCurrentStateFn}
+          updatePastStateFn={updatePastStateFn}
+          pieceStates={DEFAULT_PIECE_STATES}
+          currentStateId="state-current"
+          isEditable={true}
+        />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "2 photos" }));
+      await userEvent.click(screen.getByRole("button", { name: "Open piece photo 1" }));
+      const lightbox = screen.getByLabelText("Mock lightbox");
+      await userEvent.click(within(lightbox).getByRole("button", { name: /move to state/i }));
+      await userEvent.click(screen.getByText("Designed"));
+
+      await waitFor(() => expect(updateCurrentStateFn).toHaveBeenCalledWith(
+        "piece-1",
+        expect.objectContaining({ images: [] }),
+      ));
+      await waitFor(() => expect(updatePastStateFn).toHaveBeenCalledWith(
+        "piece-1",
+        "state-past",
+        expect.objectContaining({
+          images: [expect.objectContaining({ url: "https://example.com/a.jpg" })],
+        }),
+      ));
+      await waitFor(() => expect(onPieceUpdated).toHaveBeenCalledWith(finalPiece));
+    });
+
+    it("shows error message when move API call fails", async () => {
+      const updateCurrentStateFn = vi.fn().mockRejectedValue(new Error("Network error"));
+      const updatePastStateFn = vi.fn();
+
+      render(
+        <PiecePhotoGallery
+          images={makeImages()}
+          pieceId="piece-1"
+          currentStateNotes="Current notes"
+          onPieceUpdated={vi.fn()}
+          updateCurrentStateFn={updateCurrentStateFn}
+          updatePastStateFn={updatePastStateFn}
+          pieceStates={DEFAULT_PIECE_STATES}
+          currentStateId="state-current"
+          isEditable={true}
+        />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "2 photos" }));
+      await userEvent.click(screen.getByRole("button", { name: "Open piece photo 1" }));
+      const lightbox = screen.getByLabelText("Mock lightbox");
+      await userEvent.click(within(lightbox).getByRole("button", { name: /move to state/i }));
+      await userEvent.click(screen.getByText("Designed"));
+
+      await waitFor(() =>
+        expect(screen.getByText("Failed to move image. Please try again.")).toBeInTheDocument(),
+      );
+    });
+
+    it("closes move dialog on cancel", async () => {
+      render(
+        <PiecePhotoGallery
+          images={makeImages()}
+          pieceId="piece-1"
+          currentStateNotes="Current notes"
+          onPieceUpdated={vi.fn()}
+          updateCurrentStateFn={vi.fn()}
+          updatePastStateFn={vi.fn()}
+          pieceStates={DEFAULT_PIECE_STATES}
+          currentStateId="state-current"
+          isEditable={true}
+        />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "2 photos" }));
+      await userEvent.click(screen.getByRole("button", { name: "Open piece photo 1" }));
+      const lightbox = screen.getByLabelText("Mock lightbox");
+      await userEvent.click(within(lightbox).getByRole("button", { name: /move to state/i }));
+      expect(screen.getByText("Move image to state")).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+      await waitFor(() =>
+        expect(screen.queryByText("Move image to state")).not.toBeInTheDocument(),
+      );
+    });
   });
 
   it("exits image deletion early when the pending image is no longer editable", async () => {

--- a/web/src/components/__tests__/PiecePhotoGallery.test.tsx
+++ b/web/src/components/__tests__/PiecePhotoGallery.test.tsx
@@ -616,6 +616,30 @@ describe("PiecePhotoGallery", () => {
       expect(screen.queryByText("Wheel Thrown")).not.toBeInTheDocument();
     });
 
+    it("opens state picker showing current state when a past-state image is open", async () => {
+      render(
+        <PiecePhotoGallery
+          images={makeImages()}
+          pieceId="piece-1"
+          currentStateNotes="Current notes"
+          onPieceUpdated={vi.fn()}
+          updateCurrentStateFn={vi.fn()}
+          updatePastStateFn={vi.fn()}
+          pieceStates={DEFAULT_PIECE_STATES}
+          currentStateId="state-current"
+          isEditable={true}
+        />,
+      );
+
+      await userEvent.click(screen.getByRole("button", { name: "2 photos" }));
+      await userEvent.click(screen.getByRole("button", { name: "Open piece photo 2" }));
+      await userEvent.click(screen.getByRole("button", { name: /move to state/i }));
+
+      // Image at index 1 has stateId "state-past"; dialog should only show "state-current"
+      expect(screen.getByText("Wheel Thrown")).toBeInTheDocument();
+      expect(screen.queryByText("Designed")).not.toBeInTheDocument();
+    });
+
     it("moves a current-state image to a past state via two sequential API calls", async () => {
       const pastStateAfterRemove = {
         id: "state-past",
@@ -721,7 +745,7 @@ describe("PiecePhotoGallery", () => {
       };
       const pieceAfterSourceRemove = makeUpdatedPiece({
         current_state: currentStateWithOriginalImage,
-        history: [currentStateWithOriginalImage, pastStateAfterRemove],
+        history: [pastStateAfterRemove],
       });
       const finalPiece = makeUpdatedPiece();
       const updatePastStateFn = vi.fn().mockResolvedValue(pieceAfterSourceRemove);

--- a/web/src/components/__tests__/PiecePhotoGallery.test.tsx
+++ b/web/src/components/__tests__/PiecePhotoGallery.test.tsx
@@ -109,8 +109,8 @@ function makeSingleImage(
 }
 
 const DEFAULT_PIECE_STATES = [
-  { id: "state-current", state: "wheel_thrown" as const, label: "Wheel Thrown" },
-  { id: "state-past", state: "designed" as const, label: "Designed" },
+  { id: "state-current", label: "Wheel Thrown" },
+  { id: "state-past", label: "Designed" },
 ];
 
 function makeUpdatedPiece(overrides: Partial<PieceDetail> = {}): PieceDetail {
@@ -564,8 +564,7 @@ describe("PiecePhotoGallery", () => {
 
       await userEvent.click(screen.getByRole("button", { name: "2 photos" }));
       await userEvent.click(screen.getByRole("button", { name: "Open piece photo 1" }));
-      const lightbox = screen.getByLabelText("Mock lightbox");
-      const moveBtn = within(lightbox).getByRole("button", { name: /move to state/i });
+      const moveBtn = screen.getByRole("button", { name: /move to state/i });
 
       expect(moveBtn).toBeDisabled();
     });
@@ -587,8 +586,7 @@ describe("PiecePhotoGallery", () => {
 
       await userEvent.click(screen.getByRole("button", { name: "2 photos" }));
       await userEvent.click(screen.getByRole("button", { name: "Open piece photo 1" }));
-      const lightbox = screen.getByLabelText("Mock lightbox");
-      const moveBtn = within(lightbox).getByRole("button", { name: /move to state/i });
+      const moveBtn = screen.getByRole("button", { name: /move to state/i });
 
       expect(moveBtn).not.toBeDisabled();
     });
@@ -610,8 +608,7 @@ describe("PiecePhotoGallery", () => {
 
       await userEvent.click(screen.getByRole("button", { name: "2 photos" }));
       await userEvent.click(screen.getByRole("button", { name: "Open piece photo 1" }));
-      const lightbox = screen.getByLabelText("Mock lightbox");
-      await userEvent.click(within(lightbox).getByRole("button", { name: /move to state/i }));
+      await userEvent.click(screen.getByRole("button", { name: /move to state/i }));
 
       // Image at index 0 has stateId "state-current"; dialog should only show "state-past"
       expect(screen.getByText("Move image to state")).toBeInTheDocument();
@@ -671,8 +668,7 @@ describe("PiecePhotoGallery", () => {
 
       await userEvent.click(screen.getByRole("button", { name: "2 photos" }));
       await userEvent.click(screen.getByRole("button", { name: "Open piece photo 1" }));
-      const lightbox = screen.getByLabelText("Mock lightbox");
-      await userEvent.click(within(lightbox).getByRole("button", { name: /move to state/i }));
+      await userEvent.click(screen.getByRole("button", { name: /move to state/i }));
       await userEvent.click(screen.getByText("Designed"));
 
       await waitFor(() => expect(updateCurrentStateFn).toHaveBeenCalledWith(
@@ -684,6 +680,87 @@ describe("PiecePhotoGallery", () => {
         "state-past",
         expect.objectContaining({
           images: [expect.objectContaining({ url: "https://example.com/a.jpg" })],
+        }),
+      ));
+      await waitFor(() => expect(onPieceUpdated).toHaveBeenCalledWith(finalPiece));
+    });
+
+    it("moves a past-state image to the current state via two sequential updatePastState / updateCurrentState calls", async () => {
+      const pastStateAfterRemove = {
+        id: "state-past",
+        state: "designed" as const,
+        notes: "",
+        created: new Date("2024-01-14T10:00:00Z"),
+        last_modified: new Date("2024-01-14T10:00:00Z"),
+        images: [],
+        previous_state: null,
+        next_state: "wheel_thrown" as const,
+        custom_fields: {},
+        has_been_edited: false,
+      };
+      const currentStateWithOriginalImage = {
+        id: "state-current",
+        state: "wheel_thrown" as const,
+        notes: "Current notes",
+        created: new Date("2024-01-16T10:00:00Z"),
+        last_modified: new Date("2024-01-16T10:00:00Z"),
+        images: [
+          {
+            url: "https://example.com/a.jpg",
+            caption: "Freshly thrown",
+            cloudinary_public_id: "piece/a",
+            cloud_name: null,
+            crop: null,
+            created: new Date("2024-01-16T10:00:00Z"),
+          },
+        ],
+        previous_state: "designed" as const,
+        next_state: null,
+        custom_fields: {},
+        has_been_edited: false,
+      };
+      const pieceAfterSourceRemove = makeUpdatedPiece({
+        current_state: currentStateWithOriginalImage,
+        history: [currentStateWithOriginalImage, pastStateAfterRemove],
+      });
+      const finalPiece = makeUpdatedPiece();
+      const updatePastStateFn = vi.fn().mockResolvedValue(pieceAfterSourceRemove);
+      const updateCurrentStateFn = vi.fn().mockResolvedValue(finalPiece);
+      const onPieceUpdated = vi.fn();
+
+      render(
+        <PiecePhotoGallery
+          images={makeImages()}
+          pieceId="piece-1"
+          currentStateNotes="Current notes"
+          currentStateCustomFields={{}}
+          onPieceUpdated={onPieceUpdated}
+          updateCurrentStateFn={updateCurrentStateFn}
+          updatePastStateFn={updatePastStateFn}
+          pieceStates={DEFAULT_PIECE_STATES}
+          currentStateId="state-current"
+          isEditable={true}
+        />,
+      );
+
+      // Open photo 2 (index 1) — the past-state image with stateId="state-past"
+      await userEvent.click(screen.getByRole("button", { name: "2 photos" }));
+      await userEvent.click(screen.getByRole("button", { name: "Open piece photo 2" }));
+      await userEvent.click(screen.getByRole("button", { name: /move to state/i }));
+      // Picker shows only "state-current" ("Wheel Thrown") since source is "state-past"
+      await userEvent.click(screen.getByText("Wheel Thrown"));
+
+      await waitFor(() => expect(updatePastStateFn).toHaveBeenCalledWith(
+        "piece-1",
+        "state-past",
+        expect.objectContaining({ images: [] }),
+      ));
+      await waitFor(() => expect(updateCurrentStateFn).toHaveBeenCalledWith(
+        "piece-1",
+        expect.objectContaining({
+          images: expect.arrayContaining([
+            expect.objectContaining({ url: "https://example.com/b.jpg" }),
+          ]),
         }),
       ));
       await waitFor(() => expect(onPieceUpdated).toHaveBeenCalledWith(finalPiece));
@@ -709,8 +786,7 @@ describe("PiecePhotoGallery", () => {
 
       await userEvent.click(screen.getByRole("button", { name: "2 photos" }));
       await userEvent.click(screen.getByRole("button", { name: "Open piece photo 1" }));
-      const lightbox = screen.getByLabelText("Mock lightbox");
-      await userEvent.click(within(lightbox).getByRole("button", { name: /move to state/i }));
+      await userEvent.click(screen.getByRole("button", { name: /move to state/i }));
       await userEvent.click(screen.getByText("Designed"));
 
       await waitFor(() =>
@@ -735,8 +811,7 @@ describe("PiecePhotoGallery", () => {
 
       await userEvent.click(screen.getByRole("button", { name: "2 photos" }));
       await userEvent.click(screen.getByRole("button", { name: "Open piece photo 1" }));
-      const lightbox = screen.getByLabelText("Mock lightbox");
-      await userEvent.click(within(lightbox).getByRole("button", { name: /move to state/i }));
+      await userEvent.click(screen.getByRole("button", { name: /move to state/i }));
       expect(screen.getByText("Move image to state")).toBeInTheDocument();
 
       await userEvent.click(screen.getByRole("button", { name: "Cancel" }));

--- a/web/src/components/__tests__/PiecePhotoGallery.test.tsx
+++ b/web/src/components/__tests__/PiecePhotoGallery.test.tsx
@@ -564,7 +564,9 @@ describe("PiecePhotoGallery", () => {
 
       await userEvent.click(screen.getByRole("button", { name: "2 photos" }));
       await userEvent.click(screen.getByRole("button", { name: "Open piece photo 1" }));
-      const moveBtn = screen.getByRole("button", { name: /move to state/i });
+      // The mock lightbox is a plain div inside the RTL container, which the open gallery Dialog
+      // marks aria-hidden. Use hidden:true to bypass that filter.
+      const moveBtn = screen.getByRole("button", { name: /move to state/i, hidden: true });
 
       expect(moveBtn).toBeDisabled();
     });
@@ -586,7 +588,7 @@ describe("PiecePhotoGallery", () => {
 
       await userEvent.click(screen.getByRole("button", { name: "2 photos" }));
       await userEvent.click(screen.getByRole("button", { name: "Open piece photo 1" }));
-      const moveBtn = screen.getByRole("button", { name: /move to state/i });
+      const moveBtn = screen.getByRole("button", { name: /move to state/i, hidden: true });
 
       expect(moveBtn).not.toBeDisabled();
     });
@@ -608,7 +610,7 @@ describe("PiecePhotoGallery", () => {
 
       await userEvent.click(screen.getByRole("button", { name: "2 photos" }));
       await userEvent.click(screen.getByRole("button", { name: "Open piece photo 1" }));
-      await userEvent.click(screen.getByRole("button", { name: /move to state/i }));
+      await userEvent.click(screen.getByRole("button", { name: /move to state/i, hidden: true }));
 
       // Image at index 0 has stateId "state-current"; dialog should only show "state-past"
       expect(screen.getByText("Move image to state")).toBeInTheDocument();
@@ -633,7 +635,7 @@ describe("PiecePhotoGallery", () => {
 
       await userEvent.click(screen.getByRole("button", { name: "2 photos" }));
       await userEvent.click(screen.getByRole("button", { name: "Open piece photo 2" }));
-      await userEvent.click(screen.getByRole("button", { name: /move to state/i }));
+      await userEvent.click(screen.getByRole("button", { name: /move to state/i, hidden: true }));
 
       // Image at index 1 has stateId "state-past"; dialog should only show "state-current"
       expect(screen.getByText("Wheel Thrown")).toBeInTheDocument();
@@ -667,7 +669,7 @@ describe("PiecePhotoGallery", () => {
       };
       const pieceAfterRemove = makeUpdatedPiece({
         current_state: currentStateAfterRemove,
-        history: [currentStateAfterRemove, pastStateAfterRemove],
+        history: [pastStateAfterRemove],
       });
       const finalPiece = makeUpdatedPiece();
 
@@ -692,7 +694,7 @@ describe("PiecePhotoGallery", () => {
 
       await userEvent.click(screen.getByRole("button", { name: "2 photos" }));
       await userEvent.click(screen.getByRole("button", { name: "Open piece photo 1" }));
-      await userEvent.click(screen.getByRole("button", { name: /move to state/i }));
+      await userEvent.click(screen.getByRole("button", { name: /move to state/i, hidden: true }));
       await userEvent.click(screen.getByText("Designed"));
 
       await waitFor(() => expect(updateCurrentStateFn).toHaveBeenCalledWith(
@@ -770,7 +772,7 @@ describe("PiecePhotoGallery", () => {
       // Open photo 2 (index 1) — the past-state image with stateId="state-past"
       await userEvent.click(screen.getByRole("button", { name: "2 photos" }));
       await userEvent.click(screen.getByRole("button", { name: "Open piece photo 2" }));
-      await userEvent.click(screen.getByRole("button", { name: /move to state/i }));
+      await userEvent.click(screen.getByRole("button", { name: /move to state/i, hidden: true }));
       // Picker shows only "state-current" ("Wheel Thrown") since source is "state-past"
       await userEvent.click(screen.getByText("Wheel Thrown"));
 
@@ -810,7 +812,7 @@ describe("PiecePhotoGallery", () => {
 
       await userEvent.click(screen.getByRole("button", { name: "2 photos" }));
       await userEvent.click(screen.getByRole("button", { name: "Open piece photo 1" }));
-      await userEvent.click(screen.getByRole("button", { name: /move to state/i }));
+      await userEvent.click(screen.getByRole("button", { name: /move to state/i, hidden: true }));
       await userEvent.click(screen.getByText("Designed"));
 
       await waitFor(() =>
@@ -835,7 +837,7 @@ describe("PiecePhotoGallery", () => {
 
       await userEvent.click(screen.getByRole("button", { name: "2 photos" }));
       await userEvent.click(screen.getByRole("button", { name: "Open piece photo 1" }));
-      await userEvent.click(screen.getByRole("button", { name: /move to state/i }));
+      await userEvent.click(screen.getByRole("button", { name: /move to state/i, hidden: true }));
       expect(screen.getByText("Move image to state")).toBeInTheDocument();
 
       await userEvent.click(screen.getByRole("button", { name: "Cancel" }));

--- a/web/src/stories/PiecePhotoGallery.stories.tsx
+++ b/web/src/stories/PiecePhotoGallery.stories.tsx
@@ -34,6 +34,7 @@ const mockImages = [
     cloudinary_public_id: "test1",
     cloud_name: "glaze",
     stateLabel: "Thrown",
+    stateId: "state-1",
     editableCurrentStateIndex: null,
   },
   {
@@ -42,6 +43,7 @@ const mockImages = [
     cloudinary_public_id: "test2",
     cloud_name: "glaze",
     stateLabel: "Trimmed",
+    stateId: "state-2",
     editableCurrentStateIndex: null,
   },
 ];


### PR DESCRIPTION
## Summary

- Adds a "Move to state" button to the `ImageLightbox` footer so piece owners can reassign an image from one workflow state to another without deleting and re-uploading.
- The affordance is enabled only when `piece.is_editable = True`; it renders as a disabled button with an explanatory tooltip otherwise.
- No new backend endpoint — uses the existing `updateCurrentState` / `updatePastState` API calls in a sequenced two-step move (remove from source, append to target using the refreshed piece response).

## Changes

**`web/src/components/PiecePhotoGallery.tsx`**
- Added `stateId: string` to `PiecePhotoGalleryImage` type
- New props: `pieceStates`, `currentStateId`, `isEditable`, `updatePastStateFn`
- "Move to state" button in lightbox footer (enabled / disabled-with-tooltip based on `isEditable`)
- Inline state-picker dialog opens on click, listing all other states; `handleMoveImage` performs the two-step sequential API move

**`web/src/components/PieceDetail.tsx`**
- Populates `stateId: state.id` in the `galleryImages` flatMap
- Passes `pieceStates`, `currentStateId`, `isEditable`, `updatePastStateFn` in `galleryProps`

**`web/src/components/__tests__/PiecePhotoGallery.test.tsx`**
- Updated all existing fixtures to include `stateId`
- Added 6 new tests covering: button hidden without `pieceStates`, disabled with tooltip when `!isEditable`, enabled when `isEditable`, state picker shows only other states, successful two-step move calls correct API fns, error message on failure, cancel closes dialog

## Test plan

- [ ] `rtk bazel test //web:web_piece_photo_gallery_test` — 20 tests pass
- [ ] `rtk bazel build --config=lint //web/...` — no type or lint errors
- [ ] Manual: open a piece with `is_editable=True` and images in multiple states → open lightbox → "Move to state" button enabled → picker lists other states → move works
- [ ] Manual: same piece with `is_editable=False` → button disabled with tooltip "Piece must be editable to move images."
- [ ] Manual: mobile swipe navigation unaffected

Closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)
