### PR TITLE
ci: trigger CD directly on chart/** and infra/** pushes to main

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,13 @@ on:
     workflows: [CI]
     types: [completed]
     branches: [main]
+  # Chart-only pushes skip CI entirely (chart/** is in CI paths-ignore).
+  # Trigger CD directly so helm changes don't require a manual dispatch.
+  push:
+    branches: [main]
+    paths:
+      - "chart/**"
+      - "infra/**"
   workflow_dispatch:
     inputs:
       sha:
@@ -19,7 +26,7 @@ jobs:
   deploy:
     name: Deploy to droplet
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
+    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' || github.event_name == 'push'
     environment: glaze-droplet
     concurrency:
       group: deploy-production
@@ -283,7 +290,7 @@ jobs:
   deploy-modal:
     name: Deploy Services to Modal
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'
+    if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' || github.event_name == 'push'
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
Part of #622.

## Problem

Chart-only merges (e.g. #629) never trigger CI/CD:
- CI has `chart/**` in `paths-ignore` → CI skips
- CD triggers on `workflow_run: [CI]` → no CI run = no CD trigger
- Result: helm changes silently don't deploy; require a manual `workflow_dispatch`

## Fix

Add a `push` trigger to CD scoped to `chart/**` and `infra/**`:

```yaml
push:
  branches: [main]
  paths:
    - "chart/**"
    - "infra/**"
```

Also add `github.event_name == 'push'` to the deploy job's `if:` condition, which previously only passed for `workflow_run` success or `workflow_dispatch`.

Chart and infra changes require no test validation (CI correctly skips them) but do need deploying. This makes the pipeline complete for all change types.

## Test plan
- [ ] Merge this PR — confirm CD runs automatically on main push
- [ ] Confirm the deploy job executes (not skipped by the `if:` condition)

Part of #622.

🤖 Generated with [Claude Code](https://claude.com/claude-code)