### PR TITLE
Fix SPA fallback for Vite chunk assets

### DIFF
--- a/api/tests/test_piece_detail.py
+++ b/api/tests/test_piece_detail.py
@@ -644,6 +644,23 @@ class TestPublicPieceMetadata:
         assert "<title>PotterDoc</title>" in html
         assert "og:title" not in html
 
+    def test_chunk_asset_paths_do_not_fall_back_to_the_spa_html(
+        self, client, tmp_path, monkeypatch
+    ):
+        import backend.urls
+
+        index_html = tmp_path / "index.html"
+        index_html.write_text(
+            "<html><head><title>PotterDoc</title></head><body></body></html>",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(backend.urls, "_INDEX_HTML", index_html)
+
+        response = client.get("/chunks/vendor-react.js")
+
+        assert response.status_code == 404
+        assert "<title>PotterDoc</title>" not in response.content.decode()
+
 
 # ---------------------------------------------------------------------------
 # GET /api/pieces/{id}/current_state/

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -110,7 +110,8 @@ urlpatterns = [
         name="swagger",
     ),
     path("pieces/<uuid:piece_id>", _piece_spa),
-    # Catch-all: serve the React SPA for any non-API route so client-side
-    # routing works on hard refresh or direct URL navigation.
-    re_path(r"^(?!api/|admin/|static/).*$", _spa),
+    # Catch-all: serve the React SPA for client routes only. File-like URLs
+    # (for example Vite chunk files) must fall through so static handling can
+    # return the real asset or a 404 instead of HTML.
+    re_path(r"^(?!api/|admin/|static/|.*\..*$).*$", _spa),
 ]

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "glaze-shell-v1";
+const CACHE_NAME = "glaze-shell-v2";
 const APP_SHELL = [
   "/",
   "/index.html",


### PR DESCRIPTION
## Summary
- Prevent the SPA catch-all from serving HTML for file-like URLs such as Vite chunk files.
- Bump the service worker cache name so browsers drop stale cached HTML and fetch the corrected chunk responses.
- Add a regression test that verifies `/chunks/vendor-react.js` falls through instead of receiving `index.html`.

## Validation
- `bazel test //api:api_piece_test --test_output=errors`
- `bazel build --config=lint //...`
- `bazel build //web:vite_run`
