### PR TITLE
fix: add change_alias_prompt to UserPreferencesDialog

### DIFF
--- a/web/src/components/UserPreferencesDialog.tsx
+++ b/web/src/components/UserPreferencesDialog.tsx
@@ -123,9 +123,15 @@ export default function UserPreferencesDialog({
             initialAlias={initialAlias}
             initialSelectedRefs={initialSelectedRefs}
             initialTutorialVisibility={initialTutorialVisibility}
+            initialAliasPromptVisibility={initialAliasPromptVisibility}
             activeSectionId={activeSectionId}
             onSectionChange={onSectionChange}
-            onSave={async (alias, selectedRefs, tutorialVisibility) => {
+            onSave={async (
+              alias,
+              selectedRefs,
+              tutorialVisibility,
+              aliasPromptVisibility,
+            ) => {
               const response = await saveState.execute(
                 {
                   process_summary_fields: selectedRefs,
@@ -133,7 +139,7 @@ export default function UserPreferencesDialog({
                     [TUTORIAL_TOGGLE_KEYS.SUMMARY_CUSTOMIZE_POPUP]:
                       tutorialVisibility,
                     [TUTORIAL_TOGGLE_KEYS.CHANGE_ALIAS_PROMPT]:
-                      initialAliasPromptVisibility,
+                      aliasPromptVisibility,
                   },
                 },
                 alias,
@@ -161,6 +167,7 @@ function PreferencesForm({
   initialAlias,
   initialSelectedRefs,
   initialTutorialVisibility,
+  initialAliasPromptVisibility,
   activeSectionId,
   onSectionChange,
   onSave,
@@ -171,12 +178,14 @@ function PreferencesForm({
   initialAlias: string;
   initialSelectedRefs: string[];
   initialTutorialVisibility: TutorialVisibility;
+  initialAliasPromptVisibility: TutorialVisibility;
   activeSectionId: PreferencesSectionId | null;
   onSectionChange: (sectionId: PreferencesSectionId | null) => void;
   onSave: (
     alias: string,
     selectedRefs: string[],
     tutorialVisibility: TutorialVisibility,
+    aliasPromptVisibility: TutorialVisibility,
   ) => Promise<void>;
   onCancel: () => void;
   isSaving: boolean;
@@ -185,6 +194,8 @@ function PreferencesForm({
   const [selectedRefs, setSelectedRefs] = useState(initialSelectedRefs);
   const [tutorialVisibility, setTutorialVisibility] =
     useState<TutorialVisibility>(initialTutorialVisibility);
+  const [aliasPromptVisibility, setAliasPromptVisibility] =
+    useState<TutorialVisibility>(initialAliasPromptVisibility);
 
   function toggleRef(ref: string) {
     setSelectedRefs((prev) =>
@@ -333,6 +344,24 @@ function PreferencesForm({
                   </Stack>
                 }
               />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={aliasPromptVisibility}
+                    onChange={() => setAliasPromptVisibility((prev) => !prev)}
+                  />
+                }
+                label={
+                  <Stack spacing={0.25}>
+                    <Typography variant="body2">
+                      Show the "Change your alias!" tip
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      Controls the alias guidance shown on the piece list.
+                    </Typography>
+                  </Stack>
+                }
+              />
             </FormGroup>
           </AccordionDetails>
         </Accordion>
@@ -343,7 +372,14 @@ function PreferencesForm({
         </Button>
         <Button
           variant="contained"
-          onClick={() => void onSave(alias, selectedRefs, tutorialVisibility)}
+          onClick={() =>
+            void onSave(
+              alias,
+              selectedRefs,
+              tutorialVisibility,
+              aliasPromptVisibility,
+            )
+          }
           disabled={isSaving}
         >
           Save

--- a/web/src/components/__tests__/UserPreferencesDialog.test.tsx
+++ b/web/src/components/__tests__/UserPreferencesDialog.test.tsx
@@ -113,9 +113,16 @@ describe("UserPreferencesDialog", () => {
   it("expands the Tutorials section when routed there", async () => {
     renderDialog("tutorials");
 
-    expect(await screen.findByText("Show the summary customization tip")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Show the summary customization tip"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Show the "Change your alias!" tip'),
+    ).toBeInTheDocument();
     // Identity accordion is collapsed — its alias textbox should not be visible.
-    expect(screen.queryByRole("textbox", { name: /alias/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("textbox", { name: /alias/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("saves the full preferences document when toggling tutorials", async () => {
@@ -167,6 +174,65 @@ describe("UserPreferencesDialog", () => {
           tutorials: {
             summary_customize_popover: false,
             change_alias_prompt: true,
+          },
+        },
+        "",
+      );
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  it("saves the full preferences document when toggling the alias tutorial", async () => {
+    const user = userEvent.setup();
+    const saveUserPreferences = vi.fn(async (preferences) => preferences);
+    const onClose = vi.fn();
+
+    render(
+      <PreferencesDialogProvider
+        openPreferencesDialog={vi.fn()}
+        saveUserPreferences={saveUserPreferences}
+      >
+        <CurrentUserProvider
+          currentUser={{
+            id: 1,
+            is_staff: false,
+            openid_subject: "",
+            preferences: {
+              process_summary_fields: ["piece.name"],
+              tutorials: {
+                summary_customize_popover: true,
+                change_alias_prompt: true,
+              },
+            },
+          }}
+        >
+          <UserPreferencesDialog
+            open
+            activeSectionId="tutorials"
+            onClose={onClose}
+            onSectionChange={vi.fn()}
+          />
+        </CurrentUserProvider>
+      </PreferencesDialogProvider>,
+    );
+
+    await user.click(
+      await screen.findByRole("checkbox", {
+        name: /"Change your alias!" tip/i,
+        hidden: true,
+      }),
+    );
+    await user.click(
+      await screen.findByRole("button", { name: /save/i, hidden: true }),
+    );
+
+    await waitFor(() => {
+      expect(saveUserPreferences).toHaveBeenCalledWith(
+        {
+          process_summary_fields: ["piece.name"],
+          tutorials: {
+            summary_customize_popover: true,
+            change_alias_prompt: false,
           },
         },
         "",


### PR DESCRIPTION
## Problem
The `change_alias_prompt` tutorial visibility was not tracked in the User Preferences UI, and its state was not correctly persisted during preference saves.

## Solution
- Added the "Change your alias!" toggle to the **Preferences > Tutorials** section.
- Updated `UserPreferencesDialog.tsx` to manage and save the `change_alias_prompt` state.
- Added verification tests in `UserPreferencesDialog.test.tsx`.

Closes #689