### PR TITLE
fix(cd): roll web and worker sequentially to reduce deploy memory pressure

### DIFF
--- a/tools/helm_deploy.sh
+++ b/tools/helm_deploy.sh
@@ -32,11 +32,34 @@ $SSH "${DEPLOY_HOST}" << 'ENDSSH'
     helm rollback glaze -n default --wait --timeout 2m
   fi
 
-  helm_upgrade() {
+  # Deployments to roll sequentially, in order. Each is paused before the
+  # helm upgrade so Kubernetes accepts the new spec without immediately
+  # starting pods, then resumed one at a time to avoid concurrent memory
+  # spikes on the single-core node.
+  SEQUENTIAL_DEPLOYMENTS="glaze-web glaze-worker"
+
+  rollout_sequential() {
+    echo "==> Pausing deployments before upgrade..."
+    for dep in $SEQUENTIAL_DEPLOYMENTS; do
+      kubectl rollout pause deployment/$dep -n default 2>/dev/null || true
+    done
+
+    echo "==> Applying Helm chart (no wait — rollouts are paused)..."
     helm upgrade --install glaze ~/glaze-chart-deploy/glaze/ \
       -f ~/glaze-values-override.yaml \
-      --timeout 5m \
-      --wait &
+      --timeout 5m
+
+    echo "==> Rolling deployments sequentially..."
+    for dep in $SEQUENTIAL_DEPLOYMENTS; do
+      echo "--- resuming $dep ---"
+      kubectl rollout resume deployment/$dep -n default
+      kubectl rollout status deployment/$dep -n default --timeout=5m
+      echo "--- $dep ready ---"
+    done
+  }
+
+  helm_upgrade() {
+    rollout_sequential &
     HELM_PID=$!
 
     while kill -0 $HELM_PID 2>/dev/null; do


### PR DESCRIPTION
## Problem

On the single-core 2 GiB node, Helm triggers all Deployment rollouts simultaneously by default. With `maxSurge:1`, this means two web pods (~128 MiB each) and two worker pods (~99 MiB each) run concurrently during every deploy — a ~230 MiB transient spike on a node already near its resident set limit. This contributed to today's OOM cascade.

## Change

Before `helm upgrade`, pause `glaze-web` and `glaze-worker`. Helm applies the new specs without triggering pod churn. Then resume and wait for each deployment to complete in sequence:

1. Resume `glaze-web` → wait for rollout complete
2. Resume `glaze-worker` → wait for rollout complete

`maxSurge:1` is preserved so there's zero per-service downtime. Peak transient overhead drops from ~230 MiB (two simultaneous surges) to ~130 MiB (one at a time).

`glaze-otelcol` is excluded — it has its own image and rarely changes alongside app deploys.

## Verification

Watch a deploy after merge:
```bash
kubectl get pods -n default -w
```
Only one new pod should appear at a time — web new pod starts, old terminates, then worker new pod starts.
