### PR TITLE
fix(cd): resolve image tag from latest release for chart-only deploys

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -83,6 +83,25 @@ jobs:
           authkey: ${{ secrets.TAILSCALE_AUTH_KEY }}
           tags: tag:ci
 
+      - name: Resolve image tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Chart-only pushes (chart/** or infra/** without a CI run) have no
+          # Docker image built for github.sha. Reuse the most recently deployed
+          # image tag from the latest GitHub release instead.
+          if [ "${{ github.event_name }}" = "push" ] && [ -z "${{ github.event.workflow_run.head_sha }}" ]; then
+            IMAGE_TAG=$(gh release list --repo ${{ github.repository }} --limit 1 --json tagName --jq '.[0].tagName' | sed 's/release-//')
+            if [ -z "$IMAGE_TAG" ]; then
+              echo "ERROR: Could not resolve image tag from latest release." >&2
+              exit 1
+            fi
+            echo "Chart-only deploy: reusing image tag $IMAGE_TAG (not ${{ github.sha }})"
+          else
+            IMAGE_TAG="${{ env.DEPLOY_SHA }}"
+          fi
+          echo "IMAGE_TAG=$IMAGE_TAG" >> "$GITHUB_ENV"
+
       - name: Bootstrap ESO credentials
         env:
           DEPLOY_HOST: ${{ vars.DEPLOY_HOST_TAILSCALE }}
@@ -180,7 +199,7 @@ jobs:
         run: |
           cat > /tmp/values-override.yaml << EOF
           image:
-            tag: "${{ env.DEPLOY_SHA }}"
+            tag: "${IMAGE_TAG}"
           infisical:
             projectSlug: "${INFISICAL_PROJECT_SLUG}"
           appConfig:


### PR DESCRIPTION
## Problem

PR #632 (chart-only `startupProbe` timeout change) triggered CD via the direct
`push` trigger added in PR #630. But `DEPLOY_SHA` resolved to `github.sha` — the
chart-only commit — which has no corresponding Docker image (CI skips `chart/**`).

Result: `ErrImagePull` / `ImagePullBackOff` on the deploy-init job.

## Fix

Add a **Resolve image tag** step before Bootstrap ESO credentials:
- On a chart-only `push` trigger (no `workflow_run.head_sha`), query the latest
  GitHub release tag (created by every successful code deploy) and use that SHA
  as the image tag.
- On all other triggers (`workflow_run`, `workflow_dispatch`), use `DEPLOY_SHA`
  as before.

The `image.tag` in values-override.yaml is then set from `$IMAGE_TAG` (step env)
rather than the workflow-level `${{ env.DEPLOY_SHA }}` expression.

## Test plan
- [ ] Verify next chart-only push triggers CD and deploys successfully without `ErrImagePull`
- [ ] Verify code deploys (triggered via `workflow_run`) still use the correct image SHA

Part of #622.