### PR TITLE
fix(infra): add resource requests to traefik and tailscale proxy to prevent OOM eviction

### DIFF
--- a/infra/k3s/tailscale-operator.yaml
+++ b/infra/k3s/tailscale-operator.yaml
@@ -36,6 +36,23 @@ spec:
         remoteRef:
           key: TAILSCALE_OAUTH_CLIENT_SECRET
 ---
+# Set resource requests on all Tailscale proxy pods (ts-traefik-tailscale etc.)
+# so they get Burstable QoS and a lower OOM kill priority than BestEffort pods.
+# Actual idle RSS for ts-traefik-tailscale is ~46 MiB.
+apiVersion: tailscale.com/v1alpha1
+kind: ProxyClass
+metadata:
+  name: default
+  namespace: tailscale
+spec:
+  statefulSet:
+    pod:
+      tailscaleContainer:
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "64Mi"
+---
 apiVersion: helm.cattle.io/v1
 kind: HelmChart
 metadata:

--- a/infra/k3s/traefik.yaml
+++ b/infra/k3s/traefik.yaml
@@ -43,12 +43,17 @@ spec:
           type: "LoadBalancer"
           annotations:
             external-dns.alpha.kubernetes.io/hostname: "admin.potterdoc.com,headlamp.potterdoc.com"
+            tailscale.com/proxy-class: "default"
           spec:
             loadBalancerClass: "tailscale"
     ports:
       websecure:
         expose:
           tailscale: true
+    resources:
+      requests:
+        cpu: "50m"
+        memory: "64Mi"
     updateStrategy:
       type: "RollingUpdate"
       rollingUpdate:


### PR DESCRIPTION
## Problem

On the single-core 2 GiB node, Helm's default behaviour triggers all Deployment rollouts simultaneously. With `maxSurge:1` this means two web pods (~128 MiB each) and two worker pods (~99 MiB each) run concurrently during every deploy — a ~230 MiB transient spike on a node already near its resident set limit. This is what caused the OOM cascade today.

## Changes

**`infra/k3s/traefik.yaml`** — resource requests on traefik → Burstable QoS, protected from OOM kills

**`infra/k3s/tailscale-operator.yaml`** — `ProxyClass` with resource requests on Tailscale proxy pods → Burstable QoS for `ts-traefik-tailscale`

**`tools/helm_deploy.sh`** — sequential rollout strategy:
1. Pause `glaze-web` and `glaze-worker` before `helm upgrade`
2. `helm upgrade` applies the new specs without triggering pod churn
3. Resume and wait for `glaze-web` to fully roll out
4. Then resume and wait for `glaze-worker`

This keeps `maxSurge:1` (zero per-service downtime) while eliminating concurrent pod generations across services. Peak memory impact per deploy drops from ~230 MiB to ~130 MiB (one surge at a time).

`glaze-otelcol` is excluded — it has its own image and rarely rolls alongside app changes.

## Verification

After merge, watch a deploy and confirm only one new pod appears at a time in `kubectl get pods -n default -w`.
