### PR TITLE
Fix db backup CronJob cleanup

### DIFF
--- a/chart/glaze/templates/configmap-backup.yaml
+++ b/chart/glaze/templates/configmap-backup.yaml
@@ -285,7 +285,7 @@ data:
         if [[ "${local_started}" == "1" ]]; then
           "$PG_CTL" -D "$pgdata" -m fast -w stop >/dev/null 2>&1 || true
         fi
-        rm -rf "$workdir"
+        [[ -n "${workdir:-}" ]] && rm -rf "$workdir"
       }
       trap cleanup EXIT
 

--- a/chart/glaze/templates/configmap-backup.yaml
+++ b/chart/glaze/templates/configmap-backup.yaml
@@ -285,7 +285,9 @@ data:
         if [[ "${local_started}" == "1" ]]; then
           "$PG_CTL" -D "$pgdata" -m fast -w stop >/dev/null 2>&1 || true
         fi
-        [[ -n "${workdir:-}" ]] && rm -rf "$workdir"
+        if [[ -n "${workdir:-}" ]]; then
+          rm -rf "$workdir"
+        fi
       }
       trap cleanup EXIT
 

--- a/tests/test_backup_cronjob.py
+++ b/tests/test_backup_cronjob.py
@@ -41,4 +41,5 @@ def test_backup_script_keeps_restore_state_alive_for_trap():
 
     assert script.count("local_started=0") == 2
     assert script.index("local_started=0") < script.index("main() {")
-    assert '[[ -n "${workdir:-}" ]] && rm -rf "$workdir"' in script
+    assert 'if [[ -n "${workdir:-}" ]]; then' in script
+    assert 'rm -rf "$workdir"' in script

--- a/tests/test_backup_cronjob.py
+++ b/tests/test_backup_cronjob.py
@@ -41,3 +41,4 @@ def test_backup_script_keeps_restore_state_alive_for_trap():
 
     assert script.count("local_started=0") == 2
     assert script.index("local_started=0") < script.index("main() {")
+    assert '[[ -n "${workdir:-}" ]] && rm -rf "$workdir"' in script


### PR DESCRIPTION
Make the database backup CronJob fully succeed in production.

- Prefix `pg_dump` with `PGPASSWORD` so the backup job can authenticate noninteractively.
- Keep `local_started` in script scope so the EXIT trap can stop the temporary restore instance even on early exits.
- Replace the trap cleanup one-liner with a safe shell block so `set -e` does not treat cleanup as a failure.
- Add regression coverage for the backup script behavior in the rendered Helm chart.

Validation:
- `rtk bazel test //tests:common_test`
- `rtk bazel build --config=lint //...`

Deployment verification:
- Manually ran `glaze-db-backup-manual-final-check` in prod and confirmed the job completed successfully end to end.
