### PR TITLE
fix: resolve production CSRF failures on PATCH and write operations

### DIFF
--- a/api/auth_views.py
+++ b/api/auth_views.py
@@ -110,6 +110,7 @@ def auth_logout(request: Request) -> Response:
     },
     description="Bootstrap response: public config plus the current user if authenticated.",
 )
+@ensure_csrf_cookie
 @api_view(["GET"])
 @permission_classes([AllowAny])
 @traced
@@ -454,7 +455,9 @@ def _collect_export_data(user: Any, request: Request) -> tuple[str, str, list[Im
     profile_json = json.dumps(
         {
             "alias": profile.alias if profile else None,
-            "preferences": profile.preferences if profile and isinstance(profile.preferences, dict) else {},
+            "preferences": profile.preferences
+            if profile and isinstance(profile.preferences, dict)
+            else {},
         },
         default=str,
     )

--- a/api/static/admin/js/cloudinary_image_widget.js
+++ b/api/static/admin/js/cloudinary_image_widget.js
@@ -22,8 +22,8 @@
   function getCsrfToken() {
     return (document.cookie.split(';')
       .map(function (c) { return c.trim(); })
-      .filter(function (c) { return c.startsWith('csrftoken='); })
-      .map(function (c) { return c.substring('csrftoken='.length); })[0] || '');
+      .filter(function (c) { return c.startsWith('potterdoc_csrftoken='); })
+      .map(function (c) { return c.substring('potterdoc_csrftoken='.length); })[0] || '');
   }
 
   /**

--- a/api/tests/test_auth.py
+++ b/api/tests/test_auth.py
@@ -70,6 +70,12 @@ class TestAuthEndpointsMocked:
         response = auth_views.csrf(request)
         assert response.status_code == 204
 
+    def test_auth_me_sets_csrf_cookie(self, client, settings):
+        settings.GOOGLE_OAUTH_CLIENT_ID = "test-client-id"
+        response = client.get("/api/auth/me/")
+        assert response.status_code == 200
+        assert "potterdoc_csrftoken" in response.cookies
+
     def test_auth_me_includes_preferences(self, client, user, settings):
         settings.GOOGLE_OAUTH_CLIENT_ID = "test-client-id"
         UserProfile.objects.create(

--- a/api/tests/test_host_settings.py
+++ b/api/tests/test_host_settings.py
@@ -40,9 +40,7 @@ def test_backend_settings_includes_admin_ingress_host(monkeypatch):
         ("backend.test_settings", {}),
     ],
 )
-def test_backend_settings_share_parent_domain_cookies(
-    monkeypatch, module_name, env
-):
+def test_backend_settings_share_parent_domain_cookies(monkeypatch, module_name, env):
     monkeypatch.setenv("ALLOWED_HOST", "potterdoc.com")
     monkeypatch.setenv("ADMIN_INGRESS_HOST", "admin.potterdoc.com")
     monkeypatch.delenv("ALLOWED_HOSTS", raising=False)
@@ -52,7 +50,8 @@ def test_backend_settings_share_parent_domain_cookies(
     settings = _reload_settings_module(module_name)
 
     assert settings.SESSION_COOKIE_DOMAIN == ".potterdoc.com"
-    assert settings.CSRF_COOKIE_DOMAIN == ".potterdoc.com"
+    assert getattr(settings, "CSRF_COOKIE_DOMAIN", None) is None
+    assert settings.CSRF_COOKIE_NAME == "potterdoc_csrftoken"
 
 
 def test_backend_production_settings_enable_hsts_preload(monkeypatch):

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -320,6 +320,7 @@ LOGGING = {
 # Security settings
 SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
 SECURE_CROSS_ORIGIN_OPENER_POLICY = "same-origin-allow-popups"
+CSRF_COOKIE_NAME = "potterdoc_csrftoken"
 
 if IS_PRODUCTION:
     SESSION_COOKIE_SECURE = True
@@ -331,7 +332,6 @@ if IS_PRODUCTION:
     SECURE_REDIRECT_EXEMPT = [r"^api/health/"]
     if _COOKIE_DOMAIN:
         SESSION_COOKIE_DOMAIN = _COOKIE_DOMAIN
-        CSRF_COOKIE_DOMAIN = _COOKIE_DOMAIN
 
 # Remote ML Offloading (Modal)
 REMOTE_REMBG_URL = os.environ.get("REMOTE_REMBG_URL", "")

--- a/backend/test_settings.py
+++ b/backend/test_settings.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 import dj_database_url
 
-
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 # Default test runs should be deterministic and not depend on production env vars.
@@ -73,7 +72,6 @@ _COOKIE_DOMAIN = _shared_cookie_domain(
 )
 if _COOKIE_DOMAIN:
     SESSION_COOKIE_DOMAIN = _COOKIE_DOMAIN
-    CSRF_COOKIE_DOMAIN = _COOKIE_DOMAIN
 
 
 INSTALLED_APPS = [
@@ -302,3 +300,4 @@ LOGGING = {
 
 SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
 SECURE_CROSS_ORIGIN_OPENER_POLICY = "same-origin-allow-popups"
+CSRF_COOKIE_NAME = "potterdoc_csrftoken"

--- a/tests/test_admin_access.py
+++ b/tests/test_admin_access.py
@@ -7,9 +7,7 @@ from pathlib import Path
 
 def test_admin_ingress_routes_static_assets():
     repo_root = Path(__file__).resolve().parents[1]
-    admin_ingress = (
-        repo_root / "chart/glaze/templates/ingress-admin.yaml"
-    ).read_text()
+    admin_ingress = (repo_root / "chart/glaze/templates/ingress-admin.yaml").read_text()
     admin_public_ingress = (
         repo_root / "chart/glaze/templates/ingress-admin-public.yaml"
     ).read_text()
@@ -20,18 +18,13 @@ def test_admin_ingress_routes_static_assets():
 
 def test_admin_ingress_is_tailnet_only():
     repo_root = Path(__file__).resolve().parents[1]
-    admin_ingress = (
-        repo_root / "chart/glaze/templates/ingress-admin.yaml"
-    ).read_text()
-    middleware = (
-        repo_root / "chart/glaze/templates/middleware-tailscale-only.yaml"
-    ).read_text()
+    admin_ingress = (repo_root / "chart/glaze/templates/ingress-admin.yaml").read_text()
 
+    assert "default-{{ $fullName }}-security-headers@kubernetescrd" in admin_ingress
     assert (
-        "default-{{ $fullName }}-security-headers@kubernetescrd" in admin_ingress
+        'traefik.ingress.kubernetes.io/router.entrypoints: "websecure-tailscale"'
+        in admin_ingress
     )
-    assert "default-{{ $fullName }}-tailscale-only@kubernetescrd" in admin_ingress
-    assert '{{ .Values.network.tailscaleCidr | quote }}' in middleware
 
 
 def test_public_admin_ingress_remains_explicitly_public():
@@ -41,8 +34,7 @@ def test_public_admin_ingress_remains_explicitly_public():
     ).read_text()
 
     assert (
-        "default-{{ $fullName }}-security-headers@kubernetescrd"
-        in admin_public_ingress
+        "default-{{ $fullName }}-security-headers@kubernetescrd" in admin_public_ingress
     )
     assert (
         "default-{{ $fullName }}-tailscale-only@kubernetescrd"

--- a/tests/test_host_firewall.py
+++ b/tests/test_host_firewall.py
@@ -37,4 +37,4 @@ def test_host_firewall_documents_sensitive_ports():
 
     assert "public kube API" in script
     assert "kubelet" in script
-    assert "incidental NodePorts" in script
+    assert "NodePort exposure" in script

--- a/web/src/util/__tests__/api.test.ts
+++ b/web/src/util/__tests__/api.test.ts
@@ -100,7 +100,7 @@ describe("client setup", () => {
     expect(mockCreate).toHaveBeenCalledWith({ baseURL: "/api/" });
     expect(mockClient.defaults).toMatchObject({
       withCredentials: true,
-      xsrfCookieName: "csrftoken",
+      xsrfCookieName: "potterdoc_csrftoken",
       xsrfHeaderName: "X-CSRFToken",
     });
   });

--- a/web/src/util/api.ts
+++ b/web/src/util/api.ts
@@ -96,7 +96,7 @@ export type UserPreferences = {
 
 const client = axios.create({ baseURL: "/api/" });
 client.defaults.withCredentials = true;
-client.defaults.xsrfCookieName = "csrftoken";
+client.defaults.xsrfCookieName = "potterdoc_csrftoken";
 client.defaults.xsrfHeaderName = "X-CSRFToken";
 const expoBaseUrl = (
   globalThis as { process?: { env?: Record<string, string | undefined> } }


### PR DESCRIPTION
Closes #682

## Summary of Changes
This PR addresses CSRF verification failures in production (where write operations such as `PATCH` were failing due to token conflicts or missing CSRF cookies on session load).

### 1. Django Settings
- Set `CSRF_COOKIE_NAME = "potterdoc_csrftoken"` to partition the cookie namespace, avoiding conflicts with legacy/generic `csrftoken` cookies.
- Omitted `CSRF_COOKIE_DOMAIN = _COOKIE_DOMAIN` (defaults to `None`), ensuring the CSRF cookie is host-only. This prevents subdomain vs. host-level cookie conflicts on `potterdoc.com` while maintaining `SESSION_COOKIE_DOMAIN = ".potterdoc.com"` for admin auth sharing.

### 2. Frontend & API Clients
- Configured Axios defaults to use the new `potterdoc_csrftoken` cookie name.
- Updated the Cloudinary image widget script used in the Django Admin to read `potterdoc_csrftoken`.

### 3. Bootstrap CSRF Delivery
- Added the `@ensure_csrf_cookie` decorator to the `/api/auth/me/` (`auth_me`) view, ensuring any user loading the app (authenticated or not) always has a fresh CSRF cookie ready.

### 4. Tests
- Updated `api/tests/test_host_settings.py` and `web/src/util/__tests__/api.test.ts` to reflect the new CSRF settings.
- Added a regression test `test_auth_me_sets_csrf_cookie` in `api/tests/test_auth.py`.
- Fixed broken pre-existing assertions in `tests/test_admin_access.py` and `tests/test_host_firewall.py` related to `middleware-tailscale-only.yaml` deletion and comments.

## Verification
- Verified all backend and frontend unit tests pass: `rtk bazel test //...`
- Verified all linters and build targets pass.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
