### PR TITLE
chore: scope Modal secrets to glaze-droplet

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -104,6 +104,7 @@ jobs:
     name: Deploy Services to Modal
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' || github.event_name == 'push'
+    environment: glaze-droplet
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
This updates `cd.yml` so the `deploy-modal` job uses the `glaze-droplet` environment and reads `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET` from environment-scoped secrets.

Why:
- The Modal credentials were moved out of repo-scoped secrets.
- `deploy-modal` needs to resolve the new environment-scoped values to keep CD working.

Validation:
- Parsed the workflow YAML successfully.
- Verified the diff is limited to the intended workflow line.

Closes #544
