### PR TITLE
fix(health): cache Redis client in CeleryTaskInterface to prevent cold-start 503

### DIFF
--- a/api/tasks.py
+++ b/api/tasks.py
@@ -131,20 +131,28 @@ class InMemoryTaskInterface:
 class CeleryTaskInterface:
     """Submits tasks to a Celery broker."""
 
-    def health_check(self) -> bool:
+    def __init__(self) -> None:
         from django.conf import settings
         from redis import Redis
 
-        # If we have a broker URL, try a ping.
-        if not settings.CELERY_BROKER_URL:
-            return False
+        self._redis: Redis | None = (
+            Redis.from_url(
+                settings.CELERY_BROKER_URL,
+                socket_connect_timeout=2,
+                socket_timeout=2,
+            )
+            if settings.CELERY_BROKER_URL
+            else None
+        )
 
+    def health_check(self) -> bool:
+        if self._redis is None:
+            return False
         try:
             # Assumes Redis broker; Celery doesn't provide a cheap generic
             # "broker_is_up" without a full connection/handshake.
             # NOTE: Update this if the broker ever changes away from Redis.
-            r = Redis.from_url(settings.CELERY_BROKER_URL, socket_timeout=1)
-            return bool(r.ping())
+            return bool(self._redis.ping())
         except Exception:
             return False
 

--- a/api/tests/test_celery_tasks.py
+++ b/api/tests/test_celery_tasks.py
@@ -55,7 +55,9 @@ class TestCeleryTaskInterface:
         interface = CeleryTaskInterface()
         assert interface.health_check() is True
         mock_redis_from_url.assert_called_once_with(
-            "redis://localhost:6379/0", socket_timeout=1
+            "redis://localhost:6379/0",
+            socket_connect_timeout=2,
+            socket_timeout=2,
         )
 
     @patch("redis.Redis.from_url")


### PR DESCRIPTION
Part of #622.

## Problem

`CeleryTaskInterface.health_check()` called `Redis.from_url(...)` on every invocation — a new TCP connection to Redis every 10 s. On the **first readiness probe** after pod startup (k8s DNS cold, no existing TCP connection to the Redis service), the connect + PING exceeded the 1 s `socket_timeout`, the method returned `False`, and the health endpoint responded 503. The pod recovered on the next probe once the connection existed in OS state.

Event trail from the deploy after #629 landed:
```
3m25s  Startup probe failed: connection refused       (gunicorn loading — expected)
2m42s  Startup probe failed: context deadline exceeded (first slow request — expected)
2m38s  Readiness probe failed: statuscode: 503         ← this PR fixes
```

## Fix

Cache the `Redis` client in `CeleryTaskInterface.__init__` so the connection is established once at startup. `health_check()` reuses the pooled connection on every subsequent call. Also adds `socket_connect_timeout=2` (was unbounded) and raises `socket_timeout` to 2 s.

## Test plan
- [ ] CD deploys — new web pod shows zero `Readiness probe failed` events after startup probe passes
- [ ] `kubectl get events --field-selector type=Warning` shows only `Startup probe failed` entries (expected) and nothing after pod reaches Ready

Part of #622.

🤖 Generated with [Claude Code](https://claude.com/claude-code)