### PR TITLE
fix(preferences): surface save errors in dialog; add combined-payload test

### DIFF
--- a/api/tests/test_auth.py
+++ b/api/tests/test_auth.py
@@ -182,6 +182,27 @@ class TestAuthEndpointsMocked:
         assert response.status_code == 200
         assert response.json()["alias"] == "My Alias"
 
+    def test_auth_preferences_patch_combined_alias_and_tutorials(self, client, user):
+        UserProfile.objects.create(user=user)
+        response = client.patch(
+            "/api/auth/preferences/",
+            {
+                "alias": "Studio Mug",
+                "preferences": {
+                    "process_summary_fields": ["piece.name"],
+                    "tutorials": {"summary_customize_popover": "don't"},
+                },
+            },
+            format="json",
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["alias"] == "Studio Mug"
+        assert data["preferences"]["process_summary_fields"] == ["piece.name"]
+        assert data["preferences"]["tutorials"]["summary_customize_popover"] == "don't"
+        user.profile.refresh_from_db()
+        assert user.profile.alias == "Studio Mug"
+
 
 @pytest.mark.django_db
 class TestAuthMe:
@@ -219,9 +240,7 @@ class TestAuthMe:
         response = auth_views.auth_me(request)
         assert response.status_code == 503
 
-    def test_refreshes_session_cookie_for_shared_admin_domain(
-        self, user, settings
-    ):
+    def test_refreshes_session_cookie_for_shared_admin_domain(self, user, settings):
         settings.GOOGLE_OAUTH_CLIENT_ID = "my-client-id"
         settings.SESSION_COOKIE_DOMAIN = ".potterdoc.com"
 
@@ -232,8 +251,7 @@ class TestAuthMe:
 
         assert response.status_code == 200
         assert (
-            response.cookies[settings.SESSION_COOKIE_NAME]["domain"]
-            == ".potterdoc.com"
+            response.cookies[settings.SESSION_COOKIE_NAME]["domain"] == ".potterdoc.com"
         )
 
     def test_admin_login_redirects_to_apex_bootstrap(self, settings):
@@ -257,9 +275,7 @@ class TestAuthMe:
         target = urlparse(response["Location"])
         assert target.scheme == "https"
         assert target.netloc == "potterdoc.com"
-        assert parse_qs(target.query)["next"] == [
-            "https://admin.potterdoc.com/admin/"
-        ]
+        assert parse_qs(target.query)["next"] == ["https://admin.potterdoc.com/admin/"]
 
 
 @pytest.mark.django_db

--- a/web/src/components/UserPreferencesDialog.tsx
+++ b/web/src/components/UserPreferencesDialog.tsx
@@ -3,6 +3,7 @@ import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
+  Alert,
   Box,
   Button,
   Checkbox,
@@ -104,6 +105,12 @@ export default function UserPreferencesDialog({
             <Typography color="error">
               Failed to load your preferences.
             </Typography>
+          ) : null}
+
+          {saveState.error !== null ? (
+            <Alert severity="error">
+              Couldn't save your preferences. Please try again.
+            </Alert>
           ) : null}
 
           <PreferencesForm

--- a/web/src/components/__tests__/UserPreferencesDialog.test.tsx
+++ b/web/src/components/__tests__/UserPreferencesDialog.test.tsx
@@ -217,4 +217,51 @@ describe("UserPreferencesDialog", () => {
       expect(onClose).toHaveBeenCalled();
     });
   });
+
+  it("shows an error message and does not close when saving fails", async () => {
+    const saveUserPreferences = vi.fn().mockRejectedValue(new Error("Server error"));
+    const onClose = vi.fn();
+
+    render(
+      <PreferencesDialogProvider
+        openPreferencesDialog={vi.fn()}
+        saveUserPreferences={saveUserPreferences}
+      >
+        <CurrentUserProvider
+          currentUser={{
+            id: 1,
+            is_staff: false,
+            openid_subject: "",
+            alias: "",
+            preferences: {
+              // Match the fetchUserPreferences mock return value so that the
+              // preferencesKey doesn't change on fetch, avoiding a PreferencesForm
+              // remount that would detach the save button before it can be clicked.
+              process_summary_fields: ["piece.name"],
+              tutorials: {
+                summary_customize_popover: "show",
+              },
+            },
+          }}
+        >
+          <UserPreferencesDialog
+            open
+            activeSectionId={null}
+            onClose={onClose}
+            onSectionChange={vi.fn()}
+          />
+        </CurrentUserProvider>
+      </PreferencesDialogProvider>,
+    );
+
+    // fireEvent bypasses aria-hidden; MUI Dialog's Fade transition keeps content
+    // aria-hidden in jsdom so userEvent won't reach it.
+    const saveButton = await screen.findByRole("button", { name: /save/i, hidden: true });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/couldn't save your preferences/i)).toBeInTheDocument();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- **Frontend**: `UserPreferencesDialog` previously swallowed save failures silently — if the PATCH threw (e.g. a 403 CSRF in production), `useAsyncFn` captured the error in `saveState.error` but nothing was rendered to the user. Now shows an inline `<Alert severity="error">` when `saveState.error` is non-null, and a new test verifies the alert appears and `onClose` is not called on failure.
- **Backend**: adds `test_auth_preferences_patch_combined_alias_and_tutorials` — a regression test covering the exact frontend payload (`alias` + `preferences.tutorials` in one PATCH). This combination had no prior test coverage. The test passes, confirming the serializer/view handles it correctly.

## Root cause note (backend — tracked separately)

The attached JSON on #651 shows the production failure is a **403 CSRF token mismatch**. `updateUserPreferences` already calls `ensureCsrfCookie()` before the PATCH, and the CSRF middleware and `X-CSRFToken` header are wired correctly. The mismatch appears to be a stale 32-char (pre-Django 4.0 format) cookie that Django 6.0 no longer accepts. This is a broader backend/deployment issue outside the scope of this PR.

## Test plan

- [ ] `rtk bazel test //web:web_user_preferences_dialog_test` — new error-state test passes
- [ ] `rtk bazel test //api:api_auth_test` — new combined-payload test passes
- [ ] Open Preferences dialog in the running app, confirm Save still works normally
- [ ] (To verify the error UI) simulate a save failure by temporarily making `saveUserPreferences` throw — alert appears, dialog stays open

Closes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)