### PR TITLE
[codex] add CSP middleware

### DIFF
--- a/chart/glaze/templates/middleware-security-headers.yaml
+++ b/chart/glaze/templates/middleware-security-headers.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ include "glaze.fullname" . }}-security-headers
+  labels:
+    {{- include "glaze.labels" . | nindent 4 }}
+spec:
+  headers:
+    contentSecurityPolicy: >-
+      default-src 'self';
+      script-src 'self' https://accounts.google.com https://apis.google.com https://upload-widget.cloudinary.com;
+      style-src 'self' 'unsafe-inline' https://accounts.google.com https://fonts.googleapis.com;
+      img-src 'self' data: https://res.cloudinary.com;
+      connect-src 'self' https://api.cloudinary.com;
+      font-src 'self' https://fonts.gstatic.com;
+      frame-src https://accounts.google.com https://widget.cloudinary.com https://upload-widget.cloudinary.com;
+      object-src 'none';
+      base-uri 'self';
+      form-action 'self';
+{{- end }}

--- a/chart/glaze/values.yaml
+++ b/chart/glaze/values.yaml
@@ -102,6 +102,7 @@ ingress:
   className: traefik
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.middlewares: default-glaze-security-headers@kubernetescrd
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
   hosts:


### PR DESCRIPTION
Closes #582

Summary:
- Adds a Traefik `Middleware` that sets `Content-Security-Policy` for the deployed app.
- Wires the middleware into the chart's Ingress annotations so it applies to prod traffic.
- Allows the current Google sign-in flow, Cloudinary upload widget, and Google Fonts assets already used by the app.

Validation:
- `git diff --check`
- `rtk bazel build --config=lint //...`
- `rtk bazel test //...` (passes for the touched areas; fails on an unrelated pre-existing mypy error in `api/auth_views.py:183`)
