### PR TITLE
fix: enforce image-only file type restrictions on Cloudinary upload signatures

### DIFF
--- a/api/cloudinary_views.py
+++ b/api/cloudinary_views.py
@@ -134,6 +134,10 @@ def cloudinary_widget_sign(request: Request) -> Response:
             status=status.HTTP_400_BAD_REQUEST,
         )
 
+    # Enforce image-only uploads regardless of what the client sends.
+    params_to_sign["resource_type"] = "image"
+    params_to_sign["allowed_formats"] = "jpg,jpeg,png,webp,heic,avif"
+
     # Cloudinary signature format: sorted key=value pairs joined by '&',
     # then append the API secret and SHA1-hash the result.
     signing_string = "&".join(

--- a/api/cloudinary_views.py
+++ b/api/cloudinary_views.py
@@ -135,8 +135,11 @@ def cloudinary_widget_sign(request: Request) -> Response:
         )
 
     # Enforce image-only uploads regardless of what the client sends.
-    params_to_sign["resource_type"] = "image"
-    params_to_sign["allowed_formats"] = "jpg,jpeg,png,webp,heic,avif"
+    params_to_sign = {
+        **params_to_sign,
+        "resource_type": "image",
+        "allowed_formats": "jpg,jpeg,png,webp,heic,avif",
+    }
 
     # Cloudinary signature format: sorted key=value pairs joined by '&',
     # then append the API secret and SHA1-hash the result.

--- a/api/tests/test_cloudinary_upload_signature.py
+++ b/api/tests/test_cloudinary_upload_signature.py
@@ -147,6 +147,13 @@ class TestCloudinaryWidgetSign:
         ).hexdigest()
         assert response.json() == {"signature": expected}
 
+        # Confirm the signature differs from what the tampered params would have produced.
+        tampered_string = "&".join(f"{k}={params[k]}" for k in sorted(params.keys()))
+        tampered_sig = hashlib.sha1(
+            f"{tampered_string}super-secret".encode("utf-8")
+        ).hexdigest()
+        assert response.json()["signature"] != tampered_sig
+
     def test_enforces_allowed_formats(self, client, monkeypatch):
         monkeypatch.setenv("CLOUDINARY_API_SECRET", "super-secret")
 

--- a/api/tests/test_cloudinary_upload_signature.py
+++ b/api/tests/test_cloudinary_upload_signature.py
@@ -112,7 +112,59 @@ class TestCloudinaryWidgetSign:
         )
 
         assert response.status_code == 200
-        signing_string = "folder=glaze&timestamp=1700000000"
+        # Server enforces allowed_formats and resource_type before signing.
+        enforced = {
+            **params,
+            "allowed_formats": "jpg,jpeg,png,webp,heic,avif",
+            "resource_type": "image",
+        }
+        signing_string = "&".join(f"{k}={enforced[k]}" for k in sorted(enforced.keys()))
+        expected = hashlib.sha1(
+            f"{signing_string}super-secret".encode("utf-8")
+        ).hexdigest()
+        assert response.json() == {"signature": expected}
+
+    def test_enforces_resource_type_image(self, client, monkeypatch):
+        monkeypatch.setenv("CLOUDINARY_API_SECRET", "super-secret")
+
+        # Client sends resource_type=video; server must override it to image.
+        params = {"resource_type": "video", "timestamp": "1700000000"}
+        response = client.post(
+            "/api/uploads/cloudinary/widget-signature/",
+            {"params_to_sign": params},
+            format="json",
+        )
+
+        assert response.status_code == 200
+        enforced = {
+            **params,
+            "allowed_formats": "jpg,jpeg,png,webp,heic,avif",
+            "resource_type": "image",
+        }
+        signing_string = "&".join(f"{k}={enforced[k]}" for k in sorted(enforced.keys()))
+        expected = hashlib.sha1(
+            f"{signing_string}super-secret".encode("utf-8")
+        ).hexdigest()
+        assert response.json() == {"signature": expected}
+
+    def test_enforces_allowed_formats(self, client, monkeypatch):
+        monkeypatch.setenv("CLOUDINARY_API_SECRET", "super-secret")
+
+        # Client omits allowed_formats; server must inject the allowlist.
+        params = {"timestamp": "1700000000"}
+        response = client.post(
+            "/api/uploads/cloudinary/widget-signature/",
+            {"params_to_sign": params},
+            format="json",
+        )
+
+        assert response.status_code == 200
+        enforced = {
+            **params,
+            "allowed_formats": "jpg,jpeg,png,webp,heic,avif",
+            "resource_type": "image",
+        }
+        signing_string = "&".join(f"{k}={enforced[k]}" for k in sorted(enforced.keys()))
         expected = hashlib.sha1(
             f"{signing_string}super-secret".encode("utf-8")
         ).hexdigest()


### PR DESCRIPTION
## Summary

- Enforces `resource_type=image` and `allowed_formats=jpg,jpeg,png,webp,heic,avif` server-side in the Cloudinary widget signature endpoint, regardless of what the client sends
- A client can no longer obtain a valid signature for non-image uploads by tampering with `params_to_sign`
- Updates the existing signature test to account for the enforced params; adds two new tests covering the override behavior

## Security

The signature endpoint previously signed whatever `params_to_sign` the client supplied. A client could request a signature for `resource_type=video` or omit `allowed_formats` entirely. This fix makes the server unconditionally overwrite those fields before computing the SHA1, closing the bypass.

## Test plan

- [ ] `rtk bazel test //api:api_test` — all 10 test targets pass
- [ ] `test_enforces_resource_type_image` — POST with `resource_type=video`, assert signature matches image-constrained params
- [ ] `test_enforces_allowed_formats` — POST without `allowed_formats`, assert signature includes the enforced allowlist
- [ ] Manual: in a dev environment, POST a tampered payload and confirm the returned signature matches the image-constrained one

Closes #583

🤖 Generated with [Claude Code](https://claude.com/claude-code)
