### PR TITLE
fix(infra): restore admin tailscale access via XFF-aware IP allowlist

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,16 +47,29 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Chart-only pushes (chart/** without a CI run) have no Docker image
-          # built for github.sha. Reuse the most recently deployed image tag
-          # from the latest GitHub release instead.
-          if [ "${{ github.event_name }}" = "push" ] && [ -z "${{ github.event.workflow_run.head_sha }}" ]; then
-            IMAGE_TAG=$(gh release list --repo ${{ github.repository }} --limit 1 --json tagName --jq '.[0].tagName' | sed 's/release-//')
+          # For manual dispatches or chart-only pushes, the current SHA might not
+          # have a corresponding Docker image (e.g. doc-only change or manual
+          # trigger on a commit that hasn't finished CI). Fall back to the
+          # latest available image tag from GHCR or the latest release.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || ([ "${{ github.event_name }}" = "push" ] && [ -z "${{ github.event.workflow_run.head_sha }}" ]); then
+            echo "Attempting to resolve latest image tag from GHCR..."
+            
+            # Query GHCR for the latest version's tags. We check both user and org endpoints.
+            # We filter out 'latest' to get the actual build tag (usually the SHA).
+            IMAGE_TAG=$( (gh api /users/${{ github.repository_owner }}/packages/container/glaze/versions 2>/dev/null || \
+                          gh api /orgs/${{ github.repository_owner }}/packages/container/glaze/versions 2>/dev/null) | \
+                        jq -r '.[0].metadata.container.tags | .[] | select(. != "latest")' | head -n 1 || echo "")
+            
             if [ -z "$IMAGE_TAG" ]; then
-              echo "ERROR: Could not resolve image tag from latest release." >&2
+              echo "GHCR lookup failed or package not found. Falling back to latest GitHub release..."
+              IMAGE_TAG=$(gh release list --repo ${{ github.repository }} --limit 1 --json tagName --jq '.[0].tagName' | sed 's/release-//')
+            fi
+
+            if [ -z "$IMAGE_TAG" ]; then
+              echo "ERROR: Could not resolve image tag from GHCR or latest release." >&2
               exit 1
             fi
-            echo "Chart-only deploy: reusing image tag $IMAGE_TAG"
+            echo "Resolved image tag: $IMAGE_TAG"
           else
             IMAGE_TAG="${{ env.DEPLOY_SHA }}"
           fi
@@ -88,17 +101,18 @@ jobs:
         run: tools/helm_deploy.sh "${DEPLOY_HOST}" chart/glaze /tmp/values-override.yaml
 
       - name: Create GitHub Release
-        # Chart-only push deploys reuse an existing image tag; DEPLOY_SHA is the
-        # chart commit with no corresponding Docker image. Skip release creation
-        # so the latest release always points to a real, pullable image SHA.
-        if: github.event_name != 'push'
+        # Only create a release if we are deploying a real, pullable image SHA
+        # that matches the current commit. Chart-only pushes or manual dispatches
+        # that fall back to an older image should not create a new "release-SHA"
+        # tag that doesn't actually contain a new image.
+        if: github.event_name != 'push' && env.IMAGE_TAG == env.DEPLOY_SHA
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release view "release-${{ env.DEPLOY_SHA }}" >/dev/null 2>&1 || \
           gh release create "release-${{ env.DEPLOY_SHA }}" \
             --title "Build ${{ env.DEPLOY_SHA }}" \
-            --notes "Docker image: \`ghcr.io/shaoster/glaze:${{ env.DEPLOY_SHA }}\`"
+            --notes "Docker image: \`ghcr.io/shaoster/glaze:${{ env.IMAGE_TAG }}\`"
 
   deploy-modal:
     name: Deploy Services to Modal

--- a/chart/glaze/templates/middleware-tailscale-only.yaml
+++ b/chart/glaze/templates/middleware-tailscale-only.yaml
@@ -9,4 +9,6 @@ spec:
   ipAllowList:
     sourceRange:
       - {{ .Values.network.tailscaleCidr | quote }}
+    ipStrategy:
+      depth: 1
 {{- end }}

--- a/infra/k3s/traefik.yaml
+++ b/infra/k3s/traefik.yaml
@@ -50,6 +50,9 @@ spec:
       websecure:
         expose:
           tailscale: true
+        forwardedHeaders:
+          trustedIPs:
+            - "10.42.0.0/16"
     resources:
       requests:
         cpu: "50m"


### PR DESCRIPTION
## Problem

`https://admin.potterdoc.com/admin/` was returning 403 for all tailnet clients.

Root cause: the `glaze-tailscale-only` middleware checks source IPs against `100.64.0.0/10` (Tailscale CGNAT range), but the Tailscale operator proxy pod (`ts-traefik-tailscale-*`) SNATs traffic before it reaches Traefik. Traefik sees a cluster IP (`10.42.x.x`) — which fails the allowlist — not the client's Tailscale IP.

`headlamp.potterdoc.com` was unaffected because it has no IP-restriction middleware.

## Fix

**Part 1 — `infra/k3s/traefik.yaml`**: add `forwardedHeaders.trustedIPs: 10.42.0.0/16` on the `websecure` entrypoint. This tells Traefik to trust `X-Forwarded-For` headers from cluster pod IPs (the proxy pod's actual source address) and strip forged XFF from all other sources.

**Part 2 — `chart/glaze/templates/middleware-tailscale-only.yaml`**: add `ipStrategy.depth: 1` so the middleware evaluates the XFF-carried client Tailscale IP instead of the (SNAT'd) source IP.

## Security posture

Removing the middleware was considered and rejected — the `glaze-admin` ingress uses `ingressClassName: traefik` so the public Traefik also handles `admin.potterdoc.com`. An attacker who knows the public IP could bypass Tailscale DNS and reach the route directly. The middleware is genuine defense-in-depth, not redundant.

The two-part fix preserves this: Traefik strips forged XFF from any source outside `10.42.0.0/16`, so only the Tailscale proxy pod (already inside the cluster, implicitly trusted) can set an XFF that passes the allowlist. The admin remains inaccessible from the public internet.

## Deployment note

`infra/k3s/traefik.yaml` is **not** applied by the CD pipeline — it must be `scp`'d to `/var/lib/rancher/k3s/server/manifests/traefik-config.yaml` on the node manually. Both changes have already been applied and validated on the live cluster (Helm revision 118; middleware and entrypoint config confirmed via `kubectl`).

The CD pipeline will re-apply the glaze Helm chart changes on next merge.
