### PR TITLE
fix(k8s): use static /etc/k3s-resolv.conf to eliminate DNSConfigForming warnings

### DIFF
--- a/infra/k3s/config.yaml
+++ b/infra/k3s/config.yaml
@@ -23,9 +23,16 @@ kube-controller-manager-arg:
   - "concurrent-statefulset-syncs=2"
   - "concurrent-service-syncs=1"
   - "concurrent-job-syncs=2"
-# Use the uplink resolv.conf (direct DigitalOcean nameservers) instead of the
-# systemd-resolved stub. The stub resolver path (/etc/resolv.conf → 127.0.0.53)
-# causes kubelet to see Tailscale's extra nameservers and exceed the 3-nameserver
-# pod limit, producing continuous DNSConfigForming warnings in every pod.
+# Point kubelet at a static resolv.conf with only the two unique DigitalOcean
+# nameservers. Two problems make the standard paths unusable:
+#   /etc/resolv.conf → 127.0.0.53 (systemd stub): Tailscale injects extra
+#     nameservers via systemd-resolved, pushing the total past the 3-entry pod
+#     limit and producing DNSConfigForming warnings on every pod.
+#   /run/systemd/resolve/resolv.conf (uplink): DO's DHCP pushes 67.207.67.3
+#     twice AND Tailscale adds more entries; the first three lines seen by
+#     kubelet are "67.207.67.3 67.207.67.2 67.207.67.3" — a duplicate — which
+#     still triggers the DNSConfigForming warning before deduplication.
+# Fix: ensure_cluster.sh writes /etc/k3s-resolv.conf with exactly the two
+# unique DO nameservers; kubelet reads that instead of either dynamic path.
 kubelet-arg:
-  - "resolv-conf=/run/systemd/resolve/resolv.conf"
+  - "resolv-conf=/etc/k3s-resolv.conf"

--- a/tools/ensure_cluster.sh
+++ b/tools/ensure_cluster.sh
@@ -2,12 +2,13 @@
 # Ensures the cluster is fully ready to accept a Helm deploy.
 #
 # CONTRACT: when this script exits 0, the following are all true:
-#   1. k3s is running with the config declared in infra/k3s/config.yaml
-#   2. All k3s auto-deploy manifests (ESO HelmChart, HelmChartConfig overrides,
+#   1. /etc/k3s-resolv.conf exists with the two unique DO nameservers
+#   2. k3s is running with the config declared in infra/k3s/config.yaml
+#   3. All k3s auto-deploy manifests (ESO HelmChart, HelmChartConfig overrides,
 #      cert-manager, headlamp, etc.) are present on the node
-#   3. External Secrets Operator is installed and its deployment is rollout-ready
-#   4. The Infisical machine identity is present as the infisical-auth Secret
-#   5. glaze-secrets exists in the default namespace (ESO has synced from Infisical)
+#   4. External Secrets Operator is installed and its deployment is rollout-ready
+#   5. The Infisical machine identity is present as the infisical-auth Secret
+#   6. glaze-secrets exists in the default namespace (ESO has synced from Infisical)
 #
 # Idempotent: each step is a no-op when already converged. Safe to run on every
 # deploy — fast on a healthy cluster, self-healing on a degraded one.
@@ -18,6 +19,15 @@ set -euo pipefail
 DEPLOY_HOST="${1:?Usage: ensure_cluster.sh <deploy_host>}"
 SSH="ssh -o StrictHostKeyChecking=no"
 SCP="scp -o StrictHostKeyChecking=no"
+
+# ── static kubelet resolv.conf ───────────────────────────────────────────────
+# Write /etc/k3s-resolv.conf with only the two unique DO nameservers.
+# See infra/k3s/config.yaml for why neither dynamic path is safe to use.
+echo "==> Writing /etc/k3s-resolv.conf..."
+$SSH "${DEPLOY_HOST}" 'cat > /etc/k3s-resolv.conf <<EOF
+nameserver 67.207.67.2
+nameserver 67.207.67.3
+EOF'
 
 # ── k3s server config ────────────────────────────────────────────────────────
 echo "==> Syncing k3s server config..."


### PR DESCRIPTION
## Summary

The `DNSConfigForming` warning ("Nameserver limits were exceeded, some nameservers have been omitted") persists because the root cause is at the kubelet level, not the coredns level.

**Root cause:** `/run/systemd/resolve/resolv.conf` (the uplink file kubelet currently reads) has 6 nameserver entries — DigitalOcean's DHCP pushes `67.207.67.3` twice and Tailscale adds more via systemd-resolved. Kubelet takes the first 3 for each pod's DNS config: `67.207.67.3 67.207.67.2 67.207.67.3`. The duplicate triggers the warning before deduplication removes it.

Neither standard path is safe:
- `/etc/resolv.conf` → `127.0.0.53` (systemd stub): Tailscale injects extra nameservers, pushing total past the 3-entry pod limit
- `/run/systemd/resolve/resolv.conf` (uplink): duplicate entry triggers the warning

**Fix:** `ensure_cluster.sh` writes `/etc/k3s-resolv.conf` with exactly the two unique DO nameservers (`67.207.67.2`, `67.207.67.3`). `config.yaml` points kubelet at that static file.

Since `config.yaml` changes, `ensure_cluster.sh` will detect the diff and restart k3s.

## Test plan

- [ ] After deploy, `kubectl get events -A --field-selector type=Warning` — no `DNSConfigForming` entries on new pods
- [ ] `kubectl run -it --rm dns-test --image=busybox --restart=Never -- nslookup potterdoc.com` resolves correctly

Closes #622

🤖 Generated with [Claude Code](https://claude.com/claude-code)