### PR TITLE
fix(helm): run celery worker with --pool=solo to halve idle RSS

### DIFF
--- a/chart/glaze/templates/deployment-worker.yaml
+++ b/chart/glaze/templates/deployment-worker.yaml
@@ -20,6 +20,7 @@ spec:
         - name: worker
           image: "{{ .Values.worker.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["python", "-m", "celery", "-A", "backend", "worker", "-l", "INFO", "--pool=solo"]
           securityContext:
             runAsUser: 1001
             runAsGroup: 1001

--- a/chart/glaze/values.yaml
+++ b/chart/glaze/values.yaml
@@ -97,7 +97,7 @@ worker:
       memory: "64Mi"
       cpu: "50m"
     limits:
-      memory: "200Mi"
+      memory: "128Mi"
 
 otelcol:
   enabled: true


### PR DESCRIPTION
## Problem

Investigated why the celery worker uses ~162 MiB at idle despite processing no tasks. Root cause: Celery's default prefork pool spawns a master process + one child process, each loading the full Django app (~93 MiB + ~100 MiB RSS). The child exists purely to execute tasks — at idle it just sits there consuming memory.

## Change

Adds `--pool=solo` via a `command:` override in the worker deployment template. Solo pool runs the worker in a single process (~80 MiB expected), eliminating the idle child fork entirely. Also drops the worker memory limit from 200 MiB → 128 MiB to match.

No image rebuild needed — the `command:` field overrides the image entrypoint.

**Tradeoff:** tasks run synchronously in the main process (non-preemptible). Acceptable for current light usage; revert to prefork if concurrent task throughput becomes a requirement.

## Verification

- Before: 2 python processes, ~162 MiB combined RSS (cgroup `memory.current`)
- Expected after: 1 python process, ~80 MiB RSS
