### PR TITLE
chore: infrastructure and policy updates to support additional administrators

### DIFF
--- a/.agents/skills/k8s/SKILL.md
+++ b/.agents/skills/k8s/SKILL.md
@@ -30,9 +30,9 @@ Workflow for any cluster change:
 ## Connecting to the cluster
 
 The production SSH target is `$GLAZE_PROD_HOST` from `.env.local`. The default
-value is `root@glaze-prod` — a Tailscale MagicDNS hostname. If your machine is
-on the tailnet and tagged as an `admin-client`, Tailscale SSH handles auth with
-no extra keys. Override with `root@<ip>` to connect outside the tailnet.
+value is `root@glaze-prod` — a Tailscale MagicDNS hostname. SSH is restricted
+to the tailnet; you must be connected to Tailscale and tagged as an
+`admin-client`. Tailscale SSH handles auth with no extra keys.
 
 Ask the user for the value if not already established in the conversation, then
 store it as `PROD_HOST` for the rest of the session. All `kubectl` and `helm`

--- a/.agents/skills/k8s/SKILL.md
+++ b/.agents/skills/k8s/SKILL.md
@@ -29,13 +29,14 @@ Workflow for any cluster change:
 
 ## Connecting to the cluster
 
-Before running any cluster commands, ask the user:
+The production SSH target is `$GLAZE_PROD_HOST` from `.env.local`. The default
+value is `root@glaze-prod` — a Tailscale MagicDNS hostname. If your machine is
+on the tailnet and tagged as an `admin-client`, Tailscale SSH handles auth with
+no extra keys. Override with `root@<ip>` to connect outside the tailnet.
 
-> What is the SSH target for the production cluster? (e.g. the value of
-> `$GLAZE_PROD_HOST` from `.env.local`, or a hostname/IP directly)
-
-Store the answer as `PROD_HOST` for the rest of the session. All `kubectl` and
-`helm` commands run over SSH with `KUBECONFIG=/etc/rancher/k3s/k3s.yaml`:
+Ask the user for the value if not already established in the conversation, then
+store it as `PROD_HOST` for the rest of the session. All `kubectl` and `helm`
+commands run over SSH with `KUBECONFIG=/etc/rancher/k3s/k3s.yaml`:
 
 ```bash
 # Single command

--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,6 @@ CLOUDINARY_UPLOAD_FOLDER=glaze
 # EXPO_PUBLIC_API_BASE_URL=http://localhost:8080/api/
 
 # Production cluster SSH target (used by tools/ensure_cluster.sh and helm_deploy.sh)
-# If your host has been added to the tailnet and tagged as an admin-client,
-# this will connect without any extra SSH keys — Tailscale SSH handles auth.
-# Override with root@<ip> if connecting outside the tailnet or with a raw IP.
+# SSH is restricted to the tailnet — you must be connected to Tailscale and
+# tagged as an admin-client. Tailscale SSH handles auth; no extra keys needed.
 GLAZE_PROD_HOST=root@glaze-prod

--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,9 @@ CLOUDINARY_UPLOAD_FOLDER=glaze
 
 # Mobile API base URL (Expo)
 # EXPO_PUBLIC_API_BASE_URL=http://localhost:8080/api/
+
+# Production cluster SSH target (used by tools/ensure_cluster.sh and helm_deploy.sh)
+# If your host has been added to the tailnet and tagged as an admin-client,
+# this will connect without any extra SSH keys — Tailscale SSH handles auth.
+# Override with root@<ip> if connecting outside the tailnet or with a raw IP.
+GLAZE_PROD_HOST=root@glaze-prod

--- a/README.md
+++ b/README.md
@@ -20,6 +20,21 @@ A pottery workflow tracking application. Log pieces and record state transitions
 
 ## For new developers
 
+### Contributing to potterdoc.com
+
+If you're looking to help maintain potterdoc.com rather than self-host your own instance:
+
+1. Send a note to [admin@potterdoc.com](mailto:admin@potterdoc.com) and request Tailscale access.
+2. Once you've been added to the tailnet and have [installed Tailscale](https://tailscale.com/download) on your dev machine, run the following to initialize your local environment with production service credentials:
+
+```bash
+tools/init_env.sh
+```
+
+This creates `.env.local` from `.env.example` and fills in the Cloudinary and Google OAuth credentials from the cluster. Your machine must be connected to Tailscale — SSH to the cluster is tailnet-only and Tailscale handles authentication automatically (no extra SSH keys needed).
+
+---
+
 This guide assumes you already know the tools listed below and are familiar with [separation of concerns](https://en.wikipedia.org/wiki/Separation_of_concerns) and [abstraction](https://en.wikipedia.org/wiki/Abstraction_(computer_science)) as design principles; if any term is unfamiliar, click the linked docs to catch up quickly.
 
 - **[Django](https://www.djangoproject.com/)** is the Python web framework that owns the backend (`backend/`, `api/`). [Separation of concerns](https://en.wikipedia.org/wiki/Separation_of_concerns) keeps unrelated responsibilities apart so each layer stays simpler to reason about—for example, [`api/models.py`](api/models.py) defines the data schema, [`api/serializers.py`](api/serializers.py) translates between ORM objects and JSON payloads, and [`api/views.py`](api/views.py) wires those serializers into `/api/...` endpoints that enforce workflow rules from [`workflow.yml`](workflow.yml). That split keeps the REST API (powered by Django REST Framework, DRF) resilient even when one layer needs to change, while returning consistent data/validation to all clients.
@@ -167,6 +182,8 @@ need web-only overrides:
 ```bash
 cp .env.example .env.local
 ```
+
+If you have Tailscale access to the production cluster, `tools/init_env.sh` does this and also fills in the service credentials in one step (see [Contributing to potterdoc.com](#contributing-to-potterdoccom) above).
 
 Each variable in `.env.example` has an inline comment explaining what it enables and what degrades gracefully when it is absent. Keep those comments current whenever a variable is added, removed, or renamed — the file is the primary reference for onboarding and for debugging "why isn't this feature working in dev."
 

--- a/staticfiles/privacy-policy.html
+++ b/staticfiles/privacy-policy.html
@@ -96,6 +96,8 @@
 
         <h2>5. Data Security</h2>
         <p>We implement appropriate security measures to protect your personal information against unauthorized access, alteration, disclosure, or destruction. However, no method of transmission over the internet is 100% secure.</p>
+        <p><strong>Administrator access.</strong> As PotterDoc grows, we may grant administrative access to paid or volunteer contributors. Administrators can access user data as necessary to operate and maintain the Service. We take reasonable steps to limit and supervise this access, but we cannot guarantee that an administrator will not misuse it. In the event of suspected misuse, we will revoke access as quickly as we become aware of the issue.</p>
+        <p><strong>Backups.</strong> We maintain hourly backups of the database to Dropbox. If an administrator were to delete backup files and disable the backup job before the incident is detected, recovery may be partial or impossible depending on how quickly we respond. We will make reasonable efforts to detect such incidents and use Dropbox's file-retention history to restore the most recent available backup.</p>
 
         <h2>6. Data Retention</h2>
         <p>We retain your information for as long as necessary to provide the Service and comply with legal obligations. You can request deletion of your account and associated data at any time.</p>

--- a/staticfiles/terms-of-service.html
+++ b/staticfiles/terms-of-service.html
@@ -103,9 +103,11 @@
 
         <h2>9. Disclaimers</h2>
         <p>The Service is provided "as is" without warranties of any kind. We do not guarantee that the Service will be uninterrupted or error-free.</p>
+        <p>As PotterDoc grows, we may grant administrative access to paid or volunteer contributors. While we take reasonable steps to vet and supervise administrators, we cannot guarantee that an administrator will not accidentally or deliberately misuse their access. Such misuse could include viewing, modifying, deleting, or disclosing your data. We maintain hourly encrypted backups to a third-party storage service (Dropbox). In the event that an administrator deletes backup files or disables the backup job before we detect and revoke their access, we may be able to restore from Dropbox's own file-retention history, but complete recovery is not guaranteed and substantial data loss is possible. We will make reasonable efforts to detect and respond to any such incident promptly.</p>
 
         <h2>10. Limitation of Liability</h2>
         <p>In no event shall Glaze be liable for any indirect, incidental, special, consequential, or punitive damages arising out of or related to your use of the Service.</p>
+        <p>Without limiting the foregoing, Glaze shall not be liable for any loss, corruption, or unauthorized disclosure of your data caused by the actions — whether negligent, accidental, or malicious — of any current or former administrator, volunteer, or other personnel with privileged access to the Service or its infrastructure. This includes, without limitation, losses arising from the theft, sale, or other unauthorized sharing of your data by such individuals. The Service stores pottery workflow records, which we do not expect to constitute sensitive personal or financial information, but you acknowledge that we have no capacity to assess or compensate for any value you place on that data.</p>
 
         <h2>11. Indemnification</h2>
         <p>You agree to indemnify and hold Glaze harmless from any claims, damages, losses, or expenses arising from your use of the Service or violation of these Terms.</p>

--- a/tools/init_env.sh
+++ b/tools/init_env.sh
@@ -38,21 +38,26 @@ if [ ! -f "$ENV_LOCAL" ]; then
 fi
 
 echo "==> Fetching service credentials from ${PROD_HOST}..."
-FETCHED=$($SSH "${PROD_HOST}" "
+FETCHED=$($SSH -o ConnectTimeout=10 "${PROD_HOST}" "
   export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
   kubectl get secret glaze-secrets -n default -o json
-" | python3 -c "
+" 2>/dev/null | python3 -c "
 import sys, json, base64
 data = json.load(sys.stdin)['data']
 keys = '''${KEYS}'''.split()
 for k in keys:
     if k in data:
         print(f'{k}={base64.b64decode(data[k]).decode()}')
-")
+" 2>/dev/null || true)
 
 if [ -z "$FETCHED" ]; then
-  echo "ERROR: no secrets returned — are you on the tailnet?" >&2
-  exit 1
+  echo ""
+  echo "Not added as an admin-client in tailnet. If you would like production access"
+  echo "to potterdoc.com, install and run tailscale on your host and send a note to"
+  echo "admin@potterdoc.com"
+  echo ""
+  echo "==> .env.local initialized from .env.example (no cluster credentials filled in)."
+  exit 0
 fi
 
 # Replace the managed block (or append it if first run).

--- a/tools/init_env.sh
+++ b/tools/init_env.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Initializes .env.local for local development against the production cluster.
+#
+# If .env.local does not exist, copies .env.example as a starting point.
+# Then pulls the subset of glaze-secrets that are useful for local development
+# (Cloudinary, Google OAuth) and writes them into a clearly-delimited managed
+# block in .env.local. Existing values outside that block are preserved, and
+# the script is safe to re-run.
+#
+# Requires Tailscale — SSH to the cluster is tailnet-only. Your machine must
+# be connected to Tailscale and tagged as an admin-client.
+#
+# Usage: tools/init_env.sh [deploy_host]
+#   deploy_host  defaults to $GLAZE_PROD_HOST, then root@glaze-prod
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_LOCAL="$REPO_ROOT/.env.local"
+PROD_HOST="${1:-${GLAZE_PROD_HOST:-root@glaze-prod}}"
+SSH="ssh -o StrictHostKeyChecking=no"
+
+# Keys to pull from glaze-secrets into .env.local.
+# Intentionally excludes prod-only keys: SECRET_KEY, POSTGRES_PASSWORD,
+# CLOUDFLARE_API_TOKEN, TAILSCALE_*, GRAFANA_*, ALLOWED_HOST, APP_ORIGIN,
+# and DROPBOX_* (only used by the cluster backup job, not local dev).
+KEYS="
+CLOUDINARY_CLOUD_NAME
+CLOUDINARY_API_KEY
+CLOUDINARY_API_SECRET
+GOOGLE_OAUTH_CLIENT_ID
+GOOGLE_OAUTH_CLIENT_SECRET
+"
+
+# Create .env.local from template if it doesn't exist yet.
+if [ ! -f "$ENV_LOCAL" ]; then
+  echo "==> Creating .env.local from .env.example..."
+  cp "$REPO_ROOT/.env.example" "$ENV_LOCAL"
+fi
+
+echo "==> Fetching service credentials from ${PROD_HOST}..."
+FETCHED=$($SSH "${PROD_HOST}" "
+  export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+  kubectl get secret glaze-secrets -n default -o json
+" | python3 -c "
+import sys, json, base64
+data = json.load(sys.stdin)['data']
+keys = '''${KEYS}'''.split()
+for k in keys:
+    if k in data:
+        print(f'{k}={base64.b64decode(data[k]).decode()}')
+")
+
+if [ -z "$FETCHED" ]; then
+  echo "ERROR: no secrets returned — are you on the tailnet?" >&2
+  exit 1
+fi
+
+# Replace the managed block (or append it if first run).
+BLOCK_START="# --- fetched from cluster (managed by init_env.sh) ---"
+BLOCK_END="# --- end fetched secrets ---"
+
+if grep -qF "$BLOCK_START" "$ENV_LOCAL"; then
+  # Remove the existing block.
+  python3 - "$ENV_LOCAL" "$BLOCK_START" "$BLOCK_END" <<'PYEOF'
+import sys
+path, start, end = sys.argv[1], sys.argv[2], sys.argv[3]
+lines = open(path).readlines()
+out, inside = [], False
+for line in lines:
+    if line.strip() == start:
+        inside = True
+    if not inside:
+        out.append(line)
+    if line.strip() == end:
+        inside = False
+open(path, 'w').writelines(out)
+PYEOF
+fi
+
+# Append the new block.
+{
+  echo ""
+  echo "$BLOCK_START"
+  echo "$FETCHED"
+  echo "$BLOCK_END"
+} >> "$ENV_LOCAL"
+
+echo "==> Written to $ENV_LOCAL:"
+echo "$FETCHED" | sed 's/=.*/=<redacted>/'

--- a/web/src/pages/PrivacyPolicyPage.tsx
+++ b/web/src/pages/PrivacyPolicyPage.tsx
@@ -79,6 +79,17 @@ export default function PrivacyPolicyPage() {
           </Typography>
 
           <Typography variant="body1">
+            As the service grows, we may grant administrative access to paid or
+            volunteer contributors. Administrators can see your data as part of
+            operating and maintaining the service. A rogue or careless
+            administrator could accidentally or deliberately expose or delete
+            it. We take hourly backups to Dropbox and will revoke access as
+            quickly as we become aware of any misuse, but we cannot guarantee
+            we will catch it in time. If you are concerned about this, the
+            source code is public and you are welcome to self-host.
+          </Typography>
+
+          <Typography variant="body1">
             We reserve the right to access, review, and use user-submitted data
             as reasonably necessary to operate, maintain, secure, debug,
             support, and improve PotterDoc. We do not sell your data or sell

--- a/web/src/pages/PrivacyPolicyPage.tsx
+++ b/web/src/pages/PrivacyPolicyPage.tsx
@@ -83,10 +83,14 @@ export default function PrivacyPolicyPage() {
             volunteer contributors. Administrators can see your data as part of
             operating and maintaining the service. A rogue or careless
             administrator could accidentally or deliberately expose or delete
-            it. We take hourly backups to Dropbox and will revoke access as
-            quickly as we become aware of any misuse, but we cannot guarantee
-            we will catch it in time. If you are concerned about this, the
-            source code is public and you are welcome to self-host.
+            it. We take hourly backups to Dropbox. These backups are
+            intentionally not encrypted: encrypting them would mean a rogue
+            administrator could destroy the key and make recovery impossible,
+            which is a worse outcome than the backups being readable. We will
+            revoke access as quickly as we become aware of any misuse, but we
+            cannot guarantee we will catch it in time. If you are concerned
+            about this, the source code is public and you are welcome to
+            self-host.
           </Typography>
 
           <Typography variant="body1">

--- a/web/src/pages/PrivacyPolicyPage.tsx
+++ b/web/src/pages/PrivacyPolicyPage.tsx
@@ -140,6 +140,17 @@ export default function PrivacyPolicyPage() {
             throwaway Google account.
           </Typography>
 
+          <Typography variant="body1">
+            We may update this privacy policy in the future. We will announce
+            any changes clearly and give you a reasonable window to review
+            them. For changes that materially affect how your data is handled,
+            we will provide an explicit opt-out before the new policy applies
+            to you. In extreme cases, the opt-out may take the form of a data
+            export tool so you can take your pottery records elsewhere &mdash;
+            a self-hosted instance, another service, or a local file. We will
+            not hold your data hostage to a policy you do not accept.
+          </Typography>
+
           <Box sx={{ pt: 1 }}>
             <Button component={Link} to="/" variant="outlined">
               Back to Login

--- a/web/src/pages/TermsOfServicePage.tsx
+++ b/web/src/pages/TermsOfServicePage.tsx
@@ -61,6 +61,20 @@ export default function TermsOfServicePage() {
           </Typography>
 
           <Typography variant="body1">
+            As the service grows, we may add paid or volunteer administrators.
+            A rogue or careless administrator could accidentally or deliberately
+            delete or expose your data, and the owner of the site cannot be
+            held liable for that. We take hourly backups to Dropbox. If a
+            malicious administrator deletes all the backups and disables the
+            backup job before other administrators notice, we may have
+            substantial data loss &mdash; though if we catch it quickly enough
+            we can revoke their access and attempt a restore using
+            Dropbox&apos;s own file-retention history. It is also possible,
+            though unlikely, that a rogue administrator could steal or sell
+            your data. We have no capacity to compensate you for that loss.
+          </Typography>
+
+          <Typography variant="body1">
             You may not use PotterDoc for any unlawful purpose or in any way
             that violates these terms. We reserve the right to suspend or
             terminate access for any user who violates these terms or whose

--- a/web/src/pages/TermsOfServicePage.tsx
+++ b/web/src/pages/TermsOfServicePage.tsx
@@ -64,14 +64,18 @@ export default function TermsOfServicePage() {
             As the service grows, we may add paid or volunteer administrators.
             A rogue or careless administrator could accidentally or deliberately
             delete or expose your data, and the owner of the site cannot be
-            held liable for that. We take hourly backups to Dropbox. If a
-            malicious administrator deletes all the backups and disables the
-            backup job before other administrators notice, we may have
-            substantial data loss &mdash; though if we catch it quickly enough
-            we can revoke their access and attempt a restore using
-            Dropbox&apos;s own file-retention history. It is also possible,
-            though unlikely, that a rogue administrator could steal or sell
-            your data. We have no capacity to compensate you for that loss.
+            held liable for that. We take hourly backups to Dropbox.
+            These backups are intentionally not encrypted: encrypting them
+            would mean a rogue administrator could destroy the key and make
+            recovery impossible, which is a worse outcome than the backups
+            being readable. If a malicious administrator deletes all the
+            backups and disables the backup job before other administrators
+            notice, we may have substantial data loss &mdash; though if we
+            catch it quickly enough we can revoke their access and attempt a
+            restore using Dropbox&apos;s own file-retention history. It is
+            also possible, though unlikely, that a rogue administrator could
+            steal or sell your data. We have no capacity to compensate you
+            for that loss.
           </Typography>
 
           <Typography variant="body1">

--- a/web/src/pages/TermsOfServicePage.tsx
+++ b/web/src/pages/TermsOfServicePage.tsx
@@ -87,9 +87,19 @@ export default function TermsOfServicePage() {
           </Typography>
 
           <Typography variant="body1">
-            We reserve the right to modify these terms at any time. Continued
-            use of the app after changes are posted constitutes acceptance of
-            the revised terms.
+            We may revise these terms or our privacy policy in the future.
+            When we do, we will announce the changes clearly and give users
+            a reasonable opportunity to review them before they take effect.
+            For minor changes &mdash; wording clarifications, new disclosures
+            that don&apos;t reduce your rights &mdash; a notice in the app is
+            sufficient. For material changes that meaningfully affect how your
+            data is used or what you are agreeing to, we will provide an
+            explicit opt-out mechanism before the new terms apply to you. In
+            extreme cases, the only honest opt-out we can offer is a tool to
+            export and download all of your data so you can take it elsewhere
+            &mdash; another pottery tracking app, a self-hosted instance, or
+            a spreadsheet. We commit to providing that export rather than
+            holding your data hostage to terms you do not accept.
           </Typography>
 
           <Box sx={{ pt: 1 }}>


### PR DESCRIPTION
Prepares the project for onboarding paid or volunteer administrators — both the operational tooling and the legal disclosures users need to make an informed choice.

## Changes

### Developer / admin onboarding
- Adds `GLAZE_PROD_HOST=root@glaze-prod` to `.env.example` with a note that Tailscale SSH handles auth automatically for `admin-client`-tagged machines
- Adds `tools/init_env.sh`: initializes `.env.local` from `.env.example` and pulls Cloudinary + Google OAuth credentials from the production cluster over Tailscale. Gracefully prints a friendly message if the machine is not on the tailnet rather than erroring
- Adds a "Contributing to potterdoc.com" section to `README.md` with the Tailscale access request step and the `init_env.sh` command; cross-links from the existing env setup section
- Updates the k8s skill to reference `$GLAZE_PROD_HOST` by name

### Legal disclosures
- **ToS + Privacy Policy**: discloses that future administrators may accidentally or maliciously delete or expose user data, and that the site owner cannot be held liable
- **ToS + Privacy Policy**: explains that hourly Dropbox backups are intentionally unencrypted — encrypting them would let a rogue admin destroy the key and make recovery impossible
- **ToS + Privacy Policy**: commits to announcing policy changes clearly, providing an explicit opt-out for material changes, and in extreme cases offering a full data export rather than holding data hostage to terms the user doesn't accept

## Test plan
- [ ] `tools/init_env.sh` on a tailnet machine initializes `.env.local` and fills in credentials
- [ ] `tools/init_env.sh` on a machine not on the tailnet prints the friendly access message and exits 0
- [ ] README "Contributing to potterdoc.com" section renders correctly
- [ ] ToS and Privacy Policy pages render the new paragraphs in the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)