### PR TITLE
Fix db backup CronJob auth

### DIFF
--- a/chart/glaze/templates/configmap-backup.yaml
+++ b/chart/glaze/templates/configmap-backup.yaml
@@ -18,6 +18,7 @@ data:
     readonly PSQL="${PG_BIN_DIR}/psql"
     readonly DROPBOX_API_HOST="api.dropboxapi.com"
     readonly DROPBOX_CONTENT_HOST="content.dropboxapi.com"
+    local_started=0
 
     log() {
       printf '%s %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$*"
@@ -272,7 +273,7 @@ data:
       require_env DROPBOX_BACKUP_FOLDER
       require_env BACKUP_RETENTION_DAYS
 
-      local workdir pgdata socket_dir dump_path sha256 access_token backup_path cutoff_epoch local_started=0
+      local workdir pgdata socket_dir dump_path sha256 access_token backup_path cutoff_epoch
       workdir="$(mktemp -d)"
       pgdata="${workdir}/pgdata"
       socket_dir="${workdir}/socket"
@@ -289,7 +290,7 @@ data:
       trap cleanup EXIT
 
       log "dumping ${POSTGRES_DB} from ${POSTGRES_HOST}"
-      "$PG_DUMP" \
+      PGPASSWORD="$POSTGRES_PASSWORD" "$PG_DUMP" \
         -h "$POSTGRES_HOST" \
         -U "$POSTGRES_USER" \
         -d "$POSTGRES_DB" \

--- a/tests/test_backup_cronjob.py
+++ b/tests/test_backup_cronjob.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+
+def _backup_script_text() -> str:
+    template_path = (
+        Path(__file__).resolve().parents[1]
+        / "chart"
+        / "glaze"
+        / "templates"
+        / "configmap-backup.yaml"
+    )
+    lines = template_path.read_text().splitlines()
+
+    script_lines: list[str] = []
+    in_script = False
+    for line in lines:
+        if line == "  backup.sh: |":
+            in_script = True
+            continue
+        if not in_script:
+            continue
+        if line.startswith("    "):
+            script_lines.append(line[4:])
+            continue
+        if line.strip() == "":
+            script_lines.append("")
+            continue
+        break
+
+    return "\n".join(script_lines)
+
+
+def test_backup_script_authenticates_pg_dump():
+    script = _backup_script_text()
+
+    assert 'PGPASSWORD="$POSTGRES_PASSWORD" "$PG_DUMP"' in script
+
+
+def test_backup_script_keeps_restore_state_alive_for_trap():
+    script = _backup_script_text()
+
+    assert script.count("local_started=0") == 2
+    assert script.index("local_started=0") < script.index("main() {")


### PR DESCRIPTION
Fix the hourly database backup CronJob so it completes in production.

- Prefix `pg_dump` with `PGPASSWORD` so the backup job can authenticate noninteractively.
- Keep `local_started` in script scope so the EXIT trap can stop the temporary restore instance even on early exits.
- Add a regression test that pins both behaviors in the rendered backup script.

Validation:
- `rtk bazel test //tests:common_test`
- `rtk bazel build --config=lint //...`
