### PR TITLE
ui: collapsible identity section and preferences routing refinements

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -65,9 +65,9 @@ vi.mock("./components/UserPreferencesDialog", () => ({
     onSectionChange,
   }: {
     open: boolean;
-    activeSectionId: "process-summary" | "tutorials" | null;
+    activeSectionId: "process-summary" | "tutorials" | "identity" | null;
     onClose: () => void;
-    onSectionChange: (sectionId: "process-summary" | "tutorials" | null) => void;
+    onSectionChange: (sectionId: "process-summary" | "tutorials" | "identity" | null) => void;
   }) =>
     open ? (
       <div>
@@ -77,6 +77,7 @@ vi.mock("./components/UserPreferencesDialog", () => ({
           Process Summary
         </button>
         <button onClick={() => onSectionChange("tutorials")}>Tutorials</button>
+        <button onClick={() => onSectionChange("identity")}>Identity</button>
         <button onClick={onClose}>Cancel</button>
       </div>
     ) : null,
@@ -432,7 +433,20 @@ describe("App auth flow", () => {
     await userEvent.click(screen.getByText("Preferences"));
 
     expect(screen.getByText("User Preferences Dialog")).toBeInTheDocument();
-    expect(window.location.pathname).toBe("/preferences/process-summary");
+    expect(window.location.pathname).toBe("/preferences");
+  });
+
+  it("opens the identity preferences route directly", async () => {
+    vi.mocked(fetchAppInit).mockResolvedValue({ googleOauthClientId: "test-client-id", adminBaseUrl: null, user: MOCK_USER });
+    window.history.pushState({}, "", "/preferences/identity");
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText("User Preferences Dialog")).toBeInTheDocument();
+    });
+
+    expect(window.location.pathname).toBe("/preferences/identity");
   });
 
   it("opens the tutorials preferences route directly", async () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -390,7 +390,7 @@ function AppShell({
     [currentUser, onCurrentUserUpdated],
   );
   const openPreferencesDialog = useCallback(
-    (sectionId: PreferencesSectionId | null = "process-summary") => {
+    (sectionId: PreferencesSectionId | null = null) => {
       navigate(sectionId ? `/preferences/${sectionId}` : "/preferences");
     },
     [navigate],
@@ -484,7 +484,7 @@ function AppShell({
               <MenuItem
                 onClick={() => {
                   setMenuAnchor(null);
-                  openPreferencesDialog("process-summary");
+                  openPreferencesDialog(null);
                 }}
               >
                 <ListItemIcon>

--- a/web/src/components/CurrentUserContext.tsx
+++ b/web/src/components/CurrentUserContext.tsx
@@ -3,7 +3,7 @@ import { createContext, useContext } from "react";
 import type { ReactNode } from "react";
 import type { AuthUser, UserPreferences } from "../util/api";
 
-export type PreferencesSectionId = "process-summary" | "tutorials";
+export type PreferencesSectionId = "process-summary" | "tutorials" | "identity";
 
 const CurrentUserContext = createContext<AuthUser | null>(null);
 

--- a/web/src/components/UserPreferencesDialog.tsx
+++ b/web/src/components/UserPreferencesDialog.tsx
@@ -182,15 +182,39 @@ function PreferencesForm({
   return (
     <>
       <Stack spacing={2}>
-        <TextField
-          label="Alias"
-          value={alias}
-          onChange={(e) => setAlias(e.target.value.slice(0, 50))}
-          helperText="How you'd like to identify yourself in the app. Not visible to others."
-          fullWidth
-          disabled={isSaving}
-          inputProps={{ maxLength: 50 }}
-        />
+        <Accordion
+          disableGutters
+          expanded={activeSectionId === "identity"}
+          onChange={(_, expanded) => {
+            if (expanded) {
+              onSectionChange("identity");
+            } else if (activeSectionId === "identity") {
+              onSectionChange(null);
+            }
+          }}
+        >
+          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+            <Stack spacing={0.25}>
+              <Typography variant="subtitle1" component="span">
+                Identity
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Manage your display name and alias.
+              </Typography>
+            </Stack>
+          </AccordionSummary>
+          <AccordionDetails>
+            <TextField
+              label="Alias"
+              value={alias}
+              onChange={(e) => setAlias(e.target.value.slice(0, 50))}
+              helperText="How you'd like to identify yourself in the app. Not visible to others."
+              fullWidth
+              disabled={isSaving}
+              inputProps={{ maxLength: 50 }}
+            />
+          </AccordionDetails>
+        </Accordion>
         <Accordion
           disableGutters
           expanded={activeSectionId === "process-summary"}

--- a/web/src/components/__tests__/UserPreferencesDialog.test.tsx
+++ b/web/src/components/__tests__/UserPreferencesDialog.test.tsx
@@ -22,9 +22,10 @@ import UserPreferencesDialog from "../UserPreferencesDialog";
 import {
   CurrentUserProvider,
   PreferencesDialogProvider,
+  type PreferencesSectionId,
 } from "../CurrentUserContext";
 
-function renderDialog(activeSectionId: "process-summary" | "tutorials") {
+function renderDialog(activeSectionId: PreferencesSectionId | null) {
   return render(
     <PreferencesDialogProvider
       openPreferencesDialog={vi.fn()}
@@ -102,15 +103,16 @@ describe("UserPreferencesDialog", () => {
     ).toBeInTheDocument();
     // Tutorials accordion is collapsed — its checkbox should not be visible.
     expect(screen.queryByRole("checkbox", { name: /summary customization tip/i })).not.toBeInTheDocument();
+    // Identity accordion is collapsed — its alias textbox should not be visible.
+    expect(screen.queryByRole("textbox", { name: /alias/i })).not.toBeInTheDocument();
   });
 
   it("expands the Tutorials section when routed there", async () => {
     renderDialog("tutorials");
 
     expect(await screen.findByText("Show the summary customization tip")).toBeInTheDocument();
-    expect(
-      screen.queryByText("Select the fields that should appear in your process summaries. Images are excluded."),
-    ).not.toBeInTheDocument();
+    // Identity accordion is collapsed — its alias textbox should not be visible.
+    expect(screen.queryByRole("textbox", { name: /alias/i })).not.toBeInTheDocument();
   });
 
   it("saves the full preferences document when toggling tutorials", async () => {
@@ -168,6 +170,19 @@ describe("UserPreferencesDialog", () => {
     });
   });
 
+  it("expands the Identity section when routed there", async () => {
+    renderDialog("identity");
+
+    expect(await screen.findByText("Identity")).toBeInTheDocument();
+    expect(
+      screen.getByText("Manage your display name and alias."),
+    ).toBeInTheDocument();
+    // Alias field should be visible.
+    expect(screen.getByRole("textbox", { name: /alias/i })).toBeInTheDocument();
+    // Tutorials accordion is collapsed — its checkbox should not be visible.
+    expect(screen.queryByRole("checkbox", { name: /summary customization tip/i })).not.toBeInTheDocument();
+  });
+
   it("saves alias when the alias field is filled in", async () => {
     const saveUserPreferences = vi.fn(async (preferences) => preferences);
     const onClose = vi.fn();
@@ -193,7 +208,7 @@ describe("UserPreferencesDialog", () => {
         >
           <UserPreferencesDialog
             open
-            activeSectionId={null}
+            activeSectionId="identity"
             onClose={onClose}
             onSectionChange={vi.fn()}
           />


### PR DESCRIPTION
This PR implements UI refinements to the User Preferences Dialog and updates its routing behavior to fix two related issues:

1. **collapsible and route-able "Identity" section (fixes #666)**:
   - Reorganizes the User Preferences Dialog to place the "Alias" field within a new collapsible `Accordion` titled "Identity".
   - Links the expanded state of this accordion to the new `/preferences/identity` route/section ID.
   - Restores the collapsed state when navigating back to the root `/preferences` path.

2. **Preferences navigation from the user dropdown menu (fixes #665)**:
   - Updates the user menu dropdown's click handler to target the preferences root path (`/preferences`) instead of forcing `/preferences/process-summary`.
   - Modifies `openPreferencesDialog` to default to `null` (preferences root) instead of `"process-summary"`.

### Verification

- Expanded test coverage in [UserPreferencesDialog.test.tsx](file:///home/phil/code/glaze/.agent-worktrees/antigravity/issue-665-666-preferences/web/src/components/__tests__/UserPreferencesDialog.test.tsx) and [App.test.tsx](file:///home/phil/code/glaze/.agent-worktrees/antigravity/issue-665-666-preferences/web/src/App.test.tsx) to verify routing states, expand/collapse behaviors, and alias updates.
- All Bazel test targets (`rtk bazel test //...`) and linters (`rtk bazel build --config=lint //...`) pass successfully.

Closes #665
Closes #666

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
