### PR TITLE
chore: Ignore zsh history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,6 +214,8 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file. However, if you prefer, 
 #  you could uncomment the following to ignore the entire vscode folder
 # .vscode/
+# Mac users probably don't want to check in their personal shell history, so we ignore those by default.
+.vscode/.zsh_history
 
 # Ruff stuff:
 .ruff_cache/


### PR DESCRIPTION
On mac, the documented dev setup throws the zsh history under .vscode. We don't want to accidentally commit that.