### PR TITLE
fix: prevent SPA caching and fix MUI chunk split crash in prod

### DIFF
--- a/backend/urls.py
+++ b/backend/urls.py
@@ -31,7 +31,9 @@ def _index_html() -> str | None:
 def _spa(request: HttpRequest) -> HttpResponse | HttpResponseNotFound:
     index_html = _index_html()
     if index_html is not None:
-        return HttpResponse(index_html, content_type="text/html")
+        response = HttpResponse(index_html, content_type="text/html")
+        response["Cache-Control"] = "no-cache, no-store, must-revalidate"
+        return response
     return HttpResponseNotFound("Frontend not built.")
 
 
@@ -94,10 +96,12 @@ def _piece_spa(request: HttpRequest, piece_id) -> HttpResponse | HttpResponseNot
     index_html = _index_html()
     if index_html is None:
         return HttpResponseNotFound("Frontend not built.")
-    return HttpResponse(
+    response = HttpResponse(
         _inject_piece_metadata(index_html, request, piece_id),
         content_type="text/html",
     )
+    response["Cache-Control"] = "no-cache, no-store, must-revalidate"
+    return response
 
 
 urlpatterns = [

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -50,20 +50,6 @@ export default defineConfig(({ mode }) => {
           entryFileNames: "[name].js",
           chunkFileNames: "chunks/[name].js",
           assetFileNames: "assets/[name].[ext]",
-          manualChunks(id) {
-            if (
-              id.includes("node_modules/react") ||
-              id.includes("node_modules/react-dom")
-            ) {
-              return "vendor-react";
-            }
-            if (
-              id.includes("node_modules/@mui") ||
-              id.includes("node_modules/@emotion")
-            ) {
-              return "vendor-mui";
-            }
-          },
         },
       },
     },


### PR DESCRIPTION
## Summary

- **`backend/urls.py`**: Both SPA views (`_spa` and `_piece_spa`) now return `Cache-Control: no-cache, no-store, must-revalidate`. Without this header, browsers apply heuristic caching to `index.html` (typically 10% of `Last-Modified` age), serving stale bundle references for hours after a deploy. Cloudflare was already passing through (`CF-Cache-Status: DYNAMIC`), so this was pure browser-side staleness.

- **`web/vite.config.ts`**: Removes the `manualChunks` function that split React and MUI into separate vendor chunks. With Vite 8 (Rolldown) + the React Compiler (`@rolldown/plugin-babel`), this caused a prod-only crash: `forwardRef` components (e.g. MUI `Paper`, used internally by `Tabs`) resolved as module namespace objects rather than callable exports in lazy chunks, producing `TypeError: ... is not a function`. Rolldown handles chunk splitting automatically and does not need manual hints.

## Test plan

- [ ] Deploy and verify `curl -sI https://potterdoc.com/ | grep cache-control` returns `no-cache, no-store, must-revalidate`
- [ ] Navigate to LandingPage in prod — confirm no `TypeError: is not a function` crash in console
- [ ] Confirm Rolldown still produces reasonable chunk sizes (no single massive bundle)
