### PR TITLE
fix(k8s): fix probe timeouts and DNS config for system components

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -118,6 +118,32 @@ jobs:
           ssh -o StrictHostKeyChecking=no "${DEPLOY_HOST}" \
             'KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f -'
 
+      - name: Sync k3s server config
+        env:
+          DEPLOY_HOST: ${{ vars.DEPLOY_HOST_TAILSCALE }}
+        run: |
+          # config.yaml is the k3s server config (not a k8s manifest). Sync it to
+          # /etc/rancher/k3s/config.yaml and restart k3s only if it changed, since
+          # a restart briefly takes down the cluster API.
+          scp -o StrictHostKeyChecking=no infra/k3s/config.yaml \
+            "${DEPLOY_HOST}":/tmp/k3s-config-new.yaml
+          ssh -o StrictHostKeyChecking=no "${DEPLOY_HOST}" '
+            if ! cmp -s /tmp/k3s-config-new.yaml /etc/rancher/k3s/config.yaml; then
+              echo "k3s config changed — applying and restarting k3s..."
+              cp /tmp/k3s-config-new.yaml /etc/rancher/k3s/config.yaml
+              systemctl restart k3s
+              echo "Waiting for k3s API to come back..."
+              for i in $(seq 1 30); do
+                KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl get nodes &>/dev/null && break
+                [ $i -eq 30 ] && echo "ERROR: k3s did not recover after restart" && exit 1
+                sleep 5
+              done
+              echo "k3s restarted and ready."
+            else
+              echo "k3s config unchanged — skipping restart."
+            fi
+          '
+
       - name: Sync k3s manifests
         env:
           DEPLOY_HOST: ${{ vars.DEPLOY_HOST_TAILSCALE }}
@@ -183,6 +209,36 @@ jobs:
               sleep 5
             done
             echo 'glaze-secrets is ready.'
+          "
+
+      - name: Patch system component probe timeouts
+        env:
+          DEPLOY_HOST: ${{ vars.DEPLOY_HOST_TAILSCALE }}
+        run: |
+          # System components (headlamp, cert-manager-webhook, coredns) ship with
+          # timeoutSeconds: 1 probes, which spuriously fail under CPU pressure on
+          # this single-core node. Patch them to 5s. kubectl patch is idempotent —
+          # re-applying the same value is a no-op. The container name is required
+          # as the strategic-merge key so only the named container is targeted.
+          ssh -o StrictHostKeyChecking=no "${DEPLOY_HOST}" "
+            set -e
+            export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+
+            patch_probe_timeout() {
+              local ns=\$1 deploy=\$2 container=\$3 timeout=\$4
+              kubectl patch deployment \$deploy -n \$ns --type=strategic-merge-patch -p \"{
+                \\\"spec\\\":{\\\"template\\\":{\\\"spec\\\":{\\\"containers\\\":[{
+                  \\\"name\\\":\\\"\$container\\\",
+                  \\\"livenessProbe\\\":{\\\"timeoutSeconds\\\":\$timeout},
+                  \\\"readinessProbe\\\":{\\\"timeoutSeconds\\\":\$timeout}
+                }]}}}}\" 2>/dev/null \
+                && echo \\\"Patched \$ns/\$deploy (timeoutSeconds=\$timeout)\\\" \
+                || echo \\\"Skipped \$ns/\$deploy (not found)\\\"
+            }
+
+            patch_probe_timeout kube-system headlamp headlamp 5
+            patch_probe_timeout cert-manager cert-manager-webhook cert-manager-webhook 5
+            patch_probe_timeout kube-system coredns coredns 5
           "
 
       - name: Ship chart and render values override

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -118,7 +118,7 @@ jobs:
           ssh -o StrictHostKeyChecking=no "${DEPLOY_HOST}" \
             'KUBECONFIG=/etc/rancher/k3s/k3s.yaml kubectl apply -f -'
 
-      - name: Sync k3s server config
+      - name: Sync k3s server config and restart if changed
         env:
           DEPLOY_HOST: ${{ vars.DEPLOY_HOST_TAILSCALE }}
         run: |
@@ -226,14 +226,20 @@ jobs:
 
             patch_probe_timeout() {
               local ns=\$1 deploy=\$2 container=\$3 timeout=\$4
+              # Suppress only "not found" (exit 1 from kubectl when the deployment
+              # doesn't exist yet). Other errors (API unreachable, bad kubeconfig)
+              # still surface via stderr so they don't silently skip a real failure.
+              if ! kubectl get deployment \$deploy -n \$ns &>/dev/null; then
+                echo \"Skipped \$ns/\$deploy (not found)\"
+                return 0
+              fi
               kubectl patch deployment \$deploy -n \$ns --type=strategic-merge-patch -p \"{
                 \\\"spec\\\":{\\\"template\\\":{\\\"spec\\\":{\\\"containers\\\":[{
                   \\\"name\\\":\\\"\$container\\\",
                   \\\"livenessProbe\\\":{\\\"timeoutSeconds\\\":\$timeout},
                   \\\"readinessProbe\\\":{\\\"timeoutSeconds\\\":\$timeout}
-                }]}}}}\" 2>/dev/null \
-                && echo \\\"Patched \$ns/\$deploy (timeoutSeconds=\$timeout)\\\" \
-                || echo \\\"Skipped \$ns/\$deploy (not found)\\\"
+                }]}}}}\"
+              echo \\\"Patched \$ns/\$deploy (timeoutSeconds=\$timeout)\\\"
             }
 
             patch_probe_timeout kube-system headlamp headlamp 5

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -226,9 +226,10 @@ jobs:
 
             patch_probe_timeout() {
               local ns=\$1 deploy=\$2 container=\$3 timeout=\$4
-              # Suppress only "not found" (exit 1 from kubectl when the deployment
-              # doesn't exist yet). Other errors (API unreachable, bad kubeconfig)
-              # still surface via stderr so they don't silently skip a real failure.
+              # &>/dev/null suppresses all output — both "not found" and API errors.
+              # API errors would surface from kubectl patch below if get succeeds;
+              # in practice this step runs after the API is confirmed reachable by
+              # "Wait for cluster dependencies".
               if ! kubectl get deployment \$deploy -n \$ns &>/dev/null; then
                 echo \"Skipped \$ns/\$deploy (not found)\"
                 return 0

--- a/infra/k3s/config.yaml
+++ b/infra/k3s/config.yaml
@@ -11,3 +11,9 @@ kube-controller-manager-arg:
   - "concurrent-statefulset-syncs=2"
   - "concurrent-service-syncs=1"
   - "concurrent-job-syncs=2"
+# Use the uplink resolv.conf (direct DigitalOcean nameservers) instead of the
+# systemd-resolved stub. The stub resolver path (/etc/resolv.conf → 127.0.0.53)
+# causes kubelet to see Tailscale's extra nameservers and exceed the 3-nameserver
+# pod limit, producing continuous DNSConfigForming warnings in every pod.
+kubelet-arg:
+  - "resolv-conf=/run/systemd/resolve/resolv.conf"


### PR DESCRIPTION
## Problems

Three persistent warning classes observed on the single-core 2GB node:

### 1. `DNSConfigForming` (every pod, 16h+)
Tailscale injects nameservers via the systemd-resolved stub (`127.0.0.53`), pushing the total nameserver count past Kubernetes' 3-server pod limit. Kubelet silently drops servers and logs a `DNSConfigForming` warning for every pod.

**Fix:** Add `kubelet-arg: resolv-conf=/run/systemd/resolve/resolv.conf` to `infra/k3s/config.yaml`. The uplink resolv.conf has only DigitalOcean's two nameservers (`67.207.67.3`, `67.207.67.2`) — no Tailscale stub. A new "Sync k3s server config" CD step SCPs `config.yaml` and restarts k3s only when the file changes.

### 2. headlamp liveness/readiness failures (3 restarts, ongoing)
### 3. cert-manager-webhook liveness/readiness failures (**30 restarts**, ongoing)
### 4. CoreDNS readiness failures (x216 over 16h)

All three ship with `timeoutSeconds: 1` probes. Under CPU pressure on a single core (especially during app rollouts), health endpoints can't respond in 1s. The cert-manager-webhook's 30 restarts mean TLS certificate issuance has been repeatedly disrupted.

cert-manager is kubectl-installed (not helm-managed), so probe settings can't be overridden via chart values.

**Fix:** Add a "Patch system component probe timeouts" CD step that uses `kubectl patch --type=strategic-merge-patch` to set `timeoutSeconds: 5` on headlamp, cert-manager-webhook, and coredns. The patch is idempotent — re-applying the same value is a no-op.

## Test plan
- [ ] Merge and confirm CD runs the two new steps without error
- [ ] After deploy: `kubectl get events -A --field-selector type=Warning` shows no new `DNSConfigForming` or `Unhealthy` events from these components
- [ ] cert-manager-webhook restart count stabilizes

Part of #622.