### PR TITLE
fix(k8s): pin coredns forwarders to deduplicate DigitalOcean nameservers

### DIFF
--- a/infra/k3s/coredns-custom.yaml
+++ b/infra/k3s/coredns-custom.yaml
@@ -1,0 +1,20 @@
+# WHY: k3s's coredns manifest reads /run/systemd/resolve/resolv.conf (the uplink
+# resolver) instead of the systemd-resolved stub at 127.0.0.53, to avoid
+# Tailscale injecting extra nameservers that exceed the 3-nameserver pod limit.
+# However, the DigitalOcean uplink resolv.conf has a duplicate 67.207.67.3 entry,
+# which triggers a DNSConfigForming warning on every pod:
+#   "Nameserver limits were exceeded, some nameservers have been omitted"
+#
+# The k3s coredns Deployment mounts a ConfigMap named "coredns-custom" (optional)
+# at /etc/coredns/custom/, and the Corefile already contains:
+#   import /etc/coredns/custom/*.override
+# This file overrides the forward directive with the two unique DO nameservers,
+# bypassing the node resolv.conf entirely for upstream resolution.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-custom
+  namespace: kube-system
+data:
+  forward.override: |
+    forward . 67.207.67.2 67.207.67.3

--- a/infra/k3s/probe-timeouts.yaml
+++ b/infra/k3s/probe-timeouts.yaml
@@ -19,6 +19,7 @@
 #    pod ("Nameserver limits were exceeded, some nameservers have been omitted").
 #    Fix: pin coredns's upstream forwarders to the two unique DO nameservers
 #    explicitly, bypassing the node resolv.conf entirely for upstream resolution.
+#    (implemented in coredns-custom.yaml)
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChartConfig

--- a/infra/k3s/probe-timeouts.yaml
+++ b/infra/k3s/probe-timeouts.yaml
@@ -44,10 +44,3 @@ spec:
       timeoutSeconds: 5
     readinessProbe:
       timeoutSeconds: 5
-    servers:
-    - zones:
-      - zone: .
-      port: 53
-      plugins:
-      - name: forward
-        parameters: ". 67.207.67.2 67.207.67.3"

--- a/infra/k3s/probe-timeouts.yaml
+++ b/infra/k3s/probe-timeouts.yaml
@@ -1,16 +1,24 @@
 # WHY: This cluster runs on a single-core DigitalOcean droplet (~2 GB RAM).
-# Under CPU pressure (image pulls, rollouts, GC spikes), the default
-# timeoutSeconds: 1 on system component probes causes spurious failures and
-# unnecessary pod restarts that further destabilize the node.
+# Two classes of problems are addressed here via HelmChartConfig overrides —
+# the k3s-native declarative alternative to imperative kubectl patch.
+# k3s merges these values into the managed HelmChart on every reconcile.
 #
-# Fix: override probe timeouts to 5s via HelmChartConfig. This is the
-# declarative k3s-native alternative to imperative `kubectl patch` — k3s
-# merges these values into the managed HelmChart on every reconcile.
+# 1. PROBE TIMEOUTS
+#    The default timeoutSeconds: 1 on system component probes causes spurious
+#    failures under CPU pressure (image pulls, rollouts, GC spikes), triggering
+#    unnecessary pod restarts that further destabilize the node.
+#    Fix: raise probe timeouts to 5s on cert-manager-webhook and coredns.
+#    (headlamp is set directly in headlamp.yaml valuesContent)
 #
-# Affected components and their default timeoutSeconds:
-#   cert-manager webhook : 1s  (webhook.livenessProbe / webhook.readinessProbe)
-#   coredns              : 1s  (livenessProbe / readinessProbe)
-#   headlamp             : 1s  (set directly in headlamp.yaml valuesContent)
+# 2. COREDNS NAMESERVER DEDUPLICATION
+#    kubelet is configured to read /run/systemd/resolve/resolv.conf (the uplink
+#    resolver) instead of the systemd-resolved stub at 127.0.0.53, to avoid
+#    Tailscale injecting extra nameservers that exceed the 3-nameserver pod limit.
+#    However, the DigitalOcean uplink resolv.conf itself contains a duplicate
+#    entry for 67.207.67.3, which produces a DNSConfigForming warning on every
+#    pod ("Nameserver limits were exceeded, some nameservers have been omitted").
+#    Fix: pin coredns's upstream forwarders to the two unique DO nameservers
+#    explicitly, bypassing the node resolv.conf entirely for upstream resolution.
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChartConfig
@@ -36,3 +44,10 @@ spec:
       timeoutSeconds: 5
     readinessProbe:
       timeoutSeconds: 5
+    servers:
+    - zones:
+      - zone: .
+      port: 53
+      plugins:
+      - name: forward
+        parameters: ". 67.207.67.2 67.207.67.3"


### PR DESCRIPTION
## Summary

- DigitalOcean's uplink \`resolv.conf\` (\`/run/systemd/resolve/resolv.conf\`) contains a duplicate \`67.207.67.3\` entry
- kubelet reads this file directly (per the PR #637 fix that avoided Tailscale's extra nameservers overflowing the 3-entry pod limit)
- The duplicate triggers a \`DNSConfigForming\` warning on every pod: _"Nameserver limits were exceeded, some nameservers have been omitted"_
- Fix: add \`infra/k3s/coredns-custom.yaml\` — a ConfigMap named \`coredns-custom\` in \`kube-system\` containing a \`forward.override\` file that replaces \`forward . /etc/resolv.conf\` with the two unique DO nameservers (\`67.207.67.2\`, \`67.207.67.3\`)

The k3s coredns Deployment already mounts this ConfigMap at \`/etc/coredns/custom/\` (\`optional: true\`), and the live Corefile already contains \`import /etc/coredns/custom/*.override\`. No changes to the Deployment or Corefile are needed.

Note: \`HelmChartConfig\` \`valuesContent\` was considered but does not apply here — k3s manages coredns via a raw manifest, not a Helm release, so Helm values never reach the Corefile.

No operator action required — \`ensure_cluster.sh\` syncs all \`infra/k3s/*.yaml\` manifests on every deploy.

## Test plan

- [ ] Wait ~60s after deploy for coredns \`reload\` plugin to pick up the ConfigMap change
- [ ] Confirm \`kubectl get events -A --field-selector type=Warning\` no longer shows \`DNSConfigForming\` entries
- [ ] Confirm cluster DNS still resolves external names correctly (e.g. \`kubectl run -it --rm dns-test --image=busybox --restart=Never -- nslookup potterdoc.com\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)