### PR TITLE
fix(k8s): raise startupProbe timeoutSeconds to 10s on web

### DIFF
--- a/chart/glaze/templates/deployment-web.yaml
+++ b/chart/glaze/templates/deployment-web.yaml
@@ -33,7 +33,7 @@ spec:
                   value: {{ .Values.appConfig.allowedHost | default "localhost" | quote }}
             failureThreshold: 20
             periodSeconds: 5
-            timeoutSeconds: 5
+            timeoutSeconds: 10
           livenessProbe:
             httpGet:
               path: /api/health/ready/


### PR DESCRIPTION
Part of #622.

## Problem

Every deploy produced `Startup probe failed: context deadline exceeded` warnings during the web pod's startup window. The health endpoint's first response takes up to ~8 s on a cold single-core node (DB connection pool init, migration executor warm-up) — exceeding the 5 s `timeoutSeconds` on the startup probe.

## Fix

Raise `startupProbe.timeoutSeconds` from 5 s to 10 s. The overall startup budget is unchanged: `failureThreshold: 20 × periodSeconds: 5` still allows 100 s total. The only difference is each individual attempt gets 10 s before timing out, which comfortably covers the cold-start response time.

After this change, the startup window should only produce `connection refused` entries (gunicorn not yet listening) with no `context deadline exceeded`.

Part of #622 — does not close until all warning classes are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)