### PR TITLE
fix(k8s): startupProbe on web to eliminate readiness probe false alarms

### DIFF
--- a/chart/glaze/templates/deployment-web.yaml
+++ b/chart/glaze/templates/deployment-web.yaml
@@ -24,6 +24,16 @@ spec:
             - name: http
               containerPort: 8000
               protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /api/health/ready/
+              port: 8000
+              httpHeaders:
+                - name: Host
+                  value: {{ .Values.appConfig.allowedHost | default "localhost" | quote }}
+            failureThreshold: 20
+            periodSeconds: 5
+            timeoutSeconds: 5
           livenessProbe:
             httpGet:
               path: /api/health/ready/
@@ -31,7 +41,6 @@ spec:
               httpHeaders:
                 - name: Host
                   value: {{ .Values.appConfig.allowedHost | default "localhost" | quote }}
-            initialDelaySeconds: 60
             periodSeconds: 30
             timeoutSeconds: 3
           readinessProbe:
@@ -41,7 +50,6 @@ spec:
               httpHeaders:
                 - name: Host
                   value: {{ .Values.appConfig.allowedHost | default "localhost" | quote }}
-            initialDelaySeconds: 35
             periodSeconds: 10
             timeoutSeconds: 3
           envFrom:


### PR DESCRIPTION
Part of #622.

## Problem

Every deploy produced a `Readiness probe failed: context deadline exceeded` warning on the web pod. Root cause: Django cold start on a single-core node takes ~40 s, and `initialDelaySeconds: 35` put the first readiness probe right in the middle of startup. The pod would pass on the second attempt (45 s) but the warning was logged and blocked rolling deploy hand-off.

## Fix

Replace the guessed `initialDelaySeconds` with a `startupProbe`:

```yaml
startupProbe:
  httpGet:
    path: /api/health/ready/
    port: 8000
  failureThreshold: 20
  periodSeconds: 5
  timeoutSeconds: 5   # 100 s total startup budget
```

- `initialDelaySeconds` removed from liveness and readiness — the startup probe gates them
- During the startup window, `Startup probe failed` events are expected and informational (pod not yet in service); they do not affect traffic routing
- After startup probe passes, steady-state probes run clean

## Verified on cluster

Revision 92 deployed. New web pod (glaze-web-58f6d9476-xmfdb) showed exactly 2 `Startup probe failed` events during boot (connection refused at 7 s, timeout at 23 s), then reached Ready with no further warnings.

## Test plan
- [ ] CD deploys — confirm no `Readiness probe failed` events on web pod
- [ ] Confirm exactly 0 `Unhealthy` events on the web pod after it reaches Ready

Part of #622 — does not close until all warning classes are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)