### PR TITLE
infra: DNS-01 cert for admin.potterdoc.com via Cloudflare API

### DIFF
--- a/api/auth_views.py
+++ b/api/auth_views.py
@@ -115,11 +115,10 @@ def auth_me(request: Request) -> Response:
         )
     user = request.user if request.user.is_authenticated else None
     admin_host = settings.ADMIN_INGRESS_HOST
-    is_staff = user is not None and user.is_staff
     return Response(
         {
             "googleOauthClientId": client_id,
-            "adminBaseUrl": f"https://{admin_host}" if (is_staff and admin_host) else None,
+            "adminBaseUrl": f"https://{admin_host}" if (request.user.is_staff and admin_host) else None,
             "user": AuthUserSerializer(user).data if user else None,
         }
     )

--- a/api/auth_views.py
+++ b/api/auth_views.py
@@ -114,9 +114,12 @@ def auth_me(request: Request) -> Response:
             status=status.HTTP_503_SERVICE_UNAVAILABLE,
         )
     user = request.user if request.user.is_authenticated else None
+    admin_host = settings.ADMIN_INGRESS_HOST
+    is_staff = user is not None and user.is_staff
     return Response(
         {
             "googleOauthClientId": client_id,
+            "adminBaseUrl": f"https://{admin_host}" if (is_staff and admin_host) else None,
             "user": AuthUserSerializer(user).data if user else None,
         }
     )

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -34,6 +34,7 @@ else:
 DEBUG = not IS_PRODUCTION
 
 ADMIN_URL = os.environ.get("ADMIN_URL", "admin")
+ADMIN_INGRESS_HOST = os.environ.get("ADMIN_INGRESS_HOST", "")
 
 ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
 # ALLOWED_HOSTS: comma-separated hostnames (e.g. "potterdoc.com,www.potterdoc.com")

--- a/chart/glaze/templates/configmap.yaml
+++ b/chart/glaze/templates/configmap.yaml
@@ -60,6 +60,9 @@ data:
   INVITE_LINK_BASE_URL: {{ .Values.appConfig.inviteLinkBaseUrl | quote }}
   GOOGLE_OAUTH_CLIENT_ID: {{ .Values.appConfig.googleOauthClientId | quote }}
   ADMIN_URL: {{ .Values.appConfig.adminUrl | quote }}
+  {{- if .Values.adminIngress.enabled }}
+  ADMIN_INGRESS_HOST: {{ .Values.adminIngress.host | quote }}
+  {{- end }}
   CLOUDINARY_CLOUD_NAME: {{ .Values.appConfig.cloudinaryCloudName | quote }}
   CLOUDINARY_UPLOAD_FOLDER: {{ .Values.appConfig.cloudinaryUploadFolder | quote }}
   CLOUDINARY_UPLOAD_PRESET: {{ .Values.appConfig.cloudinaryUploadPreset | quote }}

--- a/chart/glaze/templates/externalsecret-cloudflare.yaml
+++ b/chart/glaze/templates/externalsecret-cloudflare.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.adminIngress.enabled -}}
+apiVersion: external-secrets.io/v1
+kind: ClusterExternalSecret
+metadata:
+  name: {{ include "glaze.fullname" . }}-cloudflare-token
+  labels:
+    {{- include "glaze.labels" . | nindent 4 }}
+spec:
+  namespaceSelectors:
+    - matchLabels:
+        kubernetes.io/metadata.name: cert-manager
+  refreshTime: 1h
+  externalSecretSpec:
+    refreshInterval: 1h
+    secretStoreRef:
+      name: infisical
+      kind: ClusterSecretStore
+    target:
+      name: cloudflare-api-token
+      creationPolicy: Owner
+    data:
+      - secretKey: api-token
+        remoteRef:
+          key: CLOUDFLARE_API_TOKEN
+{{- end }}

--- a/infra/k3s/clusterissuer.yaml
+++ b/infra/k3s/clusterissuer.yaml
@@ -1,0 +1,22 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    email: shaoster@gmail.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+      - http01:
+          ingress:
+            class: traefik
+      - dns01:
+          cloudflare:
+            apiTokenSecretRef:
+              name: cloudflare-api-token
+              key: api-token
+        selector:
+          dnsNames:
+            - admin.potterdoc.com

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -19,7 +19,7 @@ vi.mock("./util/api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./util/api")>();
   return {
     ...actual,
-    fetchAppInit: vi.fn().mockResolvedValue({ googleOauthClientId: "test-client-id", user: null }),
+    fetchAppInit: vi.fn().mockResolvedValue({ googleOauthClientId: "test-client-id", adminBaseUrl: null, user: null }),
     loginWithGoogle: vi.fn(),
     logoutUser: vi.fn().mockResolvedValue(undefined),
     validateInviteCode: vi.fn(),
@@ -128,7 +128,7 @@ describe("App auth flow", () => {
     vi.clearAllMocks();
     _googleOnSuccess = undefined;
     window.history.pushState({}, "", "/");
-    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", user: null });
+    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", adminBaseUrl: null, user: null });
     sessionStorage.clear();
   });
 
@@ -286,7 +286,7 @@ describe("App auth flow", () => {
   });
 
   it("switches between landing tabs and keeps the URL in sync", async () => {
-    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", user: MOCK_USER });
+    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", adminBaseUrl: null, user: MOCK_USER });
 
     render(<App />);
 
@@ -322,7 +322,7 @@ describe("App auth flow", () => {
   });
 
   it("clicking Log out calls logoutUser and returns to the login form", async () => {
-    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", user: MOCK_USER });
+    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", adminBaseUrl: null, user: MOCK_USER });
     vi.mocked(logoutUser).mockResolvedValue(undefined);
 
     render(<App />);
@@ -347,7 +347,7 @@ describe("App auth flow", () => {
   });
 
   it("shows the manual crop tool menu item only for admin users and routes to it", async () => {
-    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", user: MOCK_ADMIN_USER });
+    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", adminBaseUrl: "https://admin.potterdoc.com", user: MOCK_ADMIN_USER });
 
     render(<App />);
 
@@ -367,7 +367,7 @@ describe("App auth flow", () => {
   });
 
   it("shows the Admin Tool menu item only for admin users and redirects to /admin/", async () => {
-    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", user: MOCK_ADMIN_USER });
+    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", adminBaseUrl: "https://admin.potterdoc.com", user: MOCK_ADMIN_USER });
 
     render(<App />);
 
@@ -379,11 +379,11 @@ describe("App auth flow", () => {
 
     await userEvent.click(screen.getByText(MOCK_DISPLAY_NAME));
     const adminLink = screen.getByText("Admin Tool").closest("a");
-    expect(adminLink).toHaveAttribute("href", "/admin/");
+    expect(adminLink).toHaveAttribute("href", "https://admin.potterdoc.com/admin/");
   });
 
   it("does not show the manual crop tool menu item for non-admin users", async () => {
-    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", user: MOCK_USER });
+    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", adminBaseUrl: null, user: MOCK_USER });
 
     render(<App />);
 
@@ -399,7 +399,7 @@ describe("App auth flow", () => {
   });
 
   it("navigates to the piece summary preferences route from the user menu", async () => {
-    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", user: MOCK_USER });
+    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", adminBaseUrl: null, user: MOCK_USER });
 
     render(<App />);
 
@@ -417,7 +417,7 @@ describe("App auth flow", () => {
   });
 
   it("opens the tutorials preferences route directly", async () => {
-    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", user: MOCK_USER });
+    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", adminBaseUrl: null, user: MOCK_USER });
     window.history.pushState({}, "", "/preferences/tutorials");
 
     render(<App />);
@@ -430,7 +430,7 @@ describe("App auth flow", () => {
   });
 
   it("cancels preferences back to the current piece detail instead of the pieces list return target", async () => {
-    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", user: MOCK_USER });
+    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", adminBaseUrl: null, user: MOCK_USER });
     vi.mocked(fetchPiece).mockResolvedValue({
       id: "piece-1",
       name: "Tall Mug",
@@ -475,7 +475,7 @@ describe("App auth flow", () => {
   });
 
   it("activates the analyze tab on direct navigation to /analyze", async () => {
-    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", user: MOCK_USER });
+    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", adminBaseUrl: null, user: MOCK_USER });
     window.history.pushState({}, "", "/analyze");
 
     render(<App />);
@@ -502,7 +502,7 @@ describe("invite page routing", () => {
   });
 
   it("renders InvitePage at /invite when the user is already signed in", async () => {
-    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", user: MOCK_USER });
+    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", adminBaseUrl: null, user: MOCK_USER });
     vi.mocked(validateInviteCode).mockResolvedValue({ valid: true });
     window.history.pushState({}, "", "/invite?code=test-uuid");
 
@@ -514,7 +514,7 @@ describe("invite page routing", () => {
   });
 
   it("renders InvitePage at /invite when not signed in", async () => {
-    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", user: null });
+    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", adminBaseUrl: null, user: null });
     vi.mocked(validateInviteCode).mockResolvedValue({ valid: true });
     window.history.pushState({}, "", "/invite?code=test-uuid");
 
@@ -526,7 +526,7 @@ describe("invite page routing", () => {
   });
 
   it("stores invite code in sessionStorage after validation", async () => {
-    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", user: null });
+    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", adminBaseUrl: null, user: null });
     vi.mocked(validateInviteCode).mockResolvedValue({ valid: true });
     window.history.pushState({}, "", "/invite?code=my-invite-uuid");
 
@@ -540,7 +540,7 @@ describe("invite page routing", () => {
   });
 
   it("shows error for invalid invite code", async () => {
-    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", user: null });
+    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", adminBaseUrl: null, user: null });
     vi.mocked(validateInviteCode).mockRejectedValue({
       response: { data: { detail: "This code has been used." } },
     });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -432,10 +432,12 @@ function UnauthenticatedApp({
 
 function AppShell({
   currentUser,
+  adminBaseUrl,
   onLogout,
   onCurrentUserUpdated,
 }: {
   currentUser: AuthUser;
+  adminBaseUrl: string | null;
   onLogout: () => void;
   onCurrentUserUpdated: (user: AuthUser) => void;
 }) {
@@ -600,16 +602,18 @@ function AppShell({
                     </ListItemIcon>
                     Cloudinary Cleanup
                   </MenuItem>
-                  <MenuItem
-                    component="a"
-                    href="/admin/"
-                    onClick={() => setMenuAnchor(null)}
-                  >
-                    <ListItemIcon>
-                      <AdminPanelSettingsIcon fontSize="small" />
-                    </ListItemIcon>
-                    Admin Tool
-                  </MenuItem>
+                  {adminBaseUrl && (
+                    <MenuItem
+                      component="a"
+                      href={`${adminBaseUrl}/admin/`}
+                      onClick={() => setMenuAnchor(null)}
+                    >
+                      <ListItemIcon>
+                        <AdminPanelSettingsIcon fontSize="small" />
+                      </ListItemIcon>
+                      Admin Tool
+                    </MenuItem>
+                  )}
                 </>
               ) : null}
               <MenuItem
@@ -650,10 +654,12 @@ function AppShell({
 
 function AuthenticatedApp({
   currentUser,
+  adminBaseUrl,
   onLogout,
   onCurrentUserUpdated,
 }: {
   currentUser: AuthUser;
+  adminBaseUrl: string | null;
   onLogout: () => void;
   onCurrentUserUpdated: (user: AuthUser) => void;
 }) {
@@ -665,6 +671,7 @@ function AuthenticatedApp({
             element={
               <AppShell
                 currentUser={currentUser}
+                adminBaseUrl={adminBaseUrl}
                 onLogout={onLogout}
                 onCurrentUserUpdated={onCurrentUserUpdated}
               />
@@ -787,6 +794,7 @@ export default function App() {
         ) : init?.user ? (
           <AuthenticatedApp
             currentUser={init.user}
+            adminBaseUrl={init.adminBaseUrl}
             onLogout={handleLogout}
             onCurrentUserUpdated={handleCurrentUserUpdated}
           />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -735,7 +735,7 @@ function AuthenticatedApp({
           </Route>,
         ),
       ),
-    [currentUser, onLogout, onCurrentUserUpdated],
+    [adminBaseUrl, currentUser, onLogout, onCurrentUserUpdated],
   );
 
   return <RouterProvider router={router} />;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -686,7 +686,7 @@ function AuthenticatedApp({
               path="/tools/glaze-import"
               element={
                 currentUser.is_staff ? (
-                  <GlazeImportToolPage />
+                  <GlazeImportToolPage adminBaseUrl={adminBaseUrl} />
                 ) : (
                   <Navigate to="/" replace />
                 )

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -326,110 +326,6 @@ function AuthLanding({
   );
 }
 
-function UnauthenticatedApp({
-  onAuthenticated,
-}: {
-  onAuthenticated: (user: AuthUser) => void;
-}) {
-  const router = useMemo(
-    () =>
-      createBrowserRouter(
-        createRoutesFromElements(
-          <>
-            <Route
-              path="/"
-              element={<AuthLanding onAuthenticated={onAuthenticated} />}
-            />
-            <Route
-              path="/about"
-              element={
-                <ErrorBoundary>
-                  <Suspense
-                    fallback={
-                      <Box
-                        sx={{
-                          display: "flex",
-                          justifyContent: "center",
-                          py: 4,
-                        }}
-                      >
-                        <CircularProgress />
-                      </Box>
-                    }
-                  >
-                    <AboutPage />
-                  </Suspense>
-                </ErrorBoundary>
-              }
-            />
-            <Route
-              path="/privacy-policy"
-              element={
-                <ErrorBoundary>
-                  <Suspense
-                    fallback={
-                      <Box
-                        sx={{
-                          display: "flex",
-                          justifyContent: "center",
-                          py: 4,
-                        }}
-                      >
-                        <CircularProgress />
-                      </Box>
-                    }
-                  >
-                    <PrivacyPolicyPage />
-                  </Suspense>
-                </ErrorBoundary>
-              }
-            />
-            <Route
-              path="/terms-of-service"
-              element={
-                <ErrorBoundary>
-                  <Suspense
-                    fallback={
-                      <Box
-                        sx={{
-                          display: "flex",
-                          justifyContent: "center",
-                          py: 4,
-                        }}
-                      >
-                        <CircularProgress />
-                      </Box>
-                    }
-                  >
-                    <TermsOfServicePage />
-                  </Suspense>
-                </ErrorBoundary>
-              }
-            />
-            <Route
-              path="/pieces/:id/*"
-              element={<PublicPieceShell />}
-            />
-            <Route
-              path="/invite"
-              element={
-                <ErrorBoundary>
-                  <Suspense fallback={<Box sx={{ display: "flex", justifyContent: "center", py: 4 }}><CircularProgress /></Box>}>
-                    <InvitePage />
-                  </Suspense>
-                </ErrorBoundary>
-              }
-            />
-            <Route path="*" element={<Navigate to="/" replace />} />
-          </>,
-        ),
-      ),
-    [onAuthenticated],
-  );
-
-  return <RouterProvider router={router} />;
-}
-
 function AppShell({
   currentUser,
   adminBaseUrl,
@@ -650,6 +546,110 @@ function AppShell({
       </PreferencesDialogProvider>
     </CurrentUserProvider>
   );
+}
+
+function UnauthenticatedApp({
+  onAuthenticated,
+}: {
+  onAuthenticated: (user: AuthUser) => void;
+}) {
+  const router = useMemo(
+    () =>
+      createBrowserRouter(
+        createRoutesFromElements(
+          <>
+            <Route
+              path="/"
+              element={<AuthLanding onAuthenticated={onAuthenticated} />}
+            />
+            <Route
+              path="/about"
+              element={
+                <ErrorBoundary>
+                  <Suspense
+                    fallback={
+                      <Box
+                        sx={{
+                          display: "flex",
+                          justifyContent: "center",
+                          py: 4,
+                        }}
+                      >
+                        <CircularProgress />
+                      </Box>
+                    }
+                  >
+                    <AboutPage />
+                  </Suspense>
+                </ErrorBoundary>
+              }
+            />
+            <Route
+              path="/privacy-policy"
+              element={
+                <ErrorBoundary>
+                  <Suspense
+                    fallback={
+                      <Box
+                        sx={{
+                          display: "flex",
+                          justifyContent: "center",
+                          py: 4,
+                        }}
+                      >
+                        <CircularProgress />
+                      </Box>
+                    }
+                  >
+                    <PrivacyPolicyPage />
+                  </Suspense>
+                </ErrorBoundary>
+              }
+            />
+            <Route
+              path="/terms-of-service"
+              element={
+                <ErrorBoundary>
+                  <Suspense
+                    fallback={
+                      <Box
+                        sx={{
+                          display: "flex",
+                          justifyContent: "center",
+                          py: 4,
+                        }}
+                      >
+                        <CircularProgress />
+                      </Box>
+                    }
+                  >
+                    <TermsOfServicePage />
+                  </Suspense>
+                </ErrorBoundary>
+              }
+            />
+            <Route
+              path="/pieces/:id/*"
+              element={<PublicPieceShell />}
+            />
+            <Route
+              path="/invite"
+              element={
+                <ErrorBoundary>
+                  <Suspense fallback={<Box sx={{ display: "flex", justifyContent: "center", py: 4 }}><CircularProgress /></Box>}>
+                    <InvitePage />
+                  </Suspense>
+                </ErrorBoundary>
+              }
+            />
+            <Route path="*" element={<Navigate to="/" replace />} />
+          </>,
+        ),
+      ),
+    [onAuthenticated],
+  );
+
+  return <RouterProvider router={router} />;
 }
 
 function AuthenticatedApp({

--- a/web/src/pages/GlazeImportToolPage.tsx
+++ b/web/src/pages/GlazeImportToolPage.tsx
@@ -23,12 +23,10 @@ import CloudUploadIcon from "@mui/icons-material/CloudUpload";
 import MergeIcon from "@mui/icons-material/MergeType";
 import {
   extractErrorMessage,
-  fetchAppInit,
   importManualSquareCropRecords,
   type CloudinaryWidgetConfig,
   type ManualSquareCropImportResponse,
 } from "../util/api";
-import { useAsync } from "../util/useAsync";
 import { openCloudinaryUploadWidget } from "../util/cloudinaryUpload";
 import GlazeImportCropStage from "./glazeImportTool/GlazeImportCropStage";
 import GlazeImportImportStage from "./glazeImportTool/GlazeImportImportStage";
@@ -74,9 +72,7 @@ function buildCloudinaryJpgUrl(
 ) {
   return `https://res.cloudinary.com/${config.cloud_name}/image/upload/f_jpg/${publicId}.jpg`;
 }
-export default function GlazeImportToolPage() {
-  const { data: appInit } = useAsync(fetchAppInit);
-  const adminBaseUrl = appInit?.adminBaseUrl ?? null;
+export default function GlazeImportToolPage({ adminBaseUrl }: { adminBaseUrl: string | null }) {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const recordsRef = useRef<UploadedRecord[]>([]);
 

--- a/web/src/pages/GlazeImportToolPage.tsx
+++ b/web/src/pages/GlazeImportToolPage.tsx
@@ -25,7 +25,6 @@ import {
   extractErrorMessage,
   fetchAppInit,
   importManualSquareCropRecords,
-  fetchAppInit,
   type CloudinaryWidgetConfig,
   type ManualSquareCropImportResponse,
 } from "../util/api";

--- a/web/src/pages/GlazeImportToolPage.tsx
+++ b/web/src/pages/GlazeImportToolPage.tsx
@@ -23,10 +23,13 @@ import CloudUploadIcon from "@mui/icons-material/CloudUpload";
 import MergeIcon from "@mui/icons-material/MergeType";
 import {
   extractErrorMessage,
+  fetchAppInit,
   importManualSquareCropRecords,
+  fetchAppInit,
   type CloudinaryWidgetConfig,
   type ManualSquareCropImportResponse,
 } from "../util/api";
+import { useAsync } from "../util/useAsync";
 import { openCloudinaryUploadWidget } from "../util/cloudinaryUpload";
 import GlazeImportCropStage from "./glazeImportTool/GlazeImportCropStage";
 import GlazeImportImportStage from "./glazeImportTool/GlazeImportImportStage";
@@ -73,6 +76,8 @@ function buildCloudinaryJpgUrl(
   return `https://res.cloudinary.com/${config.cloud_name}/image/upload/f_jpg/${publicId}.jpg`;
 }
 export default function GlazeImportToolPage() {
+  const { data: appInit } = useAsync(fetchAppInit);
+  const adminBaseUrl = appInit?.adminBaseUrl ?? null;
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const recordsRef = useRef<UploadedRecord[]>([]);
 
@@ -623,6 +628,7 @@ export default function GlazeImportToolPage() {
 
       {activeTab === TAB_IMPORT ? (
         <GlazeImportImportStage
+          adminBaseUrl={adminBaseUrl}
           allReviewed={allReviewed}
           importRunning={importRunning}
           importError={importError}
@@ -638,6 +644,7 @@ export default function GlazeImportToolPage() {
 
       {activeTab === TAB_RECONCILE ? (
         <GlazeImportReconcileStage
+          adminBaseUrl={adminBaseUrl}
           duplicateResults={duplicateResults}
           records={records}
           reconciledIds={reconciledIds}

--- a/web/src/pages/__tests__/GlazeImportImportStage.test.tsx
+++ b/web/src/pages/__tests__/GlazeImportImportStage.test.tsx
@@ -8,6 +8,7 @@ describe("GlazeImportImportStage", () => {
   it("blocks import before all records are reviewed", () => {
     render(
       <GlazeImportImportStage
+        adminBaseUrl={null}
         allReviewed={false}
         importRunning={false}
         importError={null}
@@ -28,6 +29,7 @@ describe("GlazeImportImportStage", () => {
 
     render(
       <GlazeImportImportStage
+        adminBaseUrl={null}
         allReviewed
         importRunning={false}
         importError={null}

--- a/web/src/pages/__tests__/GlazeImportReconcileStage.test.tsx
+++ b/web/src/pages/__tests__/GlazeImportReconcileStage.test.tsx
@@ -39,6 +39,7 @@ describe("GlazeImportReconcileStage", () => {
 
     render(
       <GlazeImportReconcileStage
+        adminBaseUrl={null}
         duplicateResults={[
           {
             client_id: "record-1",

--- a/web/src/pages/glazeImportTool/GlazeImportImportStage.tsx
+++ b/web/src/pages/glazeImportTool/GlazeImportImportStage.tsx
@@ -4,6 +4,7 @@ import GlazeImportProgressList from "./GlazeImportProgressList";
 import type { UploadProgressEntry } from "./glazeImportToolTypes";
 
 interface GlazeImportImportStageProps {
+  adminBaseUrl: string | null;
   allReviewed: boolean;
   importRunning: boolean;
   importError: string | null;
@@ -23,6 +24,7 @@ const IMPORT_STATUS_LABELS: Record<UploadProgressEntry["status"], string> = {
 };
 
 export default function GlazeImportImportStage({
+  adminBaseUrl,
   allReviewed,
   importRunning,
   importError,
@@ -94,8 +96,8 @@ export default function GlazeImportImportStage({
             }}
           >
             {importResult.results.map((result) => {
-              const adminPath = result.object_id
-                ? `/admin/api/${result.kind.replace("_", "")}/${result.object_id}/change/`
+              const adminPath = result.object_id && adminBaseUrl
+                ? `${adminBaseUrl}/admin/api/${result.kind.replace("_", "")}/${result.object_id}/change/`
                 : null;
               return (
                 <ListItemButton

--- a/web/src/pages/glazeImportTool/GlazeImportReconcileStage.tsx
+++ b/web/src/pages/glazeImportTool/GlazeImportReconcileStage.tsx
@@ -13,6 +13,7 @@ import type { ManualSquareCropImportResponse } from "../../util/api";
 import type { UploadedRecord } from "./glazeImportToolTypes";
 
 interface GlazeImportReconcileStageProps {
+  adminBaseUrl: string | null;
   duplicateResults: ManualSquareCropImportResponse["results"];
   records: UploadedRecord[];
   reconciledIds: Set<string>;
@@ -20,6 +21,7 @@ interface GlazeImportReconcileStageProps {
 }
 
 export default function GlazeImportReconcileStage({
+  adminBaseUrl,
   duplicateResults,
   records,
   reconciledIds,
@@ -39,8 +41,8 @@ export default function GlazeImportReconcileStage({
       <Stack spacing={2}>
         {duplicateResults.map((result) => {
           const sourceRecord = records.find((record) => record.id === result.client_id);
-          const adminPath = result.object_id
-            ? `/admin/api/${result.kind.replace("_", "")}/${result.object_id}/change/`
+          const adminPath = result.object_id && adminBaseUrl
+            ? `${adminBaseUrl}/admin/api/${result.kind.replace("_", "")}/${result.object_id}/change/`
             : null;
           const isResolved = reconciledIds.has(result.client_id);
           return (

--- a/web/src/util/api.ts
+++ b/web/src/util/api.ts
@@ -317,6 +317,7 @@ export async function ensureCsrfCookie(): Promise<void> {
 
 export interface AppInit {
   googleOauthClientId: string;
+  adminBaseUrl: string | null;
   user: AuthUser | null;
 }
 
@@ -324,6 +325,7 @@ export async function fetchAppInit(): Promise<AppInit> {
   const { data } = await client.get<AppInit>("auth/me/");
   return {
     googleOauthClientId: data.googleOauthClientId,
+    adminBaseUrl: data.adminBaseUrl ?? null,
     user: data.user ? normalizeAuthUser(data.user) : null,
   };
 }


### PR DESCRIPTION
## Summary

Restricts Django admin access to `admin.potterdoc.com`, a subdomain served exclusively over Tailscale, to satisfy a security audit finding that admin was publicly reachable on the internet.

- `ingress-admin-public` (already deployed) blocks `potterdoc.com/admin/` for all Cloudflare-proxied traffic via a Traefik `IPAllowList` middleware — returns 403 to the public internet
- `ingress-admin` routes `admin.potterdoc.com` with the same Tailscale-only `IPAllowList` — only reachable from within the Tailscale network
- The blocker for `admin.potterdoc.com` going live was that cert-manager couldn't provision a TLS cert via HTTP-01 (Let's Encrypt can't reach a Tailscale IP). This PR fixes that with DNS-01 via Cloudflare API
- `adminBaseUrl` is returned from `auth/me/` only for authenticated staff users, so the admin hostname is not disclosed to the public or non-staff users
- All frontend admin links updated to use `adminBaseUrl` from the backend

## Changes

**Infra:**
- `ClusterExternalSecret` syncs `CLOUDFLARE_API_TOKEN` from Infisical into the `cert-manager` namespace
- `infra/k3s/clusterissuer.yaml` tracks `ClusterIssuer` in source (was hand-applied); adds DNS-01 solver scoped to `admin.potterdoc.com` alongside existing HTTP-01

**Backend:**
- `ADMIN_INGRESS_HOST` setting (injected via Helm configmap when `adminIngress.enabled`)
- `auth/me/` returns `adminBaseUrl` — non-null only for authenticated staff

**Frontend:**
- `AppInit.adminBaseUrl: string | null` threaded from `App` → `AuthenticatedApp` → `AppShell` and `GlazeImportToolPage`
- Nav menu Admin Tool link uses `adminBaseUrl`; hidden when null (non-staff or dev)
- Import stage admin object links use `adminBaseUrl`; disabled when null

## Deployment steps

1. Add `CLOUDFLARE_API_TOKEN` to Infisical (prod, path `/`) — **already done**
2. `helm upgrade glaze ./chart/glaze` — deploys `ClusterExternalSecret`; ESO creates `cloudflare-api-token` in `cert-manager` namespace; injects `ADMIN_INGRESS_HOST` into backend pod
3. `kubectl apply -f infra/k3s/clusterissuer.yaml` — updates `ClusterIssuer` with DNS-01 solver
4. cert-manager automatically retries the pending `glaze-admin-tls` certificate request

## Test plan

- [ ] `kubectl get secret cloudflare-api-token -n cert-manager` exists after helm upgrade
- [ ] `kubectl describe certificate glaze-admin-tls -n default` shows challenge progressing then Ready
- [ ] `https://admin.potterdoc.com/admin/` loads over HTTPS **on Tailscale**
- [ ] `https://admin.potterdoc.com/admin/` returns 403 **off Tailscale**
- [ ] `https://potterdoc.com/admin/` returns 403 from the public internet
- [ ] Nav menu Admin Tool link points to `https://admin.potterdoc.com/admin/` for staff
- [ ] Nav menu Admin Tool link is absent for non-staff users
- [ ] `GET /api/auth/me/` returns `adminBaseUrl: null` for unauthenticated and non-staff users

🤖 Generated with [Claude Code](https://claude.com/claude-code)
