### PR TITLE
[codex] Remove piece thumbnail crop cache

### DIFF
--- a/api/management/commands/backpopulate_crops.py
+++ b/api/management/commands/backpopulate_crops.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand, CommandError
 
-from api.models import AsyncTask, Image, Piece, PieceStateImage
+from api.models import AsyncTask, Image, PieceStateImage
 from api.tasks import get_task_interface
 
 
@@ -62,26 +62,12 @@ class Command(BaseCommand):
                 if force
                 else PieceStateImage.objects.filter(image=image, crop__isnull=True)
             )
-            piece_qs = (
-                Piece.objects.filter(thumbnail=image)
-                if force
-                else Piece.objects.filter(thumbnail=image, thumbnail_crop__isnull=True)
-            )
-
-            piece_ids = list(piece_qs.values_list("id", flat=True))
             psi_ids = list(link_qs.values_list("id", flat=True))
 
-            if not piece_ids and not psi_ids:
+            if not psi_ids:
                 skipped += 1
                 continue
 
-            for piece_id in piece_ids:
-                work_items.append(
-                    {
-                        "image_id": str(image.id),
-                        "piece_id": str(piece_id),
-                    }
-                )
             for psi_id in psi_ids:
                 work_items.append(
                     {

--- a/api/management/commands/clear_crops.py
+++ b/api/management/commands/clear_crops.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 
-from api.models import Piece, PieceStateImage
+from api.models import PieceStateImage
 
 
 class Command(BaseCommand):
@@ -17,19 +17,12 @@ class Command(BaseCommand):
         dry_run = options["dry_run"]
 
         state_qs = PieceStateImage.objects.exclude(crop=None)
-        thumb_qs = Piece.objects.exclude(thumbnail_crop=None)
-
         state_count = state_qs.count()
-        thumb_count = thumb_qs.count()
 
         if not dry_run:
             state_qs.update(crop=None)
-            thumb_qs.update(thumbnail_crop=None)
 
         mode = "Would clear" if dry_run else "Cleared"
         self.stdout.write(
-            self.style.SUCCESS(
-                f"{mode} {state_count} state image crops and "
-                f"{thumb_count} thumbnail crops."
-            )
+            self.style.SUCCESS(f"{mode} {state_count} state image crops.")
         )

--- a/api/migrations/0029_remove_piece_thumbnail_crop.py
+++ b/api/migrations/0029_remove_piece_thumbnail_crop.py
@@ -1,0 +1,14 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0028_flatten_tutorial_preferences"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="piece",
+            name="thumbnail_crop",
+        ),
+    ]

--- a/api/models.py
+++ b/api/models.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any
 
 from django.apps import apps
 from django.conf import settings
-from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Q
 from django.utils import timezone
@@ -239,7 +238,6 @@ class Piece(models.Model):
         to="api.Image",
         related_name="thumbnail_for_pieces",
     )
-    thumbnail_crop = models.JSONField(null=True, blank=True, default=None)
     shared = models.BooleanField(default=False)
     showcase_story = models.TextField(blank=True, default="")
     showcase_fields = models.JSONField(default=list)
@@ -311,18 +309,46 @@ class Piece(models.Model):
             return self.fields_last_modified
         return max(self.fields_last_modified, cs.last_modified)
 
-    def clean(self):
-        if self.thumbnail_crop is not None:
-            thumbnail = self.thumbnail if self.thumbnail_id else None
-            if thumbnail is None or not thumbnail.cloudinary_public_id:
-                raise ValidationError(
-                    {
-                        "thumbnail_crop": "thumbnail_crop requires a Cloudinary-backed thumbnail."
-                    }
+    def _thumbnail_crop_from_history(self) -> dict | None:
+        """Return the current thumbnail crop from piece history when available."""
+
+        thumbnail = self.thumbnail if self.thumbnail_id else None
+        if thumbnail is None:
+            return None
+
+        def _crop_from_links(links):
+            matching_links = [link for link in links if link.image_id == thumbnail.id]
+            if not matching_links:
+                return None
+            latest_link = max(matching_links, key=lambda link: link.pk)
+            return latest_link.crop
+
+        states = self._prefetched_states()
+        if states is not None:
+            links = []
+            for state in states:
+                prefetched_links = getattr(state, "_prefetched_objects_cache", {}).get(
+                    "image_links"
                 )
+                if prefetched_links is None:
+                    continue
+                links.extend(prefetched_links)
+            return _crop_from_links(links)
+
+        links = (
+            PieceStateImage.objects.filter(
+                piece_state__piece=self,
+                image=thumbnail,
+            )
+            .order_by("-pk")
+            .only("crop", "image_id")
+        )
+        return _crop_from_links(links)
+
+    def get_thumbnail_crop(self) -> dict | None:
+        return self._thumbnail_crop_from_history()
 
     def save(self, *args, **kwargs):
-        self.clean()
         super().save(*args, **kwargs)
 
     def __str__(self) -> str:

--- a/api/models.py
+++ b/api/models.py
@@ -335,7 +335,7 @@ class Piece(models.Model):
                 links.extend(prefetched_links)
             return _crop_from_links(links)
 
-        links = (
+        links = list(
             PieceStateImage.objects.filter(
                 piece_state__piece=self,
                 image=thumbnail,

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -61,7 +61,6 @@ from .preferences import (
 from .serializer_registry import _GLOBAL_ENTRY_SERIALIZERS, global_entry_serializer
 from .utils import (
     captioned_image_to_dict,
-    crop_to_dict,
     get_or_create_location,
     image_to_dict,
     normalize_image_payload,
@@ -507,7 +506,7 @@ class PieceSummarySerializer(serializers.ModelSerializer):
         thumbnail = image_to_dict(obj.thumbnail)
         if thumbnail is None:
             return None
-        return {**thumbnail, "crop": obj.thumbnail_crop}
+        return {**thumbnail, "crop": obj.get_thumbnail_crop()}
 
     @extend_schema_field(serializers.IntegerField(min_value=0))
     def get_photo_count(self, obj: Piece) -> int:
@@ -586,13 +585,9 @@ class PieceCreateSerializer(serializers.ModelSerializer):
             user=user, piece=piece, state=ENTRY_STATE, notes=notes, order=1
         )
 
-        # Queue auto-detection for thumbnail if Cloudinary and no crop provided.
-        if (
-            thumbnail
-            and thumbnail.cloud_name
-            and thumbnail.cloudinary_public_id
-            and piece.thumbnail_crop is None
-        ):
+        # Queue auto-detection for Cloudinary thumbnails so the matching piece
+        # history image can pick up a crop if one exists.
+        if thumbnail and thumbnail.cloud_name and thumbnail.cloudinary_public_id:
             from .tasks import get_task_interface
 
             task = AsyncTask.objects.create(
@@ -915,19 +910,13 @@ class PieceUpdateSerializer(serializers.Serializer):
             instance.thumbnail = normalize_image_payload(
                 thumbnail_payload, user=instance.user
             )
-            crop = (
-                crop_to_dict(thumbnail_payload.get("crop"))
-                if thumbnail_payload is not None
-                else None
-            )
-            instance.thumbnail_crop = crop
 
-            # Queue auto-detection if it's a new Cloudinary thumbnail without a crop.
+            # Queue auto-detection for Cloudinary thumbnails so the matching
+            # piece history image can pick up a crop if one exists.
             if (
                 instance.thumbnail
                 and instance.thumbnail.cloud_name
                 and instance.thumbnail.cloudinary_public_id
-                and crop is None
             ):
                 from .tasks import get_task_interface
 

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -196,7 +196,7 @@ def ping_task(task: AsyncTask) -> Dict[str, str]:
 @TaskRegistry.register("detect_subject_crop")
 def detect_subject_crop(task: AsyncTask) -> dict | None:
     """Download an image, get a segmentation mask, derive crop, update targets."""
-    from .models import CropRun, Image, Piece, PieceStateImage
+    from .models import CropRun, Image, PieceStateImage
     from .utils import run_crop_inference
 
     params = task.input_params or {}
@@ -271,18 +271,6 @@ def detect_subject_crop(task: AsyncTask) -> dict | None:
         return {"status": "skipped", "reason": crop_run.error or crop_run.status}
     crop = crop_run.crop
 
-    updated = False
-    piece_skip_reason = None
-    if piece_id:
-        with transaction.atomic():
-            piece = Piece.objects.select_for_update().get(id=piece_id)
-            if piece.thumbnail_crop is None:
-                piece.thumbnail_crop = crop
-                piece.save(update_fields=["thumbnail_crop"])
-                updated = True
-            else:
-                piece_skip_reason = "Piece already has a thumbnail crop"
-
     psi_skip_reason = None
     if piece_state_image is not None:
         with transaction.atomic():
@@ -292,22 +280,16 @@ def detect_subject_crop(task: AsyncTask) -> dict | None:
             if psi.crop is None:
                 psi.crop = crop
                 psi.save(update_fields=["crop"])
-                updated = True
+                return {"status": "success", "crop": crop, "updated": True}
             else:
                 psi_skip_reason = "PieceStateImage already has a crop"
                 logger.warning(
                     f"detect_subject_crop skipped psi={psi.id}: crop already set by user, not overwriting"
                 )
-
-    if not updated:
-        return {
-            "status": "skipped",
-            "reason": psi_skip_reason
-            or piece_skip_reason
-            or "No crop targets were updated",
-        }
-
-    return {"status": "success", "crop": crop, "updated": updated}
+    return {
+        "status": "skipped",
+        "reason": psi_skip_reason or "No crop targets were updated",
+    }
 
 
 def fail_stuck_tasks(hours: int = 1) -> int:

--- a/api/tests/test_async_tasks.py
+++ b/api/tests/test_async_tasks.py
@@ -222,7 +222,7 @@ class TestDetectSubjectCropTask:
         assert task.status == AsyncTask.Status.SUCCESS
         assert task.result["status"] == "skipped"
 
-    def test_writes_thumbnail_crop_for_piece(self, user, monkeypatch):
+    def test_writes_crop_for_thumbnail_image_via_piece_id(self, user, monkeypatch):
         from api.models import CropRun
 
         image = self._make_cloudinary_image(user)
@@ -242,25 +242,25 @@ class TestDetectSubjectCropTask:
             },
         )
         self._run_sync(task.id)
-        piece_state_image.piece_state.piece.refresh_from_db()
-        assert piece_state_image.piece_state.piece.thumbnail_crop == crop
         piece_state_image.refresh_from_db()
         assert piece_state_image.crop == crop
         task.refresh_from_db()
         assert task.status == AsyncTask.Status.SUCCESS
         assert task.result["status"] == "success"
 
-    def test_skips_piece_that_already_has_crop(self, user, monkeypatch):
+    def test_skips_piece_state_image_that_already_has_crop_via_piece_id(
+        self, user, monkeypatch
+    ):
         from api.models import CropRun, Piece, PieceState, PieceStateImage
 
         image = self._make_cloudinary_image(user)
-        existing = {"x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0}
-        piece = Piece.objects.create(
-            user=user, name="Mug", thumbnail=image, thumbnail_crop=existing
-        )
+        piece = Piece.objects.create(user=user, name="Mug", thumbnail=image)
         state = PieceState.objects.create(piece=piece, user=user, state="designed")
         piece_state_image = PieceStateImage.objects.create(
-            piece_state=state, image=image, order=0
+            piece_state=state,
+            image=image,
+            order=0,
+            crop={"x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0},
         )
         crop_run = self._mock_crop_run(
             piece_state_image,
@@ -274,18 +274,16 @@ class TestDetectSubjectCropTask:
             user, {"image_id": str(image.id), "piece_id": str(piece.id)}
         )
         self._run_sync(task.id)
-        piece.refresh_from_db()
-        assert piece.thumbnail_crop == existing  # unchanged
         piece_state_image.refresh_from_db()
         assert piece_state_image.crop == {
-            "x": 0.2,
-            "y": 0.2,
-            "width": 0.5,
-            "height": 0.5,
+            "x": 0.0,
+            "y": 0.0,
+            "width": 1.0,
+            "height": 1.0,
         }
         task.refresh_from_db()
         assert task.status == AsyncTask.Status.SUCCESS
-        assert task.result["status"] == "success"
+        assert task.result["status"] == "skipped"
 
     def test_writes_crop_for_piece_state_image(self, user, monkeypatch):
         from api.models import ENTRY_STATE, CropRun, Piece, PieceState, PieceStateImage
@@ -333,7 +331,12 @@ class TestDetectSubjectCropTask:
         )
         self._run_sync(task.id)
         psi.refresh_from_db()
-        assert psi.crop == existing  # unchanged
+        assert psi.crop == {
+            "x": 0.0,
+            "y": 0.0,
+            "width": 1.0,
+            "height": 1.0,
+        }  # unchanged
         task.refresh_from_db()
         assert task.result["status"] == "skipped"
 
@@ -472,8 +475,6 @@ class TestRemoteDetectSubjectCrop:
         assert task.status == AsyncTask.Status.SUCCESS
         assert task.result["status"] == "success"
 
-        piece.refresh_from_db()
-        assert piece.thumbnail_crop is not None
         piece_state_image.refresh_from_db()
         assert piece_state_image.crop is not None
 

--- a/api/tests/test_patch_image_crop.py
+++ b/api/tests/test_patch_image_crop.py
@@ -81,6 +81,41 @@ class TestPatchImageCrop:
         )
         assert link.crop == VALID_CROP
 
+    def test_success_updates_thumbnail_image_crop_in_piece_response(
+        self, client, user
+    ):
+        piece = Piece.objects.create(user=user, name="Thumbnail Bowl", is_editable=True)
+        state = PieceState.objects.create(
+            piece=piece,
+            user=user,
+            state=ENTRY_STATE,
+            order=1,
+        )
+        image = Image.objects.create(
+            user=user,
+            url="https://example.com/thumb.jpg",
+            cloud_name="demo",
+            cloudinary_public_id="pieces/thumb",
+        )
+        original_crop = {"x": 0.05, "y": 0.1, "width": 0.6, "height": 0.6}
+        PieceStateImage.objects.create(
+            piece_state=state,
+            image=image,
+            crop=original_crop,
+            order=0,
+        )
+        piece.thumbnail = image
+        piece.save(update_fields=["thumbnail"])
+
+        response = client.patch(
+            f"/api/images/{image.id}/crop/",
+            VALID_CROP,
+            format="json",
+        )
+
+        assert response.status_code == 200
+        assert response.json()["thumbnail"]["crop"] == VALID_CROP
+
     def test_non_owner_returns_404(self, other_client, image_in_editable_piece):
         image = image_in_editable_piece
         response = other_client.patch(

--- a/api/tests/test_piece_detail.py
+++ b/api/tests/test_piece_detail.py
@@ -368,13 +368,13 @@ class TestPieceDetail:
             "image_id": str(piece.thumbnail.id),
             "width": None,
             "height": None,
+            "crop": None,
         }
         assert piece.thumbnail == {
             "url": thumbnail["url"],
             "cloudinary_public_id": thumbnail["cloudinary_public_id"],
             "cloud_name": thumbnail["cloud_name"],
         }
-        assert piece.thumbnail_crop == thumbnail["crop"]
 
     def test_owner_can_share_completed_piece(self, client, piece):
         PieceState.objects.create(

--- a/api/tests/test_utils.py
+++ b/api/tests/test_utils.py
@@ -3,7 +3,7 @@ from django.contrib.auth.models import User
 from django.core.management import call_command
 from django.core.management.base import CommandError
 
-from api.models import AsyncTask, GlazeCombination, GlazeType, Image, Piece
+from api.models import AsyncTask, GlazeCombination, GlazeType, Image
 from api.utils import (
     cloudinary_getinfo_url,
     crop_to_dict,
@@ -123,7 +123,11 @@ class TestBackpopulateCropsCommand:
         """--dry-run prints a count but creates no AsyncTask records."""
         image = self._make_cloudinary_image()
         user = self._make_user()
-        Piece.objects.create(user=user, name="Mug", thumbnail=image)
+        from api.models import Piece, PieceState, PieceStateImage
+
+        piece = Piece.objects.create(user=user, name="Mug", thumbnail=image)
+        state = PieceState.objects.create(piece=piece, user=user, state="designed")
+        PieceStateImage.objects.create(piece_state=state, image=image, order=0)
 
         call_command("backpopulate_crops", "--dry-run")
 
@@ -134,15 +138,19 @@ class TestBackpopulateCropsCommand:
         with pytest.raises(CommandError, match="No superuser found"):
             call_command("backpopulate_crops")
 
-    def test_live_mode_enqueues_task_for_missing_thumbnail_crop(self, monkeypatch):
-        """A piece with no thumbnail_crop gets one AsyncTask enqueued."""
+    def test_live_mode_enqueues_task_for_missing_image_crop(self, monkeypatch):
+        """A Cloudinary piece image with no crop gets one AsyncTask enqueued."""
         monkeypatch.setattr(
             "api.tasks.InMemoryTaskInterface.submit", lambda self, task: None
         )
         superuser = self._make_superuser()
         user = self._make_user()
         image = self._make_cloudinary_image()
-        Piece.objects.create(user=user, name="Mug", thumbnail=image)
+        from api.models import Piece, PieceState, PieceStateImage
+
+        piece = Piece.objects.create(user=user, name="Mug", thumbnail=image)
+        state = PieceState.objects.create(piece=piece, user=user, state="designed")
+        PieceStateImage.objects.create(piece_state=state, image=image, order=0)
 
         call_command("backpopulate_crops")
 
@@ -153,16 +161,22 @@ class TestBackpopulateCropsCommand:
         assert tasks[0].user == superuser
 
     def test_skips_images_with_existing_crop_by_default(self, monkeypatch):
-        """Images whose pieces already have thumbnail_crop are skipped."""
+        """Images whose piece-state images already have crops are skipped."""
         monkeypatch.setattr(
             "api.tasks.InMemoryTaskInterface.submit", lambda self, task: None
         )
         self._make_superuser()
         user = self._make_user()
         image = self._make_cloudinary_image()
-        existing_crop = {"x": 0.1, "y": 0.2, "width": 0.5, "height": 0.6}
-        Piece.objects.create(
-            user=user, name="Mug", thumbnail=image, thumbnail_crop=existing_crop
+        from api.models import Piece, PieceState, PieceStateImage
+
+        piece = Piece.objects.create(user=user, name="Mug", thumbnail=image)
+        state = PieceState.objects.create(piece=piece, user=user, state="designed")
+        PieceStateImage.objects.create(
+            piece_state=state,
+            image=image,
+            order=0,
+            crop={"x": 0.1, "y": 0.2, "width": 0.5, "height": 0.6},
         )
 
         call_command("backpopulate_crops")
@@ -170,16 +184,22 @@ class TestBackpopulateCropsCommand:
         assert AsyncTask.objects.count() == 0
 
     def test_force_enqueues_tasks_for_existing_crops(self, monkeypatch):
-        """--force enqueues a task even when the piece already has thumbnail_crop."""
+        """--force enqueues a task even when the piece-state image already has crop."""
         monkeypatch.setattr(
             "api.tasks.InMemoryTaskInterface.submit", lambda self, task: None
         )
         self._make_superuser()
         user = self._make_user()
         image = self._make_cloudinary_image()
-        existing_crop = {"x": 0.1, "y": 0.2, "width": 0.5, "height": 0.6}
-        Piece.objects.create(
-            user=user, name="Mug", thumbnail=image, thumbnail_crop=existing_crop
+        from api.models import Piece, PieceState, PieceStateImage
+
+        piece = Piece.objects.create(user=user, name="Mug", thumbnail=image)
+        state = PieceState.objects.create(piece=piece, user=user, state="designed")
+        PieceStateImage.objects.create(
+            piece_state=state,
+            image=image,
+            order=0,
+            crop={"x": 0.1, "y": 0.2, "width": 0.5, "height": 0.6},
         )
 
         call_command("backpopulate_crops", "--force")

--- a/web/src/stories/PieceList.stories.tsx
+++ b/web/src/stories/PieceList.stories.tsx
@@ -20,10 +20,9 @@ import type { PieceSummary } from "../util/types";
  *
  * The pipeline has three interlocking parts that **must stay in sync**:
  *
- * 1. **`thumbnail_crop` on the API response** (`Piece.thumbnail_crop`, serialized
- *    as `thumbnail.crop` in `PieceSummary`). Relative coordinates `{x, y, width,
- *    height}` in the original image's coordinate space. Set when the user crops
- *    the thumbnail; `null` for pieces that have never been cropped.
+ * 1. **`thumbnail.crop` on the API response** in `PieceSummary`. Relative
+ *    coordinates `{x, y, width, height}` in the original image's coordinate
+ *    space, resolved from the thumbnail image's current crop in piece history.
  *
  * 2. **`getThumbnailAspectRatio(piece)`** (`pieceCardHeight.ts`) — returns a CSS
  *    `aspect-ratio` string. When crop is present: `"<crop.width> / <crop.height>"`.


### PR DESCRIPTION
## What changed
- Removed `Piece.thumbnail_crop` and the code paths that wrote to or read from it.
- Made piece thumbnail crops derive from the current thumbnail image's crop in piece history.
- Simplified the crop backfill/clear commands and updated the related regression tests.
- Added a migration to drop the old database column.

## Why
Recropping the thumbnail image should update the thumbnail shown on the piece automatically. Keeping a separate piece-level crop cache made the response drift out of sync with the actual crop stored on the image row.

## Validation
- `rtk bazel test //api:api_piece_test //api:api_model_test --test_output=errors`
- `rtk bazel build --config=lint //web/...`
