### PR TITLE
fix: enforce tailnet-only admin ingress

### DIFF
--- a/chart/glaze/templates/ingress-admin.yaml
+++ b/chart/glaze/templates/ingress-admin.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- end }}
     {{- end }}
     {{- end }}
-    traefik.ingress.kubernetes.io/router.middlewares: default-{{ $fullName }}-security-headers@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: default-{{ $fullName }}-security-headers@kubernetescrd, default-{{ $fullName }}-tailscale-only@kubernetescrd
 spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}

--- a/chart/glaze/templates/middleware-tailscale-only.yaml
+++ b/chart/glaze/templates/middleware-tailscale-only.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.ingress.enabled .Values.adminIngress.enabled -}}
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ include "glaze.fullname" . }}-tailscale-only
+  labels:
+    {{- include "glaze.labels" . | nindent 4 }}
+spec:
+  ipAllowList:
+    sourceRange:
+      - {{ .Values.network.tailscaleCidr | quote }}
+{{- end }}

--- a/tests/test_admin_access.py
+++ b/tests/test_admin_access.py
@@ -16,3 +16,35 @@ def test_admin_ingress_routes_static_assets():
 
     assert "path: /static/" in admin_ingress
     assert "path: /static/" in admin_public_ingress
+
+
+def test_admin_ingress_is_tailnet_only():
+    repo_root = Path(__file__).resolve().parents[1]
+    admin_ingress = (
+        repo_root / "chart/glaze/templates/ingress-admin.yaml"
+    ).read_text()
+    middleware = (
+        repo_root / "chart/glaze/templates/middleware-tailscale-only.yaml"
+    ).read_text()
+
+    assert (
+        "default-{{ $fullName }}-security-headers@kubernetescrd" in admin_ingress
+    )
+    assert "default-{{ $fullName }}-tailscale-only@kubernetescrd" in admin_ingress
+    assert '{{ .Values.network.tailscaleCidr | quote }}' in middleware
+
+
+def test_public_admin_ingress_remains_explicitly_public():
+    repo_root = Path(__file__).resolve().parents[1]
+    admin_public_ingress = (
+        repo_root / "chart/glaze/templates/ingress-admin-public.yaml"
+    ).read_text()
+
+    assert (
+        "default-{{ $fullName }}-security-headers@kubernetescrd"
+        in admin_public_ingress
+    )
+    assert (
+        "default-{{ $fullName }}-tailscale-only@kubernetescrd"
+        not in admin_public_ingress
+    )


### PR DESCRIPTION
## Summary

- Adds a chart-owned `glaze-tailscale-only` Traefik middleware using the configured Tailscale CIDR.
- Applies that middleware to the private `glaze-admin` ingress alongside the existing security headers middleware.
- Adds regression tests so private admin stays tailnet-only while the explicit public-admin escape hatch remains public.

## Why

The production audit found that `admin.potterdoc.com` normally resolves through Tailscale, but the origin ingress itself did not enforce the Tailscale allowlist. A direct origin-IP request with the admin Host header could reach Django instead of being denied at Traefik.

Closes #654

## Validation

- `rtk bazel test //tests:common_test --test_output=errors`
- `rtk bazel build --config=lint //tests:common_test`
- `git diff --check`
- Remote read-only Helm validation on production host temp chart:
  - `helm lint`
  - `helm template` confirmed `glaze-admin` renders both `glaze-security-headers` and `glaze-tailscale-only`
  - rendered middleware uses `100.64.0.0/10`
