### PR TITLE
chore: add gz_restore --prod flag and restore drill runbook

### DIFF
--- a/docs/ops/restore-drill-log.md
+++ b/docs/ops/restore-drill-log.md
@@ -1,0 +1,7 @@
+# Restore Drill Log
+
+Each row records one completed restore drill. See [restore-drill.md](restore-drill.md) for the runbook.
+
+| Date | Operator | Backup filename (SHA256) | Users | Pieces | Orphan pieces | Orphan states | Elapsed | Notes |
+|---|---|---|---|---|---|---|---|---|
+| <!-- fill in after drill --> | | | | | | | | |

--- a/docs/ops/restore-drill-log.md
+++ b/docs/ops/restore-drill-log.md
@@ -4,4 +4,4 @@ Each row records one completed restore drill. See [restore-drill.md](restore-dri
 
 | Date | Operator | Backup filename (SHA256) | Users | Pieces | Orphan pieces | Orphan states | Elapsed | Notes |
 |---|---|---|---|---|---|---|---|---|
-| <!-- fill in after drill --> | | | | | | | | |
+| 2026-05-24 | shaoster | e406538a97f87bd33a3111129801765a75a4c8eaaeccbc6d64cb9a247d60307f.dump | ✓ >0 | ✓ >0 | ✓ 0 | ✓ 0 | ~1 min | Restored into empty prod DB (deliberately nuked first). No user session interruption observed. |

--- a/docs/ops/restore-drill.md
+++ b/docs/ops/restore-drill.md
@@ -1,0 +1,74 @@
+# Production Restore Drill Runbook
+
+Use this runbook to restore a production database backup into production and verify it.
+Run this drill before onboarding external users, after any suspected data loss, or on a
+scheduled basis to verify the backup chain remains healthy.
+
+---
+
+## Backup source
+
+Production backups are uploaded by the `glaze-db-backup` CronJob (runs hourly).
+
+- **Dropbox path**: `Apps/potterdoc/glaze-db-backups/<sha256>.dump`
+- The filename is the SHA256 checksum of the dump file.
+- Format: `pg_dump -Fc` (custom format), no owner, no ACL.
+
+## Choosing a backup
+
+1. Open Dropbox → Apps → potterdoc → glaze-db-backups.
+2. Sort by **Date modified** descending. The most recent file is the latest backup.
+3. Note the filename (SHA256) — this is your audit reference.
+
+RPO: backups run hourly, so worst-case data loss is up to 1 hour of changes.
+
+## Running the drill
+
+Download the chosen `.dump` file from Dropbox to your local machine, then run:
+
+```bash
+gz_restore --prod /path/to/<sha256>.dump
+```
+
+The command will:
+1. Print a warning banner naming the dump file and production host.
+2. Generate a random 6-character confirmation string and require you to type it.
+3. Stream the dump into production Postgres via `ssh $GLAZE_PROD_HOST kubectl exec`.
+4. Run four verification checks (see below).
+5. Print elapsed time and all check results.
+
+`GLAZE_PROD_HOST` must be set in your `.env.local` (e.g., `root@glaze-prod`).
+
+## Verification checks
+
+The command automatically runs all four checks and fails loudly if any do not pass:
+
+| Check | Expected |
+|---|---|
+| `SELECT COUNT(*) FROM auth_user` | > 0 |
+| `SELECT COUNT(*) FROM api_piece` | > 0 |
+| Pieces with no state history | 0 |
+| Orphaned piece states | 0 |
+
+## Success criteria
+
+- `gz_restore --prod` exits 0.
+- All four verification checks pass.
+- Elapsed time is reasonable (< 10 minutes for current data volume).
+
+## After the drill
+
+Record the results in [restore-drill-log.md](restore-drill-log.md).
+
+## RPO / RTO
+
+- **RPO (Recovery Point Objective)**: ≤ 1 hour. Backups run hourly; at most one hour of
+  changes may be lost.
+- **RTO (Recovery Time Objective)**: Operator-driven. Based on recorded drills, the
+  restore + verification step takes approximately N minutes (see drill log). Re-pointing
+  the application (pod restart) adds ~1 minute on top of that.
+
+## Cleanup
+
+The drill restores into production — there is no separate disposable environment to clean
+up. If you ran a test drill against a non-production target, delete that target manually.

--- a/docs/ops/restore-drill.md
+++ b/docs/ops/restore-drill.md
@@ -65,8 +65,8 @@ Record the results in [restore-drill-log.md](restore-drill-log.md).
 - **RPO (Recovery Point Objective)**: ≤ 1 hour. Backups run hourly; at most one hour of
   changes may be lost.
 - **RTO (Recovery Time Objective)**: Operator-driven. Based on recorded drills, the
-  restore + verification step takes approximately N minutes (see drill log). Re-pointing
-  the application (pod restart) adds ~1 minute on top of that.
+  restore + verification step takes approximately 1 minute (see drill log). Active user
+  sessions survive the restore without interruption — no pod restart required.
 
 ## Cleanup
 

--- a/env-agent.sh
+++ b/env-agent.sh
@@ -541,11 +541,17 @@ gz_restore() {
         ssh "$host" "$KC kubectl exec -i glaze-postgres-0 -- bash -c 'PGPASSWORD=\"\$POSTGRES_PASSWORD\" pg_restore -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" --no-owner --no-privileges --clean --if-exists'" < "$dump_path"
 
         echo "--- verifying restore ---"
-        local user_count piece_count orphan_pieces orphan_states
-        user_count="$(ssh "$host" "$KC kubectl exec glaze-postgres-0 -- bash -c 'PGPASSWORD=\"\$POSTGRES_PASSWORD\" psql -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" -Atqc \"SELECT COUNT(*) FROM auth_user;\"")"
-        piece_count="$(ssh "$host" "$KC kubectl exec glaze-postgres-0 -- bash -c 'PGPASSWORD=\"\$POSTGRES_PASSWORD\" psql -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" -Atqc \"SELECT COUNT(*) FROM api_piece;\"")"
-        orphan_pieces="$(ssh "$host" "$KC kubectl exec glaze-postgres-0 -- bash -c 'PGPASSWORD=\"\$POSTGRES_PASSWORD\" psql -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" -Atqc \"SELECT COUNT(*) FROM api_piece p WHERE NOT EXISTS (SELECT 1 FROM api_piecestate s WHERE s.piece_id = p.id);\"")"
-        orphan_states="$(ssh "$host" "$KC kubectl exec glaze-postgres-0 -- bash -c 'PGPASSWORD=\"\$POSTGRES_PASSWORD\" psql -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" -Atqc \"SELECT COUNT(*) FROM api_piecestate s WHERE NOT EXISTS (SELECT 1 FROM api_piece p WHERE p.id = s.piece_id);\"")"
+        local verify_out user_count piece_count orphan_pieces orphan_states
+        verify_out="$(printf '%s\n' \
+            'SELECT COUNT(*) FROM auth_user;' \
+            'SELECT COUNT(*) FROM api_piece;' \
+            'SELECT COUNT(*) FROM api_piece p WHERE NOT EXISTS (SELECT 1 FROM api_piecestate s WHERE s.piece_id = p.id);' \
+            'SELECT COUNT(*) FROM api_piecestate s WHERE NOT EXISTS (SELECT 1 FROM api_piece p WHERE p.id = s.piece_id);' \
+            | ssh "$host" "$KC kubectl exec -i glaze-postgres-0 -- bash -c 'PGPASSWORD=\"\$POSTGRES_PASSWORD\" psql -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" -Atq'")"
+        user_count="$(    sed -n '1p' <<< "$verify_out")"
+        piece_count="$(   sed -n '2p' <<< "$verify_out")"
+        orphan_pieces="$( sed -n '3p' <<< "$verify_out")"
+        orphan_states="$( sed -n '4p' <<< "$verify_out")"
 
         local elapsed=$(( $(date +%s) - start_ts ))
         echo ""

--- a/env-agent.sh
+++ b/env-agent.sh
@@ -509,16 +509,16 @@ gz_restore() {
         local KC="KUBECONFIG=/etc/rancher/k3s/k3s.yaml"
 
         echo ""
-        echo "╔══════════════════════════════════════════════════════════════════╗"
-        echo "║  WARNING: PRODUCTION DATABASE OVERWRITE                         ║"
-        echo "╠══════════════════════════════════════════════════════════════════╣"
-        echo "║  This will DROP AND RECREATE the production Postgres database.  ║"
-        echo "║  All current production data will be replaced by the dump.      ║"
-        echo "║  This action is IRREVERSIBLE. There is no undo.                 ║"
-        echo "║                                                                  ║"
-        printf  "║  Dump: %-57s║\n" "$(basename "$dump_path")"
-        printf  "║  Host: %-57s║\n" "$host"
-        echo "╚══════════════════════════════════════════════════════════════════╝"
+        echo "╔═════════════════════════════════════════════════════════════════════════════════╗"
+        echo "║  WARNING: PRODUCTION DATABASE OVERWRITE                                         ║"
+        echo "╠═════════════════════════════════════════════════════════════════════════════════╣"
+        echo "║  This will DROP AND RECREATE the production Postgres database.                  ║"
+        echo "║  All current production data will be replaced by the dump.                      ║"
+        echo "║  This action is IRREVERSIBLE. There is no undo.                                 ║"
+        echo "║                                                                                 ║"
+        printf  "║  Dump: %-73s║\n" "$(basename "$dump_path")"
+        printf  "║  Host: %-73s║\n" "$host"
+        echo "╚═════════════════════════════════════════════════════════════════════════════════╝"
         echo ""
 
         local confirm_str
@@ -538,7 +538,12 @@ gz_restore() {
         start_ts="$(date +%s)"
 
         echo "--- restoring dump into production postgres ---"
+        local spinner_pid
+        (while true; do for c in '|' '/' '-' '\'; do printf '\r  %s restoring...' "$c" >&2; sleep 0.2; done; done) &
+        spinner_pid=$!
         ssh "$host" "$KC kubectl exec -i glaze-postgres-0 -- bash -c 'PGPASSWORD=\"\$POSTGRES_PASSWORD\" pg_restore -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" --no-owner --no-privileges --clean --if-exists'" < "$dump_path"
+        kill "$spinner_pid" 2>/dev/null; wait "$spinner_pid" 2>/dev/null
+        printf '\r                       \r' >&2
 
         echo "--- verifying restore ---"
         local verify_out user_count piece_count orphan_pieces orphan_states

--- a/env-agent.sh
+++ b/env-agent.sh
@@ -538,28 +538,14 @@ gz_restore() {
         start_ts="$(date +%s)"
 
         echo "--- restoring dump into production postgres ---"
-        ssh "$host" "$KC kubectl exec -i glaze-postgres-0 -- bash -c \
-            'PGPASSWORD=\"\$POSTGRES_PASSWORD\" pg_restore \
-             -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" \
-             --no-owner --no-privileges --clean --if-exists'" \
-            < "$dump_path"
+        ssh "$host" "$KC kubectl exec -i glaze-postgres-0 -- bash -c 'PGPASSWORD=\"\$POSTGRES_PASSWORD\" pg_restore -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" --no-owner --no-privileges --clean --if-exists'" < "$dump_path"
 
         echo "--- verifying restore ---"
         local user_count piece_count orphan_pieces orphan_states
-        user_count="$(ssh "$host" "$KC kubectl exec glaze-postgres-0 -- bash -c \
-            'PGPASSWORD=\"\$POSTGRES_PASSWORD\" psql -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" \
-             -Atqc \"SELECT COUNT(*) FROM auth_user;\"")"
-        piece_count="$(ssh "$host" "$KC kubectl exec glaze-postgres-0 -- bash -c \
-            'PGPASSWORD=\"\$POSTGRES_PASSWORD\" psql -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" \
-             -Atqc \"SELECT COUNT(*) FROM api_piece;\"")"
-        orphan_pieces="$(ssh "$host" "$KC kubectl exec glaze-postgres-0 -- bash -c \
-            'PGPASSWORD=\"\$POSTGRES_PASSWORD\" psql -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" \
-             -Atqc \"SELECT COUNT(*) FROM api_piece p \
-                     WHERE NOT EXISTS (SELECT 1 FROM api_piecestate s WHERE s.piece_id = p.id);\"")"
-        orphan_states="$(ssh "$host" "$KC kubectl exec glaze-postgres-0 -- bash -c \
-            'PGPASSWORD=\"\$POSTGRES_PASSWORD\" psql -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" \
-             -Atqc \"SELECT COUNT(*) FROM api_piecestate s \
-                     WHERE NOT EXISTS (SELECT 1 FROM api_piece p WHERE p.id = s.piece_id);\"")"
+        user_count="$(ssh "$host" "$KC kubectl exec glaze-postgres-0 -- bash -c 'PGPASSWORD=\"\$POSTGRES_PASSWORD\" psql -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" -Atqc \"SELECT COUNT(*) FROM auth_user;\"")"
+        piece_count="$(ssh "$host" "$KC kubectl exec glaze-postgres-0 -- bash -c 'PGPASSWORD=\"\$POSTGRES_PASSWORD\" psql -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" -Atqc \"SELECT COUNT(*) FROM api_piece;\"")"
+        orphan_pieces="$(ssh "$host" "$KC kubectl exec glaze-postgres-0 -- bash -c 'PGPASSWORD=\"\$POSTGRES_PASSWORD\" psql -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" -Atqc \"SELECT COUNT(*) FROM api_piece p WHERE NOT EXISTS (SELECT 1 FROM api_piecestate s WHERE s.piece_id = p.id);\"")"
+        orphan_states="$(ssh "$host" "$KC kubectl exec glaze-postgres-0 -- bash -c 'PGPASSWORD=\"\$POSTGRES_PASSWORD\" psql -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" -Atqc \"SELECT COUNT(*) FROM api_piecestate s WHERE NOT EXISTS (SELECT 1 FROM api_piece p WHERE p.id = s.piece_id);\"")"
 
         local elapsed=$(( $(date +%s) - start_ts ))
         echo ""

--- a/env-agent.sh
+++ b/env-agent.sh
@@ -472,24 +472,112 @@ gz_backup() {
 }
 
 gz_restore() {
-    # Restore a pg_dump (-Fc) file into the local dev Postgres.
+    # Restore a pg_dump (-Fc) file into Postgres.
     #
-    # If DATABASE_URL is already a postgres:// URL, restores directly into it.
-    # Otherwise, starts (or reuses) a persistent Docker container named
-    # glaze-dev-db on localhost:5433 and prints the DATABASE_URL to add to
-    # .env.local so the dev stack uses it.
+    # Without --prod: restores into the local dev Postgres. If DATABASE_URL is
+    # already a postgres:// URL, restores directly into it. Otherwise, starts
+    # (or reuses) a persistent Docker container named glaze-dev-db on
+    # localhost:5433 and prints the DATABASE_URL to add to .env.local.
     #
-    # Usage: gz_restore <dump_file>
+    # With --prod: restores into the PRODUCTION Postgres database via
+    # SSH + kubectl exec. Requires typing a confirmation string.
+    # THIS IS DESTRUCTIVE AND IRREVERSIBLE.
+    #
+    # Usage: gz_restore [--prod] <dump_file>
     #   dump_file: path produced by gz_backup (custom format, -Fc)
-    local dump_path="${1:-}"
+    local prod=false
+    local dump_path=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --prod) prod=true; shift ;;
+            *)      dump_path="$1"; shift ;;
+        esac
+    done
+
     if [[ -z "$dump_path" ]]; then
-        echo "Usage: gz_restore <dump_file>" >&2
+        echo "Usage: gz_restore [--prod] <dump_file>" >&2
         echo "  Tip: run 'gz_backup' first to get a dump file." >&2
         return 1
     fi
     if [[ ! -f "$dump_path" ]]; then
         echo "gz_restore: file not found: $dump_path" >&2
         return 1
+    fi
+
+    if [[ "$prod" == true ]]; then
+        local host="${GLAZE_PROD_HOST:?Set GLAZE_PROD_HOST=user@host in .env.local}"
+        local KC="KUBECONFIG=/etc/rancher/k3s/k3s.yaml"
+
+        echo ""
+        echo "╔══════════════════════════════════════════════════════════════════╗"
+        echo "║  WARNING: PRODUCTION DATABASE OVERWRITE                         ║"
+        echo "╠══════════════════════════════════════════════════════════════════╣"
+        echo "║  This will DROP AND RECREATE the production Postgres database.  ║"
+        echo "║  All current production data will be replaced by the dump.      ║"
+        echo "║  This action is IRREVERSIBLE. There is no undo.                 ║"
+        echo "║                                                                  ║"
+        printf  "║  Dump: %-57s║\n" "$(basename "$dump_path")"
+        printf  "║  Host: %-57s║\n" "$host"
+        echo "╚══════════════════════════════════════════════════════════════════╝"
+        echo ""
+
+        local confirm_str
+        confirm_str="$(openssl rand -hex 3)"
+        echo "Type the following string to confirm, or anything else to abort:"
+        echo ""
+        echo "    $confirm_str"
+        echo ""
+        local input
+        read -r input
+        if [[ "$input" != "$confirm_str" ]]; then
+            echo "Aborted — confirmation did not match." >&2
+            return 1
+        fi
+
+        local start_ts
+        start_ts="$(date +%s)"
+
+        echo "--- restoring dump into production postgres ---"
+        ssh "$host" "$KC kubectl exec -i glaze-postgres-0 -- bash -c \
+            'PGPASSWORD=\"\$POSTGRES_PASSWORD\" pg_restore \
+             -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" \
+             --no-owner --no-privileges --clean --if-exists'" \
+            < "$dump_path"
+
+        echo "--- verifying restore ---"
+        local user_count piece_count orphan_pieces orphan_states
+        user_count="$(ssh "$host" "$KC kubectl exec glaze-postgres-0 -- bash -c \
+            'PGPASSWORD=\"\$POSTGRES_PASSWORD\" psql -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" \
+             -Atqc \"SELECT COUNT(*) FROM auth_user;\"")"
+        piece_count="$(ssh "$host" "$KC kubectl exec glaze-postgres-0 -- bash -c \
+            'PGPASSWORD=\"\$POSTGRES_PASSWORD\" psql -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" \
+             -Atqc \"SELECT COUNT(*) FROM api_piece;\"")"
+        orphan_pieces="$(ssh "$host" "$KC kubectl exec glaze-postgres-0 -- bash -c \
+            'PGPASSWORD=\"\$POSTGRES_PASSWORD\" psql -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" \
+             -Atqc \"SELECT COUNT(*) FROM api_piece p \
+                     WHERE NOT EXISTS (SELECT 1 FROM api_piecestate s WHERE s.piece_id = p.id);\"")"
+        orphan_states="$(ssh "$host" "$KC kubectl exec glaze-postgres-0 -- bash -c \
+            'PGPASSWORD=\"\$POSTGRES_PASSWORD\" psql -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" \
+             -Atqc \"SELECT COUNT(*) FROM api_piecestate s \
+                     WHERE NOT EXISTS (SELECT 1 FROM api_piece p WHERE p.id = s.piece_id);\"")"
+
+        local elapsed=$(( $(date +%s) - start_ts ))
+        echo ""
+        echo "Restore complete in ${elapsed}s."
+        echo "  users:          $user_count"
+        echo "  pieces:         $piece_count"
+        echo "  orphan pieces:  $orphan_pieces  (expected 0)"
+        echo "  orphan states:  $orphan_states  (expected 0)"
+        echo ""
+
+        [[ "$user_count"     -gt 0 ]] || { echo "FAIL: no users found after restore" >&2; return 1; }
+        [[ "$piece_count"    -gt 0 ]] || { echo "FAIL: no pieces found after restore" >&2; return 1; }
+        [[ "$orphan_pieces"  -eq 0 ]] || { echo "FAIL: $orphan_pieces pieces have no state history" >&2; return 1; }
+        [[ "$orphan_states"  -eq 0 ]] || { echo "FAIL: $orphan_states orphaned piece states found" >&2; return 1; }
+
+        echo "All verification checks passed."
+        echo "Record this drill in docs/ops/restore-drill-log.md."
+        return 0
     fi
 
     command -v docker >/dev/null || {
@@ -1084,7 +1172,8 @@ _GZ_SHORTCUTS=(
     "gz_prod_shell     — Django shell on production"
     "gz_prod_dbshell   — database shell on production"
     "gz_backup [file]  — back up prod Postgres and verify it in a disposable postgres:17 container"
-    "gz_restore <file> — restore a gz_backup dump into local dev Postgres (starts Docker container if needed)"
+    "gz_restore <file>        — restore a gz_backup dump into local dev Postgres (starts Docker container if needed)"
+    "gz_restore --prod <file> — restore into PRODUCTION Postgres (requires confirmation; irreversible)"
     "gz_test           — run affected tests via Bazel (smart detection on branches; --all to run everything)"
     "gz_test_common    — run workflow schema/integrity tests (pytest tests/)"
     "gz_test_backend   — run Django API tests (pytest api/)"


### PR DESCRIPTION
## Summary

- Adds \`--prod\` flag to \`gz_restore\` in \`env-agent.sh\`: streams a Dropbox dump into production Postgres via SSH + kubectl exec, with a 6-char confirmation gate and four post-restore integrity checks
- Adds \`docs/ops/restore-drill.md\`: repeatable runbook covering backup source, how to choose a backup, how to run the drill, and RPO/RTO
- Adds \`docs/ops/restore-drill-log.md\`: table for recording drill executions (first entry filled in)

## Test plan

- [x] Confirm warning banner and confirmation prompt appear
- [x] Confirm mistyped string aborts cleanly
- [x] Restored \`e406538a97f87bd33a3111129801765a75a4c8eaaeccbc6d64cb9a247d60307f.dump\` into a deliberately emptied prod DB — all four checks passed, ~1 min elapsed, no user session interruption
- [x] Results recorded in \`docs/ops/restore-drill-log.md\`

Closes #669

🤖 Generated with [Claude Code](https://claude.com/claude-code)