### PR TITLE
fix(k8s): exempt health endpoint from SSL redirect; skip CI for chart/infra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ on:
       - "LICENSE.*"
       - "setup-*.sh"
       - "nginx/**"
+      - "chart/**"
+      - "infra/**"
+      - ".agents/**"
   pull_request:
     paths-ignore:
       - "**/*.md"
@@ -34,6 +37,9 @@ on:
       - "LICENSE.*"
       - "setup-*.sh"
       - "nginx/**"
+      - "chart/**"
+      - "infra/**"
+      - ".agents/**"
 
 jobs:
   preflight:

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -300,6 +300,7 @@ if IS_PRODUCTION:
     SECURE_HSTS_SECONDS = 31536000
     SECURE_HSTS_INCLUDE_SUBDOMAINS = True
     SECURE_SSL_REDIRECT = True
+    SECURE_REDIRECT_EXEMPT = [r"^api/health/"]
 
 # Remote ML Offloading (Modal)
 REMOTE_REMBG_URL = os.environ.get("REMOTE_REMBG_URL", "")


### PR DESCRIPTION
## Problem

`SECURE_SSL_REDIRECT = True` causes Django to return `301 → https://potterdoc.com/api/health/ready/` on every in-cluster HTTP probe. K8s 1.25+ treats cross-scheme redirects as `ProbeWarning` rather than a failure (so pods stay healthy), but this fires on **every probe cycle** — every 10s for readiness, every 30s for liveness. Confirmed via `curl -H 'Host: potterdoc.com' http://<pod-ip>:8000/api/health/ready/` from the node.

## Changes

### `backend/settings.py`
Add `SECURE_REDIRECT_EXEMPT = [r"^api/health/"]` so the health endpoint responds directly over HTTP. In-cluster probes have no TLS termination; requiring HTTPS on the health path serves no security purpose.

### `.github/workflows/ci.yml`
Add `chart/**`, `infra/**`, and `.agents/**` to `paths-ignore` on both `push` and `pull_request`. Helm chart and k3s infra files have no Bazel targets — CI would spin up a full build and test run touching nothing relevant. Agent skill docs (`.md`) were already excluded; the chart YAML was not.

## Validation

Hypothesis confirmed before this fix: `curl` from node returned `HTTP/1.1 301 Moved Permanently` with `Location: https://potterdoc.com/api/health/ready/`. After this ships, expect zero `ProbeWarning: Probe terminated redirects` events on the next deploy.

Part of #622 — tracking issue remains open until cluster health is fully green.