### PR TITLE
feat: add user alias and clear legacy PII (#596)

### DIFF
--- a/api/auth_views.py
+++ b/api/auth_views.py
@@ -114,14 +114,18 @@ def auth_preferences(request: Request) -> Response:
     if request.method == "GET":
         return Response(
             {
+                "alias": profile.alias,
                 "preferences": profile.preferences
                 if isinstance(profile.preferences, dict)
-                else {}
+                else {},
             }
         )
 
     serializer = UserPreferencesSerializer(data=request.data, partial=True)
     serializer.is_valid(raise_exception=True)
+    if "alias" in serializer.validated_data:
+        profile.alias = serializer.validated_data["alias"]
+        profile.save(update_fields=["alias"])
     if "preferences" in serializer.validated_data:
         existing_preferences = cast(
             dict[str, Any],
@@ -148,9 +152,10 @@ def auth_preferences(request: Request) -> Response:
         profile.save(update_fields=["preferences"])
     return Response(
         {
+            "alias": profile.alias,
             "preferences": profile.preferences
             if isinstance(profile.preferences, dict)
-            else {}
+            else {},
         }
     )
 

--- a/api/auth_views.py
+++ b/api/auth_views.py
@@ -123,9 +123,10 @@ def auth_preferences(request: Request) -> Response:
 
     serializer = UserPreferencesSerializer(data=request.data, partial=True)
     serializer.is_valid(raise_exception=True)
+    update_fields: list[str] = []
     if "alias" in serializer.validated_data:
         profile.alias = serializer.validated_data["alias"]
-        profile.save(update_fields=["alias"])
+        update_fields.append("alias")
     if "preferences" in serializer.validated_data:
         existing_preferences = cast(
             dict[str, Any],
@@ -149,7 +150,9 @@ def auth_preferences(request: Request) -> Response:
                     **cast(dict[str, Any], incoming_tutorials),
                 }
         profile.preferences = merged_preferences
-        profile.save(update_fields=["preferences"])
+        update_fields.append("preferences")
+    if update_fields:
+        profile.save(update_fields=update_fields)
     return Response(
         {
             "alias": profile.alias,

--- a/api/migrations/0023_userprofile_alias_clear_pii.py
+++ b/api/migrations/0023_userprofile_alias_clear_pii.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+def clear_pii_fields(apps, schema_editor):
+    User = apps.get_model("auth", "User")
+    User.objects.all().update(first_name="", last_name="", email="")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0022_scrub_pii_from_existing_users"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="userprofile",
+            name="alias",
+            field=models.CharField(blank=True, default="", max_length=50),
+        ),
+        migrations.RunPython(clear_pii_fields, migrations.RunPython.noop),
+    ]

--- a/api/models.py
+++ b/api/models.py
@@ -691,6 +691,7 @@ class UserProfile(models.Model):
         settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="profile"
     )
     openid_subject = models.CharField(max_length=255, blank=True, default="")
+    alias = models.CharField(max_length=50, blank=True, default="")
     preferences = models.JSONField(blank=True, default=dict)
 
     def __str__(self) -> str:

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -934,18 +934,25 @@ class SavedUserPreferencesSerializer(serializers.Serializer):
 
 class UserPreferencesSerializer(serializers.Serializer):
     preferences = SavedUserPreferencesSerializer(required=False)
+    alias = serializers.CharField(required=False, allow_blank=True, max_length=50)
 
 
 class AuthUserSerializer(serializers.Serializer):
     id = serializers.IntegerField(read_only=True)
     is_staff = serializers.BooleanField(read_only=True)
     openid_subject = serializers.SerializerMethodField()
+    alias = serializers.SerializerMethodField()
     preferences = serializers.SerializerMethodField()
 
     @extend_schema_field(serializers.CharField(allow_blank=True))
     def get_openid_subject(self, obj) -> str:
         profile = getattr(obj, "profile", None)
         return profile.openid_subject if profile else ""
+
+    @extend_schema_field(serializers.CharField(allow_blank=True))
+    def get_alias(self, obj) -> str:
+        profile = getattr(obj, "profile", None)
+        return profile.alias if profile else ""
 
     @extend_schema_field(SavedUserPreferencesSerializer())
     def get_preferences(self, obj) -> dict:

--- a/api/tests/test_auth.py
+++ b/api/tests/test_auth.py
@@ -135,6 +135,48 @@ class TestAuthEndpointsMocked:
             "theme": "dark",
         }
 
+    def test_auth_me_includes_alias(self, client, user):
+        UserProfile.objects.create(user=user, alias="Pottery Phil")
+        response = client.get("/api/auth/me/")
+        assert response.status_code == 200
+        assert response.json()["alias"] == "Pottery Phil"
+
+    def test_auth_me_alias_defaults_to_empty_string(self, client, user):
+        UserProfile.objects.create(user=user)
+        response = client.get("/api/auth/me/")
+        assert response.status_code == 200
+        assert response.json()["alias"] == ""
+
+    def test_auth_preferences_patch_sets_alias(self, client, user):
+        UserProfile.objects.create(user=user)
+        response = client.patch(
+            "/api/auth/preferences/",
+            {"alias": "Studio Mug"},
+            format="json",
+        )
+        assert response.status_code == 200
+        assert response.json()["alias"] == "Studio Mug"
+        user.profile.refresh_from_db()
+        assert user.profile.alias == "Studio Mug"
+
+    def test_auth_preferences_patch_clears_alias(self, client, user):
+        UserProfile.objects.create(user=user, alias="Old Name")
+        response = client.patch(
+            "/api/auth/preferences/",
+            {"alias": ""},
+            format="json",
+        )
+        assert response.status_code == 200
+        assert response.json()["alias"] == ""
+        user.profile.refresh_from_db()
+        assert user.profile.alias == ""
+
+    def test_auth_preferences_get_includes_alias(self, client, user):
+        UserProfile.objects.create(user=user, alias="My Alias")
+        response = client.get("/api/auth/preferences/")
+        assert response.status_code == 200
+        assert response.json()["alias"] == "My Alias"
+
 
 @pytest.mark.django_db
 class TestAuthGoogle:

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -1178,6 +1178,18 @@ vitest_test(
     ],
 )
 
+vitest_test(
+    name = "web_user_preferences_dialog_test",
+    srcs = ["src/components/__tests__/UserPreferencesDialog.test.tsx"],
+    tags = ["ibazel_notify_changes"],
+    deps = [
+        ":web_lib",
+    ],
+    expected_coverage = [
+        "web/src/components/UserPreferencesDialog*",
+    ],
+)
+
 # ── Web test suite ────────────────────────────────────────────────────────────
 # Aggregate target: `bazel test //web:web_test` runs all web tests.
 # Individual targets above run only when their inputs change.
@@ -1212,6 +1224,7 @@ test_suite(
         ":web_public_piece_shell_test",
         ":web_state_transition_test",
         ":web_tag_manager_test",
+        ":web_user_preferences_dialog_test",
         ":web_tag_test",
         ":web_generate_types_test",
         ":web_workflow_state_test",

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -106,6 +106,7 @@ const MOCK_USER = {
   id: 1,
   is_staff: false,
   openid_subject: MOCK_OPENID_SUBJECT,
+  alias: "",
   preferences: {
     process_summary_fields: [],
     tutorials: {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -414,13 +414,15 @@ function AppShell({
     preferencesRootMatch !== null || preferencesSectionMatch !== null;
 
   const displayName = useMemo(() => {
+    if (currentUser.alias) return currentUser.alias;
     return (currentUser.openid_subject?.slice(0, 8) ?? "…") + "…";
   }, [currentUser]);
   const saveUserPreferences = useCallback(
-    async (preferences: UserPreferences) => {
-      const response = await updateUserPreferences(preferences);
+    async (preferences: UserPreferences, alias?: string) => {
+      const response = await updateUserPreferences(preferences, alias);
       onCurrentUserUpdated({
         ...currentUser,
+        alias: response.alias,
         preferences: response.preferences,
       });
       return response.preferences;

--- a/web/src/components/CurrentUserContext.tsx
+++ b/web/src/components/CurrentUserContext.tsx
@@ -25,7 +25,7 @@ export function useCurrentUser(): AuthUser | null {
   return useContext(CurrentUserContext);
 }
 
-type SaveUserPreferences = (preferences: UserPreferences) => Promise<UserPreferences>;
+type SaveUserPreferences = (preferences: UserPreferences, alias?: string) => Promise<UserPreferences>;
 
 const PreferencesActionsContext = createContext<{
   openPreferencesDialog: (sectionId?: PreferencesSectionId | null) => void;

--- a/web/src/components/UserPreferencesDialog.tsx
+++ b/web/src/components/UserPreferencesDialog.tsx
@@ -15,6 +15,7 @@ import {
   FormGroup,
   LinearProgress,
   Stack,
+  TextField,
   Typography,
 } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
@@ -53,14 +54,15 @@ export default function UserPreferencesDialog({
   });
   const options = useMemo(() => getProcessSummaryFieldOptions(), []);
   const saveState = useAsyncFn(
-    async (preferences: UserPreferences) => {
+    async (preferences: UserPreferences, alias: string) => {
       if (!saveUserPreferences) {
         return null;
       }
-      return saveUserPreferences(preferences);
+      return saveUserPreferences(preferences, alias);
     },
     [saveUserPreferences],
   );
+  const initialAlias = data?.alias ?? currentUser?.alias ?? "";
   const initialSelectedRefs =
     data?.preferences.process_summary_fields ??
     currentUser?.preferences.process_summary_fields ??
@@ -73,7 +75,7 @@ export default function UserPreferencesDialog({
       TUTORIAL_TOGGLE_KEYS.SUMMARY_CUSTOMIZE_POPUP
     ] ??
     "show";
-  const preferencesKey = `${initialSelectedRefs.join("|")}::${initialTutorialVisibility}`;
+  const preferencesKey = `${initialAlias}::${initialSelectedRefs.join("|")}::${initialTutorialVisibility}`;
 
   const sections = useMemo(() => {
     const grouped = new Map<string, typeof options>();
@@ -107,18 +109,22 @@ export default function UserPreferencesDialog({
           <PreferencesForm
             key={preferencesKey}
             sections={sections}
+            initialAlias={initialAlias}
             initialSelectedRefs={initialSelectedRefs}
             initialTutorialVisibility={initialTutorialVisibility}
             activeSectionId={activeSectionId}
             onSectionChange={onSectionChange}
-            onSave={async (selectedRefs, tutorialVisibility) => {
-              const response = await saveState.execute({
-                process_summary_fields: selectedRefs,
-                tutorials: {
-                  [TUTORIAL_TOGGLE_KEYS.SUMMARY_CUSTOMIZE_POPUP]:
-                    tutorialVisibility,
+            onSave={async (alias, selectedRefs, tutorialVisibility) => {
+              const response = await saveState.execute(
+                {
+                  process_summary_fields: selectedRefs,
+                  tutorials: {
+                    [TUTORIAL_TOGGLE_KEYS.SUMMARY_CUSTOMIZE_POPUP]:
+                      tutorialVisibility,
+                  },
                 },
-              });
+                alias,
+              );
               if (!response) {
                 return;
               }
@@ -139,6 +145,7 @@ export default function UserPreferencesDialog({
 
 function PreferencesForm({
   sections,
+  initialAlias,
   initialSelectedRefs,
   initialTutorialVisibility,
   activeSectionId,
@@ -148,17 +155,20 @@ function PreferencesForm({
   isSaving,
 }: {
   sections: { title: string; fields: { ref: string; label: string }[] }[];
+  initialAlias: string;
   initialSelectedRefs: string[];
   initialTutorialVisibility: TutorialVisibility;
   activeSectionId: PreferencesSectionId | null;
   onSectionChange: (sectionId: PreferencesSectionId | null) => void;
   onSave: (
+    alias: string,
     selectedRefs: string[],
     tutorialVisibility: TutorialVisibility,
   ) => Promise<void>;
   onCancel: () => void;
   isSaving: boolean;
 }) {
+  const [alias, setAlias] = useState(initialAlias);
   const [selectedRefs, setSelectedRefs] = useState(initialSelectedRefs);
   const [tutorialVisibility, setTutorialVisibility] =
     useState<TutorialVisibility>(initialTutorialVisibility);
@@ -172,6 +182,15 @@ function PreferencesForm({
   return (
     <>
       <Stack spacing={2}>
+        <TextField
+          label="Alias"
+          value={alias}
+          onChange={(e) => setAlias(e.target.value.slice(0, 50))}
+          helperText="How you'd like to identify yourself in the app. Not visible to others."
+          fullWidth
+          disabled={isSaving}
+          inputProps={{ maxLength: 50 }}
+        />
         <Accordion
           disableGutters
           expanded={activeSectionId === "process-summary"}
@@ -291,7 +310,7 @@ function PreferencesForm({
         </Button>
         <Button
           variant="contained"
-          onClick={() => void onSave(selectedRefs, tutorialVisibility)}
+          onClick={() => void onSave(alias, selectedRefs, tutorialVisibility)}
           disabled={isSaving}
         >
           Save

--- a/web/src/components/__tests__/UserPreferencesDialog.test.tsx
+++ b/web/src/components/__tests__/UserPreferencesDialog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -7,6 +7,7 @@ vi.mock("../../util/api", async (importOriginal) => {
   return {
     ...actual,
     fetchUserPreferences: vi.fn().mockResolvedValue({
+      alias: "",
       preferences: {
         process_summary_fields: ["piece.name"],
         tutorials: {
@@ -34,6 +35,7 @@ function renderDialog(activeSectionId: "process-summary" | "tutorials") {
           id: 1,
           is_staff: false,
           openid_subject: "",
+          alias: "",
           preferences: {
             process_summary_fields: ["piece.name"],
             tutorials: {
@@ -68,6 +70,7 @@ describe("UserPreferencesDialog", () => {
             id: 1,
             is_staff: false,
             openid_subject: "",
+            alias: "",
             preferences: {
               process_summary_fields: ["piece.name"],
               tutorials: {
@@ -86,7 +89,7 @@ describe("UserPreferencesDialog", () => {
       </PreferencesDialogProvider>,
     );
 
-    await user.click(screen.getByRole("button", { name: "Process Summary" }));
+    await user.click(await screen.findByRole("button", { name: /Process Summary/i, hidden: true }));
     expect(onSectionChange).toHaveBeenCalledWith(null);
   });
 
@@ -97,9 +100,8 @@ describe("UserPreferencesDialog", () => {
     expect(
       screen.getByText("Choose which fields appear in process summaries."),
     ).toBeInTheDocument();
-    expect(
-      screen.queryByText("Show the summary customization tip"),
-    ).not.toBeInTheDocument();
+    // Tutorials accordion is collapsed — its checkbox should not be visible.
+    expect(screen.queryByRole("checkbox", { name: /summary customization tip/i })).not.toBeInTheDocument();
   });
 
   it("expands the Tutorials section when routed there", async () => {
@@ -145,19 +147,77 @@ describe("UserPreferencesDialog", () => {
     );
 
     await user.click(
-      screen.getByRole("checkbox", {
-        name: "Show the summary customization tip",
+      await screen.findByRole("checkbox", {
+        name: /summary customization tip/i,
+        hidden: true,
       }),
     );
-    await user.click(screen.getByRole("button", { name: "Save" }));
+    await user.click(await screen.findByRole("button", { name: /save/i, hidden: true }));
 
     await waitFor(() => {
-      expect(saveUserPreferences).toHaveBeenCalledWith({
-        process_summary_fields: ["piece.name"],
-        tutorials: {
-          summary_customize_popover: "don't",
+      expect(saveUserPreferences).toHaveBeenCalledWith(
+        {
+          process_summary_fields: ["piece.name"],
+          tutorials: {
+            summary_customize_popover: "don't",
+          },
         },
-      });
+        "",
+      );
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it("saves alias when the alias field is filled in", async () => {
+    const saveUserPreferences = vi.fn(async (preferences) => preferences);
+    const onClose = vi.fn();
+
+    render(
+      <PreferencesDialogProvider
+        openPreferencesDialog={vi.fn()}
+        saveUserPreferences={saveUserPreferences}
+      >
+        <CurrentUserProvider
+          currentUser={{
+            id: 1,
+            is_staff: false,
+            openid_subject: "",
+            alias: "",
+            preferences: {
+              process_summary_fields: ["piece.name"],
+              tutorials: {
+                summary_customize_popover: "show",
+              },
+            },
+          }}
+        >
+          <UserPreferencesDialog
+            open
+            activeSectionId={null}
+            onClose={onClose}
+            onSectionChange={vi.fn()}
+          />
+        </CurrentUserProvider>
+      </PreferencesDialogProvider>,
+    );
+
+    // Wait for the dialog content to mount, then use fireEvent to bypass
+    // aria-hidden constraints from MUI Dialog's Fade transition in jsdom.
+    const aliasInput = await waitFor(() => {
+      const input = document.querySelector<HTMLInputElement>("input");
+      if (!input) throw new Error("alias input not found");
+      return input;
+    });
+    fireEvent.change(aliasInput, { target: { value: "Studio Mug" } });
+
+    const saveButton = await screen.findByRole("button", { name: /save/i, hidden: true });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(saveUserPreferences).toHaveBeenCalledWith(
+        expect.objectContaining({ process_summary_fields: ["piece.name"] }),
+        "Studio Mug",
+      );
       expect(onClose).toHaveBeenCalled();
     });
   });

--- a/web/src/components/__tests__/UserPreferencesDialog.test.tsx
+++ b/web/src/components/__tests__/UserPreferencesDialog.test.tsx
@@ -201,13 +201,9 @@ describe("UserPreferencesDialog", () => {
       </PreferencesDialogProvider>,
     );
 
-    // Wait for the dialog content to mount, then use fireEvent to bypass
-    // aria-hidden constraints from MUI Dialog's Fade transition in jsdom.
-    const aliasInput = await waitFor(() => {
-      const input = document.querySelector<HTMLInputElement>("input");
-      if (!input) throw new Error("alias input not found");
-      return input;
-    });
+    // fireEvent bypasses aria-hidden; MUI Dialog's Fade transition keeps content
+    // aria-hidden in jsdom so userEvent won't reach it.
+    const aliasInput = await screen.findByRole("textbox", { hidden: true });
     fireEvent.change(aliasInput, { target: { value: "Studio Mug" } });
 
     const saveButton = await screen.findByRole("button", { name: /save/i, hidden: true });

--- a/web/src/util/__tests__/api.test.ts
+++ b/web/src/util/__tests__/api.test.ts
@@ -300,6 +300,7 @@ describe("auth endpoints", () => {
     id: 1,
     is_staff: false,
     openid_subject: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    alias: "",
     preferences: {
       process_summary_fields: [],
       tutorials: {
@@ -429,11 +430,13 @@ describe("auth endpoints", () => {
     const { fetchUserPreferences } = await loadApiModule();
     mockClient.get.mockResolvedValue({
       data: {
+        alias: "",
         preferences: { process_summary_fields: ["piece.name", 123] },
       },
     });
 
     await expect(fetchUserPreferences()).resolves.toEqual({
+      alias: "",
       preferences: {
         process_summary_fields: ["piece.name"],
         tutorials: {
@@ -471,6 +474,7 @@ describe("auth endpoints", () => {
     mockClient.get.mockResolvedValue({});
     mockClient.patch.mockResolvedValue({
       data: {
+        alias: "",
         preferences: { process_summary_fields: ["piece.created"] },
       },
     });
@@ -483,6 +487,7 @@ describe("auth endpoints", () => {
         },
       }),
     ).resolves.toEqual({
+      alias: "",
       preferences: {
         process_summary_fields: ["piece.created"],
         tutorials: {

--- a/web/src/util/api.ts
+++ b/web/src/util/api.ts
@@ -40,6 +40,7 @@ export type AuthUser = {
   id: number;
   is_staff: boolean;
   openid_subject: string;
+  alias: string;
   preferences: UserPreferences;
 };
 
@@ -211,6 +212,7 @@ function normalizeUserPreferences(
 function normalizeAuthUser(raw: AuthUser): AuthUser {
   return {
     ...raw,
+    alias: raw.alias ?? "",
     preferences: normalizeUserPreferences(raw.preferences),
   };
 }
@@ -311,27 +313,29 @@ export async function generateStaffInviteCode(): Promise<StaffInviteCodeResponse
 }
 
 export type UserPreferencesResponse = {
+  alias: string;
   preferences: UserPreferences;
 };
 
 export async function fetchUserPreferences(): Promise<UserPreferencesResponse> {
   const { data } = await client.get<UserPreferencesResponse>("auth/preferences/");
   return {
+    alias: data.alias ?? "",
     preferences: normalizeUserPreferences(data.preferences),
   };
 }
 
 export async function updateUserPreferences(
   preferences: UserPreferences,
+  alias?: string,
 ): Promise<UserPreferencesResponse> {
   await ensureCsrfCookie();
   const { data } = await client.patch<UserPreferencesResponse>(
     "auth/preferences/",
-    {
-      preferences,
-    },
+    { preferences, ...(alias !== undefined && { alias }) },
   );
   return {
+    alias: data.alias ?? "",
     preferences: normalizeUserPreferences(data.preferences),
   };
 }


### PR DESCRIPTION
## Summary

- Adds `alias = CharField(max_length=50, blank=True)` to `UserProfile`
- Migration 0023 adds the column and clears `first_name`, `last_name`, `email` on all existing rows (completing the zero-PII work from #579)
- `GET /api/auth/preferences/` now returns `alias`; `PATCH` accepts it as a top-level field and saves it to the profile
- `UserPreferencesDialog` gets a free-text Alias field above the accordion sections; the avatar chip shows alias when set, truncated hash otherwise
- Adds `web_user_preferences_dialog_test` Bazel target (dialog tests were previously not wired up)

Follow-up to #579.
Closes #596

## Test plan

- [ ] Backend: `rtk bazel test //api:api_auth_test`
- [ ] Frontend: `rtk bazel test //web:web_user_preferences_dialog_test //web:web_api_test`
- [ ] Manual: open Preferences, set alias, save, verify avatar chip updates, reload and confirm it persists
- [ ] Verify production DB has no values in `first_name`/`last_name`/`email` after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)