### PR TITLE
Register global models in Django Admin

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -8,6 +8,7 @@ import cloudinary
 from adminsortable2.admin import SortableAdminBase, SortableInlineAdminMixin
 from cloudinary import CloudinaryImage
 from django import forms
+from django.apps import apps
 from django.conf import settings
 from django.contrib import admin
 from django.forms import widgets
@@ -41,8 +42,12 @@ from .utils import (
 from .widgets import WorkflowStateWidget
 from .workflow import (
     build_ui_schema,
+    get_global_config,
+    get_global_names,
     get_image_fields_for_global_model,
     get_public_global_models,
+    is_factory_global,
+    is_public_global,
 )
 
 
@@ -432,6 +437,13 @@ class PublicLibraryAdmin(admin.ModelAdmin):
         super().save_model(request, obj, form, change)
 
 
+class PrivateGlobalAdmin(admin.ModelAdmin):
+    """Admin for private-only globals that are not part of the public library."""
+
+    list_display: ClassVar[tuple[str, ...]] = ("name", "user")
+    search_fields: ClassVar[tuple[str, ...]] = ("name", "user__username", "user__email")
+
+
 class GlazeTypeAdmin(PublicLibraryAdmin):
     """Admin for the public GlazeType library.
 
@@ -591,6 +603,14 @@ admin.site.register(GlazeCombination, GlazeCombinationAdmin)
 for _model_cls in get_public_global_models():
     if not admin.site.is_registered(_model_cls):
         admin.site.register(_model_cls, PublicLibraryAdmin)
+
+# Register private-only globals so they are manageable in admin as well.
+for _global_name in get_global_names():
+    if not is_factory_global(_global_name) or is_public_global(_global_name):
+        continue
+    _model_cls = apps.get_model("api", get_global_config(_global_name)["model"])
+    if not admin.site.is_registered(_model_cls):
+        admin.site.register(_model_cls, PrivateGlobalAdmin)
 
 
 class PieceStateInline(admin.TabularInline):

--- a/api/admin.py
+++ b/api/admin.py
@@ -440,8 +440,8 @@ class PublicLibraryAdmin(admin.ModelAdmin):
 class PrivateGlobalAdmin(admin.ModelAdmin):
     """Admin for private-only globals that are not part of the public library."""
 
-    list_display: ClassVar[tuple[str, ...]] = ("name", "user")
-    search_fields: ClassVar[tuple[str, ...]] = ("name", "user__username", "user__email")
+    list_display = ("name", "user")
+    search_fields = ("name", "user__username", "user__email")
 
 
 class GlazeTypeAdmin(PublicLibraryAdmin):

--- a/api/model_factories.py
+++ b/api/model_factories.py
@@ -13,6 +13,7 @@ Nothing in this module should be imported directly by application code outside o
 ``api/models.py``.  All public symbols are re-exported from there.
 """
 
+import re
 from typing import Any, ClassVar
 
 from django.conf import settings
@@ -173,6 +174,31 @@ def _pluralize_snake(name: str) -> str:
     return name + "s"
 
 
+def _humanize_camel(name: str) -> str:
+    """Convert a CamelCase model name to a human-readable label.
+
+    Examples: ``ClayBody`` -> ``Clay Body``, ``FiringTemperature`` ->
+    ``Firing Temperature``.
+    """
+    parts = re.findall(r"[A-Z]+(?=[A-Z][a-z]|\b)|[A-Z]?[a-z]+|[0-9]+", name)
+    return " ".join(parts) if parts else name
+
+
+def _pluralize_words(label: str) -> str:
+    """Pluralize the final word in a human-readable label."""
+    words = label.split()
+    if not words:
+        return label
+    last = words[-1]
+    if last.endswith(("s", "x", "z", "ch", "sh")):
+        words[-1] = last + "es"
+    elif last.endswith("y") and len(last) > 1 and last[-2].lower() not in "aeiou":
+        words[-1] = last[:-1] + "ies"
+    else:
+        words[-1] = last + "s"
+    return " ".join(words)
+
+
 def dsl_field_to_django_field(field_name: str, field_def: dict) -> models.Field:
     """Convert a workflow.yml DSL field definition to a Django model Field.
 
@@ -243,6 +269,8 @@ def make_simple_global_model(global_name: str) -> type:
     is_private: bool = bool(config.get("private", True))
     dsl_fields: dict = config.get("fields", {})
     plural: str = config.get("plural", _pluralize_snake(global_name))
+    verbose_name = _humanize_camel(model_name)
+    verbose_name_plural = _pluralize_words(verbose_name)
 
     attrs: dict = {
         "__module__": "api.models",
@@ -297,7 +325,15 @@ def make_simple_global_model(global_name: str) -> type:
             )
         )
 
-    attrs["Meta"] = type("Meta", (), {"constraints": constraints})
+    attrs["Meta"] = type(
+        "Meta",
+        (),
+        {
+            "constraints": constraints,
+            "verbose_name": verbose_name,
+            "verbose_name_plural": verbose_name_plural,
+        },
+    )
     _deregister_model_if_exists("api", model_name)
     return type(model_name, (GlobalModel,), attrs)
 
@@ -338,6 +374,8 @@ def make_compose_global_models(global_name: str) -> tuple[type, type]:
     is_private: bool = bool(config.get("private", True))
     dsl_fields: dict = config.get("fields", {})
     plural: str = config.get("plural", _pluralize_snake(global_name))
+    verbose_name = _humanize_camel(model_name)
+    verbose_name_plural = _pluralize_words(verbose_name)
 
     # compose_from has exactly one key (the M2M relationship name, e.g. 'glaze_types').
     compose_key = next(iter(compose_from))
@@ -505,7 +543,15 @@ def make_compose_global_models(global_name: str) -> tuple[type, type]:
                 name=f"uniq_{global_name}_name_per_user",
             )
         )
-    composite_attrs["Meta"] = type("Meta", (), {"constraints": constraints})
+    composite_attrs["Meta"] = type(
+        "Meta",
+        (),
+        {
+            "constraints": constraints,
+            "verbose_name": verbose_name,
+            "verbose_name_plural": verbose_name_plural,
+        },
+    )
 
     # compute_name — joins component display names with the standard separator.
     @staticmethod  # type: ignore[misc]
@@ -694,7 +740,11 @@ def make_favorite_model(global_name: str) -> type:
                         fields=["user", global_name],
                         name=f"uniq_favorite_{global_name}_per_user",
                     )
-                ]
+                ],
+                "verbose_name": _humanize_camel(f"Favorite{model_name}"),
+                "verbose_name_plural": _pluralize_words(
+                    _humanize_camel(f"Favorite{model_name}")
+                ),
             },
         ),
     }
@@ -757,7 +807,11 @@ def make_piece_state_global_ref_model(global_name: str) -> type:
                         fields=["piece_state", "field_name"],
                         name=f"uniq_piece_state_{global_name}_ref",
                     )
-                ]
+                ],
+                "verbose_name": _humanize_camel(ref_model_class_name),
+                "verbose_name_plural": _pluralize_words(
+                    _humanize_camel(ref_model_class_name)
+                ),
             },
         ),
     }
@@ -801,6 +855,10 @@ def make_taggable_model(global_name: str) -> type:
                         name=f"uniq_{global_name}_tag",
                     )
                 ],
+                "verbose_name": _humanize_camel(through_model_name),
+                "verbose_name_plural": _pluralize_words(
+                    _humanize_camel(through_model_name)
+                ),
             },
         ),
     }

--- a/api/tests/test_public_library.py
+++ b/api/tests/test_public_library.py
@@ -333,6 +333,58 @@ class TestGlazeAdminSite:
         assert result == app_list
         assert all(app["app_label"] != "public_libraries" for app in result)
 
+    def test_public_globals_are_registered_and_labeled(self):
+        from django.contrib import admin
+        from django.urls import reverse
+
+        import api.admin as api_admin  # ensure registration side effects are loaded
+        from api.workflow import get_public_global_models
+
+        superuser = User.objects.create_superuser(
+            username="admin-public-libs@example.com",
+            email="admin-public-libs@example.com",
+            password="password",
+        )
+        request = RequestFactory().get(reverse("admin:index"))
+        request.user = superuser
+
+        public_models = get_public_global_models()
+        for model in public_models:
+            assert admin.site.is_registered(model), (
+                f"{model.__name__} is not registered in admin.site"
+            )
+
+        app_list = api_admin.admin.site.get_app_list(request)
+        public_section = next(
+            app for app in app_list if app["app_label"] == "public_libraries"
+        )
+        public_names = {model["name"] for model in public_section["models"]}
+        expected_names = {model._meta.verbose_name_plural for model in public_models}
+
+        assert public_names == expected_names
+
+    def test_private_globals_are_registered_in_api_section(self):
+        from django.contrib import admin
+        from django.urls import reverse
+
+        import api.admin as api_admin  # ensure registration side effects are loaded
+
+        superuser = User.objects.create_superuser(
+            username="admin-private-libs@example.com",
+            email="admin-private-libs@example.com",
+            password="password",
+        )
+        request = RequestFactory().get(reverse("admin:index"))
+        request.user = superuser
+
+        assert admin.site.is_registered(Location)
+
+        app_list = api_admin.admin.site.get_app_list(request)
+        api_section = next(app for app in app_list if app["app_label"] == "api")
+        api_names = {model["name"] for model in api_section["models"]}
+
+        assert "Locations" in api_names
+
 
 @pytest.mark.django_db
 class TestGlazeTypeAdmin:


### PR DESCRIPTION
## Summary
- Register private-only globals like `Location` in Django Admin under the normal `Api` section.
- Keep public globals in the dedicated `Public Libraries` section.
- Add human-readable plural labels for generated models so `ClayBody` appears as `Clay Bodies`.

## Verification
- `rtk bazel test //api:api_glaze_test`
- `rtk bazel test //api:api_model_test`
