### PR TITLE
fix: add missing production security settings

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -291,6 +291,13 @@ LOGGING = {
 SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
 SECURE_CROSS_ORIGIN_OPENER_POLICY = "same-origin-allow-popups"
 
+if IS_PRODUCTION:
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
+    SECURE_HSTS_SECONDS = 31536000
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+    SECURE_SSL_REDIRECT = True
+
 # Remote ML Offloading (Modal)
 REMOTE_REMBG_URL = os.environ.get("REMOTE_REMBG_URL", "")
 MODAL_AUTH_TOKEN = os.environ.get("MODAL_AUTH_TOKEN", "")


### PR DESCRIPTION
## Description
This PR addresses security gaps in the production configuration by adding several missing Django security settings to `backend/settings.py`.

### Changes
- **SESSION_COOKIE_SECURE**: Set to `True` to ensure session cookies are only transmitted over HTTPS.
- **CSRF_COOKIE_SECURE**: Set to `True` to ensure CSRF cookies are only transmitted over HTTPS.
- **SECURE_HSTS_SECONDS**: Set to `31536000` (1 year) to enable HTTP Strict Transport Security.
- **SECURE_HSTS_INCLUDE_SUBDOMAINS**: Set to `True` to apply HSTS to all subdomains.
- **SECURE_SSL_REDIRECT**: Set to `True` to enforce HTTPS redirects at the Django level (belt-and-suspenders with Nginx).

### Verification
- Verified by running `PRODUCTION=1 SECRET_KEY=dummy python manage.py check --deploy` in the worktree.
- Confirmed that security warnings `W004`, `W008`, `W012`, and `W016` are resolved.

### Security
**[SECURITY]** These changes harden the production environment by enforcing HTTPS for sensitive cookies and informing browsers to only use secure connections via HSTS.

Closes #580