### PR TITLE
fix(k8s): deduplicate coredns nameservers via coredns-custom ConfigMap

### DIFF
--- a/infra/k3s/coredns-custom.yaml
+++ b/infra/k3s/coredns-custom.yaml
@@ -1,0 +1,20 @@
+# WHY: k3s's coredns manifest reads /run/systemd/resolve/resolv.conf (the uplink
+# resolver) instead of the systemd-resolved stub at 127.0.0.53, to avoid
+# Tailscale injecting extra nameservers that exceed the 3-nameserver pod limit.
+# However, the DigitalOcean uplink resolv.conf has a duplicate 67.207.67.3 entry,
+# which triggers a DNSConfigForming warning on every pod:
+#   "Nameserver limits were exceeded, some nameservers have been omitted"
+#
+# The k3s coredns Deployment mounts a ConfigMap named "coredns-custom" (optional)
+# at /etc/coredns/custom/, and the Corefile already contains:
+#   import /etc/coredns/custom/*.override
+# This file overrides the forward directive with the two unique DO nameservers,
+# bypassing the node resolv.conf entirely for upstream resolution.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-custom
+  namespace: kube-system
+data:
+  forward.override: |
+    forward . 67.207.67.2 67.207.67.3

--- a/infra/k3s/probe-timeouts.yaml
+++ b/infra/k3s/probe-timeouts.yaml
@@ -11,6 +11,17 @@
 #   cert-manager webhook : 1s  (webhook.livenessProbe / webhook.readinessProbe)
 #   coredns              : 1s  (livenessProbe / readinessProbe)
 #   headlamp             : 1s  (set directly in headlamp.yaml valuesContent)
+#
+# COREDNS NAMESERVER DEDUPLICATION
+#    kubelet is configured to read /run/systemd/resolve/resolv.conf (the uplink
+#    resolver) instead of the systemd-resolved stub at 127.0.0.53, to avoid
+#    Tailscale injecting extra nameservers that exceed the 3-nameserver pod limit.
+#    However, the DigitalOcean uplink resolv.conf itself contains a duplicate
+#    entry for 67.207.67.3, which produces a DNSConfigForming warning on every
+#    pod ("Nameserver limits were exceeded, some nameservers have been omitted").
+#    Fix: pin coredns's upstream forwarders to the two unique DO nameservers
+#    explicitly, bypassing the node resolv.conf entirely for upstream resolution.
+#    (implemented in coredns-custom.yaml)
 ---
 apiVersion: helm.cattle.io/v1
 kind: HelmChartConfig


### PR DESCRIPTION
## Summary

Cherry-pick of the coredns nameserver fix from #644 (which landed on an intermediate branch) onto main.

- DigitalOcean's uplink `resolv.conf` (`/run/systemd/resolve/resolv.conf`) contains a duplicate `67.207.67.3` entry
- kubelet reads this file directly (PR #637 fix for Tailscale nameserver overflow)
- The duplicate triggers a `DNSConfigForming` warning on every pod: _"Nameserver limits were exceeded, some nameservers have been omitted"_
- Fix: add `infra/k3s/coredns-custom.yaml` — a ConfigMap named `coredns-custom` in `kube-system` with a `forward.override` file pinning upstream resolvers to the two unique DO nameservers (`67.207.67.2`, `67.207.67.3`)

The k3s coredns Deployment already mounts this ConfigMap at `/etc/coredns/custom/` (`optional: true`), and the Corefile already has `import /etc/coredns/custom/*.override`. No changes to the Deployment or Corefile needed.

`ensure_cluster.sh` syncs all `infra/k3s/*.yaml` on every deploy — no operator action required.

## Test plan

- [ ] Wait ~60s after deploy for coredns `reload` plugin to pick up the ConfigMap
- [ ] `kubectl get events -A --field-selector type=Warning` — no `DNSConfigForming` entries
- [ ] `kubectl run -it --rm dns-test --image=busybox --restart=Never -- nslookup potterdoc.com` — resolves correctly

Closes #622

🤖 Generated with [Claude Code](https://claude.com/claude-code)