### PR TITLE
chore: restrict production host firewall exposure

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -78,12 +78,22 @@ Triggers:
 Also runs unconditionally as the first step of `cd.yml` (`Ensure cluster`) — so every deploy self-heals a degraded cluster without manual intervention.
 
 Runs `tools/ensure_cluster.sh`:
-1. Sync `/etc/rancher/k3s/config.yaml` and restart k3s if changed
-2. Sync k3s auto-deploy manifests to `/var/lib/rancher/k3s/server/manifests/`
+1. Converge the host firewall so public internet reaches only HTTP/HTTPS app
+   ingress; SSH, Kubernetes API, kubelet, and cluster administration stay
+   behind Tailscale
+2. Sync `/etc/rancher/k3s/config.yaml` and restart k3s if changed
+3. Sync k3s auto-deploy manifests to `/var/lib/rancher/k3s/server/manifests/`
    (includes `probe-timeouts.yaml` — declarative `HelmChartConfig` for system component probe timeouts)
-3. Bootstrap Infisical machine identity as a Kubernetes Secret for ESO
-4. Wait for ESO to be ready
-5. Wait for the Tailscale front door (`traefik-tailscale`) to report `TailscaleProxyReady=True` and an assigned `100.x` IP
+4. Bootstrap Infisical machine identity as a Kubernetes Secret for ESO
+5. Wait for ESO to be ready
+6. Wait for the Tailscale front door (`traefik-tailscale`) to report `TailscaleProxyReady=True` and an assigned `100.x` IP
+
+The firewall is managed by a host `systemd` oneshot service named
+`glaze-host-firewall.service`, which loads `/etc/glaze-host-firewall.nft`.
+The nftables INPUT policy allows loopback, established traffic, `tailscale0`,
+k3s internal interfaces (`cni0`, `flannel.1`), public `80/tcp` and `443/tcp`,
+and drops all other host INPUT traffic, including public `22/tcp`, `6443/tcp`,
+`10250/tcp`, Tailscale direct `41641/udp`, and incidental NodePorts.
 
 ---
 

--- a/tests/test_host_firewall.py
+++ b/tests/test_host_firewall.py
@@ -1,0 +1,40 @@
+"""Regression tests for production host firewall convergence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _ensure_cluster_script() -> str:
+    return (
+        Path(__file__).resolve().parents[1] / "tools" / "ensure_cluster.sh"
+    ).read_text()
+
+
+def test_ensure_cluster_converges_host_firewall():
+    script = _ensure_cluster_script()
+
+    assert "glaze_host_firewall" in script
+    assert "glaze-host-firewall.service" in script
+    assert "glaze-host-firewall-apply" in script
+    assert "nft delete table inet glaze_host_firewall" in script
+    assert "systemctl enable glaze-host-firewall.service" in script
+    assert "systemctl restart glaze-host-firewall.service" in script
+
+
+def test_host_firewall_keeps_public_surface_intentional():
+    script = _ensure_cluster_script()
+
+    assert 'iif "tailscale0" accept' in script
+    assert 'iifname { "cni0", "flannel.1" } accept' in script
+    assert "tcp dport { 80, 443 } accept" in script
+    assert "udp dport 41641 accept" not in script
+    assert "counter drop" in script
+
+
+def test_host_firewall_documents_sensitive_ports():
+    script = _ensure_cluster_script()
+
+    assert "public kube API" in script
+    assert "kubelet" in script
+    assert "incidental NodePorts" in script

--- a/tools/ensure_cluster.sh
+++ b/tools/ensure_cluster.sh
@@ -10,6 +10,7 @@
 #   5. The Infisical machine identity is present as the infisical-auth Secret
 #   6. glaze-secrets exists in the default namespace (ESO has synced from Infisical)
 #   7. traefik-tailscale is ready and has an assigned Tailscale IP
+#   8. host firewall drops public control-plane and incidental NodePort traffic
 #
 # Idempotent: each step is a no-op when already converged. Safe to run on every
 # deploy — fast on a healthy cluster, self-healing on a degraded one.
@@ -21,6 +22,76 @@ DEPLOY_HOST="${1:?Usage: ensure_cluster.sh <deploy_host>}"
 SSH="ssh -o StrictHostKeyChecking=no"
 SCP="scp -o StrictHostKeyChecking=no"
 INFISICAL_PROJECT_SLUG="${INFISICAL_PROJECT_SLUG:?INFISICAL_PROJECT_SLUG must be set}"
+
+# ── host firewall ────────────────────────────────────────────────────────────
+# Keep the host's public surface intentionally small. The app edge remains
+# reachable on 80/443; SSH and cluster administration use Tailscale.
+echo "==> Converging host firewall..."
+$SSH "${DEPLOY_HOST}" 'bash -s' <<'ENDSSH'
+set -euo pipefail
+
+if ! command -v nft >/dev/null 2>&1; then
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update
+  apt-get install -y nftables
+fi
+
+cat > /etc/glaze-host-firewall.nft <<'EOF'
+table inet glaze_host_firewall {
+  chain input {
+    type filter hook input priority -100; policy accept;
+
+    iif "lo" accept
+    ct state established,related accept
+
+    # Private administration and Kubernetes-internal traffic.
+    iif "tailscale0" accept
+    iifname { "cni0", "flannel.1" } accept
+
+    # Public app ingress.
+    tcp dport { 80, 443 } accept
+
+    # Everything else on the host INPUT path includes public kube API, kubelet,
+    # and incidental NodePorts. Kubernetes pod/service forwarding is untouched.
+    counter drop
+  }
+}
+EOF
+
+cat > /usr/local/sbin/glaze-host-firewall-apply <<'EOF'
+#!/usr/bin/env sh
+set -eu
+
+if /usr/sbin/nft list table inet glaze_host_firewall >/dev/null 2>&1; then
+  /usr/sbin/nft delete table inet glaze_host_firewall
+fi
+
+exec /usr/sbin/nft -f /etc/glaze-host-firewall.nft
+EOF
+chmod 0755 /usr/local/sbin/glaze-host-firewall-apply
+
+cat > /etc/systemd/system/glaze-host-firewall.service <<'EOF'
+[Unit]
+Description=Glaze host firewall
+Documentation=https://github.com/shaoster/glaze
+After=network-online.target tailscaled.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/glaze-host-firewall-apply
+ExecReload=/usr/local/sbin/glaze-host-firewall-apply
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable glaze-host-firewall.service
+systemctl restart glaze-host-firewall.service
+nft list table inet glaze_host_firewall >/dev/null
+ENDSSH
 
 # ── static kubelet resolv.conf ───────────────────────────────────────────────
 # Write /etc/k3s-resolv.conf with only the two unique DO nameservers.


### PR DESCRIPTION
## Summary

- Adds a convergent host firewall step to `tools/ensure_cluster.sh` using nftables.
- Allows public app ingress only on `80/tcp` and `443/tcp`.
- Allows all traffic arriving on `tailscale0`, preserving tailnet SSH, admin, app, and Kubernetes access.
- Allows k3s internal traffic on `cni0` and `flannel.1`.
- Drops other public host INPUT traffic, including public SSH, Kubernetes API, kubelet, Tailscale direct UDP, and incidental NodePorts.
- Documents the firewall model and adds static regression tests.

## Why

A production security audit found that Kubernetes/control-plane and incidental host ports were publicly reachable and relying only on service authentication. This makes the intended network model convergent through CD instead of relying on manual host state.

Closes #655

## Validation

- `bash -n tools/ensure_cluster.sh`
- `rtk bazel test //tools:test_ensure_cluster_syntax //tests:common_test --test_output=errors`
- `rtk bazel build --config=lint //tools:test_ensure_cluster_syntax //tests:common_test`
- `git diff --check`
- Remote non-mutating `nft -c -f` parse check on the production host

## Rollout Note

This PR does not manually apply firewall rules. The firewall converges when `ensure_cluster.sh` runs through cluster setup/CD.
