### PR TITLE
Make frontend asset updates atomic

### DIFF
--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -1,18 +1,6 @@
-const CACHE_NAME = "glaze-shell-v2";
-const APP_SHELL = [
-  "/",
-  "/index.html",
-  "/site.webmanifest",
-  "/favicon.svg",
-  "/pwa-icon.svg",
-  "/mask-icon.svg",
-  "/apple-touch-icon.svg",
-];
+const CACHE_PREFIX = "glaze-shell-";
 
-self.addEventListener("install", (event) => {
-  event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(APP_SHELL)),
-  );
+self.addEventListener("install", () => {
   self.skipWaiting();
 });
 
@@ -23,7 +11,7 @@ self.addEventListener("activate", (event) => {
       .then((cacheNames) =>
         Promise.all(
           cacheNames
-            .filter((cacheName) => cacheName !== CACHE_NAME)
+            .filter((cacheName) => cacheName.startsWith(CACHE_PREFIX))
             .map((cacheName) => caches.delete(cacheName)),
         ),
       ),
@@ -52,38 +40,6 @@ self.addEventListener("fetch", (event) => {
   }
 
   if (request.mode === "navigate") {
-    event.respondWith(
-      fetch(request)
-        .then((response) => {
-          const responseClone = response.clone();
-          caches
-            .open(CACHE_NAME)
-            .then((cache) => cache.put("/index.html", responseClone));
-          return response;
-        })
-        .catch(async () => {
-          const cachedResponse = await caches.match("/index.html");
-          return cachedResponse ?? Response.error();
-        }),
-    );
-    return;
+    event.respondWith(fetch(request, { cache: "no-store" }));
   }
-
-  event.respondWith(
-    caches.match(request).then((cachedResponse) => {
-      const networkFetch = fetch(request)
-        .then((response) => {
-          if (response.ok) {
-            const responseClone = response.clone();
-            caches
-              .open(CACHE_NAME)
-              .then((cache) => cache.put(request, responseClone));
-          }
-          return response;
-        })
-        .catch(() => cachedResponse);
-
-      return cachedResponse ?? networkFetch;
-    }),
-  );
 });

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -47,8 +47,15 @@ export default defineConfig(({ mode }) => {
           "admin-widget": path.resolve(root, "src/admin.tsx"),
         },
         output: {
-          entryFileNames: "[name].js",
-          chunkFileNames: "chunks/[name].js",
+          // Hash the frontend entry and split chunks so each release gets its
+          // own immutable asset URLs. The admin widget stays stable because
+          // Django loads it via `static("admin-widget.js")`.
+          entryFileNames(chunkInfo) {
+            return chunkInfo.name === "admin-widget"
+              ? "[name].js"
+              : "[name]-[hash].js";
+          },
+          chunkFileNames: "chunks/[name]-[hash].js",
           assetFileNames: "assets/[name].[ext]",
         },
       },


### PR DESCRIPTION
## Summary
- Hash the main frontend entry and split chunk filenames so each release advertises immutable app asset URLs instead of reusing stable vendor chunk paths.
- Keep `admin-widget.js` stable because Django admin loads it by name via static files.
- Replace the service worker app-shell cache with a cleanup/update-safe handler that deletes old `glaze-shell-*` caches and fetches navigations with `no-store`.

## Why
A cached frontend shell can otherwise keep requesting stale chunk URLs while the backend/image has already moved on. With hashed app assets plus no service-worker shell cache, the browser either keeps using an older complete asset set from its normal HTTP cache or fetches the newest shell from the deployed backend, instead of mixing an old `index.html` with a newer image that no longer contains those stable chunk names.

## Validation
- `rtk bazel test //...`
- `rtk bazel build --config=lint //...`
- `rtk bazel build //web:vite_run`
- `source env-agent.sh && _gz_build`

## Notes
- `source env-agent.sh && gz_build` failed because this shell exposes the documented build helper as `_gz_build`; `_gz_build` completed successfully.
