### PR TITLE
[codex] Exclude stories from web coverage

### DIFF
--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -311,7 +311,6 @@ js_library(
             "src/assets/**/*",
             "src/components/**/*",
             "src/pages/**/*",
-            "src/stories/**/*",
             "*.json",
             "*.config.*",
             "public/**/*",


### PR DESCRIPTION
Exclude Storybook files from web coverage

This change removes `src/stories/**` from `//web:web_lib`, which is the source set used by the app build and web coverage jobs.

Why:
- Storybook stories are documentation/demo assets, not app code.
- Keeping them in `web_lib` caused frontend coverage metrics to count them as part of the application surface.
- `//web:storybook_lib` still includes the stories, so Storybook builds remain unchanged.

Validation:
- `rtk bazel test //web:web_test`
- `rtk bazel build --config=lint //web/...`
