### PR TITLE
feat: restrict /api/health/ready/ to cluster-internal traffic via Traefik middleware

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -193,20 +193,6 @@ jobs:
               --wait
           "
 
-      - name: Smoke test
-        env:
-          ALLOWED_HOST: ${{ vars.ALLOWED_HOST }}
-        run: |
-          for i in $(seq 1 6); do
-            if curl -sf "https://${ALLOWED_HOST}/api/health/ready/" --max-time 10; then
-              echo "Smoke test passed"
-              exit 0
-            fi
-            echo "Attempt $i failed, retrying in 10s..."
-            sleep 10
-          done
-          echo "Smoke test failed after 6 attempts" >&2
-          exit 1
 
       - name: Create GitHub Release
         env:

--- a/chart/glaze/templates/ingress-health.yaml
+++ b/chart/glaze/templates/ingress-health.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "glaze.fullname" . -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-health
+  labels:
+    {{- include "glaze.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.ingress.annotations }}
+    {{- range $key, $value := . }}
+    {{- if ne $key "traefik.ingress.kubernetes.io/router.middlewares" }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+    traefik.ingress.kubernetes.io/router.middlewares: default-{{ $fullName }}-security-headers@kubernetescrd, default-{{ $fullName }}-health-internal-only@kubernetescrd
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          - path: /api/health/ready/
+            pathType: Exact
+            backend:
+              service:
+                name: {{ $fullName }}-web
+                port:
+                  number: 80
+    {{- end }}
+{{- end }}

--- a/chart/glaze/templates/middleware-health-internal.yaml
+++ b/chart/glaze/templates/middleware-health-internal.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ include "glaze.fullname" . }}-health-internal-only
+  labels:
+    {{- include "glaze.labels" . | nindent 4 }}
+spec:
+  # SINGLE-NODE: ipAllowList is sufficient for single-node k3s. For multi-node
+  # clusters, replace with a NetworkPolicy or mTLS approach.
+  ipAllowList:
+    sourceRange:
+      - {{ .Values.network.podCidr | quote }}
+      - {{ .Values.network.serviceCidr | quote }}
+{{- end }}

--- a/chart/glaze/values.yaml
+++ b/chart/glaze/values.yaml
@@ -127,3 +127,12 @@ resources:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+# SINGLE-NODE: These CIDRs are k3s flannel defaults for a single-node deployment.
+# If the cluster ever moves to multi-node/HA or a different CNI, revisit
+# middleware-health-internal.yaml and consider NetworkPolicy or mTLS instead.
+network:
+  # SINGLE-NODE: k3s flannel pod CIDR default. Revisit for multi-node/HA clusters.
+  podCidr: "10.42.0.0/16"
+  # SINGLE-NODE: k3s service CIDR default. Revisit for multi-node/HA clusters.
+  serviceCidr: "10.43.0.0/16"


### PR DESCRIPTION
## Summary

- Adds a Traefik `Middleware` (`health-internal-only`) using `ipAllowList` to restrict `/api/health/ready/` to the k3s pod and service CIDRs (`10.42.0.0/16`, `10.43.0.0/16`).
- Adds a dedicated `Ingress` for `/api/health/ready/` (pathType: Exact) that applies the new middleware; Traefik's exact-path routing takes precedence over the main catch-all `/`, so `ingress.yaml` is unchanged.
- Adds `network.podCidr` / `network.serviceCidr` Helm values (k3s flannel defaults) so CIDRs can be overridden without editing templates.
- Removes the CD smoke-test step that curled the endpoint from the public internet — `helm upgrade --wait` already blocks on readiness probes, which run in-cluster and continue to receive 200.

> **Single-node caveat:** The `ipAllowList` approach is tagged `# SINGLE-NODE:` in `middleware-health-internal.yaml` and `values.yaml`. If the cluster moves to multi-node/HA, revisit this middleware and consider `NetworkPolicy` or mTLS instead.

## Test plan

- [ ] `helm template chart/glaze` renders `Middleware/glaze-health-internal-only` and `Ingress/glaze-health` correctly.
- [ ] After deploy: `curl -sf https://potterdoc.com/api/health/ready/` from outside the cluster → 403.
- [ ] From inside the cluster (e.g. `kubectl run curl-test --rm -it --image=curlimages/curl --restart=Never -- curl -sf http://glaze-web/api/health/ready/`) → 200.
- [ ] Kubernetes readiness probe (in-cluster) still passes and pod reaches `Ready`.
- [ ] CD deploy succeeds without the removed smoke test step.

Closes #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)
