### PR TITLE
[codex] split admin ingress host

### DIFF
--- a/chart/glaze/templates/ingress-admin.yaml
+++ b/chart/glaze/templates/ingress-admin.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingress.enabled .Values.adminIngress.enabled -}}
 {{- $fullName := include "glaze.fullname" . -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -21,17 +21,12 @@ spec:
   {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
-    {{- range .Values.ingress.tls }}
     - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
+        - {{ .Values.adminIngress.host | quote }}
+      secretName: {{ .Values.adminIngress.tlsSecret }}
   {{- end }}
   rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ .Values.adminIngress.host | quote }}
       http:
         paths:
           - path: /{{ $.Values.appConfig.adminUrl | trimSuffix "/" }}/
@@ -48,5 +43,4 @@ spec:
                 name: {{ $fullName }}-web
                 port:
                   number: 80
-    {{- end }}
 {{- end }}

--- a/chart/glaze/templates/ingress-admin.yaml
+++ b/chart/glaze/templates/ingress-admin.yaml
@@ -19,7 +19,7 @@ spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
-  {{- if .Values.ingress.tls }}
+  {{- if .Values.adminIngress.tlsSecret }}
   tls:
     - hosts:
         - {{ .Values.adminIngress.host | quote }}

--- a/chart/glaze/values.yaml
+++ b/chart/glaze/values.yaml
@@ -37,6 +37,11 @@ appConfig:
   otelEnabled: ""
   adminUrl: "admin"
 
+adminIngress:
+  enabled: true
+  host: admin.potterdoc.com
+  tlsSecret: glaze-admin-tls
+
 postgres:
   image: postgres:17
   user: glaze

--- a/infra/k3s/README.md
+++ b/infra/k3s/README.md
@@ -187,7 +187,7 @@ public hostname for these private endpoints.
 Use [`./setup-k3s-tailscale.sh`](/home/phil/code/glaze/.agent-worktrees/claude/issue-tailscale-k3s-access/setup-k3s-tailscale.sh) to join the droplet to the tailnet and enable Tailscale SSH.
 
 ### Django Admin
-Django Admin is available at `https://glaze.example.com/admin/` (or the configured `adminUrl`). Access is restricted by a Traefik `IPAllowList` middleware. You must be connected to the Tailscale network to access it.
+Django Admin is available at `https://admin.potterdoc.com/admin/` (or the configured `adminUrl`). Access is restricted by a Traefik `IPAllowList` middleware. You must be connected to the Tailscale network to access it.
 
 If you keep the public hostname, you will also need DNS routing that sends that
 name to the droplet's tailnet address. Otherwise, use the droplet's Tailscale


### PR DESCRIPTION
## What changed
- Split the admin ingress onto its own hostname, `admin.potterdoc.com`.
- Kept Headlamp on its own tailnet-only hostname.
- Updated the k3s docs to reflect the real admin URL.

## Why
- The admin route should not be coupled to the main app hostname now that access is tailnet-restricted.
- A dedicated hostname matches the Cloudflare DNS setup and keeps the deployment configuration explicit.

## Validation
- `git diff --check`
- `bash -n setup-k3s-tailscale.sh`
- Confirmed Nginx was removed from the droplet after cleanup.
