### PR TITLE
fix: scrub raw PII from pre-zero-PII auth accounts

### DIFF
--- a/api/migrations/0022_scrub_pii_from_existing_users.py
+++ b/api/migrations/0022_scrub_pii_from_existing_users.py
@@ -1,0 +1,33 @@
+import hashlib
+
+from django.db import migrations
+
+
+def scrub_pii(apps, schema_editor):
+    User = apps.get_model("auth", "User")
+    UserProfile = apps.get_model("api", "UserProfile")
+
+    for profile in UserProfile.objects.select_related("user").all():
+        raw_sub = profile.openid_subject
+        # Skip accounts already holding a sha256 hex digest (64 chars, all hex).
+        if len(raw_sub) == 64 and all(c in "0123456789abcdef" for c in raw_sub):
+            continue
+
+        hashed = hashlib.sha256(raw_sub.encode()).hexdigest()
+        profile.openid_subject = hashed
+        profile.save(update_fields=["openid_subject"])
+
+        user = profile.user
+        user.username = hashed
+        user.email = ""
+        user.save(update_fields=["username", "email"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0021_set_unusable_passwords"),
+    ]
+
+    operations = [
+        migrations.RunPython(scrub_pii, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
## Summary
- Migration 0021 (PR #592) set unusable passwords but did not scrub PII from accounts created before the zero-PII auth change
- 5 accounts still have raw Google subject IDs in `openid_subject` and Gmail addresses in `username`/`email`
- This migration hashes any non-hashed `openid_subject` in-place with sha256, sets `username` to the hash, and clears `email` — matching the behavior of newly registered accounts

## Test plan
- [x] `api_migration_test` passes
- [x] `api_auth_test` passes
- [ ] Confirm no rows with raw subject IDs or emails remain in DB after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)