### PR TITLE
fix: avoid re-sourcing env.sh in gz_worktrees --purge

### DIFF
--- a/env-agent.sh
+++ b/env-agent.sh
@@ -990,7 +990,7 @@ _gz_worktrees_purge() {
                 if [[ $skip -eq 0 ]]; then
                     echo "  Removing..."
                     # Stop servers if running
-                    (cd "$wt_path" && source env.sh && gz_stop >/dev/null 2>&1)
+                    (_GLAZE_PIDS="$wt_path/.dev-pids"; gz_stop >/dev/null 2>&1)
                     git -C "$GLAZE_SHARED_ROOT" worktree remove --force "$wt_path"
                 fi
             fi


### PR DESCRIPTION
Optimize `gz_worktrees --purge` to avoid re-sourcing `env.sh` in each worktree. This improves performance and prevents unwanted side effects during cleanup.

### Changes
- Modified `_gz_worktrees_purge` in `env-agent.sh` to stop running servers by directly targeting the worktree's `.dev-pids` directory instead of sourcing the full environment.
- Replaced the subshell that sourced `env.sh` with one that just sets `_GLAZE_PIDS` and calls `gz_stop`.

This change ensures that `gz_worktrees --purge` remains fast and silent while still correctly cleaning up orphaned server processes.
