### PR TITLE
fix(k8s): switch redis probe to tcpSocket with 3s timeout

### DIFF
--- a/chart/glaze/templates/statefulset-redis.yaml
+++ b/chart/glaze/templates/statefulset-redis.yaml
@@ -27,15 +27,17 @@ spec:
             - name: data
               mountPath: /data
           livenessProbe:
-            exec:
-              command: ["redis-cli", "ping"]
+            tcpSocket:
+              port: 6379
             initialDelaySeconds: 30
             periodSeconds: 10
+            timeoutSeconds: 3
           readinessProbe:
-            exec:
-              command: ["redis-cli", "ping"]
+            tcpSocket:
+              port: 6379
             initialDelaySeconds: 5
             periodSeconds: 5
+            timeoutSeconds: 3
   volumeClaimTemplates:
     - metadata:
         name: data


### PR DESCRIPTION
## Problem

`redis-cli ping` is an exec probe that spawns a new subprocess on every probe cycle. On this single-core node, fork/exec under deployment-time I/O contention (image pulls, migration jobs, pod startups all concurrent) repeatedly exceeded the default `timeoutSeconds: 1`, triggering false liveness failures that killed a healthy redis container. Confirmed correlation: all 5 redis restarts in pod history were deployment-coincident, never during idle operation.

## Change

- Switch liveness and readiness probes from `exec: redis-cli ping` to `tcpSocket: port: 6379`
- Set `timeoutSeconds: 3` on both probes as belt-and-suspenders

`tcpSocket` eliminates subprocess spawn entirely — kubelet opens the socket directly. A listening redis socket is sufficient health signal for this single-node setup.

## Validation

Applied manually via helm upgrade (revision 79). Redis has been stable with 0 restarts since. All remaining warning events predate the fix.

Part of #622 — tracking issue remains open until cluster health is fully green.