### PR TITLE
fix(k8s): add initialDelaySeconds to startupProbe on web

### DIFF
--- a/chart/glaze/templates/deployment-web.yaml
+++ b/chart/glaze/templates/deployment-web.yaml
@@ -31,6 +31,7 @@ spec:
               httpHeaders:
                 - name: Host
                   value: {{ .Values.appConfig.allowedHost | default "localhost" | quote }}
+            initialDelaySeconds: 15
             failureThreshold: 20
             periodSeconds: 5
             timeoutSeconds: 10


### PR DESCRIPTION
## Problem

During rollouts, `/api/health/ready/` exceeds the 10s `timeoutSeconds` on the first
probe hit — Django is still doing lazy initialization (DB connections, caches) when
the probe arrives. This burns through the startup budget unnecessarily and generates
Warning events.

## Fix

Add `initialDelaySeconds: 15` to the `startupProbe`. Django has 15s to start listening
before the first probe attempt, after which the normal 20×5s budget applies.

Total startup budget: 15s + 100s = 115s, comfortable for a cold single-core node.

Part of #622.