### PR TITLE
fix: cap user dropdown chip width to 16ch

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -491,7 +491,7 @@ function AppShell({
               sx={{
                 cursor: "pointer",
                 flexShrink: 0,
-                minWidth: "16ch",
+                maxWidth: "16ch",
               }}
             />
             <Menu


### PR DESCRIPTION
This PR changes the user dropdown chip from `minWidth: "16ch"` to `maxWidth: "16ch"`. This ensures the chip has a consistent upper bound but shrinks gracefully to fit shorter aliases or display names.
