### PR TITLE
feat: strip EXIF metadata from Cloudinary uploads

### DIFF
--- a/api/cloudinary_views.py
+++ b/api/cloudinary_views.py
@@ -134,11 +134,12 @@ def cloudinary_widget_sign(request: Request) -> Response:
             status=status.HTTP_400_BAD_REQUEST,
         )
 
-    # Enforce image-only uploads regardless of what the client sends.
+    # Enforce image-only uploads and strip EXIF regardless of what the client sends.
     params_to_sign = {
         **params_to_sign,
         "resource_type": "image",
         "allowed_formats": "jpg,jpeg,png,webp,heic,avif",
+        "exif": "false",
     }
 
     # Cloudinary signature format: sorted key=value pairs joined by '&',

--- a/api/tests/test_cloudinary_upload_signature.py
+++ b/api/tests/test_cloudinary_upload_signature.py
@@ -112,10 +112,11 @@ class TestCloudinaryWidgetSign:
         )
 
         assert response.status_code == 200
-        # Server enforces allowed_formats and resource_type before signing.
+        # Server enforces allowed_formats, resource_type, and exif before signing.
         enforced = {
             **params,
             "allowed_formats": "jpg,jpeg,png,webp,heic,avif",
+            "exif": "false",
             "resource_type": "image",
         }
         signing_string = "&".join(f"{k}={enforced[k]}" for k in sorted(enforced.keys()))
@@ -139,6 +140,7 @@ class TestCloudinaryWidgetSign:
         enforced = {
             **params,
             "allowed_formats": "jpg,jpeg,png,webp,heic,avif",
+            "exif": "false",
             "resource_type": "image",
         }
         signing_string = "&".join(f"{k}={enforced[k]}" for k in sorted(enforced.keys()))
@@ -169,6 +171,7 @@ class TestCloudinaryWidgetSign:
         enforced = {
             **params,
             "allowed_formats": "jpg,jpeg,png,webp,heic,avif",
+            "exif": "false",
             "resource_type": "image",
         }
         signing_string = "&".join(f"{k}={enforced[k]}" for k in sorted(enforced.keys()))
@@ -176,6 +179,37 @@ class TestCloudinaryWidgetSign:
             f"{signing_string}super-secret".encode("utf-8")
         ).hexdigest()
         assert response.json() == {"signature": expected}
+
+    def test_enforces_exif_stripped(self, client, monkeypatch):
+        monkeypatch.setenv("CLOUDINARY_API_SECRET", "super-secret")
+
+        # Client sends exif=true; server must override it to false.
+        params = {"exif": "true", "timestamp": "1700000000"}
+        response = client.post(
+            "/api/uploads/cloudinary/widget-signature/",
+            {"params_to_sign": params},
+            format="json",
+        )
+
+        assert response.status_code == 200
+        enforced = {
+            **params,
+            "allowed_formats": "jpg,jpeg,png,webp,heic,avif",
+            "exif": "false",
+            "resource_type": "image",
+        }
+        signing_string = "&".join(f"{k}={enforced[k]}" for k in sorted(enforced.keys()))
+        expected = hashlib.sha1(
+            f"{signing_string}super-secret".encode("utf-8")
+        ).hexdigest()
+        assert response.json() == {"signature": expected}
+
+        # Confirm the signature differs from what the tampered params would have produced.
+        tampered_string = "&".join(f"{k}={params[k]}" for k in sorted(params.keys()))
+        tampered_sig = hashlib.sha1(
+            f"{tampered_string}super-secret".encode("utf-8")
+        ).hexdigest()
+        assert response.json()["signature"] != tampered_sig
 
     def test_returns_400_when_params_not_dict(self, client, monkeypatch):
         monkeypatch.setenv("CLOUDINARY_API_SECRET", "super-secret")


### PR DESCRIPTION
## Summary

- Injects `exif=false` server-side into `cloudinary_widget_sign` alongside the existing `resource_type` and `allowed_formats` overrides
- Because the parameter is included in the HMAC signing string, clients cannot revert it by supplying their own `exif` value
- No frontend changes needed — the Upload Widget respects signed parameters

## Test plan

- [x] Updated `test_returns_signature`, `test_enforces_resource_type_image`, `test_enforces_allowed_formats` to include `exif=false` in their expected enforced params
- [x] Added `test_enforces_exif_stripped` — verifies a client-supplied `exif=true` is overridden and the resulting signature differs from the tampered params
- [x] `//api:api_admin_test` passes

Closes #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)
