### PR TITLE
feat: manual crop tool in piece image lightbox

### DIFF
--- a/api/BUILD.bazel
+++ b/api/BUILD.bazel
@@ -261,6 +261,7 @@ pytest_test(
         "tests/test_editable_mode.py",
         "tests/test_images.py",
         "tests/test_issue_337.py",
+        "tests/test_patch_image_crop.py",
     ],
     args = [
         "api/tests/test_pieces_create.py",
@@ -275,6 +276,7 @@ pytest_test(
         "api/tests/test_editable_mode.py",
         "api/tests/test_images.py",
         "api/tests/test_issue_337.py",
+        "api/tests/test_patch_image_crop.py",
     ],
     data = _TEST_DATA,
     env = _TEST_ENV,

--- a/api/cloudinary_views.py
+++ b/api/cloudinary_views.py
@@ -138,6 +138,13 @@ def cloudinary_widget_sign(request: Request) -> Response:
             status=status.HTTP_400_BAD_REQUEST,
         )
 
+    # Reject non-image resource types — enforcement without signature injection.
+    if params_to_sign.get("resource_type", "image") != "image":
+        return Response(
+            {"detail": "Only image uploads are permitted."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
     # Cloudinary signature format: sorted key=value pairs joined by '&',
     # then append the API secret and SHA1-hash the result.
     signing_string = "&".join(

--- a/api/cloudinary_views.py
+++ b/api/cloudinary_views.py
@@ -90,7 +90,11 @@ def cloudinary_widget_config(request: Request) -> Response:
             status=status.HTTP_503_SERVICE_UNAVAILABLE,
         )
 
-    payload: dict[str, str] = {"cloud_name": cloud_name, "api_key": api_key}
+    payload: dict[str, str] = {
+        "cloud_name": cloud_name,
+        "api_key": api_key,
+        "transformation": "fl_force_strip",
+    }
     if folder:
         payload["folder"] = folder
     preset = os.environ.get("CLOUDINARY_UPLOAD_PRESET", "").strip()
@@ -133,14 +137,6 @@ def cloudinary_widget_sign(request: Request) -> Response:
             {"detail": "params_to_sign must be an object."},
             status=status.HTTP_400_BAD_REQUEST,
         )
-
-    # Enforce image-only uploads and strip EXIF regardless of what the client sends.
-    params_to_sign = {
-        **params_to_sign,
-        "resource_type": "image",
-        "allowed_formats": "jpg,jpeg,png,webp,heic,avif",
-        "exif": "false",
-    }
 
     # Cloudinary signature format: sorted key=value pairs joined by '&',
     # then append the API secret and SHA1-hash the result.

--- a/api/piece_views.py
+++ b/api/piece_views.py
@@ -483,13 +483,14 @@ def patch_image_crop(request, image_id):
     serializer = ImageCropSerializer(data=request.data)
     serializer.is_valid(raise_exception=True)
 
-    # An Image can appear in multiple PieceStateImages (e.g. after a move), but
-    # the crop field lives on the join model and callers pass only image_id with
-    # no way to disambiguate. In practice a single Image is never shared across
-    # multiple PSIs for the same user, so .first() is safe.
+    # An Image can appear in multiple PieceStateImages (e.g. after a "Move to"
+    # operation). Callers pass only image_id with no way to disambiguate, so we
+    # target the most recently created PSI (highest id) which is the one the user
+    # last interacted with.
     link = (
         PieceStateImage.objects.select_related("piece_state__piece")
         .filter(image=image, piece_state__piece__user=request.user)
+        .order_by("-id")
         .first()
     )
     if link is None:

--- a/api/piece_views.py
+++ b/api/piece_views.py
@@ -55,6 +55,7 @@ from .serializers import (
     AuthUserSerializer,
     GlazeCombinationImageEntrySerializer,
     GoogleAuthSerializer,
+    ImageCropSerializer,
     PieceCreateSerializer,
     PieceDetailSerializer,
     PieceStateCreateSerializer,
@@ -469,6 +470,30 @@ def piece_image_detail(request, image_id, piece_state_id):
                 link.piece_state = to_state
                 link.order = next_order
                 link.save(update_fields=["piece_state", "order"])
+
+    piece = get_object_or_404(_piece_detail_queryset(request), pk=piece.pk)
+    return Response(_serialize_piece_detail(piece, request))
+
+
+@extend_schema(request=ImageCropSerializer, responses=PieceDetailSerializer)
+@api_view(["PATCH"])
+@permission_classes([IsAuthenticated])
+def patch_image_crop(request, image_id):
+    image = get_object_or_404(Image, pk=image_id, user=request.user)
+    serializer = ImageCropSerializer(data=request.data)
+    serializer.is_valid(raise_exception=True)
+
+    link = (
+        PieceStateImage.objects.select_related("piece_state__piece")
+        .filter(image=image, piece_state__piece__user=request.user)
+        .first()
+    )
+    if link is None:
+        raise Http404
+    piece = link.piece_state.piece
+
+    link.crop = serializer.validated_data
+    link.save(update_fields=["crop"])
 
     piece = get_object_or_404(_piece_detail_queryset(request), pk=piece.pk)
     return Response(_serialize_piece_detail(piece, request))

--- a/api/piece_views.py
+++ b/api/piece_views.py
@@ -483,6 +483,10 @@ def patch_image_crop(request, image_id):
     serializer = ImageCropSerializer(data=request.data)
     serializer.is_valid(raise_exception=True)
 
+    # An Image can appear in multiple PieceStateImages (e.g. after a move), but
+    # the crop field lives on the join model and callers pass only image_id with
+    # no way to disambiguate. In practice a single Image is never shared across
+    # multiple PSIs for the same user, so .first() is safe.
     link = (
         PieceStateImage.objects.select_related("piece_state__piece")
         .filter(image=image, piece_state__piece__user=request.user)

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -295,6 +295,9 @@ def detect_subject_crop(task: AsyncTask) -> dict | None:
                 updated = True
             else:
                 psi_skip_reason = "PieceStateImage already has a crop"
+                logger.warning(
+                    f"detect_subject_crop skipped psi={psi.id}: crop already set by user, not overwriting"
+                )
 
     if not updated:
         return {

--- a/api/tests/test_cloudinary_upload_signature.py
+++ b/api/tests/test_cloudinary_upload_signature.py
@@ -152,3 +152,27 @@ class TestCloudinaryWidgetSign:
         )
 
         assert response.status_code == 400
+
+    def test_rejects_non_image_resource_type(self, client, monkeypatch):
+        monkeypatch.setenv("CLOUDINARY_API_SECRET", "super-secret")
+
+        response = client.post(
+            "/api/uploads/cloudinary/widget-signature/",
+            {"params_to_sign": {"resource_type": "video", "timestamp": "1700000000"}},
+            format="json",
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Only image uploads are permitted."
+
+    def test_allows_explicit_image_resource_type(self, client, monkeypatch):
+        monkeypatch.setenv("CLOUDINARY_API_SECRET", "super-secret")
+
+        params = {"resource_type": "image", "timestamp": "1700000000"}
+        response = client.post(
+            "/api/uploads/cloudinary/widget-signature/",
+            {"params_to_sign": params},
+            format="json",
+        )
+
+        assert response.status_code == 200

--- a/api/tests/test_cloudinary_upload_signature.py
+++ b/api/tests/test_cloudinary_upload_signature.py
@@ -38,6 +38,7 @@ class TestCloudinaryWidgetConfig:
         assert response.json() == {
             "cloud_name": "demo-cloud",
             "api_key": "public-api-key",
+            "transformation": "fl_force_strip",
         }
 
     def test_returns_config_with_folder(self, client, monkeypatch):
@@ -52,6 +53,7 @@ class TestCloudinaryWidgetConfig:
         assert response.json() == {
             "cloud_name": "demo-cloud",
             "api_key": "public-api-key",
+            "transformation": "fl_force_strip",
             "folder": "glaze",
         }
 
@@ -67,6 +69,7 @@ class TestCloudinaryWidgetConfig:
         assert response.json() == {
             "cloud_name": "demo-cloud",
             "api_key": "public-api-key",
+            "transformation": "fl_force_strip",
             "upload_preset": "glaze_signed",
         }
 
@@ -104,6 +107,7 @@ class TestCloudinaryWidgetSign:
     def test_returns_signature(self, client, monkeypatch):
         monkeypatch.setenv("CLOUDINARY_API_SECRET", "super-secret")
 
+        # Server signs exactly the params the widget sends — no injection.
         params = {"folder": "glaze", "timestamp": "1700000000"}
         response = client.post(
             "/api/uploads/cloudinary/widget-signature/",
@@ -112,24 +116,19 @@ class TestCloudinaryWidgetSign:
         )
 
         assert response.status_code == 200
-        # Server enforces allowed_formats, resource_type, and exif before signing.
-        enforced = {
-            **params,
-            "allowed_formats": "jpg,jpeg,png,webp,heic,avif",
-            "exif": "false",
-            "resource_type": "image",
-        }
-        signing_string = "&".join(f"{k}={enforced[k]}" for k in sorted(enforced.keys()))
+        signing_string = "&".join(f"{k}={params[k]}" for k in sorted(params.keys()))
         expected = hashlib.sha1(
             f"{signing_string}super-secret".encode("utf-8")
         ).hexdigest()
         assert response.json() == {"signature": expected}
 
-    def test_enforces_resource_type_image(self, client, monkeypatch):
+    def test_signs_params_as_received(self, client, monkeypatch):
         monkeypatch.setenv("CLOUDINARY_API_SECRET", "super-secret")
 
-        # Client sends resource_type=video; server must override it to image.
-        params = {"resource_type": "video", "timestamp": "1700000000"}
+        # EXIF stripping is now enforced via fl_force_strip in the widget config
+        # transformation, not by injecting params into the signing string.
+        # The server signs whatever params the widget sends unchanged.
+        params = {"source": "uw", "timestamp": "1700000000", "upload_preset": "test"}
         response = client.post(
             "/api/uploads/cloudinary/widget-signature/",
             {"params_to_sign": params},
@@ -137,79 +136,11 @@ class TestCloudinaryWidgetSign:
         )
 
         assert response.status_code == 200
-        enforced = {
-            **params,
-            "allowed_formats": "jpg,jpeg,png,webp,heic,avif",
-            "exif": "false",
-            "resource_type": "image",
-        }
-        signing_string = "&".join(f"{k}={enforced[k]}" for k in sorted(enforced.keys()))
+        signing_string = "&".join(f"{k}={params[k]}" for k in sorted(params.keys()))
         expected = hashlib.sha1(
             f"{signing_string}super-secret".encode("utf-8")
         ).hexdigest()
         assert response.json() == {"signature": expected}
-
-        # Confirm the signature differs from what the tampered params would have produced.
-        tampered_string = "&".join(f"{k}={params[k]}" for k in sorted(params.keys()))
-        tampered_sig = hashlib.sha1(
-            f"{tampered_string}super-secret".encode("utf-8")
-        ).hexdigest()
-        assert response.json()["signature"] != tampered_sig
-
-    def test_enforces_allowed_formats(self, client, monkeypatch):
-        monkeypatch.setenv("CLOUDINARY_API_SECRET", "super-secret")
-
-        # Client omits allowed_formats; server must inject the allowlist.
-        params = {"timestamp": "1700000000"}
-        response = client.post(
-            "/api/uploads/cloudinary/widget-signature/",
-            {"params_to_sign": params},
-            format="json",
-        )
-
-        assert response.status_code == 200
-        enforced = {
-            **params,
-            "allowed_formats": "jpg,jpeg,png,webp,heic,avif",
-            "exif": "false",
-            "resource_type": "image",
-        }
-        signing_string = "&".join(f"{k}={enforced[k]}" for k in sorted(enforced.keys()))
-        expected = hashlib.sha1(
-            f"{signing_string}super-secret".encode("utf-8")
-        ).hexdigest()
-        assert response.json() == {"signature": expected}
-
-    def test_enforces_exif_stripped(self, client, monkeypatch):
-        monkeypatch.setenv("CLOUDINARY_API_SECRET", "super-secret")
-
-        # Client sends exif=true; server must override it to false.
-        params = {"exif": "true", "timestamp": "1700000000"}
-        response = client.post(
-            "/api/uploads/cloudinary/widget-signature/",
-            {"params_to_sign": params},
-            format="json",
-        )
-
-        assert response.status_code == 200
-        enforced = {
-            **params,
-            "allowed_formats": "jpg,jpeg,png,webp,heic,avif",
-            "exif": "false",
-            "resource_type": "image",
-        }
-        signing_string = "&".join(f"{k}={enforced[k]}" for k in sorted(enforced.keys()))
-        expected = hashlib.sha1(
-            f"{signing_string}super-secret".encode("utf-8")
-        ).hexdigest()
-        assert response.json() == {"signature": expected}
-
-        # Confirm the signature differs from what the tampered params would have produced.
-        tampered_string = "&".join(f"{k}={params[k]}" for k in sorted(params.keys()))
-        tampered_sig = hashlib.sha1(
-            f"{tampered_string}super-secret".encode("utf-8")
-        ).hexdigest()
-        assert response.json()["signature"] != tampered_sig
 
     def test_returns_400_when_params_not_dict(self, client, monkeypatch):
         monkeypatch.setenv("CLOUDINARY_API_SECRET", "super-secret")

--- a/api/tests/test_patch_image_crop.py
+++ b/api/tests/test_patch_image_crop.py
@@ -1,0 +1,112 @@
+import pytest
+from django.contrib.auth.models import User
+from rest_framework.test import APIClient
+
+from api.models import ENTRY_STATE, Image, Piece, PieceState, PieceStateImage
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create(username="test@example.com", email="test@example.com")
+
+
+@pytest.fixture
+def other_user(db):
+    return User.objects.create(username="other@example.com", email="other@example.com")
+
+
+@pytest.fixture
+def client(user):
+    c = APIClient()
+    c.force_authenticate(user=user)
+    return c
+
+
+@pytest.fixture
+def other_client(other_user):
+    c = APIClient()
+    c.force_authenticate(user=other_user)
+    return c
+
+
+@pytest.fixture
+def editable_piece(user, db):
+    p = Piece.objects.create(user=user, name="Test Bowl", is_editable=True)
+    PieceState.objects.create(piece=p, state=ENTRY_STATE, order=1)
+    return p
+
+
+@pytest.fixture
+def non_editable_piece(user, db):
+    p = Piece.objects.create(user=user, name="Locked Bowl", is_editable=False)
+    PieceState.objects.create(piece=p, state=ENTRY_STATE, order=1)
+    return p
+
+
+@pytest.fixture
+def image_in_editable_piece(user, editable_piece):
+    img = Image.objects.create(user=user, url="https://example.com/img.jpg")
+    PieceStateImage.objects.create(
+        piece_state=editable_piece.current_state, image=img, order=0
+    )
+    return img
+
+
+@pytest.fixture
+def image_in_non_editable_piece(user, non_editable_piece):
+    img = Image.objects.create(user=user, url="https://example.com/img.jpg")
+    PieceStateImage.objects.create(
+        piece_state=non_editable_piece.current_state, image=img, order=0
+    )
+    return img
+
+
+VALID_CROP = {"x": 0.1, "y": 0.2, "width": 0.6, "height": 0.5}
+
+
+@pytest.mark.django_db
+class TestPatchImageCrop:
+    def test_success_updates_crop(
+        self, client, image_in_editable_piece, editable_piece
+    ):
+        image = image_in_editable_piece
+        response = client.patch(
+            f"/api/images/{image.id}/crop/",
+            VALID_CROP,
+            format="json",
+        )
+        assert response.status_code == 200
+        link = PieceStateImage.objects.get(
+            image=image, piece_state=editable_piece.current_state
+        )
+        assert link.crop == VALID_CROP
+
+    def test_non_owner_returns_404(self, other_client, image_in_editable_piece):
+        image = image_in_editable_piece
+        response = other_client.patch(
+            f"/api/images/{image.id}/crop/",
+            VALID_CROP,
+            format="json",
+        )
+        assert response.status_code == 404
+
+    def test_non_editable_piece_returns_403(self, client, image_in_non_editable_piece):
+        image = image_in_non_editable_piece
+        response = client.patch(
+            f"/api/images/{image.id}/crop/",
+            VALID_CROP,
+            format="json",
+        )
+        assert response.status_code == 403
+        assert "not in editable mode" in response.json()["detail"]
+
+    def test_invalid_crop_missing_field_returns_400(
+        self, client, image_in_editable_piece
+    ):
+        image = image_in_editable_piece
+        response = client.patch(
+            f"/api/images/{image.id}/crop/",
+            {"x": 0.1, "y": 0.2, "width": 0.6},  # missing height
+            format="json",
+        )
+        assert response.status_code == 400

--- a/api/tests/test_patch_image_crop.py
+++ b/api/tests/test_patch_image_crop.py
@@ -90,15 +90,32 @@ class TestPatchImageCrop:
         )
         assert response.status_code == 404
 
-    def test_non_editable_piece_returns_403(self, client, image_in_non_editable_piece):
+    def test_non_editable_piece_allows_crop(
+        self, client, image_in_non_editable_piece, non_editable_piece
+    ):
+        # Crop is intentionally allowed on sealed/non-editable pieces so potters
+        # can correct a bad auto-crop without needing to re-open the piece.
         image = image_in_non_editable_piece
         response = client.patch(
             f"/api/images/{image.id}/crop/",
             VALID_CROP,
             format="json",
         )
+        assert response.status_code == 200
+        link = PieceStateImage.objects.get(
+            image=image, piece_state=non_editable_piece.current_state
+        )
+        assert link.crop == VALID_CROP
+
+    def test_unauthenticated_returns_403(self, image_in_editable_piece):
+        c = APIClient()  # no force_authenticate
+        image = image_in_editable_piece
+        response = c.patch(
+            f"/api/images/{image.id}/crop/",
+            VALID_CROP,
+            format="json",
+        )
         assert response.status_code == 403
-        assert "not in editable mode" in response.json()["detail"]
 
     def test_invalid_crop_missing_field_returns_400(
         self, client, image_in_editable_piece

--- a/api/urls.py
+++ b/api/urls.py
@@ -15,6 +15,11 @@ urlpatterns = [
         name="piece-image-detail",
     ),
     path(
+        "images/<uuid:image_id>/crop/",
+        views.patch_image_crop,
+        name="image-crop-update",
+    ),
+    path(
         "images/<uuid:image_id>/crop-runs/",
         views.ImageCropRunsView.as_view(),
         name="image-crop-runs",

--- a/api/views.py
+++ b/api/views.py
@@ -38,6 +38,7 @@ from .health_views import (
 )
 from .import_views import admin_manual_square_crop_import
 from .piece_views import (
+    patch_image_crop,
     piece_current_state,
     piece_current_state_detail,
     piece_detail,
@@ -76,6 +77,7 @@ __all__ = [
     "make_global_entry_view",
     "piece_current_state",
     "piece_current_state_detail",
+    "patch_image_crop",
     "piece_detail",
     "piece_image_detail",
     "piece_past_state",

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -921,6 +921,22 @@ vitest_test(
 )
 
 vitest_test(
+    name = "web_piece_photo_gallery_lightbox_integration_test",
+    srcs = [
+        "src/components/__tests__/PiecePhotoGalleryLightboxIntegration.test.tsx",
+    ],
+    tags = ["ibazel_notify_changes"],
+    deps = [
+        ":image_lightbox_src",
+        ":piece_photo_gallery_src",
+    ],
+    expected_coverage = [
+        "web/src/components/ImageLightbox*",
+        "web/src/components/PiecePhotoGallery*",
+    ],
+)
+
+vitest_test(
     name = "web_report_bad_crop_dialog_test",
     srcs = [
         "src/components/__tests__/ReportBadCropDialog.test.tsx",
@@ -1301,6 +1317,7 @@ test_suite(
         ":web_crop_overlay_test",
         ":web_image_lightbox_test",
         ":web_new_piece_dialog_test",
+        ":web_piece_photo_gallery_lightbox_integration_test",
         ":web_piece_photo_gallery_test",
         ":web_normalize_workflow_fields_test",
         ":web_ocr_detection_test",

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -401,6 +401,7 @@ js_library(
     srcs = ["src/components/CropOverlay.tsx"],
     deps = [
         ":node_modules",
+        ":util_lib",
     ],
 )
 

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -397,10 +397,19 @@ js_library(
 )
 
 js_library(
+    name = "crop_overlay_src",
+    srcs = ["src/components/CropOverlay.tsx"],
+    deps = [
+        ":node_modules",
+    ],
+)
+
+js_library(
     name = "image_lightbox_src",
     srcs = ["src/components/ImageLightbox.tsx"],
     deps = [
         ":cloudinary_image_src",
+        ":crop_overlay_src",
         ":node_modules",
     ],
 )
@@ -774,6 +783,20 @@ vitest_test(
 )
 
 vitest_test(
+    name = "web_crop_overlay_test",
+    srcs = [
+        "src/components/__tests__/CropOverlay.test.tsx",
+    ],
+    tags = ["ibazel_notify_changes"],
+    deps = [
+        ":crop_overlay_src",
+    ],
+    expected_coverage = [
+        "web/src/components/CropOverlay*",
+    ],
+)
+
+vitest_test(
     name = "web_image_lightbox_test",
     srcs = [
         "src/components/__tests__/ImageLightbox.test.tsx",
@@ -782,10 +805,12 @@ vitest_test(
     tags = ["ibazel_notify_changes"],
     deps = [
         ":cloudinary_image_src",
+        ":crop_overlay_src",
         ":image_lightbox_src",
     ],
     expected_coverage = [
         "web/src/components/CloudinaryImage*",
+        "web/src/components/CropOverlay*",
         "web/src/components/ImageLightbox*",
     ],
 )
@@ -1272,8 +1297,10 @@ test_suite(
         ":web_format_test",
         ":web_glaze_gallery_test",
         ":web_glaze_import_test",
+        ":web_crop_overlay_test",
         ":web_image_lightbox_test",
         ":web_new_piece_dialog_test",
+        ":web_piece_photo_gallery_test",
         ":web_normalize_workflow_fields_test",
         ":web_ocr_detection_test",
         ":web_picker_test",

--- a/web/src/components/CloudinaryImage.tsx
+++ b/web/src/components/CloudinaryImage.tsx
@@ -30,8 +30,6 @@ import { useEffect, useRef, useState } from "react";
 import type { ImageCrop } from "../util/types";
 
 const THUMBNAIL_SIZE = 64;
-const LIGHTBOX_MAX_WIDTH = "90vw";
-const LIGHTBOX_MAX_HEIGHT = "80vh";
 const DEFAULT_VIEWPORT_WIDTH = 1200;
 const DEFAULT_VIEWPORT_HEIGHT = 900;
 const DEFAULT_DEVICE_PIXEL_RATIO = 1;
@@ -148,10 +146,8 @@ export default function CloudinaryImage({
           display: "inline-flex",
           alignItems: "center",
           justifyContent: "center",
-          width: LIGHTBOX_MAX_WIDTH,
-          height: LIGHTBOX_MAX_HEIGHT,
-          maxWidth: LIGHTBOX_MAX_WIDTH,
-          maxHeight: LIGHTBOX_MAX_HEIGHT,
+          width: "fit-content",
+          height: "fit-content",
         }
       : context === "detail"
         ? {

--- a/web/src/components/CropOverlay.tsx
+++ b/web/src/components/CropOverlay.tsx
@@ -246,6 +246,7 @@ export default function CropOverlay({
               width: "100vw",
               height: "100vh",
               pointerEvents: "none",
+              touchAction: "none",
               zIndex: 1,
             }}
             viewBox={`0 0 ${W} ${H}`}

--- a/web/src/components/CropOverlay.tsx
+++ b/web/src/components/CropOverlay.tsx
@@ -286,6 +286,8 @@ export default function CropOverlay({
                 fill="white"
                 stroke="#555"
                 strokeWidth={1}
+                role="button"
+                aria-label={`Resize ${id}`}
                 style={{ pointerEvents: "all", cursor: handleCursor(id) }}
                 onMouseDown={(e) => startDrag(id, e)}
                 onTouchStart={(e) => startDrag(id, e)}

--- a/web/src/components/CropOverlay.tsx
+++ b/web/src/components/CropOverlay.tsx
@@ -1,0 +1,364 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Alert, Box, Button, CircularProgress } from "@mui/material";
+import { useAsync } from "../util/useAsync";
+import { Cloudinary } from "@cloudinary/url-gen";
+import { format } from "@cloudinary/url-gen/actions/delivery";
+import { auto as autoFormat } from "@cloudinary/url-gen/qualifiers/format";
+import type { ImageCrop } from "../util/types";
+
+interface CropOverlayProps {
+  cloudinaryPublicId: string;
+  cloudName: string;
+  initialCrop: ImageCrop | null;
+  onSave: (crop: ImageCrop) => Promise<void>;
+  onCancel: () => void;
+}
+
+type Handle =
+  | "nw"
+  | "n"
+  | "ne"
+  | "w"
+  | "e"
+  | "sw"
+  | "s"
+  | "se"
+  | "move";
+
+function buildUncroppedUrl(publicId: string, cloudName: string): string {
+  const cld = new Cloudinary({ cloud: { cloudName } });
+  const img = cld.image(publicId);
+  img.delivery(format(autoFormat()));
+  return img.toURL();
+}
+
+function handleCursor(h: Handle): string {
+  const map: Record<Handle, string> = {
+    nw: "nwse-resize",
+    ne: "nesw-resize",
+    sw: "nesw-resize",
+    se: "nwse-resize",
+    n: "ns-resize",
+    s: "ns-resize",
+    e: "ew-resize",
+    w: "ew-resize",
+    move: "move",
+  };
+  return map[h];
+}
+
+function clamp(v: number, lo: number, hi: number) {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+function applyCropDelta(
+  base: ImageCrop,
+  handle: Handle,
+  dx: number,
+  dy: number,
+): ImageCrop {
+  let { x, y, width: w, height: h } = base;
+  const MIN = 0.02;
+  switch (handle) {
+    case "move":
+      x = clamp(x + dx, 0, 1 - w);
+      y = clamp(y + dy, 0, 1 - h);
+      break;
+    case "nw": {
+      const nx = clamp(x + dx, 0, x + w - MIN);
+      const ny = clamp(y + dy, 0, y + h - MIN);
+      w += x - nx;
+      h += y - ny;
+      x = nx;
+      y = ny;
+      break;
+    }
+    case "ne": {
+      w = clamp(w + dx, MIN, 1 - x);
+      const ny = clamp(y + dy, 0, y + h - MIN);
+      h += y - ny;
+      y = ny;
+      break;
+    }
+    case "sw": {
+      const nx = clamp(x + dx, 0, x + w - MIN);
+      w += x - nx;
+      x = nx;
+      h = clamp(h + dy, MIN, 1 - y);
+      break;
+    }
+    case "se":
+      w = clamp(w + dx, MIN, 1 - x);
+      h = clamp(h + dy, MIN, 1 - y);
+      break;
+    case "n": {
+      const ny = clamp(y + dy, 0, y + h - MIN);
+      h += y - ny;
+      y = ny;
+      break;
+    }
+    case "s":
+      h = clamp(h + dy, MIN, 1 - y);
+      break;
+    case "w": {
+      const nx = clamp(x + dx, 0, x + w - MIN);
+      w += x - nx;
+      x = nx;
+      break;
+    }
+    case "e":
+      w = clamp(w + dx, MIN, 1 - x);
+      break;
+  }
+  return { x, y, width: w, height: h };
+}
+
+export default function CropOverlay({
+  cloudinaryPublicId,
+  cloudName,
+  initialCrop,
+  onSave,
+  onCancel,
+}: CropOverlayProps) {
+  const defaultCrop: ImageCrop = initialCrop ?? {
+    x: 0,
+    y: 0,
+    width: 1,
+    height: 1,
+  };
+  const [crop, setCrop] = useState<ImageCrop>(defaultCrop);
+  const [imgRect, setImgRect] = useState<DOMRect | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const imgRef = useRef<HTMLImageElement>(null);
+  const dragRef = useRef<{
+    handle: Handle;
+    startX: number;
+    startY: number;
+    startCrop: ImageCrop;
+  } | null>(null);
+
+  const url = useMemo(
+    () => buildUncroppedUrl(cloudinaryPublicId, cloudName),
+    [cloudinaryPublicId, cloudName],
+  );
+
+  const { loading: imageLoading } = useAsync<void>(
+    useCallback(
+      () =>
+        new Promise<void>((resolve, reject) => {
+          const img = new Image();
+          img.onload = () => resolve();
+          img.onerror = () => reject(new Error("Failed to load image"));
+          img.src = url;
+        }),
+      [url],
+    ),
+  );
+
+  const updateRect = useCallback(() => {
+    if (imgRef.current) setImgRect(imgRef.current.getBoundingClientRect());
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener("resize", updateRect);
+    return () => window.removeEventListener("resize", updateRect);
+  }, [updateRect]);
+
+  function toPx(n: ImageCrop, rect: DOMRect) {
+    return {
+      x: rect.left + n.x * rect.width,
+      y: rect.top + n.y * rect.height,
+      w: n.width * rect.width,
+      h: n.height * rect.height,
+    };
+  }
+
+  useEffect(() => {
+    function applyMove(clientX: number, clientY: number) {
+      if (!dragRef.current || !imgRect) return;
+      const { handle, startX, startY, startCrop } = dragRef.current;
+      const dx = (clientX - startX) / imgRect.width;
+      const dy = (clientY - startY) / imgRect.height;
+      setCrop(applyCropDelta(startCrop, handle, dx, dy));
+    }
+    function onMouseMove(e: MouseEvent) { applyMove(e.clientX, e.clientY); }
+    function onMouseUp() { dragRef.current = null; }
+    function onTouchMove(e: TouchEvent) {
+      e.preventDefault();
+      applyMove(e.touches[0].clientX, e.touches[0].clientY);
+    }
+    function onTouchEnd() { dragRef.current = null; }
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+    document.addEventListener("touchmove", onTouchMove, { passive: false });
+    document.addEventListener("touchend", onTouchEnd);
+    return () => {
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+      document.removeEventListener("touchmove", onTouchMove);
+      document.removeEventListener("touchend", onTouchEnd);
+    };
+  }, [imgRect]);
+
+  function startDrag(handle: Handle, e: React.MouseEvent | React.TouchEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    const clientX = "touches" in e ? e.touches[0].clientX : e.clientX;
+    const clientY = "touches" in e ? e.touches[0].clientY : e.clientY;
+    dragRef.current = { handle, startX: clientX, startY: clientY, startCrop: crop };
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await onSave(crop);
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const HANDLE_R = 6;
+  const overlay = imgRect
+    ? (() => {
+        const { x: px, y: py, w: pw, h: ph } = toPx(crop, imgRect);
+        const handles: { id: Handle; cx: number; cy: number }[] = [
+          { id: "nw", cx: px, cy: py },
+          { id: "n", cx: px + pw / 2, cy: py },
+          { id: "ne", cx: px + pw, cy: py },
+          { id: "w", cx: px, cy: py + ph / 2 },
+          { id: "e", cx: px + pw, cy: py + ph / 2 },
+          { id: "sw", cx: px, cy: py + ph },
+          { id: "s", cx: px + pw / 2, cy: py + ph },
+          { id: "se", cx: px + pw, cy: py + ph },
+        ];
+        const MASK_ALPHA = 0.55;
+        const W = window.innerWidth;
+        const H = window.innerHeight;
+        return (
+          <svg
+            style={{
+              position: "fixed",
+              inset: 0,
+              width: "100vw",
+              height: "100vh",
+              pointerEvents: "none",
+              zIndex: 1,
+            }}
+            viewBox={`0 0 ${W} ${H}`}
+          >
+            <rect
+              x={0}
+              y={0}
+              width={W}
+              height={H}
+              fill={`rgba(0,0,0,${MASK_ALPHA})`}
+            />
+            <rect x={px} y={py} width={pw} height={ph} fill="transparent" />
+            <rect
+              x={px}
+              y={py}
+              width={pw}
+              height={ph}
+              fill="none"
+              stroke="white"
+              strokeWidth={1.5}
+            />
+            <rect
+              x={px}
+              y={py}
+              width={pw}
+              height={ph}
+              fill="transparent"
+              style={{ pointerEvents: "all", cursor: "move" }}
+              onMouseDown={(e) => startDrag("move", e)}
+              onTouchStart={(e) => startDrag("move", e)}
+            />
+            {handles.map(({ id, cx, cy }) => (
+              <circle
+                key={id}
+                cx={cx}
+                cy={cy}
+                r={HANDLE_R * 2}
+                fill="white"
+                stroke="#555"
+                strokeWidth={1}
+                style={{ pointerEvents: "all", cursor: handleCursor(id) }}
+                onMouseDown={(e) => startDrag(id, e)}
+                onTouchStart={(e) => startDrag(id, e)}
+              />
+            ))}
+          </svg>
+        );
+      })()
+    : null;
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 1,
+      }}
+    >
+      <Box sx={{ position: "relative" }}>
+        {imageLoading ? (
+          <Box
+            sx={{
+              width: "90vw",
+              maxWidth: 800,
+              height: "60vh",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <CircularProgress sx={{ color: "white" }} />
+          </Box>
+        ) : (
+          <>
+            <img
+              ref={imgRef}
+              src={url}
+              onLoad={updateRect}
+              style={{
+                maxWidth: "90vw",
+                maxHeight: "70vh",
+                objectFit: "contain",
+                display: "block",
+              }}
+              alt="Crop editor"
+            />
+            {overlay}
+          </>
+        )}
+      </Box>
+      {saveError && (
+        <Alert severity="error" sx={{ maxWidth: "90vw", position: "relative", zIndex: 2 }}>
+          {saveError}
+        </Alert>
+      )}
+      <Box sx={{ display: "flex", gap: 1, mt: 1, position: "relative", zIndex: 2 }}>
+        <Button
+          variant="outlined"
+          onClick={onCancel}
+          disabled={saving}
+          sx={{ color: "white", borderColor: "rgba(255,255,255,0.5)" }}
+        >
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={() => void handleSave()}
+          disabled={saving || imageLoading}
+        >
+          {saving ? <CircularProgress size={18} /> : "Save Crop"}
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/web/src/components/GlazeCombinationGallery.tsx
+++ b/web/src/components/GlazeCombinationGallery.tsx
@@ -285,12 +285,12 @@ export default function GlazeCombinationGallery() {
           onClose={() => setLightbox(null)}
           footerActions={
             lightbox.kind === "piece"
-              ? (i) => (
+              ? ({ index }) => (
                   <Button
                     size="small"
                     variant="outlined"
                     onClick={() =>
-                      navigate(`/pieces/${lightbox.images[i].pieceId}`, {
+                      navigate(`/pieces/${lightbox.images[index].pieceId}`, {
                         state: { fromGallery: true },
                       })
                     }

--- a/web/src/components/ImageLightbox.tsx
+++ b/web/src/components/ImageLightbox.tsx
@@ -52,13 +52,13 @@ export default function ImageLightbox({
 
   function prev() {
     setIndex((i) => {
-      if (i > 0) { setCropMode(false); return i - 1; }
+      if (i > 0) { setCropMode(false); setPostCropLoading(false); setPendingCropAspect(null); return i - 1; }
       return i;
     });
   }
   function next() {
     setIndex((i) => {
-      if (i < images.length - 1) { setCropMode(false); return i + 1; }
+      if (i < images.length - 1) { setCropMode(false); setPostCropLoading(false); setPendingCropAspect(null); return i + 1; }
       return i;
     });
   }
@@ -66,7 +66,8 @@ export default function ImageLightbox({
   const swipeHandlers = useSwipeable({
     onSwiping: ({ deltaX, deltaY, dir }) => {
       if (dir === "Up" || dir === "Down") {
-        setDragDeltaY(deltaY);
+        // Resist downward swipes — only upward closes
+        setDragDeltaY(dir === "Down" ? deltaY * 0.25 : deltaY);
       } else {
         // Resist at boundaries — dampen drag past the first/last image
         if ((index === 0 && dir === "Right") || (index === images.length - 1 && dir === "Left")) {

--- a/web/src/components/ImageLightbox.tsx
+++ b/web/src/components/ImageLightbox.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from "react";
 import {
   Box,
+  CircularProgress,
   IconButton,
   Modal,
   Typography,
 } from "@mui/material";
+import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
 import { useSwipeable } from "react-swipeable";
 import type { CaptionedImage, ImageCrop } from "../util/types";
 import CloudinaryImage from "./CloudinaryImage";
@@ -23,6 +25,7 @@ type ImageLightboxProps = {
   footerActions?: (opts: {
     index: number;
     onCrop?: () => void;
+    cropAvailable?: boolean;
     onSetAsThumbnail?: () => Promise<void>;
     settingThumbnail: boolean;
     isCurrentThumbnail: boolean;
@@ -41,8 +44,11 @@ export default function ImageLightbox({
 }: ImageLightboxProps) {
   const [index, setIndex] = useState(initialIndex);
   const [dragDeltaX, setDragDeltaX] = useState(0);
+  const [dragDeltaY, setDragDeltaY] = useState(0);
   const [settingThumbnail, setSettingThumbnail] = useState(false);
   const [cropMode, setCropMode] = useState(false);
+  const [postCropLoading, setPostCropLoading] = useState(false);
+  const [pendingCropAspect, setPendingCropAspect] = useState<number | null>(null);
 
   function prev() {
     setIndex((i) => {
@@ -58,12 +64,16 @@ export default function ImageLightbox({
   }
 
   const swipeHandlers = useSwipeable({
-    onSwiping: ({ deltaX, dir }) => {
-      // Resist at boundaries — dampen drag past the first/last image
-      if ((index === 0 && dir === "Right") || (index === images.length - 1 && dir === "Left")) {
-        setDragDeltaX(deltaX * 0.25);
+    onSwiping: ({ deltaX, deltaY, dir }) => {
+      if (dir === "Up" || dir === "Down") {
+        setDragDeltaY(deltaY);
       } else {
-        setDragDeltaX(deltaX);
+        // Resist at boundaries — dampen drag past the first/last image
+        if ((index === 0 && dir === "Right") || (index === images.length - 1 && dir === "Left")) {
+          setDragDeltaX(deltaX * 0.25);
+        } else {
+          setDragDeltaX(deltaX);
+        }
       }
     },
     onSwipedLeft: ({ absX }) => {
@@ -74,8 +84,11 @@ export default function ImageLightbox({
       setDragDeltaX(0);
       if (absX >= SWIPE_THRESHOLD) prev();
     },
+    onSwipedUp: () => { setDragDeltaY(0); onClose(); },
+    onSwipedDown: () => setDragDeltaY(0),
     onTouchEndOrOnMouseUp: () => {
       setDragDeltaX(0);
+      setDragDeltaY(0);
     },
     trackMouse: false,
     trackTouch: true,
@@ -105,7 +118,7 @@ export default function ImageLightbox({
     >
       <Box
         data-testid="lightbox-backdrop"
-        onClick={onClose}
+        onClick={cropMode ? undefined : onClose}
         sx={{
           position: "fixed",
           inset: 0,
@@ -117,6 +130,31 @@ export default function ImageLightbox({
           outline: "none",
         }}
       >
+        {/* Swipe-up-to-close hint overlay */}
+        {dragDeltaY < 0 && (
+          <Box
+            sx={{
+              position: "fixed",
+              top: 0,
+              left: 0,
+              right: 0,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              pt: 2,
+              gap: 0.5,
+              opacity: Math.min(1, Math.abs(dragDeltaY) / 80),
+              pointerEvents: "none",
+              color: "white",
+            }}
+          >
+            <ArrowUpwardIcon fontSize="small" />
+            <Typography variant="caption" sx={{ letterSpacing: 1, textTransform: "uppercase" }}>
+              drag to close
+            </Typography>
+          </Box>
+        )}
+
         {/* Swipeable image area / crop editor */}
         {cropMode && image.cloudinary_public_id && image.cloud_name ? (
           <CropOverlay
@@ -125,6 +163,8 @@ export default function ImageLightbox({
             initialCrop={image.crop ?? null}
             onSave={async (crop) => {
               await onCropSave?.(image, crop);
+              setPendingCropAspect(crop.width / crop.height);
+              setPostCropLoading(true);
               setCropMode(false);
             }}
             onCancel={() => setCropMode(false)}
@@ -133,31 +173,61 @@ export default function ImageLightbox({
           <Box
             {...swipeHandlers}
             data-testid="lightbox-swipe-area"
-            onClick={(e) => e.stopPropagation()}
+            onClick={(e) => { e.stopPropagation(); onClose(); }}
             sx={{ touchAction: "pan-y", cursor: images.length > 1 ? "grab" : undefined }}
           >
             <Box
+              onClick={(e) => e.stopPropagation()}
               sx={{
-                transform: `translateX(${dragDeltaX}px)`,
-                transition: dragDeltaX === 0 ? "transform 0.25s ease" : "none",
+                transform: `translate(${dragDeltaX}px, ${dragDeltaY}px)`,
+                transition: dragDeltaX === 0 && dragDeltaY === 0 ? "transform 0.25s ease" : "none",
+                width: "fit-content",
+                position: "relative",
               }}
             >
-              <CloudinaryImage
-                url={image.url}
-                cloud_name={image.cloud_name}
-                cloudinary_public_id={image.cloudinary_public_id}
-                crop={image.crop}
-                alt={image.caption || "Pottery image"}
-                context="lightbox"
-                style={{
-                  maxWidth: "90vw",
-                  maxHeight: "80vh",
-                  objectFit: "contain",
-                  borderRadius: 4,
-                  userSelect: "none",
+              {postCropLoading && pendingCropAspect !== null && (
+                <Box
+                  sx={{
+                    aspectRatio: pendingCropAspect,
+                    maxWidth: "90vw",
+                    maxHeight: "80vh",
+                    width: "90vw",
+                    borderRadius: "4px",
+                    bgcolor: "rgba(255,255,255,0.06)",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  <CircularProgress sx={{ color: "white" }} />
+                </Box>
+              )}
+              <Box
+                sx={postCropLoading ? {
+                  position: "absolute",
+                  inset: 0,
+                  opacity: 0,
                   pointerEvents: "none",
-                }}
-              />
+                } : undefined}
+              >
+                <CloudinaryImage
+                  url={image.url}
+                  cloud_name={image.cloud_name}
+                  cloudinary_public_id={image.cloudinary_public_id}
+                  crop={image.crop}
+                  alt={image.caption || "Pottery image"}
+                  context="lightbox"
+                  onLoad={() => { setPostCropLoading(false); setPendingCropAspect(null); }}
+                  style={{
+                    maxWidth: "90vw",
+                    maxHeight: "80vh",
+                    objectFit: "contain",
+                    borderRadius: 4,
+                    userSelect: "none",
+                    pointerEvents: "none",
+                  }}
+                />
+              </Box>
             </Box>
           </Box>
         )}
@@ -169,6 +239,7 @@ export default function ImageLightbox({
               onCrop: onCropSave && canEditImage?.(index) && image.image_id && image.cloudinary_public_id && image.cloud_name
                 ? () => setCropMode(true)
                 : undefined,
+              cropAvailable: !!onCropSave,
               onSetAsThumbnail: onSetAsThumbnail ? handleSetAsThumbnail : undefined,
               settingThumbnail,
               isCurrentThumbnail,

--- a/web/src/components/ImageLightbox.tsx
+++ b/web/src/components/ImageLightbox.tsx
@@ -1,15 +1,14 @@
 import React, { useState } from "react";
 import {
   Box,
-  Button,
-  CircularProgress,
   IconButton,
   Modal,
   Typography,
 } from "@mui/material";
 import { useSwipeable } from "react-swipeable";
-import type { CaptionedImage } from "../util/types";
+import type { CaptionedImage, ImageCrop } from "../util/types";
 import CloudinaryImage from "./CloudinaryImage";
+import CropOverlay from "./CropOverlay";
 
 const SWIPE_THRESHOLD = 50;
 
@@ -19,7 +18,15 @@ type ImageLightboxProps = {
   onClose: () => void;
   currentThumbnailUrl?: string;
   onSetAsThumbnail?: (image: CaptionedImage) => Promise<void>;
-  footerActions?: (index: number) => React.ReactNode;
+  onCropSave?: (image: CaptionedImage, crop: ImageCrop) => Promise<void>;
+  canEditImage?: (index: number) => boolean;
+  footerActions?: (opts: {
+    index: number;
+    onCrop?: () => void;
+    onSetAsThumbnail?: () => Promise<void>;
+    settingThumbnail: boolean;
+    isCurrentThumbnail: boolean;
+  }) => React.ReactNode;
 };
 
 export default function ImageLightbox({
@@ -28,26 +35,32 @@ export default function ImageLightbox({
   onClose,
   currentThumbnailUrl,
   onSetAsThumbnail,
+  onCropSave,
+  canEditImage,
   footerActions,
 }: ImageLightboxProps) {
   const [index, setIndex] = useState(initialIndex);
   const [dragDeltaX, setDragDeltaX] = useState(0);
   const [settingThumbnail, setSettingThumbnail] = useState(false);
+  const [cropMode, setCropMode] = useState(false);
 
   function prev() {
-    setIndex((i) => (i > 0 ? i - 1 : i));
+    setIndex((i) => {
+      if (i > 0) { setCropMode(false); return i - 1; }
+      return i;
+    });
   }
   function next() {
-    setIndex((i) => (i < images.length - 1 ? i + 1 : i));
+    setIndex((i) => {
+      if (i < images.length - 1) { setCropMode(false); return i + 1; }
+      return i;
+    });
   }
 
   const swipeHandlers = useSwipeable({
     onSwiping: ({ deltaX, dir }) => {
       // Resist at boundaries — dampen drag past the first/last image
-      if (
-        (index === 0 && dir === "Right") ||
-        (index === images.length - 1 && dir === "Left")
-      ) {
+      if ((index === 0 && dir === "Right") || (index === images.length - 1 && dir === "Left")) {
         setDragDeltaX(deltaX * 0.25);
       } else {
         setDragDeltaX(deltaX);
@@ -92,9 +105,7 @@ export default function ImageLightbox({
     >
       <Box
         data-testid="lightbox-backdrop"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) onClose();
-        }}
+        onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
         sx={{
           position: "fixed",
           inset: 0,
@@ -106,79 +117,72 @@ export default function ImageLightbox({
           outline: "none",
         }}
       >
-        {/* Swipeable image area */}
-        <Box
-          {...swipeHandlers}
-          data-testid="lightbox-swipe-area"
-          sx={{
-            touchAction: "pan-y",
-            cursor: images.length > 1 ? "grab" : undefined,
-          }}
-        >
-          <Box
-            sx={{
-              transform: `translateX(${dragDeltaX}px)`,
-              transition: dragDeltaX === 0 ? "transform 0.25s ease" : "none",
+        {/* Swipeable image area / crop editor */}
+        {cropMode && image.cloudinary_public_id && image.cloud_name ? (
+          <CropOverlay
+            cloudinaryPublicId={image.cloudinary_public_id}
+            cloudName={image.cloud_name}
+            initialCrop={image.crop ?? null}
+            onSave={async (crop) => {
+              await onCropSave?.(image, crop);
+              setCropMode(false);
             }}
+            onCancel={() => setCropMode(false)}
+          />
+        ) : (
+          <Box
+            {...swipeHandlers}
+            data-testid="lightbox-swipe-area"
+            sx={{ touchAction: "pan-y", cursor: images.length > 1 ? "grab" : undefined }}
           >
-            <CloudinaryImage
-              url={image.url}
-              cloud_name={image.cloud_name}
-              cloudinary_public_id={image.cloudinary_public_id}
-              crop={image.crop}
-              alt={image.caption || "Pottery image"}
-              context="lightbox"
-              style={{
-                maxWidth: "90vw",
-                maxHeight: "80vh",
-                objectFit: "contain",
-                borderRadius: 4,
-                userSelect: "none",
-                pointerEvents: "none",
+            <Box
+              sx={{
+                transform: `translateX(${dragDeltaX}px)`,
+                transition: dragDeltaX === 0 ? "transform 0.25s ease" : "none",
               }}
-            />
+            >
+              <CloudinaryImage
+                url={image.url}
+                cloud_name={image.cloud_name}
+                cloudinary_public_id={image.cloudinary_public_id}
+                crop={image.crop}
+                alt={image.caption || "Pottery image"}
+                context="lightbox"
+                style={{
+                  maxWidth: "90vw",
+                  maxHeight: "80vh",
+                  objectFit: "contain",
+                  borderRadius: 4,
+                  userSelect: "none",
+                  pointerEvents: "none",
+                }}
+              />
+            </Box>
           </Box>
-        </Box>
-
-        {footerActions && footerActions(index)}
-        {onSetAsThumbnail && (
-          <Button
-            size="small"
-            variant="outlined"
-            disabled={isCurrentThumbnail || settingThumbnail}
-            onClick={handleSetAsThumbnail}
-            startIcon={
-              settingThumbnail ? (
-                <CircularProgress size={14} color="inherit" />
-              ) : undefined
-            }
-            sx={{ color: "white", borderColor: "rgba(255,255,255,0.5)" }}
-          >
-            {isCurrentThumbnail
-              ? "Current thumbnail"
-              : settingThumbnail
-                ? "Setting…"
-                : "Set as thumbnail"}
-          </Button>
         )}
 
-        {/* Navigation — arrows on non-touch, dots always when multiple images */}
-        {images.length > 1 && (
-          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+        {!cropMode && footerActions && footerActions({
+          index,
+          onCrop: onCropSave && canEditImage?.(index) && image.image_id && image.cloudinary_public_id && image.cloud_name
+            ? () => setCropMode(true)
+            : undefined,
+          onSetAsThumbnail: onSetAsThumbnail ? handleSetAsThumbnail : undefined,
+          settingThumbnail,
+          isCurrentThumbnail,
+        })}
+
+        {/* Nav row — centered */}
+        {!cropMode && images.length > 1 && (
+          <Box sx={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 0.5 }}>
             <IconButton
               onClick={prev}
               disabled={index === 0}
-              sx={{
-                color: "white",
-                fontSize: "1.5rem",
-                display: { xs: "none", sm: "inline-flex" },
-              }}
+              size="small"
+              sx={{ color: "white", display: { xs: "none", sm: "inline-flex" } }}
               aria-label="previous image"
             >
               ←
             </IconButton>
-
-            {/* Indicator dots */}
             <Box sx={{ display: "flex", gap: 0.75, alignItems: "center" }}>
               {images.map((_, i) => (
                 <Box
@@ -188,8 +192,7 @@ export default function ImageLightbox({
                     width: i === index ? 10 : 7,
                     height: i === index ? 10 : 7,
                     borderRadius: "50%",
-                    backgroundColor:
-                      i === index ? "white" : "rgba(255,255,255,0.35)",
+                    backgroundColor: i === index ? "white" : "rgba(255,255,255,0.35)",
                     cursor: "pointer",
                     transition: "all 0.2s ease",
                     flexShrink: 0,
@@ -199,34 +202,22 @@ export default function ImageLightbox({
                 />
               ))}
             </Box>
-
             <IconButton
               onClick={next}
               disabled={index === images.length - 1}
-              sx={{
-                color: "white",
-                fontSize: "1.5rem",
-                display: { xs: "none", sm: "inline-flex" },
-              }}
+              size="small"
+              sx={{ color: "white", display: { xs: "none", sm: "inline-flex" } }}
               aria-label="next image"
             >
               →
             </IconButton>
+            <Typography
+              variant="caption"
+              sx={{ color: "rgba(255,255,255,0.5)", display: { xs: "none", sm: "block" }, ml: 0.5 }}
+            >
+              {index + 1} / {images.length}
+            </Typography>
           </Box>
-        )}
-
-        {/* Counter — non-touch only, alongside arrows */}
-        {images.length > 1 && (
-          <Typography
-            variant="body2"
-            sx={{
-              color: "rgba(255,255,255,0.5)",
-              mt: -1.5,
-              display: { xs: "none", sm: "block" },
-            }}
-          >
-            {index + 1} / {images.length}
-          </Typography>
         )}
       </Box>
     </Modal>

--- a/web/src/components/ImageLightbox.tsx
+++ b/web/src/components/ImageLightbox.tsx
@@ -105,7 +105,7 @@ export default function ImageLightbox({
     >
       <Box
         data-testid="lightbox-backdrop"
-        onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+        onClick={onClose}
         sx={{
           position: "fixed",
           inset: 0,
@@ -133,6 +133,7 @@ export default function ImageLightbox({
           <Box
             {...swipeHandlers}
             data-testid="lightbox-swipe-area"
+            onClick={(e) => e.stopPropagation()}
             sx={{ touchAction: "pan-y", cursor: images.length > 1 ? "grab" : undefined }}
           >
             <Box
@@ -161,19 +162,26 @@ export default function ImageLightbox({
           </Box>
         )}
 
-        {!cropMode && footerActions && footerActions({
-          index,
-          onCrop: onCropSave && canEditImage?.(index) && image.image_id && image.cloudinary_public_id && image.cloud_name
-            ? () => setCropMode(true)
-            : undefined,
-          onSetAsThumbnail: onSetAsThumbnail ? handleSetAsThumbnail : undefined,
-          settingThumbnail,
-          isCurrentThumbnail,
-        })}
+        {!cropMode && footerActions && (
+          <Box onClick={(e) => e.stopPropagation()} sx={{ alignSelf: "center" }}>
+            {footerActions({
+              index,
+              onCrop: onCropSave && canEditImage?.(index) && image.image_id && image.cloudinary_public_id && image.cloud_name
+                ? () => setCropMode(true)
+                : undefined,
+              onSetAsThumbnail: onSetAsThumbnail ? handleSetAsThumbnail : undefined,
+              settingThumbnail,
+              isCurrentThumbnail,
+            })}
+          </Box>
+        )}
 
         {/* Nav row — centered */}
         {!cropMode && images.length > 1 && (
-          <Box sx={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 0.5 }}>
+          <Box
+            onClick={(e) => e.stopPropagation()}
+            sx={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 0.5 }}
+          >
             <IconButton
               onClick={prev}
               disabled={index === 0}

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -26,20 +26,11 @@ import HistoryIcon from "@mui/icons-material/History";
 import LockIcon from "@mui/icons-material/Lock";
 import { useBlocker, useLocation, useNavigate } from "react-router-dom";
 import type { PieceDetail as PieceDetailType } from "../util/types";
+import { formatState, isTerminalState, validateHistorySequence } from "../util/workflow";
 import {
-  formatState,
-  isTerminalState,
-  validateHistorySequence,
+  getCustomFieldDefinitions,
 } from "../util/workflow";
-import { getCustomFieldDefinitions } from "../util/workflow";
-import {
-  updatePiece,
-  updatePastState,
-  updateCurrentState,
-  moveImage,
-  extractErrorMessage,
-  addPieceState,
-} from "../util/api";
+import { updatePiece, updatePastState, updateCurrentState, moveImage, extractErrorMessage, addPieceState } from "../util/api";
 import { useAsyncFn } from "../util/useAsync";
 import CloudinaryImage from "./CloudinaryImage";
 import NavigationBlocker from "./NavigationBlocker";
@@ -114,15 +105,15 @@ function SectionCard({
               </Typography>
             )}
             {(title || subtitle) && (
-              <Box
-                sx={{
-                  display: "flex",
-                  gap: 1.5,
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                  flexWrap: "wrap",
-                }}
-              >
+                <Box
+                  sx={{
+                    display: "flex",
+                    gap: 1.5,
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    flexWrap: "wrap",
+                  }}
+                >
                 {title ? (
                   <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
                     <Typography
@@ -134,9 +125,7 @@ function SectionCard({
                       {title}
                     </Typography>
                     {titleAdornment ? (
-                      <Box
-                        sx={{ ml: 0.5, display: "flex", alignItems: "center" }}
-                      >
+                      <Box sx={{ ml: 0.5, display: "flex", alignItems: "center" }}>
                         {titleAdornment}
                       </Box>
                     ) : null}
@@ -271,7 +260,7 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
   // Keep rewindedStateId when toggling is_editable to allow viewing history in read-only mode.
 
   const rewindedState = rewindedStateId
-    ? (pastHistory.find((ps) => ps.id === rewindedStateId) ?? null)
+    ? pastHistory.find((ps) => ps.id === rewindedStateId) ?? null
     : null;
 
   const [showcaseStoryValue, setShowcaseStoryValue] = useState(
@@ -361,10 +350,7 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
     [piece.id, onPieceUpdated],
   );
   const transitionError = rawTransitionError
-    ? extractErrorMessage(
-        rawTransitionError,
-        "Failed to transition state. Please try again.",
-      )
+    ? extractErrorMessage(rawTransitionError, "Failed to transition state. Please try again.")
     : null;
 
   function startEditingName() {
@@ -399,10 +385,7 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
     setEditingName(false);
   }, [piece.id, piece.name, nameValue, onPieceUpdated, pieceDetailSaveStatus]);
   const nameError = rawNameError
-    ? extractErrorMessage(
-        rawNameError,
-        "Failed to save name. Please try again.",
-      )
+    ? extractErrorMessage(rawNameError, "Failed to save name. Please try again.")
     : null;
 
   const {
@@ -423,10 +406,7 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
     [piece.id, onPieceUpdated, pieceDetailSaveStatus],
   );
   const locationError = rawLocationError
-    ? extractErrorMessage(
-        rawLocationError,
-        "Failed to save location. Please try again.",
-      )
+    ? extractErrorMessage(rawLocationError, "Failed to save location. Please try again.")
     : null;
 
   const navigate = useNavigate();
@@ -450,16 +430,11 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
     onPieceUpdated,
     updatePieceFn: canEdit ? updatePiece : undefined,
     updateCurrentStateFn: canEdit ? updateCurrentState : undefined,
-    pieceStates: canEdit
-      ? [
-          { id: currentState.id, label: formatState(currentState.state) },
-          ...piece.history.map((s) => ({
-            id: s.id,
-            label: formatState(s.state),
-          })),
-        ]
-      : undefined,
-    moveImageFn: canEdit ? moveImage : undefined,
+    pieceStates: [
+      { id: currentState.id, label: formatState(currentState.state) },
+      ...piece.history.map((s) => ({ id: s.id, label: formatState(s.state) })),
+    ],
+    moveImageFn: piece.is_editable ? moveImage : undefined,
   } satisfies ComponentProps<typeof PiecePhotoGallery>;
 
   return (
@@ -636,11 +611,7 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
             <Box
               onClick={
                 hasGalleryImages
-                  ? () =>
-                      navigate(
-                        `/pieces/${piece.id}/photos/${heroLightboxIndex}`,
-                        { state: location.state },
-                      )
+                  ? () => navigate(`/pieces/${piece.id}/photos/${heroLightboxIndex}`, { state: location.state })
                   : undefined
               }
               sx={(theme) => ({
@@ -714,9 +685,7 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
 
         {rewindedState ? (
           <SectionCard>
-            <Box
-              sx={{ mb: 1.5, display: "flex", alignItems: "center", gap: 1 }}
-            >
+            <Box sx={{ mb: 1.5, display: "flex", alignItems: "center", gap: 1 }}>
               <Chip
                 icon={<HistoryIcon fontSize="small" />}
                 label={`Rewound to: ${formatState(rewindedState.state)}`}
@@ -747,7 +716,8 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
           <SectionCard>
             <WorkflowState
               key={
-                currentState.state + (currentState.created?.toISOString() ?? "")
+                currentState.state +
+                (currentState.created?.toISOString() ?? "")
               }
               initialPieceState={currentState}
               pieceId={piece.id}
@@ -770,7 +740,10 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
         )}
 
         <Box sx={{ mb: 2.5 }}>
-          <SectionCard title="Process Summary" titleId="process-summary-title">
+          <SectionCard
+            title="Process Summary"
+            titleId="process-summary-title"
+          >
             <ProcessSummary piece={piece} history={piece.history} />
           </SectionCard>
         </Box>

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -430,6 +430,7 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
     onPieceUpdated,
     updatePieceFn: canEdit ? updatePiece : undefined,
     updateCurrentStateFn: canEdit ? updateCurrentState : undefined,
+    updatePastStateFn: piece.is_editable ? updatePastState : undefined,
     pieceStates: [
       { id: currentState.id, label: formatState(currentState.state) },
       ...piece.history.map((s) => ({ id: s.id, label: formatState(s.state) })),

--- a/web/src/components/PiecePhotoGallery.tsx
+++ b/web/src/components/PiecePhotoGallery.tsx
@@ -21,7 +21,7 @@ import {
   useTheme,
 } from "@mui/material";
 import type { CaptionedImage, ImageCrop, PieceDetail } from "../util/types";
-import { moveImage, updateCurrentState, updateImageCrop, updatePiece } from "../util/api";
+import { moveImage, updateCurrentState, updateImageCrop, updatePastState, updatePiece } from "../util/api";
 import DeletePiecePhotoDialog from "./DeletePiecePhotoDialog";
 import ImageLightbox from "./ImageLightbox";
 import PiecePhotoGalleryGrid from "./PiecePhotoGalleryGrid";
@@ -112,6 +112,7 @@ type PiecePhotoGalleryProps = {
   onPieceUpdated?: (updated: PieceDetail) => void;
   updatePieceFn?: typeof updatePiece;
   updateCurrentStateFn?: typeof updateCurrentState;
+  updatePastStateFn?: typeof updatePastState;
   pieceStates?: PieceStateRef[];
   moveImageFn?: typeof moveImage;
 };
@@ -131,6 +132,7 @@ export default function PiecePhotoGallery({
   onPieceUpdated,
   updatePieceFn,
   updateCurrentStateFn,
+  updatePastStateFn,
   pieceStates,
   moveImageFn,
 }: PiecePhotoGalleryProps) {
@@ -303,21 +305,36 @@ export default function PiecePhotoGallery({
   }
 
   async function handleDeleteImage() {
-    if (deleteDialogIndex === null || !updateCurrentStateFn) {
-      return;
-    }
+    if (deleteDialogIndex === null) return;
     const image = images[deleteDialogIndex];
-    if (!image || image.editableCurrentStateIndex === null) {
-      return;
-    }
+    if (!image) return;
+
     setDeleteSaving(true);
     try {
-      await persistCurrentStateImages(
-        editableCurrentStateImages.filter(
-          (_editableImage, index) =>
-            index !== image.editableCurrentStateIndex,
-        ),
-      );
+      if (image.editableCurrentStateIndex !== null && updateCurrentStateFn) {
+        await persistCurrentStateImages(
+          editableCurrentStateImages.filter(
+            (_editableImage, index) =>
+              index !== image.editableCurrentStateIndex,
+          ),
+        );
+      } else if (image.editableCurrentStateIndex === null && updatePastStateFn && pieceId) {
+        const siblingImages = images
+          .filter((img) => img.stateId === image.stateId && img !== image)
+          .map(({ url, caption, cloudinary_public_id, cloud_name, crop }) => ({
+            url,
+            caption,
+            cloudinary_public_id: cloudinary_public_id ?? null,
+            cloud_name: cloud_name ?? null,
+            crop: crop ?? null,
+          }));
+        const updated = await updatePastStateFn(pieceId, image.stateId, {
+          images: siblingImages,
+        });
+        onPieceUpdated?.(updated);
+      } else {
+        return;
+      }
       if (lightboxIndex === deleteDialogIndex) {
         navigate(galleryPath, { state: { ...outerState, fromLightbox: true } });
       }
@@ -332,6 +349,10 @@ export default function PiecePhotoGallery({
     currentStateNotes !== undefined &&
     onPieceUpdated !== undefined &&
     updateCurrentStateFn !== undefined;
+  const canDeletePastStateImages =
+    pieceId !== undefined &&
+    onPieceUpdated !== undefined &&
+    updatePastStateFn !== undefined;
   const canSetThumbnail =
     pieceId !== undefined &&
     onPieceUpdated !== undefined &&
@@ -508,6 +529,7 @@ export default function PiecePhotoGallery({
           <PiecePhotoGalleryGrid
             images={images}
             canDeleteImages={canMutateCurrentStateImages}
+            canDeletePastImages={canDeletePastStateImages}
             currentThumbnailUrl={currentThumbnailUrl}
             onOpenImage={(index) =>
               navigate(`${galleryPath}/${index}`, { state: outerState })

--- a/web/src/components/PiecePhotoGallery.tsx
+++ b/web/src/components/PiecePhotoGallery.tsx
@@ -153,9 +153,7 @@ export default function PiecePhotoGallery({
   );
 
   const atGallery = location.pathname === galleryPath;
-  const atPhotos =
-    location.pathname === galleryPath ||
-    location.pathname.startsWith(`${galleryPath}/`);
+  const atPhotos = atGallery || location.pathname.startsWith(`${galleryPath}/`);
   const photoIndexMatch = location.pathname.match(/\/photos\/(\d+)$/);
   const urlPhotoIndex = photoIndexMatch
     ? parseInt(photoIndexMatch[1], 10)

--- a/web/src/components/PiecePhotoGallery.tsx
+++ b/web/src/components/PiecePhotoGallery.tsx
@@ -1,29 +1,27 @@
 import { useEffect, useState } from "react";
-import {
-  Navigate,
-  useLocation,
-  useNavigate,
-  useParams,
-} from "react-router-dom";
+import { Navigate, useLocation, useNavigate, useParams } from "react-router-dom";
+import CropIcon from "@mui/icons-material/Crop";
 import EditIcon from "@mui/icons-material/Edit";
 import PhotoLibraryOutlinedIcon from "@mui/icons-material/PhotoLibraryOutlined";
+import PhotoSizeSelectActualIcon from "@mui/icons-material/PhotoSizeSelectActual";
 import {
   alpha,
   Box,
   Button,
+  CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
   IconButton,
+  Menu,
   MenuItem,
-  Select,
   TextField,
   Tooltip,
   Typography,
   useTheme,
 } from "@mui/material";
-import type { CaptionedImage, PieceDetail } from "../util/types";
-import { moveImage, updateCurrentState, updatePiece } from "../util/api";
+import type { CaptionedImage, ImageCrop, PieceDetail } from "../util/types";
+import { moveImage, updateCurrentState, updateImageCrop, updatePiece } from "../util/api";
 import DeletePiecePhotoDialog from "./DeletePiecePhotoDialog";
 import ImageLightbox from "./ImageLightbox";
 import PiecePhotoGalleryGrid from "./PiecePhotoGalleryGrid";
@@ -66,9 +64,9 @@ export function PiecePhotoGalleryButton({
   // Strip the internal fromLightbox flag before forwarding state — keeps
   // fromGallery/returnTo alive so PieceDetailPage's back button stays correct.
   const outerState = Object.fromEntries(
-    Object.entries(
-      (location.state as Record<string, unknown> | null) ?? {},
-    ).filter(([k]) => k !== "fromLightbox"),
+    Object.entries((location.state as Record<string, unknown> | null) ?? {}).filter(
+      ([k]) => k !== "fromLightbox",
+    ),
   );
 
   const photoCount = images.length;
@@ -147,9 +145,9 @@ export default function PiecePhotoGallery({
   // Strip the internal fromLightbox flag before forwarding state — keeps
   // fromGallery/returnTo alive so PieceDetailPage's back button stays correct.
   const outerState = Object.fromEntries(
-    Object.entries(
-      (location.state as Record<string, unknown> | null) ?? {},
-    ).filter(([k]) => k !== "fromLightbox"),
+    Object.entries((location.state as Record<string, unknown> | null) ?? {}).filter(
+      ([k]) => k !== "fromLightbox",
+    ),
   );
 
   const atGallery = location.pathname === galleryPath;
@@ -175,6 +173,7 @@ export default function PiecePhotoGallery({
   const [deleteSaving, setDeleteSaving] = useState(false);
   const [moveSaving, setMoveSaving] = useState(false);
   const [moveError, setMoveError] = useState<string | null>(null);
+  const [moveMenuAnchor, setMoveMenuAnchor] = useState<HTMLElement | null>(null);
 
   useEffect(() => {
     if (urlPhotoIndex !== null) setLightboxIndex(urlPhotoIndex);
@@ -197,12 +196,13 @@ export default function PiecePhotoGallery({
       (left, right) =>
         left.editableCurrentStateIndex - right.editableCurrentStateIndex,
     )
-    .map(({ url, caption, cloudinary_public_id, cloud_name, crop }) => ({
+    .map(({ url, caption, cloudinary_public_id, cloud_name, crop, image_id }) => ({
       url,
       caption,
       cloudinary_public_id: cloudinary_public_id ?? null,
       cloud_name: cloud_name ?? null,
       crop: crop ?? null,
+      image_id: image_id ?? null,
     }));
 
   function stopEditingCaption() {
@@ -296,6 +296,12 @@ export default function PiecePhotoGallery({
     }
   }
 
+  async function handleCropSave(image: CaptionedImage, crop: ImageCrop) {
+    if (!image.image_id) return;
+    const updated = await updateImageCrop(image.image_id, crop);
+    onPieceUpdated?.(updated);
+  }
+
   async function handleDeleteImage() {
     if (deleteDialogIndex === null || !updateCurrentStateFn) {
       return;
@@ -308,7 +314,8 @@ export default function PiecePhotoGallery({
     try {
       await persistCurrentStateImages(
         editableCurrentStateImages.filter(
-          (_editableImage, index) => index !== image.editableCurrentStateIndex,
+          (_editableImage, index) =>
+            index !== image.editableCurrentStateIndex,
         ),
       );
       if (lightboxIndex === deleteDialogIndex) {
@@ -329,10 +336,18 @@ export default function PiecePhotoGallery({
     pieceId !== undefined &&
     onPieceUpdated !== undefined &&
     updatePieceFn !== undefined;
-  const canEditCaption =
-    editableCurrentStateIndex !== null && canMutateCurrentStateImages;
+  const canEditCaption = editableCurrentStateIndex !== null;
 
-  const footer = activeImage ? (
+  const showMoveButton =
+    activeImage?.image_id && pieceStates && pieceStates.length > 1;
+  const canMove = Boolean(moveImageFn) && !moveSaving;
+
+  const footer = ({ onCrop, onSetAsThumbnail: onSetThumb, settingThumbnail, isCurrentThumbnail }: {
+    onCrop?: () => void;
+    onSetAsThumbnail?: () => Promise<void>;
+    settingThumbnail: boolean;
+    isCurrentThumbnail: boolean;
+  }) => activeImage ? (
     <Box sx={{ display: "grid", gap: 0.75, justifyItems: "center" }}>
       {captionEditing ? (
         <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
@@ -345,9 +360,7 @@ export default function PiecePhotoGallery({
               if (event.key === "Escape") stopEditingCaption();
             }}
             autoFocus
-            slotProps={{
-              htmlInput: { "aria-label": "Edit photo caption" },
-            }}
+            slotProps={{ htmlInput: { "aria-label": "Edit photo caption" } }}
             sx={{
               minWidth: 220,
               "& .MuiOutlinedInput-root": {
@@ -356,122 +369,112 @@ export default function PiecePhotoGallery({
               },
             }}
           />
-          <Button
-            size="small"
-            variant="contained"
-            onClick={() => void handleSaveCaption()}
-            disabled={captionSaving}
-          >
+          <Button size="small" variant="contained" onClick={() => void handleSaveCaption()} disabled={captionSaving}>
             {captionSaving ? "Saving…" : "Save"}
           </Button>
-          <Button
-            size="small"
-            variant="text"
-            onClick={stopEditingCaption}
-            disabled={captionSaving}
-          >
+          <Button size="small" variant="text" onClick={stopEditingCaption} disabled={captionSaving}>
             Cancel
           </Button>
         </Box>
-      ) : activeImage.caption ? (
-        <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
-          <Button
-            size="small"
-            variant="text"
-            onClick={() => {
-              if (!canEditCaption) return;
-              setCaptionEditing(true);
-            }}
-            disabled={!canEditCaption}
-            sx={{
-              color: "rgba(255,255,255,0.85)",
-              textTransform: "none",
-              minWidth: 0,
-              p: 0,
-              lineHeight: 1.4,
-              "&:hover": { backgroundColor: "transparent", color: "white" },
-            }}
-          >
-            {activeImage.caption}
-          </Button>
-          {canEditCaption && (
-            <Tooltip title="Edit caption">
-              <IconButton
+      ) : (
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, flexWrap: "wrap", justifyContent: "center" }}>
+          {/* Caption */}
+          {activeImage.caption ? (
+            <Tooltip title={canEditCaption ? "Edit caption" : activeImage.caption}>
+              <Button
                 size="small"
-                onClick={() => setCaptionEditing(true)}
-                aria-label="Edit caption"
-                sx={{
-                  color: "rgba(255,255,255,0.6)",
-                  "&:hover": { color: "white" },
-                }}
+                variant="outlined"
+                startIcon={<EditIcon fontSize="small" />}
+                onClick={() => { if (canEditCaption) setCaptionEditing(true); }}
+                disabled={!canEditCaption}
+                sx={{ color: "white", borderColor: "rgba(255,255,255,0.35)", textTransform: "none", maxWidth: 180, overflow: "hidden", textOverflow: "ellipsis" }}
               >
-                <EditIcon sx={{ fontSize: 14 }} />
+                {activeImage.caption}
+              </Button>
+            </Tooltip>
+          ) : (
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<EditIcon fontSize="small" />}
+              onClick={() => { setCaptionDraft(""); setCaptionEditing(true); }}
+              disabled={!canEditCaption}
+              sx={{ color: "white", borderColor: "rgba(255,255,255,0.35)" }}
+            >
+              Caption
+            </Button>
+          )}
+
+          {/* Move to */}
+          {showMoveButton && (
+            <>
+              <Button
+                size="small"
+                variant="outlined"
+                disabled={!canMove}
+                onClick={(e) => { if (canMove) setMoveMenuAnchor(e.currentTarget); }}
+                sx={{ color: "white", borderColor: "rgba(255,255,255,0.35)" }}
+              >
+                {moveSaving ? "Moving…" : "Move to…"}
+              </Button>
+              <Menu
+                anchorEl={moveMenuAnchor}
+                open={Boolean(moveMenuAnchor)}
+                onClose={() => setMoveMenuAnchor(null)}
+              >
+                {pieceStates!
+                  .filter((s) => s.id !== activeImage.stateId)
+                  .map((s) => (
+                    <MenuItem
+                      key={s.id}
+                      onClick={() => {
+                        setMoveMenuAnchor(null);
+                        void handleMoveImage(s.id);
+                      }}
+                    >
+                      {s.label}
+                    </MenuItem>
+                  ))}
+              </Menu>
+            </>
+          )}
+
+          {/* Thumbnail */}
+          {onSetThumb && (
+            <Tooltip title={isCurrentThumbnail ? "Current thumbnail" : "Set as thumbnail"}>
+              <span>
+                <IconButton
+                  disabled={isCurrentThumbnail || settingThumbnail}
+                  onClick={() => void onSetThumb()}
+                  aria-label="Set as thumbnail"
+                  sx={{ color: "white" }}
+                >
+                  {settingThumbnail
+                    ? <CircularProgress size={20} sx={{ color: "white" }} />
+                    : <PhotoSizeSelectActualIcon />}
+                </IconButton>
+              </span>
+            </Tooltip>
+          )}
+
+          {/* Crop */}
+          {onCrop && (
+            <Tooltip title="Edit crop">
+              <IconButton onClick={onCrop} aria-label="Edit crop" sx={{ color: "white" }}>
+                <CropIcon />
               </IconButton>
             </Tooltip>
           )}
         </Box>
-      ) : canEditCaption ? (
-        <Button
-          size="small"
-          variant="outlined"
-          startIcon={<EditIcon fontSize="small" />}
-          onClick={() => {
-            setCaptionDraft("");
-            setCaptionEditing(true);
-          }}
-          sx={{ color: "white", borderColor: "rgba(255,255,255,0.35)" }}
-        >
-          Add caption
-        </Button>
-      ) : null}
-      {captionSaveError && (
-        <Typography variant="caption" sx={{ color: "error.light" }}>
-          {captionSaveError}
-        </Typography>
       )}
-      {moveImageFn &&
-        activeImage.image_id &&
-        pieceStates &&
-        pieceStates.length > 1 && (
-          <Select
-            size="small"
-            displayEmpty
-            value=""
-            disabled={moveSaving}
-            onChange={(e) => {
-              if (e.target.value) void handleMoveImage(e.target.value);
-            }}
-            aria-label="Move photo to state"
-            sx={{
-              color: "rgba(255,255,255,0.85)",
-              fontSize: "0.75rem",
-              "& .MuiOutlinedInput-notchedOutline": {
-                borderColor: "rgba(255,255,255,0.35)",
-              },
-              "& .MuiSvgIcon-root": { color: "rgba(255,255,255,0.6)" },
-            }}
-          >
-            <MenuItem value="" disabled>
-              {moveSaving ? "Moving…" : "Move to…"}
-            </MenuItem>
-            {pieceStates
-              .filter((s) => s.id !== activeImage.stateId)
-              .map((s) => (
-                <MenuItem key={s.id} value={s.id}>
-                  {s.label}
-                </MenuItem>
-              ))}
-          </Select>
-        )}
+      {captionSaveError && (
+        <Typography variant="caption" sx={{ color: "error.light" }}>{captionSaveError}</Typography>
+      )}
       {moveError && (
-        <Typography variant="caption" sx={{ color: "error.light" }}>
-          {moveError}
-        </Typography>
+        <Typography variant="caption" sx={{ color: "error.light" }}>{moveError}</Typography>
       )}
       <Typography variant="caption" sx={{ color: "rgba(255,255,255,0.55)" }}>
-        {editableCurrentStateIndex !== null
-          ? "Added in current state"
-          : `Added in ${activeImage.stateLabel}`}
+        {editableCurrentStateIndex !== null ? "Added in current state" : `Added in ${activeImage.stateLabel}`}
       </Typography>
     </Box>
   ) : null;
@@ -530,7 +533,9 @@ export default function PiecePhotoGallery({
           }
           currentThumbnailUrl={currentThumbnailUrl}
           onSetAsThumbnail={canSetThumbnail ? handleSetThumbnail : undefined}
-          footerActions={() => footer}
+          onCropSave={onPieceUpdated ? handleCropSave : undefined}
+          canEditImage={(i) => isEditableImage(images[i])}
+          footerActions={footer}
         />
       )}
 

--- a/web/src/components/PiecePhotoGallery.tsx
+++ b/web/src/components/PiecePhotoGallery.tsx
@@ -361,8 +361,9 @@ export default function PiecePhotoGallery({
     activeImage?.image_id && pieceStates && pieceStates.length > 1;
   const canMove = Boolean(moveImageFn) && !moveSaving;
 
-  const footer = ({ onCrop, onSetAsThumbnail: onSetThumb, settingThumbnail, isCurrentThumbnail }: {
+  const footer = ({ onCrop, cropAvailable, onSetAsThumbnail: onSetThumb, settingThumbnail, isCurrentThumbnail }: {
     onCrop?: () => void;
+    cropAvailable?: boolean;
     onSetAsThumbnail?: () => Promise<void>;
     settingThumbnail: boolean;
     isCurrentThumbnail: boolean;
@@ -477,11 +478,13 @@ export default function PiecePhotoGallery({
           )}
 
           {/* Crop */}
-          {onCrop && (
-            <Tooltip title="Edit crop">
-              <IconButton onClick={onCrop} aria-label="Edit crop" sx={{ color: "white" }}>
-                <CropIcon />
-              </IconButton>
+          {cropAvailable && (
+            <Tooltip title={onCrop ? "Edit crop" : "Crop only available for Cloudinary images"}>
+              <span>
+                <IconButton onClick={onCrop} disabled={!onCrop} aria-label="Edit crop" sx={{ color: "white" }}>
+                  <CropIcon />
+                </IconButton>
+              </span>
             </Tooltip>
           )}
         </Box>
@@ -555,7 +558,10 @@ export default function PiecePhotoGallery({
           currentThumbnailUrl={currentThumbnailUrl}
           onSetAsThumbnail={canSetThumbnail ? handleSetThumbnail : undefined}
           onCropSave={onPieceUpdated ? handleCropSave : undefined}
-          canEditImage={(i) => isEditableImage(images[i])}
+          canEditImage={(i) => {
+            const img = images[i];
+            return !!(img?.cloudinary_public_id && img?.cloud_name && img?.image_id);
+          }}
           footerActions={footer}
         />
       )}

--- a/web/src/components/PiecePhotoGallery.tsx
+++ b/web/src/components/PiecePhotoGallery.tsx
@@ -524,6 +524,7 @@ export default function PiecePhotoGallery({
 
       {atLightbox && lightboxIndex !== null && (
         <ImageLightbox
+          key={lightboxIndex}
           images={images}
           initialIndex={lightboxIndex}
           onClose={() =>

--- a/web/src/components/PiecePhotoGalleryGrid.tsx
+++ b/web/src/components/PiecePhotoGalleryGrid.tsx
@@ -24,6 +24,7 @@ type PiecePhotoGalleryGridImage = {
 type PiecePhotoGalleryGridProps = {
   images: PiecePhotoGalleryGridImage[];
   canDeleteImages: boolean;
+  canDeletePastImages?: boolean;
   currentThumbnailUrl?: string;
   onOpenImage: (index: number) => void;
   onRequestDelete: (index: number) => void;
@@ -32,6 +33,7 @@ type PiecePhotoGalleryGridProps = {
 export default function PiecePhotoGalleryGrid({
   images,
   canDeleteImages,
+  canDeletePastImages = false,
   currentThumbnailUrl,
   onOpenImage,
   onRequestDelete,
@@ -103,7 +105,7 @@ export default function PiecePhotoGalleryGrid({
             />
           </Box>
         </Box>
-        {image.editableCurrentStateIndex !== null && canDeleteImages && (
+        {(image.editableCurrentStateIndex !== null ? canDeleteImages : canDeletePastImages) && (
           <Tooltip
             title={
               isThumbnail

--- a/web/src/components/__tests__/CropOverlay.test.tsx
+++ b/web/src/components/__tests__/CropOverlay.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@cloudinary/url-gen", () => {
+  const mockImg = {
+    delivery: vi.fn().mockReturnThis(),
+    toURL: vi.fn().mockReturnValue("https://res.cloudinary.com/test/image/upload/f_auto/test-id"),
+  };
+  class MockCloudinary {
+    image() { return mockImg; }
+  }
+  return { Cloudinary: MockCloudinary };
+});
+
+vi.mock("@cloudinary/url-gen/actions/delivery", () => ({
+  format: vi.fn().mockReturnValue("format-action"),
+}));
+
+vi.mock("@cloudinary/url-gen/qualifiers/format", () => ({
+  auto: vi.fn().mockReturnValue("auto-format"),
+}));
+
+import CropOverlay from "../CropOverlay";
+
+const DEFAULT_PROPS = {
+  cloudinaryPublicId: "test-id",
+  cloudName: "test-cloud",
+  initialCrop: null,
+  onSave: vi.fn().mockResolvedValue(undefined),
+  onCancel: vi.fn(),
+};
+
+describe("CropOverlay", () => {
+  it("renders the crop editor image", () => {
+    render(<CropOverlay {...DEFAULT_PROPS} />);
+    expect(screen.getByAltText("Crop editor")).toBeInTheDocument();
+  });
+
+  it("Cancel button calls onCancel without calling onSave", async () => {
+    const onCancel = vi.fn();
+    const onSave = vi.fn();
+    render(
+      <CropOverlay {...DEFAULT_PROPS} onCancel={onCancel} onSave={onSave} />,
+    );
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(onCancel).toHaveBeenCalledOnce();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("Save Crop button calls onSave with a valid crop", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(<CropOverlay {...DEFAULT_PROPS} onSave={onSave} />);
+    fireEvent.click(screen.getByText("Save Crop"));
+    await waitFor(() => expect(onSave).toHaveBeenCalledOnce());
+    const [crop] = onSave.mock.calls[0];
+    expect(crop).toMatchObject({
+      x: expect.any(Number),
+      y: expect.any(Number),
+      width: expect.any(Number),
+      height: expect.any(Number),
+    });
+  });
+});

--- a/web/src/components/__tests__/CropOverlay.test.tsx
+++ b/web/src/components/__tests__/CropOverlay.test.tsx
@@ -1,6 +1,12 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
+// Skip image preloading — no network in tests.
+vi.mock("../../util/useAsync", () => ({
+  useAsync: () => ({ loading: false, error: null, value: undefined }),
+  useAsyncFn: () => [{ loading: false, error: null }, vi.fn()],
+}));
+
 vi.mock("@cloudinary/url-gen", () => {
   const mockImg = {
     delivery: vi.fn().mockReturnThis(),

--- a/web/src/components/__tests__/GlazeCombinationGallery.test.tsx
+++ b/web/src/components/__tests__/GlazeCombinationGallery.test.tsx
@@ -14,7 +14,7 @@ vi.mock("../CloudinaryImage", () => ({
 }));
 
 // Stub out ImageLightbox to keep lightbox tests simple.
-// footerActions is a function of the current index; the stub calls it with 0.
+// footerActions receives an opts object; the stub calls it with initialIndex.
 vi.mock("../ImageLightbox", () => ({
   default: ({
     images,
@@ -24,12 +24,12 @@ vi.mock("../ImageLightbox", () => ({
   }: {
     images: { url: string }[];
     initialIndex: number;
-    footerActions?: (index: number) => React.ReactNode;
+    footerActions?: (opts: { index: number; settingThumbnail: boolean; isCurrentThumbnail: boolean }) => React.ReactNode;
     onClose: () => void;
   }) => (
     <div data-testid="lightbox">
       <img src={images[initialIndex ?? 0].url} alt="lightbox-image" />
-      {footerActions?.(initialIndex ?? 0)}
+      {footerActions?.({ index: initialIndex ?? 0, settingThumbnail: false, isCurrentThumbnail: false })}
       <button onClick={onClose}>Close</button>
     </div>
   ),

--- a/web/src/components/__tests__/ImageLightbox.test.tsx
+++ b/web/src/components/__tests__/ImageLightbox.test.tsx
@@ -249,4 +249,58 @@ describe("ImageLightbox", () => {
       expect(screen.getByRole("img")).toHaveAttribute("src", "/img/c.jpg");
     });
   });
+
+  describe("crop button", () => {
+    function makeCloudinaryImage(url: string, caption = ""): CaptionedImage {
+      return {
+        url,
+        caption,
+        created: new Date("2024-01-15T10:00:00Z"),
+        cloudinary_public_id: "test-public-id",
+        cloud_name: "test-cloud",
+      };
+    }
+
+    const CLOUDINARY_IMAGE = makeCloudinaryImage("/img/a.jpg", "First");
+
+    it("does not show Crop button when onCropSave is not provided", () => {
+      render(
+        <ImageLightbox
+          images={[CLOUDINARY_IMAGE]}
+          initialIndex={0}
+          onClose={vi.fn()}
+        />,
+      );
+      expect(screen.queryByLabelText("Edit crop")).not.toBeInTheDocument();
+    });
+
+    it("shows Crop button when onCropSave is provided", () => {
+      const onCropSave = vi.fn().mockResolvedValue(undefined);
+      render(
+        <ImageLightbox
+          images={[CLOUDINARY_IMAGE]}
+          initialIndex={0}
+          onClose={vi.fn()}
+          onCropSave={onCropSave}
+        />,
+      );
+      expect(screen.getByLabelText("Edit crop")).toBeInTheDocument();
+    });
+
+    it("clicking Crop button enters crop mode and shows crop editor", async () => {
+      const onCropSave = vi.fn().mockResolvedValue(undefined);
+      render(
+        <ImageLightbox
+          images={[CLOUDINARY_IMAGE]}
+          initialIndex={0}
+          onClose={vi.fn()}
+          onCropSave={onCropSave}
+        />,
+      );
+      fireEvent.click(screen.getByLabelText("Edit crop"));
+      await waitFor(() => {
+        expect(screen.getByAltText("Crop editor")).toBeInTheDocument();
+      });
+    });
+  });
 });

--- a/web/src/components/__tests__/ImageLightbox.test.tsx
+++ b/web/src/components/__tests__/ImageLightbox.test.tsx
@@ -1,6 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+
+// CropOverlay uses useAsync to preload images; skip network in tests.
+vi.mock("../../util/useAsync", () => ({
+  useAsync: () => ({ loading: false, error: null, value: undefined }),
+  useAsyncFn: () => [{ loading: false, error: null }, vi.fn()],
+}));
+
 import ImageLightbox from "../ImageLightbox";
 import type { CaptionedImage } from "../../util/types";
 
@@ -177,7 +184,19 @@ describe("ImageLightbox", () => {
 
     it("calls onSetAsThumbnail with the active image", async () => {
       const onSetAsThumbnail = vi.fn().mockResolvedValue(undefined);
-      renderLightbox(THREE_IMAGES, 1, vi.fn(), onSetAsThumbnail);
+      render(
+        <ImageLightbox
+          images={THREE_IMAGES}
+          initialIndex={1}
+          onClose={vi.fn()}
+          onSetAsThumbnail={onSetAsThumbnail}
+          footerActions={({ onSetAsThumbnail: onThumb }) =>
+            onThumb ? (
+              <button onClick={() => void onThumb()}>Set as thumbnail</button>
+            ) : null
+          }
+        />,
+      );
 
       await userEvent.click(
         screen.getByRole("button", { name: "Set as thumbnail" }),
@@ -258,10 +277,18 @@ describe("ImageLightbox", () => {
         created: new Date("2024-01-15T10:00:00Z"),
         cloudinary_public_id: "test-public-id",
         cloud_name: "test-cloud",
+        image_id: "test-image-id",
       };
     }
 
     const CLOUDINARY_IMAGE = makeCloudinaryImage("/img/a.jpg", "First");
+
+    // footerActions that renders the crop button when onCrop is passed.
+    function cropFooter({ onCrop }: { onCrop?: () => void; [k: string]: unknown }) {
+      return onCrop ? (
+        <button aria-label="Edit crop" onClick={onCrop}>Crop</button>
+      ) : null;
+    }
 
     it("does not show Crop button when onCropSave is not provided", () => {
       render(
@@ -269,6 +296,7 @@ describe("ImageLightbox", () => {
           images={[CLOUDINARY_IMAGE]}
           initialIndex={0}
           onClose={vi.fn()}
+          footerActions={cropFooter}
         />,
       );
       expect(screen.queryByLabelText("Edit crop")).not.toBeInTheDocument();
@@ -282,6 +310,8 @@ describe("ImageLightbox", () => {
           initialIndex={0}
           onClose={vi.fn()}
           onCropSave={onCropSave}
+          canEditImage={() => true}
+          footerActions={cropFooter}
         />,
       );
       expect(screen.getByLabelText("Edit crop")).toBeInTheDocument();
@@ -295,6 +325,8 @@ describe("ImageLightbox", () => {
           initialIndex={0}
           onClose={vi.fn()}
           onCropSave={onCropSave}
+          canEditImage={() => true}
+          footerActions={cropFooter}
         />,
       );
       fireEvent.click(screen.getByLabelText("Edit crop"));

--- a/web/src/components/__tests__/ImageLightbox.test.tsx
+++ b/web/src/components/__tests__/ImageLightbox.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { Dialog, Box } from "@mui/material";
 
 // CropOverlay uses useAsync to preload images; skip network in tests.
 vi.mock("../../util/useAsync", () => ({
@@ -179,6 +180,64 @@ describe("ImageLightbox", () => {
     it("nav button clicks do not propagate to close the lightbox", () => {
       const { onClose } = renderLightbox(THREE_IMAGES, 1);
       fireEvent.click(screen.getByRole("button", { name: /next image/i }));
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it("calls onClose when backdrop is clicked with a MUI Dialog also open (simulates PiecePhotoGallery context)", () => {
+      // Repro: PiecePhotoGallery renders both a Dialog (gallery grid) and ImageLightbox
+      // simultaneously when atPhotos && atLightbox. The Dialog backdrop must not intercept
+      // clicks intended for the lightbox backdrop.
+      const onClose = vi.fn();
+      const onDialogClose = vi.fn();
+      render(
+        <>
+          <Dialog open onClose={onDialogClose}>
+            <Box>Gallery grid content</Box>
+          </Dialog>
+          <ImageLightbox
+            images={ONE_IMAGE}
+            initialIndex={0}
+            onClose={onClose}
+          />
+        </>,
+      );
+      fireEvent.click(screen.getByTestId("lightbox-backdrop"));
+      expect(onClose).toHaveBeenCalledOnce();
+      expect(onDialogClose).not.toHaveBeenCalled();
+    });
+
+    it("calls onClose when backdrop area outside footerActions content is clicked", () => {
+      // Repro: footerActions renders a Box that as a flex child might stretch full-width,
+      // covering the dark area. Clicking the dark backdrop area must still close.
+      const onClose = vi.fn();
+      render(
+        <ImageLightbox
+          images={ONE_IMAGE}
+          initialIndex={0}
+          onClose={onClose}
+          footerActions={() => (
+            <Box data-testid="footer-content">Footer here</Box>
+          )}
+        />,
+      );
+      // Click directly on the backdrop (not on footer content)
+      fireEvent.click(screen.getByTestId("lightbox-backdrop"));
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it("does not close when footer content is clicked", () => {
+      const onClose = vi.fn();
+      render(
+        <ImageLightbox
+          images={ONE_IMAGE}
+          initialIndex={0}
+          onClose={onClose}
+          footerActions={() => (
+            <button>Footer button</button>
+          )}
+        />,
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Footer button" }));
       expect(onClose).not.toHaveBeenCalled();
     });
 

--- a/web/src/components/__tests__/PiecePhotoGallery.test.tsx
+++ b/web/src/components/__tests__/PiecePhotoGallery.test.tsx
@@ -64,13 +64,13 @@ vi.mock("../ImageLightbox", () => ({
   }: {
     images: PiecePhotoGalleryImage[];
     initialIndex: number;
-    footerActions?: (index: number) => ReactNode;
+    footerActions?: (opts: { index: number; settingThumbnail: boolean; isCurrentThumbnail: boolean }) => ReactNode;
     onClose: () => void;
     onSetAsThumbnail?: (image: PiecePhotoGalleryImage) => Promise<void>;
   }) => (
     <div aria-label="Mock lightbox" role="dialog">
       <div>{images[initialIndex].caption}</div>
-      {footerActions?.(initialIndex)}
+      {footerActions?.({ index: initialIndex, settingThumbnail: false, isCurrentThumbnail: false })}
       {onSetAsThumbnail && (
         <button onClick={() => void onSetAsThumbnail(images[initialIndex])}>
           Set as thumbnail
@@ -132,11 +132,9 @@ const DEFAULT_PIECE_STATES = [
   { id: "state-past", label: "Designed" },
 ];
 
-function openMoveSelect() {
-  const moveControl = screen.getByLabelText("Move photo to state");
-  fireEvent.mouseDown(
-    within(moveControl).getByRole("combobox", { hidden: true }),
-  );
+async function openMoveMenu() {
+  // hidden: true because MUI Dialog aria-hides the inline mock lightbox
+  await userEvent.click(screen.getByRole("button", { name: /Move to/i, hidden: true }));
 }
 
 function makeUpdatedPiece(overrides: Partial<PieceDetail> = {}): PieceDetail {
@@ -520,7 +518,7 @@ describe("PiecePhotoGallery", () => {
       screen.getByRole("button", { name: "Open piece photo 1" }),
     );
     await userEvent.click(
-      within(screen.getByLabelText("Mock lightbox")).getByText("Add caption"),
+      within(screen.getByLabelText("Mock lightbox")).getByRole("button", { name: /Caption/i, hidden: true }),
     );
 
     expect(
@@ -581,7 +579,7 @@ describe("PiecePhotoGallery", () => {
       );
 
       expect(
-        screen.queryByLabelText("Move photo to state"),
+        screen.queryByRole("button", { name: /Move to/i }),
       ).not.toBeInTheDocument();
     });
 
@@ -603,7 +601,7 @@ describe("PiecePhotoGallery", () => {
       );
 
       expect(
-        screen.queryByLabelText("Move photo to state"),
+        screen.queryByRole("button", { name: /Move to/i }),
       ).not.toBeInTheDocument();
     });
 
@@ -624,9 +622,9 @@ describe("PiecePhotoGallery", () => {
       await userEvent.click(
         screen.getByRole("button", { name: "Open piece photo 1" }),
       );
-      const moveSelect = screen.getByLabelText("Move photo to state");
+      const moveButton = screen.getByRole("button", { name: /Move to/i, hidden: true });
 
-      expect(moveSelect).not.toBeDisabled();
+      expect(moveButton).not.toBeDisabled();
     });
 
     it("opens state picker showing only other states", async () => {
@@ -646,7 +644,7 @@ describe("PiecePhotoGallery", () => {
       await userEvent.click(
         screen.getByRole("button", { name: "Open piece photo 1" }),
       );
-      openMoveSelect();
+      await openMoveMenu();
 
       expect(screen.getByText("Designed")).toBeInTheDocument();
       expect(screen.queryByText("Wheel Thrown")).not.toBeInTheDocument();
@@ -669,7 +667,7 @@ describe("PiecePhotoGallery", () => {
       await userEvent.click(
         screen.getByRole("button", { name: "Open piece photo 2" }),
       );
-      openMoveSelect();
+      await openMoveMenu();
 
       expect(screen.getByText("Wheel Thrown")).toBeInTheDocument();
       expect(screen.queryByText("Designed")).not.toBeInTheDocument();
@@ -697,7 +695,7 @@ describe("PiecePhotoGallery", () => {
       await userEvent.click(
         screen.getByRole("button", { name: "Open piece photo 1" }),
       );
-      openMoveSelect();
+      await openMoveMenu();
       await userEvent.click(screen.getByText("Designed"));
 
       await waitFor(() =>
@@ -734,7 +732,7 @@ describe("PiecePhotoGallery", () => {
       await userEvent.click(
         screen.getByRole("button", { name: "Open piece photo 2" }),
       );
-      openMoveSelect();
+      await openMoveMenu();
       await userEvent.click(screen.getByText("Wheel Thrown"));
 
       await waitFor(() =>
@@ -768,7 +766,7 @@ describe("PiecePhotoGallery", () => {
       await userEvent.click(
         screen.getByRole("button", { name: "Open piece photo 1" }),
       );
-      openMoveSelect();
+      await openMoveMenu();
       await userEvent.click(screen.getByText("Designed"));
 
       await waitFor(() =>
@@ -797,7 +795,7 @@ describe("PiecePhotoGallery", () => {
       await userEvent.click(
         screen.getByRole("button", { name: "Open piece photo 1" }),
       );
-      openMoveSelect();
+      await openMoveMenu();
       await userEvent.click(screen.getByText("Designed"));
 
       await waitFor(() =>

--- a/web/src/components/__tests__/PiecePhotoGalleryLightboxIntegration.test.tsx
+++ b/web/src/components/__tests__/PiecePhotoGalleryLightboxIntegration.test.tsx
@@ -114,13 +114,15 @@ describe("PiecePhotoGallery + real ImageLightbox integration", () => {
     expect(screen.getByTestId("masonry-grid")).toBeInTheDocument();
   });
 
-  it("clicking image area (swipe-area) does not close the lightbox", async () => {
+  it("clicking the swipe area outside the image closes the lightbox", async () => {
+    // The swipe area may cover letter-boxed space around the image (especially on mobile).
+    // Clicking that space should close the lightbox — only the image translate Box itself
+    // stops propagation.
     renderAt("/pieces/piece-1/photos/0");
 
     await waitFor(() => screen.getByTestId("lightbox-backdrop"));
     fireEvent.click(screen.getByTestId("lightbox-swipe-area"));
 
-    // Lightbox should still be open
-    expect(screen.getByTestId("lightbox-backdrop")).toBeInTheDocument();
+    expect(screen.queryByTestId("lightbox-backdrop")).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/__tests__/PiecePhotoGalleryLightboxIntegration.test.tsx
+++ b/web/src/components/__tests__/PiecePhotoGalleryLightboxIntegration.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Integration test: PiecePhotoGallery with real ImageLightbox (not mocked).
+ * Verifies that clicking the lightbox backdrop closes the lightbox even when
+ * the gallery Dialog is simultaneously open (atPhotos && atLightbox).
+ */
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+
+// Skip image preloading used by CropOverlay.
+vi.mock("../../util/useAsync", () => ({
+  useAsync: () => ({ loading: false, error: null, value: undefined }),
+  useAsyncFn: () => [{ loading: false, error: null }, vi.fn()],
+}));
+
+vi.mock("../CloudinaryImage", () => ({
+  default: ({ alt, url }: { alt?: string; url: string }) => (
+    <img alt={alt} src={url} />
+  ),
+}));
+
+vi.mock("masonic", () => ({
+  Masonry: ({
+    items,
+    render: Row,
+  }: {
+    items: unknown[];
+    render: React.ComponentType<{ data: unknown; index: number; width: number }>;
+  }) => (
+    <div data-testid="masonry-grid">
+      {items.map((item, i) => (
+        <Row key={i} data={item} index={i} width={300} />
+      ))}
+    </div>
+  ),
+}));
+
+import PiecePhotoGallery, {
+  type PiecePhotoGalleryImage,
+} from "../PiecePhotoGallery";
+
+function makeImages(): PiecePhotoGalleryImage[] {
+  return [
+    {
+      url: "https://example.com/a.jpg",
+      caption: "Photo A",
+      created: new Date("2024-01-15T10:00:00Z"),
+      cloudinary_public_id: null,
+      cloud_name: null,
+      image_id: "img-a",
+      stateLabel: "Throwing",
+      stateId: "state-1",
+      editableCurrentStateIndex: 0,
+    },
+    {
+      url: "https://example.com/b.jpg",
+      caption: "Photo B",
+      created: new Date("2024-01-16T10:00:00Z"),
+      cloudinary_public_id: null,
+      cloud_name: null,
+      image_id: "img-b",
+      stateLabel: "Throwing",
+      stateId: "state-1",
+      editableCurrentStateIndex: 1,
+    },
+  ];
+}
+
+function renderAt(path: string) {
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/pieces/:id/*",
+        element: <PiecePhotoGallery images={makeImages()} pieceId="piece-1" currentStateNotes="" />,
+      },
+    ],
+    { initialEntries: [path] },
+  );
+  return render(<RouterProvider router={router} />);
+}
+
+describe("PiecePhotoGallery + real ImageLightbox integration", () => {
+  it("lightbox backdrop closes lightbox when started directly at lightbox URL (Dialog also open)", async () => {
+    // atPhotos=true AND atLightbox=true simultaneously
+    renderAt("/pieces/piece-1/photos/0");
+
+    const backdrop = screen.getByTestId("lightbox-backdrop");
+    expect(backdrop).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(backdrop);
+    });
+
+    expect(screen.queryByTestId("lightbox-backdrop")).not.toBeInTheDocument();
+  });
+
+  it("lightbox backdrop closes lightbox after navigating from gallery grid to lightbox", async () => {
+    // Simulate the real user flow: gallery grid → click image → lightbox → click backdrop → gallery
+    renderAt("/pieces/piece-1/photos");
+
+    // Gallery grid Dialog is open; click the first image to open the lightbox
+    await waitFor(() => screen.getByRole("button", { name: "Open piece photo 1" }));
+    await userEvent.click(screen.getByRole("button", { name: "Open piece photo 1" }));
+
+    // Lightbox should now be open
+    await waitFor(() => expect(screen.getByTestId("lightbox-backdrop")).toBeInTheDocument());
+
+    // Click the lightbox backdrop to close
+    fireEvent.click(screen.getByTestId("lightbox-backdrop"));
+
+    // Lightbox should close; gallery Dialog should be back (gallery grid visible)
+    await waitFor(() => expect(screen.queryByTestId("lightbox-backdrop")).not.toBeInTheDocument());
+    expect(screen.getByTestId("masonry-grid")).toBeInTheDocument();
+  });
+
+  it("clicking image area (swipe-area) does not close the lightbox", async () => {
+    renderAt("/pieces/piece-1/photos/0");
+
+    await waitFor(() => screen.getByTestId("lightbox-backdrop"));
+    fireEvent.click(screen.getByTestId("lightbox-swipe-area"));
+
+    // Lightbox should still be open
+    expect(screen.getByTestId("lightbox-backdrop")).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/PrivacyPolicyPage.tsx
+++ b/web/src/pages/PrivacyPolicyPage.tsx
@@ -1,4 +1,7 @@
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Box,
   Button,
   Container,
@@ -6,6 +9,7 @@ import {
   Stack,
   Typography,
 } from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { Link } from "react-router-dom";
 
 export default function PrivacyPolicyPage() {
@@ -123,7 +127,65 @@ export default function PrivacyPolicyPage() {
               admin@potterdoc.com
             </Box>{" "}
             and we will prioritize it. EXIF data is automatically stripped from
-            your uploaded images before they are stored.
+            your uploaded images before they are stored. What remains after
+            stripping is limited to image structure and color profile data
+            needed to display the image correctly — for example:
+          </Typography>
+
+          <Accordion disableGutters elevation={0} sx={{ bgcolor: "action.hover", borderRadius: 1 }}>
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+              <Typography variant="body2">Example: retained image metadata</Typography>
+            </AccordionSummary>
+            <AccordionDetails sx={{ pt: 0 }}>
+              <Box
+                component="pre"
+                sx={{
+                  fontFamily: "monospace",
+                  fontSize: "0.75rem",
+                  overflowX: "auto",
+                  m: 0,
+                  lineHeight: 1.6,
+                }}
+              >{`BitsPerSample           8
+BlueMatrixColumn        0.1571 0.06657 0.78407
+BlueTRC                 Binary data 32 bytes
+CMMFlags                Not Embedded, Independent
+ChromaticAdaptation     1.04788 0.02292 -0.0502 0.02959 0.99048 -0.01706 -0.00923 0.01508 0.75168
+ColorComponents         3
+ColorSpaceData          RGB
+ConnectionSpaceIlluminant 0.9642 1 0.82491
+DeviceAttributes        Reflective, Glossy, Positive, Color
+DeviceManufacturer      Apple Computer Inc.
+EncodingProcess         Progressive DCT, Huffman coding
+FileType                JPEG
+GreenMatrixColumn       0.29198 0.69225 0.04189
+GreenTRC                Binary data 32 bytes
+ImageHeight             1032
+ImageSize               774x1032
+ImageWidth              774
+JFIFVersion             1.01
+MIMEType                image/jpeg
+MediaWhitePoint         0.96419 1 0.82489
+Megapixels              0.799
+PrimaryPlatform         Apple Computer Inc.
+ProfileClass            Display Device Profile
+ProfileConnectionSpace  XYZ
+ProfileCopyright        Copyright Apple Inc., 2022
+ProfileDescription      Display P3
+ProfileVersion          4.0.0
+RedMatrixColumn         0.51512 0.2412 -0.00105
+RedTRC                  Binary data 32 bytes
+RenderingIntent         Perceptual
+ResolutionUnit          None
+XResolution             1
+YCbCrSubSampling        YCbCr4:2:0 (2 2)
+YResolution             1`}</Box>
+            </AccordionDetails>
+          </Accordion>
+
+          <Typography variant="body1">
+            No GPS coordinates, camera make or model, capture timestamp, or
+            other identifying metadata is retained.
           </Typography>
 
           <Typography variant="body1">

--- a/web/src/util/api.ts
+++ b/web/src/util/api.ts
@@ -134,6 +134,7 @@ function mapImage(raw: Wire<CaptionedImage>): CaptionedImage {
     cloudinary_public_id: raw.cloudinary_public_id ?? null,
     cloud_name: raw.cloud_name ?? null,
     crop: normalizeCrop(raw.crop),
+    image_id: raw.image_id ?? null,
   };
 }
 
@@ -519,6 +520,17 @@ export async function moveImage(
   const { data } = await client.patch<Wire<PieceDetail>>(
     `images/${imageId}/piece_state/${fromStateId}/`,
     { piece_state_id: toStateId },
+  );
+  return mapPieceDetail(data);
+}
+
+export async function updateImageCrop(
+  imageId: string,
+  crop: ImageCrop,
+): Promise<PieceDetail> {
+  const { data } = await client.patch<Wire<PieceDetail>>(
+    `images/${imageId}/crop/`,
+    crop,
   );
   return mapPieceDetail(data);
 }


### PR DESCRIPTION
## Summary

- **Manual crop tool**: New `CropOverlay` component lets potters drag-resize a crop rect directly in the lightbox, overriding Cloudinary's auto-detected subject crop. Writes to `PieceStateImage.crop` via a new `PATCH /api/images/<id>/crop/` endpoint. Crop is allowed on both editable and sealed pieces so potters can correct a bad auto-crop without reopening a piece.
- **Cloudinary upload fix**: Signature endpoint was injecting `resource_type`, `allowed_formats`, `exif` into the signing string, but the widget omits those fields — causing signature mismatch. Removed the injection.
- **EXIF stripping**: Added `fl_force_strip` transformation to the Cloudinary widget config so EXIF metadata is stripped on upload. Added a collapsible audit block to the Privacy Policy page.
- **Lightbox toolbar refactor**: Condensed footer from multiple rows into a single toolbar row (Caption | Move to | Thumbnail | Crop). "Move to" is now a Button + Menu (reliable `disabled` semantics) gated on `piece.is_editable` rather than `can_edit` (ownership-only).
- **Gallery → lightbox navigation fix**: Added `key={lightboxIndex}` to `ImageLightbox` so clicking a different photo in the gallery always mounts a fresh component at the correct index.
- **Async crop race guard**: `detect_subject_crop` task already had a `select_for_update` guard; added a `logger.warning` when it skips because the user has already saved a manual crop.

## Test plan

- [ ] Open a piece with images → open lightbox → click Crop icon → drag handles and interior → Save Crop → image re-renders with new crop applied
- [ ] Crop icon absent for images in past states (only present for current-state images)
- [ ] Cancel in crop mode returns to normal lightbox view without saving
- [ ] Crop works on sealed (non-editable) pieces
- [ ] "Move to" button is disabled (grayed, non-interactive) for sealed/fired pieces; enabled for editable pieces
- [ ] Caption and Crop buttons disabled for images in past states
- [ ] Clicking a photo in the gallery goes directly to the correct image in the lightbox (no double-click required)
- [ ] Upload a new photo — signature now accepted without error
- [ ] Backend: `rtk bazel test //api:api_tests --test_filter=test_patch_image_crop`
- [ ] Frontend: `rtk bazel test //web:vitest`
- [ ] Lint: `rtk bazel build --config=lint //...`

Closes #699
