### PR TITLE
fix(testing): make backend test settings self-contained

### DIFF
--- a/.agents/skills/django-api/SKILL.md
+++ b/.agents/skills/django-api/SKILL.md
@@ -1,7 +1,7 @@
 ---
 model: opus
 created: 2026-05-08
-modified: 2026-05-08
+modified: 2026-05-23
 reviewed: 2026-05-08
 name: django-api
 description: |
@@ -51,6 +51,14 @@ IS_PRODUCTION = bool(os.environ.get('PRODUCTION', ''))
 - Pure helper functions → unit test with `monkeypatch` to decouple from real data files or configuration
 - Prefer the API client (`client.post(...)`) for request/response tests over direct ORM
 - Add new tests to the existing file covering the same module — do not create new cross-cutting test files
+- In Glaze, API Bazel test targets default to `backend.test_settings` via the shared
+  `_TEST_ENV` in `api/BUILD.bazel`. That keeps the default test harness on the
+  self-contained settings module instead of importing production settings for
+  every run, which improves cache stability and keeps production-only branches
+  out of unrelated tests.
+- If a specific integration target truly needs production settings behavior, set
+  `DJANGO_SETTINGS_MODULE=backend.settings` explicitly at the target boundary
+  rather than importing `backend.settings` from the default test settings file.
 
 Run tests:
 ```bash

--- a/api/README.md
+++ b/api/README.md
@@ -40,6 +40,10 @@ Per-user data isolation rules:
 - Detail/update endpoints fetch objects from a user-filtered queryset. If another user's ID is requested, the API returns `404` (not `403`) to avoid leaking object existence.
 - Global reference entries are user-scoped; names are unique per user (for example, two users can both have a `Location` named "Kiln A" without colliding).
 
+## Testing
+
+API tests default to `backend.test_settings`.
+
 ## Django management
 
 | Command                   | Description                     |

--- a/api/README.md
+++ b/api/README.md
@@ -42,7 +42,16 @@ Per-user data isolation rules:
 
 ## Testing
 
-API tests default to `backend.test_settings`.
+The API Bazel test targets in [`api/BUILD.bazel`](./BUILD.bazel) set
+`DJANGO_SETTINGS_MODULE=backend.test_settings` through the shared `_TEST_ENV`
+for the default test harness. That keeps the suite on the self-contained test
+settings module instead of importing `backend.settings` for every run.
+
+This buys us two things: smaller test dependencies, and better Bazel cache
+behavior because the default suite no longer inherits production-only settings
+branches that can change unrelated test outcomes. In practice, that means the
+API tests start faster, stay easier to reason about, and only depend on the
+settings surface the tests actually need.
 
 ## Django management
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,9 +1,6 @@
 import pytest
 from django.contrib.auth.models import User
-from django.test import override_settings
 from rest_framework.test import APIClient
-
-PROD = override_settings(IS_PRODUCTION=True)
 
 from api.models import ENTRY_STATE, Piece, PieceState
 

--- a/backend/test_settings.py
+++ b/backend/test_settings.py
@@ -1,13 +1,274 @@
-from .settings import *  # noqa: F401,F403
+"""Self-contained Django settings for the default test suite.
 
-# Speed up tests that create/authenticate users by using a lightweight hasher.
+The default test configuration intentionally avoids importing backend.settings so
+tests do not inherit production-only branches by accident.
+"""
+
+import os
+from pathlib import Path
+
+import dj_database_url
+
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+# Default test runs should be deterministic and not depend on production env vars.
+IS_PRODUCTION = False
+SECRET_KEY = os.environ.get(
+    "SECRET_KEY",
+    "django-insecure-$jk-$#)vf5(ui&x2=atf+lj(zy6pxcu*ia7%z$kersf*7yrx%",
+)
+DEBUG = True
+
+ADMIN_URL = os.environ.get("ADMIN_URL", "admin")
+ADMIN_INGRESS_HOST = os.environ.get("ADMIN_INGRESS_HOST", "")
+
+ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
+_ALLOWED_HOSTS_ENV = os.environ.get("ALLOWED_HOSTS", os.environ.get("ALLOWED_HOST", ""))
+if _ALLOWED_HOSTS_ENV:
+    for host in _ALLOWED_HOSTS_ENV.split(","):
+        host = host.strip()
+        if host:
+            ALLOWED_HOSTS.append(host)
+            if "." in host and not host.startswith("www."):
+                ALLOWED_HOSTS.append(f"www.{host}")
+
+CORS_ALLOW_CREDENTIALS = True
+CORS_ALLOWED_ORIGIN_REGEXES = [
+    r"^http:\/\/localhost:*([0-9]+)?$",
+    r"^https:\/\/localhost:*([0-9]+)?$",
+]
+CSRF_TRUSTED_ORIGINS = []
+CORS_ALLOWED_ORIGINS = []
+_APP_ORIGIN = os.environ.get("APP_ORIGIN", "")
+if _APP_ORIGIN:
+    CORS_ALLOWED_ORIGINS.append(_APP_ORIGIN)
+    CSRF_TRUSTED_ORIGINS.append(_APP_ORIGIN)
+
+
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "adminsortable2",
+    "import_export",
+    "meta",
+    "rest_framework",
+    "corsheaders",
+    "drf_spectacular",
+    "api",
+]
+
 PASSWORD_HASHERS = [
     "django.contrib.auth.hashers.MD5PasswordHasher",
 ]
 
-# Tests opt into dev bootstrap behavior explicitly when needed.
+REST_FRAMEWORK = {
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.SessionAuthentication",
+    ],
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.IsAuthenticated",
+    ],
+}
+
+SPECTACULAR_SETTINGS = {
+    "TITLE": "PotterDoc API",
+    "DESCRIPTION": (
+        "Pottery workflow tracking API.\n\n"
+        "**Authentication:** All endpoints (except auth and public piece reads) "
+        "require a session cookie. To authenticate in this UI, click **Authorize** "
+        "and paste the value of your `sessionid` cookie. You can obtain it by "
+        "logging in through the web app and copying the cookie from your browser's "
+        "DevTools (Application → Cookies → `sessionid`)."
+    ),
+    "VERSION": "0.0.1",
+    "SECURITY": [{"cookieAuth": []}],
+    "COMPONENTS": {
+        "securitySchemes": {
+            "cookieAuth": {
+                "type": "apiKey",
+                "in": "cookie",
+                "name": "sessionid",
+                "description": (
+                    "Django session cookie. Log in via the web UI, then copy the "
+                    "`sessionid` value from DevTools → Application → Cookies."
+                ),
+            }
+        }
+    },
+}
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+]
+
+ROOT_URLCONF = "backend.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    }
+]
+
+WSGI_APPLICATION = "backend.wsgi.application"
+ASGI_APPLICATION = "backend.asgi.application"
+
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+USE_X_FORWARDED_HOST = False
+SESSION_COOKIE_SECURE = False
+CSRF_COOKIE_SECURE = False
+SECURE_HSTS_SECONDS = 0
+SECURE_HSTS_INCLUDE_SUBDOMAINS = False
+SECURE_SSL_REDIRECT = False
+SECURE_REDIRECT_EXEMPT = []
+
+if os.environ.get("DATABASE_URL"):
+    DATABASES = {"default": dj_database_url.config(conn_max_age=0)}
+else:
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": str(BASE_DIR / "db.sqlite3"),
+        }
+    }
+
+AUTH_PASSWORD_VALIDATORS = []
+
+LANGUAGE_CODE = "en-us"
+TIME_ZONE = "UTC"
+USE_I18N = True
+USE_TZ = True
+
+STATIC_URL = "/static/"
+STATIC_ROOT = BASE_DIR / "staticfiles"
+_WEB_DIST = BASE_DIR / "web" / "dist"
+if _WEB_DIST.is_dir():
+    WHITENOISE_ROOT = _WEB_DIST
+    STATICFILES_DIRS = [_WEB_DIST]
+
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedStaticFilesStorage",
+    },
+}
+
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+GOOGLE_OAUTH_CLIENT_ID = os.environ.get("GOOGLE_OAUTH_CLIENT_ID", "")
+GOOGLE_OAUTH_CLIENT_SECRET = os.environ.get("GOOGLE_OAUTH_CLIENT_SECRET", "")
+
+# Tests should opt into development bootstrap behavior explicitly when needed.
 DEV_BOOTSTRAP_ENABLED = False
 
-# Prevent WhiteNoise from rescanning the static file tree on every middleware
-# instantiation. API tests do not serve static files.
-MIDDLEWARE = [m for m in MIDDLEWARE if "WhiteNoiseMiddleware" not in m]  # noqa: F405
+REMOTE_REMBG_URL = os.environ.get("REMOTE_REMBG_URL", "")
+MODAL_AUTH_TOKEN = os.environ.get("MODAL_AUTH_TOKEN", "")
+
+DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL", "noreply@potterdoc.com")
+INVITE_LINK_BASE_URL = os.environ.get("INVITE_LINK_BASE_URL", "http://localhost:5173")
+EMAIL_BACKEND = os.environ.get(
+    "EMAIL_BACKEND", "django.core.mail.backends.console.EmailBackend"
+)
+EMAIL_HOST = os.environ.get("EMAIL_HOST", "localhost")
+EMAIL_PORT = int(os.environ.get("EMAIL_PORT", "1025"))
+EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER", "")
+EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD", "")
+EMAIL_USE_SSL = False
+
+REDIS_CACHE_URL = os.environ.get("REDIS_CACHE_URL", "")
+if REDIS_CACHE_URL:
+    CACHES = {
+        "default": {
+            "BACKEND": "django_redis.cache.RedisCache",
+            "LOCATION": REDIS_CACHE_URL,
+            "OPTIONS": {
+                "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            },
+        }
+    }
+else:
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+        }
+    }
+
+CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", "")
+ASYNC_TASK_BACKEND = os.environ.get(
+    "ASYNC_TASK_BACKEND", "celery" if CELERY_BROKER_URL else "inmemory"
+)
+
+CELERY_ACCEPT_CONTENT = ["json"]
+CELERY_TASK_SERIALIZER = "json"
+CELERY_RESULT_BACKEND = None
+CELERY_TASK_TRACK_STARTED = True
+CELERY_TASK_TIME_LIMIT = 30 * 60
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "console": {
+            "format": "%(levelname)s %(asctime)s %(name)s [trace=%(trace_id)s] %(message)s",
+        },
+    },
+    "filters": {
+        "otel_trace": {
+            "()": "api.logging.OtelTraceFilter",
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "console",
+            "filters": ["otel_trace"],
+        },
+    },
+    "root": {
+        "handlers": ["console"],
+        "level": "INFO",
+    },
+    "loggers": {
+        "django": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": True,
+        },
+        "django.request": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        "api": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+    },
+}
+
+SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
+SECURE_CROSS_ORIGIN_OPENER_POLICY = "same-origin-allow-popups"

--- a/docs/agents/glaze-domain.md
+++ b/docs/agents/glaze-domain.md
@@ -383,6 +383,7 @@ Name uniqueness for public globals is enforced with two conditional DB constrain
 - Every new API endpoint or serializer change → add or update a test under `api/tests/`.
 - Every new or modified `api/workflow.py` helper → add or update a test in `api/tests/test_workflow_helpers.py`, patching `_STATE_MAP` / `_GLOBALS_MAP` via `monkeypatch`.
 - **New global domain models**: adding a new entry to `workflow.yml` and running `makemigrations` is sufficient — `_register_globals()` auto-generates and registers the model at import time. The generated class is automatically enrolled in the parameterised test suites in `api/tests/test_globals.py`. No manual model or test additions are needed for registry invariants — focus new tests on model-specific constraints and API behavior instead. Set `factory: false` only if the global needs a hand-written model class with bespoke logic.
+- API tests default to `backend.test_settings`.
 
 ---
 

--- a/docs/agents/glaze-domain.md
+++ b/docs/agents/glaze-domain.md
@@ -383,7 +383,11 @@ Name uniqueness for public globals is enforced with two conditional DB constrain
 - Every new API endpoint or serializer change → add or update a test under `api/tests/`.
 - Every new or modified `api/workflow.py` helper → add or update a test in `api/tests/test_workflow_helpers.py`, patching `_STATE_MAP` / `_GLOBALS_MAP` via `monkeypatch`.
 - **New global domain models**: adding a new entry to `workflow.yml` and running `makemigrations` is sufficient — `_register_globals()` auto-generates and registers the model at import time. The generated class is automatically enrolled in the parameterised test suites in `api/tests/test_globals.py`. No manual model or test additions are needed for registry invariants — focus new tests on model-specific constraints and API behavior instead. Set `factory: false` only if the global needs a hand-written model class with bespoke logic.
-- API tests default to `backend.test_settings`.
+- API test targets in `api/BUILD.bazel` set `DJANGO_SETTINGS_MODULE=backend.test_settings`
+  through the shared `_TEST_ENV`. That keeps the default suite on the
+  self-contained test settings module instead of importing `backend.settings`
+  for every run, which makes Bazel caching more stable and keeps production-only
+  settings branches out of unrelated tests unless a target truly needs them.
 
 ---
 


### PR DESCRIPTION
## Summary
- Make `backend.test_settings` self-contained so the default API test harness no longer imports production settings.
- Remove the old test-only `PROD` override helper from `api/tests/conftest.py`.
- Document how Bazel wires the default API test harness to `backend.test_settings`, and why that helps caching and keeps production-only settings branches out of unrelated tests.
- Update the Django API skill with the same testing guidance so backend work finds the rule in the place it already looks.

## Validation
- `rtk bazel test //...`
- `rtk bazel build --config=lint //...`

Closes #626
