### PR TITLE
feat: clicking hero image opens lightbox via URL routing

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -539,7 +539,7 @@ function UnauthenticatedApp({
               }
             />
             <Route
-              path="/pieces/:id"
+              path="/pieces/:id/*"
               element={<PublicPieceShell />}
             />
             <Route
@@ -796,7 +796,7 @@ function AuthenticatedApp({
               <Route index element={<PieceListPage />} />
               <Route path="analyze/*" element={<AnalyzePage />} />
             </Route>
-            <Route path="/pieces/:id" element={<PieceDetailPage />} />
+            <Route path="/pieces/:id/*" element={<PieceDetailPage />} />
             <Route
               path="/tools/glaze-import"
               element={

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -24,7 +24,7 @@ import CheckIcon from "@mui/icons-material/Check";
 import CloseIcon from "@mui/icons-material/Close";
 import HistoryIcon from "@mui/icons-material/History";
 import LockIcon from "@mui/icons-material/Lock";
-import { useBlocker } from "react-router-dom";
+import { useBlocker, useNavigate } from "react-router-dom";
 import type { PieceDetail as PieceDetailType } from "../util/types";
 import { formatState, isTerminalState, validateHistorySequence } from "../util/workflow";
 import {
@@ -413,6 +413,17 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
     ? extractErrorMessage(rawLocationError, "Failed to save location. Please try again.")
     : null;
 
+  const navigate = useNavigate();
+  const hasGalleryImages = galleryImages.length > 0;
+  const thumbnailIndex = piece.thumbnail?.cloudinary_public_id
+    ? galleryImages.findIndex(
+        (img) =>
+          img.cloudinary_public_id !== null &&
+          img.cloudinary_public_id === piece.thumbnail?.cloudinary_public_id,
+      )
+    : -1;
+  const heroLightboxIndex = thumbnailIndex >= 0 ? thumbnailIndex : 0;
+
   const galleryProps = {
     images: galleryImages,
     pieceId: piece.id,
@@ -603,6 +614,11 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
           {/* Right column (desktop) / top (mobile): hero image */}
           <Box sx={{ gridArea: "hero" }}>
             <Box
+              onClick={
+                hasGalleryImages
+                  ? () => navigate(`/pieces/${piece.id}/photos/${heroLightboxIndex}`)
+                  : undefined
+              }
               sx={(theme) => ({
                 position: "relative",
                 overflow: "hidden",
@@ -611,6 +627,7 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
                 aspectRatio: { md: "4 / 3" },
                 backgroundColor: alpha(theme.palette.background.paper, 0.46),
                 boxShadow: `0 24px 60px ${alpha(theme.palette.common.black, 0.22)}`,
+                cursor: hasGalleryImages ? "pointer" : "default",
               })}
             >
               {piece.thumbnail ? (
@@ -650,7 +667,7 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
                   p: { xs: 1.5, sm: 2 },
                 }}
               >
-                <PiecePhotoGallery {...galleryProps} />
+                <PiecePhotoGallery {...galleryProps} showModal={false} />
               </Box>
             </Box>
             {/* Photo gallery + upload trigger — below hero on desktop only */}

--- a/web/src/components/PiecePhotoGallery.tsx
+++ b/web/src/components/PiecePhotoGallery.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Navigate, useLocation, useNavigate, useParams } from "react-router-dom";
 import EditIcon from "@mui/icons-material/Edit";
 import PhotoLibraryOutlinedIcon from "@mui/icons-material/PhotoLibraryOutlined";
 import {
@@ -50,6 +51,7 @@ type PiecePhotoGalleryProps = {
   updateCurrentStateFn?: typeof updateCurrentState;
   pieceStates?: PieceStateRef[];
   moveImageFn?: typeof moveImage;
+  showModal?: boolean;
 };
 
 function isEditableImage(
@@ -70,10 +72,26 @@ export default function PiecePhotoGallery({
   updateCurrentStateFn,
   pieceStates,
   moveImageFn,
+  showModal = true,
 }: PiecePhotoGalleryProps) {
   const theme = useTheme();
-  const [galleryOpen, setGalleryOpen] = useState(false);
-  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { id: pieceIdFromParams } = useParams<{ id: string }>();
+
+  const effectivePieceId = pieceId || pieceIdFromParams;
+  const piecePath = `/pieces/${effectivePieceId}`;
+  const galleryPath = `${piecePath}/photos`;
+
+  const atGallery = location.pathname === galleryPath;
+  const atPhotos =
+    location.pathname === galleryPath ||
+    location.pathname.startsWith(`${galleryPath}/`);
+  const photoIndexMatch = location.pathname.match(/\/photos\/(\d+)$/);
+  const urlPhotoIndex = photoIndexMatch ? parseInt(photoIndexMatch[1], 10) : null;
+  const atLightbox = urlPhotoIndex !== null && !isNaN(urlPhotoIndex);
+
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(urlPhotoIndex);
   const [captionDraft, setCaptionDraft] = useState("");
   const [captionEditing, setCaptionEditing] = useState(false);
   const [captionSaving, setCaptionSaving] = useState(false);
@@ -82,6 +100,10 @@ export default function PiecePhotoGallery({
   const [deleteSaving, setDeleteSaving] = useState(false);
   const [moveSaving, setMoveSaving] = useState(false);
   const [moveError, setMoveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (urlPhotoIndex !== null) setLightboxIndex(urlPhotoIndex);
+  }, [urlPhotoIndex]);
 
   useEffect(() => {
     if (lightboxIndex === null) return;
@@ -188,7 +210,7 @@ export default function PiecePhotoGallery({
         toStateId,
       );
       onPieceUpdated(updated);
-      setLightboxIndex(null);
+      navigate(galleryPath);
     } catch {
       setMoveError("Failed to move photo. Please try again.");
     } finally {
@@ -212,7 +234,7 @@ export default function PiecePhotoGallery({
         ),
       );
       if (lightboxIndex === deleteDialogIndex) {
-        setLightboxIndex(null);
+        navigate(galleryPath);
       }
       setDeleteDialogIndex(null);
     } finally {
@@ -376,12 +398,25 @@ export default function PiecePhotoGallery({
     </Box>
   ) : null;
 
+  if (showModal && atGallery) {
+    const fromLightbox =
+      (location.state as Record<string, unknown>)?.fromLightbox === true;
+    if (images.length === 0) return <Navigate to={piecePath} replace />;
+    if (images.length === 1) {
+      return fromLightbox ? (
+        <Navigate to={piecePath} replace />
+      ) : (
+        <Navigate to={`${galleryPath}/0`} replace />
+      );
+    }
+  }
+
   return (
     <>
       <Box
         component="button"
         type="button"
-        onClick={() => photoCount > 0 && setGalleryOpen(true)}
+        onClick={() => photoCount > 0 && navigate(galleryPath)}
         disabled={photoCount === 0}
         aria-label={triggerLabel}
         sx={{
@@ -404,33 +439,35 @@ export default function PiecePhotoGallery({
         <Typography variant="caption">{triggerLabel}</Typography>
       </Box>
 
-      <Dialog
-        open={galleryOpen}
-        onClose={() => setGalleryOpen(false)}
-        maxWidth="md"
-        fullWidth
-        aria-label="Piece photos"
-        PaperProps={{ sx: { height: "80vh", borderRadius: "8px" } }}
-      >
-        <DialogContent sx={{ p: 2 }}>
-          <PiecePhotoGalleryGrid
-            images={images}
-            canDeleteImages={canMutateCurrentStateImages}
-            currentThumbnailUrl={currentThumbnailUrl}
-            onOpenImage={setLightboxIndex}
-            onRequestDelete={setDeleteDialogIndex}
-          />
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setGalleryOpen(false)}>Close</Button>
-        </DialogActions>
-      </Dialog>
+      {showModal && (
+        <Dialog
+          open={atPhotos}
+          onClose={() => navigate(piecePath)}
+          maxWidth="md"
+          fullWidth
+          aria-label="Piece photos"
+          PaperProps={{ sx: { height: "80vh", borderRadius: "8px" } }}
+        >
+          <DialogContent sx={{ p: 2 }}>
+            <PiecePhotoGalleryGrid
+              images={images}
+              canDeleteImages={canMutateCurrentStateImages}
+              currentThumbnailUrl={currentThumbnailUrl}
+              onOpenImage={(index) => navigate(`${galleryPath}/${index}`)}
+              onRequestDelete={setDeleteDialogIndex}
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => navigate(piecePath)}>Close</Button>
+          </DialogActions>
+        </Dialog>
+      )}
 
-      {lightboxIndex !== null && (
+      {showModal && atLightbox && lightboxIndex !== null && (
         <ImageLightbox
           images={images}
           initialIndex={lightboxIndex}
-          onClose={() => setLightboxIndex(null)}
+          onClose={() => navigate(galleryPath, { state: { fromLightbox: true } })}
           currentThumbnailUrl={currentThumbnailUrl}
           onSetAsThumbnail={canSetThumbnail ? handleSetThumbnail : undefined}
           footerActions={() => footer}

--- a/web/src/components/__tests__/PieceDetail.test.tsx
+++ b/web/src/components/__tests__/PieceDetail.test.tsx
@@ -241,7 +241,7 @@ async function renderPieceDetail(
   const router = createMemoryRouter(
     [
       {
-        path: "/pieces/:id",
+        path: "/pieces/:id/*",
         element: <PieceDetail piece={piece} onPieceUpdated={onPieceUpdated} />,
       },
       {
@@ -1043,6 +1043,55 @@ describe("PieceDetail", () => {
         ),
         { timeout: 3000 }
       );
+    });
+  });
+
+  describe("hero image click", () => {
+    const galleryImage = {
+      url: "https://res.cloudinary.com/test/image/upload/v1/piece/hero.jpg",
+      caption: "Hero shot",
+      created: new Date("2024-01-15T10:00:00Z"),
+      cloudinary_public_id: "piece/hero",
+      cloud_name: "test-cloud",
+    };
+
+    it("navigates to lightbox when hero is clicked and gallery images exist", async () => {
+      const stateWithImage = makeState({ images: [galleryImage] });
+      const piece = makePiece({
+        thumbnail: {
+          url: galleryImage.url,
+          cloudinary_public_id: galleryImage.cloudinary_public_id,
+          cloud_name: galleryImage.cloud_name,
+        },
+        current_state: stateWithImage,
+        history: [stateWithImage],
+      });
+      const { router } = await renderPieceDetail(piece);
+
+      const heroBox = screen
+        .getByRole("img", { name: "Test Bowl" })
+        .closest("[style*='pointer']");
+
+      if (heroBox) {
+        fireEvent.click(heroBox);
+      } else {
+        // Click the img directly — click bubbles to the clickable parent
+        fireEvent.click(screen.getByRole("img", { name: "Test Bowl" }));
+      }
+
+      expect(router.state.location.pathname).toBe(
+        "/pieces/piece-id-1/photos/0",
+      );
+    });
+
+    it("hero has no pointer cursor and click does nothing when no gallery images", async () => {
+      const { router } = await renderPieceDetail();
+
+      const initialPath = router.state.location.pathname;
+      const img = screen.queryByRole("img", { name: "Test Bowl" });
+      if (img) fireEvent.click(img);
+
+      expect(router.state.location.pathname).toBe(initialPath);
     });
   });
 });

--- a/web/src/components/__tests__/PiecePhotoGallery.test.tsx
+++ b/web/src/components/__tests__/PiecePhotoGallery.test.tsx
@@ -1,12 +1,23 @@
-import type { CSSProperties, ReactNode } from "react";
+import type { ComponentProps, CSSProperties, ReactNode } from "react";
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
 import type { PieceDetail } from "../../util/types";
 import PiecePhotoGallery, {
   type EditablePiecePhoto,
   type PiecePhotoGalleryImage,
 } from "../PiecePhotoGallery";
+
+function renderGallery(
+  element: React.ReactElement<ComponentProps<typeof PiecePhotoGallery>>,
+) {
+  return render(
+    <MemoryRouter initialEntries={["/pieces/piece-1"]}>
+      {element}
+    </MemoryRouter>,
+  );
+}
 
 vi.mock("../CloudinaryImage", () => ({
   default: ({
@@ -155,7 +166,7 @@ function makeUpdatedPiece(overrides: Partial<PieceDetail> = {}): PieceDetail {
 
 describe("PiecePhotoGallery", () => {
   it("opens a headerless gallery dialog from the photo count chip", async () => {
-    render(
+    renderGallery(
       <PiecePhotoGallery
         images={makeImages()}
       />,
@@ -169,7 +180,7 @@ describe("PiecePhotoGallery", () => {
   });
 
   it("shows the friendly state label in the lightbox footer", async () => {
-    render(
+    renderGallery(
       <PiecePhotoGallery
         images={makeImages()}
       />,
@@ -186,7 +197,7 @@ describe("PiecePhotoGallery", () => {
     const updateCurrentStateFn = vi.fn().mockResolvedValue(updatedPiece);
     const onPieceUpdated = vi.fn();
 
-    render(
+    renderGallery(
       <PiecePhotoGallery
         images={makeImages()}
         pieceId="piece-1"
@@ -226,7 +237,7 @@ describe("PiecePhotoGallery", () => {
   it("lets current-state gallery images be deleted through the confirmation dialog", async () => {
     const updateCurrentStateFn = vi.fn().mockResolvedValue(makeUpdatedPiece());
 
-    render(
+    renderGallery(
       <PiecePhotoGallery
         images={makeImages()}
         pieceId="piece-1"
@@ -253,7 +264,7 @@ describe("PiecePhotoGallery", () => {
   it("lets you click the caption text itself to start editing and save with Enter", async () => {
     const updateCurrentStateFn = vi.fn().mockResolvedValue(makeUpdatedPiece());
 
-    render(
+    renderGallery(
       <PiecePhotoGallery
         images={makeImages()}
         pieceId="piece-1"
@@ -295,7 +306,7 @@ describe("PiecePhotoGallery", () => {
   });
 
   it("cancels caption edits with Escape", async () => {
-    render(
+    renderGallery(
       <PiecePhotoGallery
         images={makeImages()}
         pieceId="piece-1"
@@ -334,7 +345,7 @@ describe("PiecePhotoGallery", () => {
     const updateCurrentStateFn = vi.fn();
     const onPieceUpdated = vi.fn();
 
-    render(
+    renderGallery(
       <PiecePhotoGallery
         images={makeImages()}
         pieceId=""
@@ -365,7 +376,7 @@ describe("PiecePhotoGallery", () => {
   });
 
   it("closes the gallery dialog from the Close button", async () => {
-    render(
+    renderGallery(
       <PiecePhotoGallery
         images={makeImages()}
       />,
@@ -380,7 +391,7 @@ describe("PiecePhotoGallery", () => {
   });
 
   it("closes the lightbox from the close button", async () => {
-    render(
+    renderGallery(
       <PiecePhotoGallery
         images={makeImages()}
       />,
@@ -401,7 +412,7 @@ describe("PiecePhotoGallery", () => {
   it("cancels image deletion without saving", async () => {
     const updateCurrentStateFn = vi.fn().mockResolvedValue(makeUpdatedPiece());
 
-    render(
+    renderGallery(
       <PiecePhotoGallery
         images={makeImages()}
         pieceId="piece-1"
@@ -427,7 +438,7 @@ describe("PiecePhotoGallery", () => {
     const updatePieceFn = vi.fn();
     const onPieceUpdated = vi.fn();
 
-    render(
+    renderGallery(
       <PiecePhotoGallery
         images={makeImages()}
         pieceId=""
@@ -457,7 +468,7 @@ describe("PiecePhotoGallery", () => {
     const updatePieceFn = vi.fn().mockResolvedValue(updatedPiece);
     const onPieceUpdated = vi.fn();
 
-    render(
+    renderGallery(
       <PiecePhotoGallery
         images={makeImages()}
         pieceId="piece-1"
@@ -486,7 +497,7 @@ describe("PiecePhotoGallery", () => {
   });
 
   it("starts editing an empty caption with a blank input", async () => {
-    render(
+    renderGallery(
       <PiecePhotoGallery
         images={makeSingleImage({ caption: "" })}
         pieceId="piece-1"
@@ -513,7 +524,7 @@ describe("PiecePhotoGallery", () => {
   it("closes the lightbox after deleting the last image currently open", async () => {
     const updateCurrentStateFn = vi.fn().mockResolvedValue(makeUpdatedPiece());
 
-    render(
+    renderGallery(
       <PiecePhotoGallery
         images={makeSingleImage()}
         pieceId="piece-1"
@@ -539,7 +550,7 @@ describe("PiecePhotoGallery", () => {
 
   describe("move image to state", () => {
     it("does not show the move control when pieceStates is not provided", async () => {
-      render(
+      renderGallery(
         <PiecePhotoGallery
           images={makeImages()}
           pieceId="piece-1"
@@ -557,7 +568,7 @@ describe("PiecePhotoGallery", () => {
     });
 
     it("does not show the move control when moveImageFn is not provided", async () => {
-      render(
+      renderGallery(
         <PiecePhotoGallery
           images={makeImages()}
           pieceId="piece-1"
@@ -575,7 +586,7 @@ describe("PiecePhotoGallery", () => {
     });
 
     it("shows an enabled move select when the move endpoint is wired", async () => {
-      render(
+      renderGallery(
         <PiecePhotoGallery
           images={makeImages()}
           pieceId="piece-1"
@@ -595,7 +606,7 @@ describe("PiecePhotoGallery", () => {
     });
 
     it("opens state picker showing only other states", async () => {
-      render(
+      renderGallery(
         <PiecePhotoGallery
           images={makeImages()}
           pieceId="piece-1"
@@ -616,7 +627,7 @@ describe("PiecePhotoGallery", () => {
     });
 
     it("opens state picker showing current state when a past-state image is open", async () => {
-      render(
+      renderGallery(
         <PiecePhotoGallery
           images={makeImages()}
           pieceId="piece-1"
@@ -641,7 +652,7 @@ describe("PiecePhotoGallery", () => {
       const moveImageFn = vi.fn().mockResolvedValue(finalPiece);
       const onPieceUpdated = vi.fn();
 
-      render(
+      renderGallery(
         <PiecePhotoGallery
           images={makeImages()}
           pieceId="piece-1"
@@ -672,7 +683,7 @@ describe("PiecePhotoGallery", () => {
       const moveImageFn = vi.fn().mockResolvedValue(finalPiece);
       const onPieceUpdated = vi.fn();
 
-      render(
+      renderGallery(
         <PiecePhotoGallery
           images={makeImages()}
           pieceId="piece-1"
@@ -701,7 +712,7 @@ describe("PiecePhotoGallery", () => {
     it("shows error message when move API call fails", async () => {
       const moveImageFn = vi.fn().mockRejectedValue(new Error("Network error"));
 
-      render(
+      renderGallery(
         <PiecePhotoGallery
           images={makeImages()}
           pieceId="piece-1"
@@ -726,7 +737,7 @@ describe("PiecePhotoGallery", () => {
     it("closes the lightbox after a successful move", async () => {
       const moveImageFn = vi.fn().mockResolvedValue(makeUpdatedPiece());
 
-      render(
+      renderGallery(
         <PiecePhotoGallery
           images={makeImages()}
           pieceId="piece-1"
@@ -751,7 +762,7 @@ describe("PiecePhotoGallery", () => {
 
   it("exits image deletion early when the pending image is no longer editable", async () => {
     const updateCurrentStateFn = vi.fn();
-    const { rerender } = render(
+    const { rerender } = renderGallery(
       <PiecePhotoGallery
         images={makeSingleImage()}
         pieceId="piece-1"
@@ -765,13 +776,15 @@ describe("PiecePhotoGallery", () => {
     await userEvent.click(screen.getByRole("button", { name: "Delete piece photo 1" }));
 
     rerender(
-      <PiecePhotoGallery
-        images={makeSingleImage({ editableCurrentStateIndex: null })}
-        pieceId="piece-1"
-        currentStateNotes="Current notes"
-        onPieceUpdated={vi.fn()}
-        updateCurrentStateFn={updateCurrentStateFn}
-      />,
+      <MemoryRouter initialEntries={["/pieces/piece-1"]}>
+        <PiecePhotoGallery
+          images={makeSingleImage({ editableCurrentStateIndex: null })}
+          pieceId="piece-1"
+          currentStateNotes="Current notes"
+          onPieceUpdated={vi.fn()}
+          updateCurrentStateFn={updateCurrentStateFn}
+        />
+      </MemoryRouter>,
     );
 
     await userEvent.click(screen.getByRole("button", { name: "Remove" }));


### PR DESCRIPTION
## Summary

- Hero image on piece detail now has pointer cursor and opens the image lightbox when clicked (only when gallery images exist)
- Gallery/lightbox state is now URL-routed: `pieces/:id/photos` = gallery, `pieces/:id/photos/:N` = lightbox — enabling deep links and browser back/forward
- Single-photo special case: gallery auto-redirects to lightbox on entry, and auto-closes back to piece detail on lightbox close

## State machine

| From | Action | To |
|---|---|---|
| PieceDetail | hero click, 0 photos | — (no affordance) |
| PieceDetail | hero click, 1+ photos | Lightbox at thumbnail index |
| PieceDetail | gallery button | Gallery |
| Gallery | close | PieceDetail |
| Gallery | photo thumbnail click | Lightbox(N) |
| Gallery (0 images) | render | → PieceDetail (redirect) |
| Gallery (1 image), from PieceDetail | render | → Lightbox(0) (redirect) |
| Gallery (1 image), from Lightbox | render | → PieceDetail (redirect) |
| Lightbox | close | Gallery |
| Lightbox | prev/next/swipe | Lightbox(N±1) internal |

## Implementation notes

- `PiecePhotoGallery` uses `useNavigate`/`useLocation` instead of `galleryOpen`/`lightboxIndex` state
- Gallery Dialog stays open at both `/photos` and `/photos/:N` so the delete button in the gallery grid remains accessible while the lightbox is open (matching previous behavior)
- Mobile gallery instance gets `showModal={false}` to prevent a second Dialog from rendering
- `App.tsx` routes changed from `/pieces/:id` to `/pieces/:id/*` (both authenticated and public routers)

## Test plan
- [ ] Open a piece with photos — click hero → lightbox opens at thumbnail image
- [ ] Close lightbox → gallery opens; close gallery → back to piece detail
- [ ] Piece with 1 photo: click hero → lightbox opens; close lightbox → back to piece detail (no gallery)
- [ ] Piece with 0 photos: hero has no pointer cursor, click does nothing
- [ ] Gallery button → gallery → click thumbnail → lightbox → close → gallery → close → piece detail
- [ ] All 49 tests pass, lint clean

Closes #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)
