### PR TITLE
ops(575): migrate secrets to Infisical + ESO, Tailscale SSH

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -72,7 +72,7 @@ jobs:
           done
 
       - name: Connect to Tailscale
-        uses: tailscale/github-action@v3
+        uses: tailscale/github-action@6cae46e2d796f265265cfcf628b72a32b4d7cade  # v3
         with:
           oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
@@ -86,13 +86,15 @@ jobs:
         run: |
           # Push Infisical machine identity to cluster so ESO can authenticate.
           # ESO owns the full glaze-secrets sync from here; CD no longer manages app secrets.
-          ssh -o StrictHostKeyChecking=no "${DEPLOY_HOST}" "
-            KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl create secret generic infisical-auth \
-              --from-literal=clientId='${INFISICAL_CLIENT_ID}' \
-              --from-literal=clientSecret='${INFISICAL_CLIENT_SECRET}' \
+          # Credentials are passed as env vars on the remote side to avoid shell quoting issues.
+          ssh -o StrictHostKeyChecking=no "${DEPLOY_HOST}" \
+            INFISICAL_CLIENT_ID="${INFISICAL_CLIENT_ID}" \
+            INFISICAL_CLIENT_SECRET="${INFISICAL_CLIENT_SECRET}" \
+            'KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl create secret generic infisical-auth \
+              --from-literal=clientId="$INFISICAL_CLIENT_ID" \
+              --from-literal=clientSecret="$INFISICAL_CLIENT_SECRET" \
               --dry-run=client -o yaml | \
-            KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f -
-          "
+            KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f -'
 
       - name: Ship chart and render values override
         env:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,38 +33,25 @@ jobs:
 
       - name: Verify deploy inputs
         env:
-          DEPLOY_HOST: ${{ vars.DEPLOY_HOST }}
-          SECRET_KEY: ${{ secrets.SECRET_KEY }}
-          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          DEPLOY_HOST_TAILSCALE: ${{ vars.DEPLOY_HOST_TAILSCALE }}
+          TAILSCALE_OAUTH_CLIENT_ID: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+          TAILSCALE_OAUTH_CLIENT_SECRET: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
+          INFISICAL_CLIENT_ID: ${{ secrets.INFISICAL_CLIENT_ID }}
+          INFISICAL_CLIENT_SECRET: ${{ secrets.INFISICAL_CLIENT_SECRET }}
+          INFISICAL_PROJECT_SLUG: ${{ vars.INFISICAL_PROJECT_SLUG }}
           ALLOWED_HOST: ${{ vars.ALLOWED_HOST }}
           APP_ORIGIN: ${{ vars.APP_ORIGIN }}
           GOOGLE_OAUTH_CLIENT_ID: ${{ vars.GOOGLE_OAUTH_CLIENT_ID }}
           CLOUDINARY_CLOUD_NAME: ${{ vars.CLOUDINARY_CLOUD_NAME }}
-          CLOUDINARY_API_KEY: ${{ secrets.CLOUDINARY_API_KEY }}
-          CLOUDINARY_API_SECRET: ${{ secrets.CLOUDINARY_API_SECRET }}
           CLOUDINARY_UPLOAD_FOLDER: ${{ vars.CLOUDINARY_UPLOAD_FOLDER }}
           CLOUDINARY_UPLOAD_PRESET: ${{ vars.CLOUDINARY_UPLOAD_PRESET }}
           CLOUDINARY_PUBLIC_UPLOAD_FOLDER: ${{ vars.CLOUDINARY_PUBLIC_UPLOAD_FOLDER }}
-          EMAIL_HOST: ${{ vars.EMAIL_HOST }}
-          EMAIL_PORT: ${{ vars.EMAIL_PORT }}
-          EMAIL_HOST_USER: ${{ vars.EMAIL_HOST_USER }}
-          EMAIL_HOST_PASSWORD: ${{ secrets.EMAIL_HOST_PASSWORD }}
-          EMAIL_USE_SSL: ${{ vars.EMAIL_USE_SSL }}
-          DEFAULT_FROM_EMAIL: ${{ vars.DEFAULT_FROM_EMAIL }}
-          INVITE_LINK_BASE_URL: ${{ vars.INVITE_LINK_BASE_URL }}
-          REMOTE_REMBG_URL: ${{ vars.REMOTE_REMBG_URL }}
-          OTEL_ENABLED: ${{ vars.OTEL_ENABLED }}
-          GRAFANA_CLOUD_OTLP_TOKEN: ${{ secrets.GRAFANA_CLOUD_OTLP_TOKEN }}
-          MODAL_AUTH_TOKEN: ${{ secrets.MODAL_AUTH_TOKEN }}
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-          DROPBOX_APP_KEY: ${{ secrets.DROPBOX_APP_KEY }}
-          DROPBOX_APP_SECRET: ${{ secrets.DROPBOX_APP_SECRET }}
-          DROPBOX_REFRESH_TOKEN: ${{ secrets.DROPBOX_REFRESH_TOKEN }}
         run: |
-          critical="DEPLOY_HOST SECRET_KEY POSTGRES_PASSWORD ALLOWED_HOST APP_ORIGIN CLOUDINARY_CLOUD_NAME CLOUDINARY_API_KEY CLOUDINARY_API_SECRET CLOUDINARY_UPLOAD_FOLDER CLOUDINARY_UPLOAD_PRESET CLOUDINARY_PUBLIC_UPLOAD_FOLDER DROPBOX_APP_KEY DROPBOX_APP_SECRET DROPBOX_REFRESH_TOKEN"
-          features="EMAIL_HOST EMAIL_PORT EMAIL_HOST_USER EMAIL_HOST_PASSWORD EMAIL_USE_SSL DEFAULT_FROM_EMAIL INVITE_LINK_BASE_URL REMOTE_REMBG_URL OTEL_ENABLED GRAFANA_CLOUD_OTLP_TOKEN MODAL_AUTH_TOKEN MODAL_TOKEN_ID MODAL_TOKEN_SECRET"
-          
+          critical="DEPLOY_HOST_TAILSCALE TAILSCALE_OAUTH_CLIENT_ID TAILSCALE_OAUTH_CLIENT_SECRET INFISICAL_CLIENT_ID INFISICAL_CLIENT_SECRET INFISICAL_PROJECT_SLUG ALLOWED_HOST APP_ORIGIN CLOUDINARY_CLOUD_NAME CLOUDINARY_UPLOAD_FOLDER CLOUDINARY_UPLOAD_PRESET CLOUDINARY_PUBLIC_UPLOAD_FOLDER"
+          features="EMAIL_HOST EMAIL_PORT EMAIL_HOST_USER EMAIL_USE_SSL DEFAULT_FROM_EMAIL INVITE_LINK_BASE_URL REMOTE_REMBG_URL OTEL_ENABLED MODAL_TOKEN_ID MODAL_TOKEN_SECRET"
+
           missing_critical=0
           for name in $critical; do
             if [ -z "${!name:-}" ]; then
@@ -84,55 +71,32 @@ jobs:
             fi
           done
 
-      - name: Set up SSH
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -H $(echo "${{ vars.DEPLOY_HOST }}" | cut -d@ -f2) >> ~/.ssh/known_hosts
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
+          tags: tag:ci
 
-      - name: Sync secrets to cluster
+      - name: Bootstrap ESO credentials
         env:
-          DEPLOY_HOST: ${{ vars.DEPLOY_HOST }}
-          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
-          SECRET_KEY: ${{ secrets.SECRET_KEY }}
-          CLOUDINARY_API_KEY: ${{ secrets.CLOUDINARY_API_KEY }}
-          CLOUDINARY_API_SECRET: ${{ secrets.CLOUDINARY_API_SECRET }}
-          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
-          EMAIL_HOST_PASSWORD: ${{ secrets.EMAIL_HOST_PASSWORD }}
-          GRAFANA_CLOUD_OTLP_TOKEN: ${{ secrets.GRAFANA_CLOUD_OTLP_TOKEN }}
-          MODAL_AUTH_TOKEN: ${{ secrets.MODAL_AUTH_TOKEN }}
-          DROPBOX_APP_KEY: ${{ secrets.DROPBOX_APP_KEY }}
-          DROPBOX_APP_SECRET: ${{ secrets.DROPBOX_APP_SECRET }}
-          DROPBOX_REFRESH_TOKEN: ${{ secrets.DROPBOX_REFRESH_TOKEN }}
+          DEPLOY_HOST: ${{ vars.DEPLOY_HOST_TAILSCALE }}
+          INFISICAL_CLIENT_ID: ${{ secrets.INFISICAL_CLIENT_ID }}
+          INFISICAL_CLIENT_SECRET: ${{ secrets.INFISICAL_CLIENT_SECRET }}
         run: |
-          # Write secrets to a tmpfs-backed file, apply to cluster, then delete.
-          cat > /tmp/glaze-secrets.env << EOF
-          POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-          SECRET_KEY=${SECRET_KEY}
-          CLOUDINARY_API_KEY=${CLOUDINARY_API_KEY}
-          CLOUDINARY_API_SECRET=${CLOUDINARY_API_SECRET}
-          GOOGLE_OAUTH_CLIENT_SECRET=${GOOGLE_OAUTH_CLIENT_SECRET}
-          EMAIL_HOST_PASSWORD=${EMAIL_HOST_PASSWORD}
-          GRAFANA_CLOUD_OTLP_TOKEN=${GRAFANA_CLOUD_OTLP_TOKEN}
-          MODAL_AUTH_TOKEN=${MODAL_AUTH_TOKEN}
-          DROPBOX_APP_KEY=${DROPBOX_APP_KEY}
-          DROPBOX_APP_SECRET=${DROPBOX_APP_SECRET}
-          DROPBOX_REFRESH_TOKEN=${DROPBOX_REFRESH_TOKEN}
-          EOF
-          scp /tmp/glaze-secrets.env "${DEPLOY_HOST}":~/glaze-secrets.env
-          rm /tmp/glaze-secrets.env
-          ssh "${DEPLOY_HOST}" "
-            KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl create secret generic glaze-secrets \
-              --from-env-file=\$HOME/glaze-secrets.env \
+          # Push Infisical machine identity to cluster so ESO can authenticate.
+          # ESO owns the full glaze-secrets sync from here; CD no longer manages app secrets.
+          ssh -o StrictHostKeyChecking=no "${DEPLOY_HOST}" "
+            KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl create secret generic infisical-auth \
+              --from-literal=clientId='${INFISICAL_CLIENT_ID}' \
+              --from-literal=clientSecret='${INFISICAL_CLIENT_SECRET}' \
               --dry-run=client -o yaml | \
             KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f -
-            rm \$HOME/glaze-secrets.env
           "
 
       - name: Ship chart and render values override
         env:
-          DEPLOY_HOST: ${{ vars.DEPLOY_HOST }}
+          DEPLOY_HOST: ${{ vars.DEPLOY_HOST_TAILSCALE }}
           ALLOWED_HOST: ${{ vars.ALLOWED_HOST }}
           APP_ORIGIN: ${{ vars.APP_ORIGIN }}
           INVITE_LINK_BASE_URL: ${{ vars.INVITE_LINK_BASE_URL }}
@@ -148,10 +112,13 @@ jobs:
           DEFAULT_FROM_EMAIL: ${{ vars.DEFAULT_FROM_EMAIL }}
           REMOTE_REMBG_URL: ${{ vars.REMOTE_REMBG_URL }}
           OTEL_ENABLED: ${{ vars.OTEL_ENABLED }}
+          INFISICAL_PROJECT_SLUG: ${{ vars.INFISICAL_PROJECT_SLUG }}
         run: |
           cat > /tmp/values-override.yaml << EOF
           image:
             tag: "${{ env.DEPLOY_SHA }}"
+          infisical:
+            projectSlug: "${INFISICAL_PROJECT_SLUG}"
           appConfig:
             allowedHost: "${ALLOWED_HOST}"
             appOrigin: "${APP_ORIGIN}"
@@ -179,14 +146,14 @@ jobs:
                 hosts:
                   - "${ALLOWED_HOST}"
           EOF
-          scp -r chart/glaze "${DEPLOY_HOST}":~/glaze-chart-deploy/
-          scp /tmp/values-override.yaml "${DEPLOY_HOST}":~/glaze-values-override.yaml
+          scp -o StrictHostKeyChecking=no -r chart/glaze "${DEPLOY_HOST}":~/glaze-chart-deploy/
+          scp -o StrictHostKeyChecking=no /tmp/values-override.yaml "${DEPLOY_HOST}":~/glaze-values-override.yaml
 
       - name: Deploy via Helm
         env:
-          DEPLOY_HOST: ${{ vars.DEPLOY_HOST }}
+          DEPLOY_HOST: ${{ vars.DEPLOY_HOST_TAILSCALE }}
         run: |
-          ssh "${DEPLOY_HOST}" "
+          ssh -o StrictHostKeyChecking=no "${DEPLOY_HOST}" "
             KUBECONFIG=/etc/rancher/k3s/k3s.yaml helm upgrade --install glaze ~/glaze-chart-deploy/glaze/ \
               -f ~/glaze-values-override.yaml \
               --timeout 5m \

--- a/chart/glaze/templates/externalsecret.yaml
+++ b/chart/glaze/templates/externalsecret.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: glaze-secrets
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: infisical
+    kind: ClusterSecretStore
+  target:
+    name: glaze-secrets
+    creationPolicy: Owner
+  dataFrom:
+    - find:
+        path: /

--- a/chart/glaze/templates/externalsecret.yaml
+++ b/chart/glaze/templates/externalsecret.yaml
@@ -2,6 +2,8 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: glaze-secrets
+  labels:
+    {{- include "glaze.labels" . | nindent 4 }}
 spec:
   refreshInterval: 1h
   secretStoreRef:
@@ -10,6 +12,9 @@ spec:
   target:
     name: glaze-secrets
     creationPolicy: Owner
+  # Uses find to pull all secrets in the project root.
+  # The glaze-production Infisical project must contain only glaze secrets —
+  # anything added to the project will appear in glaze-secrets.
   dataFrom:
     - find:
         path: /

--- a/chart/glaze/templates/secretstore.yaml
+++ b/chart/glaze/templates/secretstore.yaml
@@ -2,6 +2,8 @@ apiVersion: external-secrets.io/v1beta1
 kind: ClusterSecretStore
 metadata:
   name: infisical
+  labels:
+    {{- include "glaze.labels" . | nindent 4 }}
 spec:
   provider:
     infisical:
@@ -9,11 +11,11 @@ spec:
         universalAuthCredentials:
           clientId:
             name: infisical-auth
-            namespace: default
+            namespace: {{ .Release.Namespace }}
             key: clientId
           clientSecret:
             name: infisical-auth
-            namespace: default
+            namespace: {{ .Release.Namespace }}
             key: clientSecret
       secretsScope:
         projectSlug: {{ .Values.infisical.projectSlug | quote }}

--- a/chart/glaze/templates/secretstore.yaml
+++ b/chart/glaze/templates/secretstore.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: infisical
+spec:
+  provider:
+    infisical:
+      auth:
+        universalAuthCredentials:
+          clientId:
+            name: infisical-auth
+            namespace: default
+            key: clientId
+          clientSecret:
+            name: infisical-auth
+            namespace: default
+            key: clientSecret
+      secretsScope:
+        projectSlug: {{ .Values.infisical.projectSlug | quote }}
+        environmentSlug: "prod"
+        recursive: false

--- a/chart/glaze/values.yaml
+++ b/chart/glaze/values.yaml
@@ -9,13 +9,17 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
-# Sensitive variables must be in a Secret named 'glaze-secrets'.
-# Create it manually on the cluster before first deploy:
-#   kubectl create secret generic glaze-secrets --from-env-file=.env.production
-# Expected keys: POSTGRES_PASSWORD, SECRET_KEY, CLOUDINARY_API_KEY,
-# CLOUDINARY_API_SECRET, EMAIL_HOST_PASSWORD, GRAFANA_CLOUD_OTLP_TOKEN,
-# MODAL_AUTH_TOKEN, GOOGLE_OAUTH_CLIENT_SECRET, DROPBOX_APP_KEY,
-# DROPBOX_APP_SECRET, DROPBOX_REFRESH_TOKEN
+# Sensitive variables are managed by External Secrets Operator (ESO) syncing from
+# Infisical Cloud. The 'glaze-secrets' k8s Secret is owned by the ExternalSecret
+# resource and populated automatically. See docs/ops/infisical-setup.md.
+#
+# Bootstrap prerequisite: a k8s Secret named 'infisical-auth' must exist with
+# keys 'clientId' and 'clientSecret' (Infisical machine identity credentials).
+# This is created by the CD workflow on each deploy.
+
+infisical:
+  # Infisical project slug — set in values-override.yaml during CD.
+  projectSlug: ""
 
 # Non-secret app config — all values overridden via -f values-override.yaml in CD.
 # Keys here are documentation of what must be set; defaults are intentionally empty.

--- a/docs/ops/incident-response.md
+++ b/docs/ops/incident-response.md
@@ -1,0 +1,76 @@
+# Incident Response — Credential Compromise
+
+Use this runbook when you suspect a secret has been exposed or is actively being abused.
+
+---
+
+## Immediate Actions (first 15 minutes)
+
+### 1. Rotate the compromised secret first
+
+Go directly to the relevant dashboard and invalidate the exposed credential before anything else. Do not wait to understand the full scope — revoke first, investigate after.
+
+| Compromised secret | Immediate action |
+|---|---|
+| `DEPLOY_SSH_KEY` (old) | Remove the public key from `~/.ssh/authorized_keys` on the droplet |
+| `INFISICAL_CLIENT_SECRET` | Revoke in Infisical → Access Control → Machine Identities → `glaze-eso` |
+| `TAILSCALE_OAUTH_CLIENT_SECRET` | Revoke in Tailscale admin → Settings → OAuth Clients |
+| `POSTGRES_PASSWORD` | `ALTER USER glaze WITH PASSWORD '<new>'` (see rotation runbook) |
+| `SECRET_KEY` | Generate new key, update Infisical, restart pods (all sessions invalidated) |
+| Any Cloudinary / Resend / Grafana / Modal key | Revoke in the provider dashboard |
+
+### 2. Force an immediate ESO sync
+
+ESO refreshes every hour by default. After updating the secret in Infisical, trigger an immediate sync:
+
+```bash
+KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl annotate externalsecret glaze-secrets \
+  force-sync=$(date +%s) --overwrite
+```
+
+Verify the sync completed:
+```bash
+KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl get externalsecret glaze-secrets
+# STATUS should return to "Valid / True" within ~30 seconds
+```
+
+### 3. Restart affected pods
+
+After ESO syncs the new value:
+
+```bash
+KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl rollout restart \
+  deployment/glaze-web deployment/glaze-worker deployment/glaze-otelcol
+```
+
+For `POSTGRES_PASSWORD` also restart the backup cronjob's next run (it picks up the new secret on the next scheduled execution automatically).
+
+---
+
+## Secondary Actions (first hour)
+
+### Audit access logs
+
+- **Infisical audit log**: Project → Audit Logs — look for unexpected machine identity usage or secret reads
+- **Grafana / OTel traces**: Check for anomalous API calls or error spikes around the suspected exposure window
+- **k8s events**: `kubectl get events --sort-by='.lastTimestamp'`
+- **GitHub Actions**: Check recent CD runs for unexpected secret access patterns
+
+### Rotate adjacent secrets
+
+If one secret was exposed, assume any secret stored in the same location may be at risk. Rotate the full inventory using [the rotation runbook](secret-rotation.md) if the exposure vector was broad (e.g., a `.env` file committed to git, a GitHub secret visible to a compromised runner).
+
+### Check for data exfiltration indicators
+
+- Unusual Cloudinary upload activity (Cloudinary Usage dashboard)
+- Unexpected Postgres queries (check `pg_stat_activity` or OTel slow query logs)
+- Unexpected outbound requests from pods (OTel traces + k8s network policy logs)
+
+---
+
+## After Containment
+
+- Document: what was exposed, when, how it was discovered, and what was rotated
+- File a GitHub issue or private note in the ops log with the timeline
+- If user data may have been accessed, review applicable privacy obligations
+- Update this runbook if the response revealed a gap in coverage

--- a/docs/ops/incident-response.md
+++ b/docs/ops/incident-response.md
@@ -12,7 +12,6 @@ Go directly to the relevant dashboard and invalidate the exposed credential befo
 
 | Compromised secret | Immediate action |
 |---|---|
-| `DEPLOY_SSH_KEY` (old) | Remove the public key from `~/.ssh/authorized_keys` on the droplet |
 | `INFISICAL_CLIENT_SECRET` | Revoke in Infisical → Access Control → Machine Identities → `glaze-eso` |
 | `TAILSCALE_OAUTH_CLIENT_SECRET` | Revoke in Tailscale admin → Settings → OAuth Clients |
 | `POSTGRES_PASSWORD` | `ALTER USER glaze WITH PASSWORD '<new>'` (see rotation runbook) |

--- a/docs/ops/infisical-setup.md
+++ b/docs/ops/infisical-setup.md
@@ -1,0 +1,175 @@
+# Infisical + ESO Bootstrap Guide
+
+One-time setup to migrate secrets from manual k8s management to Infisical Cloud + External Secrets Operator.
+
+## Prerequisites
+
+- Access to the k3s droplet via Tailscale
+- `kubectl` configured against the cluster (`KUBECONFIG=/etc/rancher/k3s/k3s.yaml`)
+- `helm` available on the droplet
+
+---
+
+## 1. Create Infisical Account and Project
+
+1. Sign up at [infisical.com](https://infisical.com) (free Personal tier)
+2. Create a new project — name it `glaze-production`
+3. Note the **project slug** (shown in the URL and project settings)
+
+### Load all secrets into the `prod` environment
+
+Navigate to the project's **prod** environment and add each key:
+
+| Key | Source |
+|---|---|
+| `POSTGRES_PASSWORD` | Current k8s secret or `.env.production` |
+| `SECRET_KEY` | Current k8s secret |
+| `CLOUDINARY_API_KEY` | Cloudinary dashboard |
+| `CLOUDINARY_API_SECRET` | Cloudinary dashboard |
+| `GOOGLE_OAUTH_CLIENT_SECRET` | Google Cloud Console |
+| `EMAIL_HOST_PASSWORD` | Resend dashboard |
+| `GRAFANA_CLOUD_OTLP_TOKEN` | Grafana Cloud dashboard |
+| `MODAL_AUTH_TOKEN` | Modal dashboard |
+| `DROPBOX_APP_KEY` | Dropbox developer console |
+| `DROPBOX_APP_SECRET` | Dropbox developer console |
+| `DROPBOX_REFRESH_TOKEN` | Dropbox developer console |
+
+### Create a machine identity for ESO
+
+1. In Infisical: **Access Control → Machine Identities → Create**
+2. Name it `glaze-eso`
+3. Assign it **read-only** access to the `glaze-production` project, `prod` environment
+4. Under **Universal Auth**: create a client credential
+5. Copy the **Client ID** and **Client Secret** — you will not see the secret again
+
+---
+
+## 2. Install External Secrets Operator on k3s
+
+SSH to the droplet and run:
+
+```bash
+helm repo add external-secrets https://charts.external-secrets.io
+helm repo update
+helm install external-secrets external-secrets/external-secrets \
+  -n external-secrets \
+  --create-namespace \
+  --set installCRDs=true
+```
+
+Verify:
+```bash
+KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl get pods -n external-secrets
+```
+
+---
+
+## 3. Update GitHub Secrets and Variables
+
+### Remove (no longer needed after migration is verified)
+
+```bash
+# App secrets — now managed by Infisical
+gh secret delete DEPLOY_SSH_KEY --env glaze-droplet
+gh secret delete POSTGRES_PASSWORD --env glaze-droplet
+gh secret delete SECRET_KEY --env glaze-droplet
+gh secret delete CLOUDINARY_API_KEY --env glaze-droplet
+gh secret delete CLOUDINARY_API_SECRET --env glaze-droplet
+gh secret delete GOOGLE_OAUTH_CLIENT_SECRET --env glaze-droplet
+gh secret delete EMAIL_HOST_PASSWORD --env glaze-droplet
+gh secret delete GRAFANA_CLOUD_OTLP_TOKEN --env glaze-droplet
+gh secret delete MODAL_AUTH_TOKEN --env glaze-droplet
+gh secret delete DROPBOX_APP_KEY --env glaze-droplet
+gh secret delete DROPBOX_APP_SECRET --env glaze-droplet
+gh secret delete DROPBOX_REFRESH_TOKEN --env glaze-droplet
+```
+
+### Add
+
+```bash
+# Infisical ESO machine identity
+gh secret set INFISICAL_CLIENT_ID --env glaze-droplet --body "<client-id>"
+gh secret set INFISICAL_CLIENT_SECRET --env glaze-droplet --body "<client-secret>"
+
+# Tailscale OAuth client (see section 4)
+gh secret set TAILSCALE_OAUTH_CLIENT_ID --env glaze-droplet --body "<oauth-client-id>"
+gh secret set TAILSCALE_OAUTH_CLIENT_SECRET --env glaze-droplet --body "<oauth-client-secret>"
+
+# Infisical project slug (non-secret variable)
+gh variable set INFISICAL_PROJECT_SLUG --env glaze-droplet --body "glaze-production"
+
+# Tailscale IP or hostname of the droplet (non-secret variable)
+gh variable set DEPLOY_HOST_TAILSCALE --env glaze-droplet --body "<user>@<tailscale-ip>"
+```
+
+---
+
+## 4. Set Up Tailscale SSH
+
+This replaces `DEPLOY_SSH_KEY` for CI/CD deploy access.
+
+### On the droplet
+
+Enable Tailscale SSH:
+```bash
+sudo tailscale up --ssh
+```
+
+### In Tailscale admin console
+
+1. Go to **Access Controls** and add a tag-based ACL rule:
+
+```json
+{
+  "tagOwners": {
+    "tag:ci": ["autogroup:admin"],
+    "tag:prod-server": ["autogroup:admin"]
+  },
+  "acls": [
+    {
+      "action": "accept",
+      "src": ["tag:ci"],
+      "dst": ["tag:prod-server:22"]
+    }
+  ]
+}
+```
+
+2. Tag the droplet as `tag:prod-server` in the Tailscale admin machines list.
+
+### Create Tailscale OAuth client for GitHub Actions
+
+1. In Tailscale admin: **Settings → OAuth Clients → Generate OAuth Client**
+2. Scope: **Devices: write** (needed to create ephemeral nodes)
+3. Pre-approved tags: `tag:ci`
+4. Copy **Client ID** and **Client Secret** → add to GitHub Secrets (see section 3)
+
+---
+
+## 5. Request Cure53 Audit Report
+
+Email `security@infisical.com` requesting the Cure53 penetration test report before go-live. This is a due-diligence step — see `docs/ops/incident-response.md` for the broader trust model.
+
+---
+
+## 6. Verify the Migration
+
+After the first successful CD deploy with the new workflow:
+
+```bash
+# Confirm ESO created and populated glaze-secrets
+KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl get secret glaze-secrets -o yaml
+
+# Confirm all 11 keys are present
+KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl get secret glaze-secrets \
+  -o jsonpath='{.data}' | python3 -c "import sys,json; print(list(json.load(sys.stdin).keys()))"
+
+# Confirm ExternalSecret status is Ready
+KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl get externalsecret glaze-secrets
+```
+
+Expected output for the last command:
+```
+NAME            STORE       REFRESH INTERVAL   STATUS   READY
+glaze-secrets   infisical   1h                 Valid    True
+```

--- a/docs/ops/secret-rotation.md
+++ b/docs/ops/secret-rotation.md
@@ -1,0 +1,127 @@
+# Secret Rotation Runbook
+
+Run this annually, after any suspected exposure, or after any collaborator offboarding.
+
+## How Rotation Works
+
+Infisical is the single source of truth. ESO polls Infisical every hour and syncs changes to the `glaze-secrets` k8s Secret automatically. The rotation flow for most secrets is:
+
+1. Generate a new credential in the relevant dashboard
+2. Update the value in Infisical (`glaze-production` project → `prod` environment)
+3. ESO propagates the change to the cluster within 1 hour
+4. Restart affected pods to pick up the new value
+
+For an **immediate** sync (e.g., suspected breach), see [Incident Response](incident-response.md).
+
+---
+
+## Secrets Inventory
+
+### App secrets (managed via Infisical → ESO)
+
+| Secret | Dashboard | Notes |
+|---|---|---|
+| `POSTGRES_PASSWORD` | n/a — script below | Requires `ALTER USER` + pod restart |
+| `SECRET_KEY` | n/a — script below | Invalidates all active user sessions |
+| `CLOUDINARY_API_KEY` / `CLOUDINARY_API_SECRET` | [Cloudinary Console](https://console.cloudinary.com) → Settings → Security | Rotate together |
+| `EMAIL_HOST_PASSWORD` | [Resend Dashboard](https://resend.com/api-keys) | Generate new key, revoke old |
+| `GRAFANA_CLOUD_OTLP_TOKEN` | Grafana Cloud → API Keys | |
+| `MODAL_AUTH_TOKEN` | Modal Dashboard → Settings → Auth Tokens | |
+| `GOOGLE_OAUTH_CLIENT_SECRET` | [Google Cloud Console](https://console.cloud.google.com) → APIs & Services → Credentials | Select the OAuth 2.0 client, regenerate secret |
+| `DROPBOX_APP_KEY` / `DROPBOX_APP_SECRET` / `DROPBOX_REFRESH_TOKEN` | [Dropbox App Console](https://www.dropbox.com/developers/apps) | See Dropbox section below |
+
+### Infrastructure secrets (managed via GitHub Secrets)
+
+| Secret | Where to rotate | Notes |
+|---|---|---|
+| `INFISICAL_CLIENT_SECRET` | Infisical → Access Control → Machine Identities → `glaze-eso` | See section below |
+| `TAILSCALE_OAUTH_CLIENT_SECRET` | Tailscale Admin → Settings → OAuth Clients | See section below |
+| `BAZEL_REMOTE_API_KEY` | BuildBuddy dashboard | CI only — update `BAZEL_REMOTE_API_KEY` GitHub secret |
+| `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET` | Modal Dashboard | Modal deploy job only |
+
+---
+
+## Step-by-Step Rotation
+
+### Django `SECRET_KEY`
+
+```bash
+python3 -c "
+import secrets, string
+alphabet = string.ascii_letters + string.digits + '!@#\$%^&*(-_=+)'
+print(''.join(secrets.choice(alphabet) for _ in range(50)))
+"
+```
+
+Update in Infisical. After ESO syncs, restart web and worker pods:
+```bash
+KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl rollout restart deployment/glaze-web deployment/glaze-worker
+```
+
+> Note: all active user sessions are invalidated on restart.
+
+### `POSTGRES_PASSWORD`
+
+1. Generate a new password (use the script above or a password manager)
+2. Update the database:
+   ```bash
+   KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl exec -it \
+     $(kubectl get pod -l app=glaze-postgres -o jsonpath='{.items[0].metadata.name}') -- \
+     psql -U glaze -c "ALTER USER glaze WITH PASSWORD '<new-password>';"
+   ```
+3. Update in Infisical
+4. After ESO syncs, restart web, worker, and otelcol pods:
+   ```bash
+   KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl rollout restart \
+     deployment/glaze-web deployment/glaze-worker deployment/glaze-otelcol
+   ```
+
+### Dropbox tokens
+
+Dropbox uses an offline refresh token. If `DROPBOX_REFRESH_TOKEN` needs to be rotated:
+
+1. Go to the Dropbox App Console → your app → OAuth 2 → Generate access token
+2. Use the Dropbox OAuth flow to obtain a new refresh token (see the existing backup script for the OAuth scope requirements)
+3. Update `DROPBOX_APP_KEY`, `DROPBOX_APP_SECRET`, and `DROPBOX_REFRESH_TOKEN` in Infisical
+
+### `INFISICAL_CLIENT_SECRET` (ESO machine identity)
+
+This is a bootstrap credential stored in GitHub Secrets, not in Infisical itself.
+
+1. In Infisical: Access Control → Machine Identities → `glaze-eso` → Client Credentials → Create new
+2. Update `INFISICAL_CLIENT_SECRET` in GitHub Secrets:
+   ```bash
+   gh secret set INFISICAL_CLIENT_SECRET --env glaze-droplet --body "<new-secret>"
+   ```
+3. The next CD deploy will push the new credential to the cluster via the "Bootstrap ESO credentials" step
+4. Revoke the old client credential in Infisical
+
+### `TAILSCALE_OAUTH_CLIENT_SECRET`
+
+1. In Tailscale admin: Settings → OAuth Clients → create a new client (same scopes: Devices write, tag:ci pre-approved)
+2. Update in GitHub Secrets:
+   ```bash
+   gh secret set TAILSCALE_OAUTH_CLIENT_ID --env glaze-droplet --body "<new-client-id>"
+   gh secret set TAILSCALE_OAUTH_CLIENT_SECRET --env glaze-droplet --body "<new-client-secret>"
+   ```
+3. Revoke the old OAuth client in Tailscale admin
+
+---
+
+## Post-Rotation Checklist
+
+- [ ] All Infisical secrets updated
+- [ ] `INFISICAL_CLIENT_SECRET` rotated and updated in GitHub
+- [ ] `TAILSCALE_OAUTH_CLIENT_SECRET` rotated and updated in GitHub
+- [ ] `BAZEL_REMOTE_API_KEY` rotated and updated in GitHub
+- [ ] `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET` rotated if applicable
+- [ ] Old credentials revoked in their respective dashboards
+- [ ] Smoke test passing after pod restarts
+- [ ] Calendar reminder set for next annual rotation
+- [ ] This checklist copied/linked as a comment on the rotation tracking issue
+
+---
+
+## Immediate Rotation (Suspected Breach)
+
+If you suspect a secret has been compromised, do not wait for the 1-hour ESO sync cycle. See [Incident Response](incident-response.md).


### PR DESCRIPTION
## Summary

Migrates all production secrets from manually-managed k8s Secrets + GitHub environment secrets to Infisical Cloud + External Secrets Operator (ESO), and replaces the long-lived `DEPLOY_SSH_KEY` with Tailscale SSH for CI/CD deployments.

**Before:** CD workflow pushed 11 secrets to the cluster on every deploy. Rotation required updating ~10 places per secret.

**After:** CD workflow pushes 2 credentials (Infisical machine identity). ESO owns the full `glaze-secrets` k8s Secret and syncs all app secrets autonomously on a 1h cycle. Rotation = update one place in Infisical.

## Changes

### Helm chart
- `chart/glaze/templates/secretstore.yaml` — new `ClusterSecretStore` pointing to Infisical Cloud via Universal Auth
- `chart/glaze/templates/externalsecret.yaml` — new `ExternalSecret` that owns and populates `glaze-secrets`, pulling all secrets from the Infisical `prod` environment
- `chart/glaze/values.yaml` — replace manual secret creation comment with ESO bootstrap contract; add `infisical.projectSlug`

### CD workflow
- Remove `DEPLOY_SSH_KEY` setup and `known_hosts` scanning (replaced by Tailscale SSH)
- Remove "Sync secrets to cluster" step (11 app secrets no longer flow through CD)
- Simplify "Verify deploy inputs" to check the 4 new infra credentials instead of 11 app secrets
- Add `tailscale/github-action@v3` — runner joins Tailscale ephemerally on each deploy
- Add "Bootstrap ESO credentials" — pushes only `infisical-auth` k8s Secret (2 keys)
- Propagate `infisical.projectSlug` into the values override

### Ops documentation (new)
- `docs/ops/infisical-setup.md` — one-time bootstrap guide: Infisical account setup, ESO install, GitHub Secrets migration, Tailscale SSH configuration, and verification steps
- `docs/ops/secret-rotation.md` — annual rotation runbook with per-secret steps and post-rotation checklist
- `docs/ops/incident-response.md` — immediate remediation guide including the ESO force-sync command for bypassing the 1h refresh cycle on suspected breach

## Manual prerequisites before this PR can go live

This PR ships the code; the following one-time ops steps must be completed on the cluster before the new CD workflow will succeed. They are documented in `docs/ops/infisical-setup.md`.

- [ ] Create Infisical account + project, load all 11 secrets, create read-only machine identity
- [ ] Install ESO on k3s (`helm install external-secrets ...`)
- [ ] Enable Tailscale SSH on the droplet (`tailscale up --ssh`)
- [ ] Configure Tailscale ACL: `tag:ci` → SSH → `tag:prod-server`
- [ ] Create Tailscale OAuth client + add to GitHub Secrets
- [ ] Add `INFISICAL_CLIENT_ID`, `INFISICAL_CLIENT_SECRET`, `INFISICAL_PROJECT_SLUG`, `DEPLOY_HOST_TAILSCALE` to GitHub environment
- [ ] Remove old secrets from GitHub environment (after verifying ESO sync works)
- [ ] Request Cure53 audit report from security@infisical.com

## Security notes

- The bootstrap step passes 2 read-only Infisical credentials via SSH — narrower scope than the prior 11-secret push
- Tailscale SSH ACL must restrict `tag:ci` to SSH only on `tag:prod-server`
- Force-sync for immediate rotation on breach: `kubectl annotate externalsecret glaze-secrets force-sync=$(date +%s) --overwrite`

Closes #575
