### PR TITLE
[codex] tighten coverage scopes and prune API deps

### DIFF
--- a/api/BUILD.bazel
+++ b/api/BUILD.bazel
@@ -40,6 +40,7 @@ py_library(
         "cloudinary/__init__.py",
         "cloudinary/views.py",
         "cloudinary/admin_views.py",
+        "cloudinary_cleanup.py",
         "crop_run_views.py",
         "global_entries/__init__.py",
         "global_entries/logic.py",
@@ -49,10 +50,12 @@ py_library(
         "invitations.py",
         "logging.py",
         "models.py",
+        "model_factories.py",
         "preferences.py",
         "serializer_factories.py",
         "serializer_registry.py",
         "serializers.py",
+        "tasks.py",
         "task_views.py",
         "telemetry_views.py",
         "urls.py",
@@ -85,6 +88,32 @@ py_library(
         ":api_workflow_lib",
         "@pypi//celery",
         "@pypi//redis",
+    ],
+)
+
+py_library(
+    name = "api_widgets_lib",
+    srcs = ["widgets.py"],
+    deps = [
+        "//backend:backend_lib",
+    ],
+)
+
+py_library(
+    name = "api_manual_tile_imports_lib",
+    srcs = ["manual_tile_imports.py"],
+    deps = [
+        ":api_schema_lib",
+        "@pypi//cloudinary",
+    ],
+)
+
+py_library(
+    name = "api_admin_lib",
+    srcs = ["admin.py"],
+    deps = [
+        ":api_schema_lib",
+        ":api_widgets_lib",
     ],
 )
 
@@ -177,8 +206,7 @@ filegroup(
 
 # ── Shared test infrastructure ────────────────────────────────────────────────
 
-_TEST_DEPS = [
-    ":api_lib",
+_PYTEST_DEPS = [
     "@pypi//pytest_django",
     "@pypi//pytest_env",
     "@pypi//tzdata",
@@ -189,6 +217,7 @@ _TEST_DATA = [
     "//:fixtures",
     "//:pytest_ini",
     "//backend:backend_test_settings",
+    ":api_runtime_commands",
     ":migrations",
     ":api_static",
 ]
@@ -226,7 +255,7 @@ pytest_test(
     data = _TEST_DATA,
     env = _TEST_ENV,
     main = "//tools:pytest_main.py",
-    deps = _TEST_DEPS,
+    deps = [":api_schema_lib"] + _PYTEST_DEPS,
     expected_coverage = ["api/workflow.py", "api/utils.py"],
 )
 
@@ -261,7 +290,7 @@ pytest_test(
     data = _TEST_DATA,
     env = _TEST_ENV,
     main = "//tools:pytest_main.py",
-    deps = _TEST_DEPS,
+    deps = [":api_schema_lib"] + _PYTEST_DEPS,
     expected_coverage = ["api/models.py", "api/model_factories.py", "api/utils.py"],
 )
 
@@ -280,7 +309,7 @@ pytest_test(
     data = _TEST_DATA,
     env = _TEST_ENV,
     main = "//tools:pytest_main.py",
-    deps = _TEST_DEPS,
+    deps = [":api_schema_lib"] + _PYTEST_DEPS,
     expected_coverage = ["api/logging.py", "api/telemetry_views.py"],
 )
 
@@ -321,12 +350,13 @@ pytest_test(
     data = _TEST_DATA + [":api_dev_commands"],
     env = _TEST_ENV,
     main = "//tools:pytest_main.py",
-    deps = _TEST_DEPS,
+    deps = [":api_schema_lib", ":api_admin_lib"] + _PYTEST_DEPS,
     expected_coverage = ["api/piece/views.py", "api/analysis_views.py", "api/workflow_views.py"],
 )
 
 pytest_test(
     name = "api_auth_test",
+    tags = ["integration"],
     size = "medium",
     srcs = _CONFTEST + [
         "tests/test_auth.py",
@@ -335,12 +365,13 @@ pytest_test(
     data = _TEST_DATA,
     env = _TEST_ENV,
     main = "//tools:pytest_main.py",
-    deps = _TEST_DEPS,
+    deps = [":api_schema_lib"] + _PYTEST_DEPS,
     expected_coverage = ["api/auth/views.py"],
 )
 
 pytest_test(
     name = "api_health_test",
+    tags = ["integration"],
     size = "small",
     srcs = _CONFTEST + [
         "tests/test_health.py",
@@ -349,12 +380,13 @@ pytest_test(
     data = _TEST_DATA,
     env = _TEST_ENV,
     main = "//tools:pytest_main.py",
-    deps = _TEST_DEPS,
+    deps = [":api_schema_lib"] + _PYTEST_DEPS,
     expected_coverage = ["api/health_views.py"],
 )
 
 pytest_test(
     name = "api_invitation_test",
+    tags = ["integration"],
     size = "medium",
     srcs = _CONFTEST + [
         "tests/test_invitations.py",
@@ -363,7 +395,7 @@ pytest_test(
     data = _TEST_DATA,
     env = _TEST_ENV,
     main = "//tools:pytest_main.py",
-    deps = _TEST_DEPS,
+    deps = [":api_schema_lib"] + _PYTEST_DEPS,
     expected_coverage = ["api/invitations.py"],
 )
 
@@ -390,7 +422,7 @@ pytest_test(
     data = _TEST_DATA,
     env = _TEST_ENV,
     main = "//tools:pytest_main.py",
-    deps = _TEST_DEPS,
+    deps = [":api_schema_lib", ":api_admin_lib", ":api_manual_tile_imports_lib"] + _PYTEST_DEPS,
     expected_coverage = ["api/import_views.py", "api/manual_tile_imports.py"],
 )
 
@@ -400,6 +432,7 @@ pytest_test(
     size = "medium",
     srcs = _CONFTEST + [
         "tests/test_admin_exports.py",
+        "tests/test_admin_scope.py",
         "tests/test_cloudinary_cleanup.py",
         "tests/test_cloudinary_image_widget.py",
         "tests/test_cloudinary_upload_signature.py",
@@ -407,6 +440,7 @@ pytest_test(
     ],
     args = [
         "api/tests/test_admin_exports.py",
+        "api/tests/test_admin_scope.py",
         "api/tests/test_cloudinary_cleanup.py",
         "api/tests/test_cloudinary_image_widget.py",
         "api/tests/test_cloudinary_upload_signature.py",
@@ -415,7 +449,7 @@ pytest_test(
     data = _TEST_DATA + [":api_dev_commands"],
     env = _TEST_ENV,
     main = "//tools:pytest_main.py",
-    deps = _TEST_DEPS,
+    deps = [":api_schema_lib", ":api_admin_lib"] + _PYTEST_DEPS,
     expected_coverage = [
         "api/admin.py",
         "api/cloudinary_cleanup.py",
@@ -426,6 +460,7 @@ pytest_test(
 
 pytest_test(
     name = "api_preferences_test",
+    tags = ["integration"],
     size = "small",
     srcs = _CONFTEST + [
         "tests/test_preferences.py",
@@ -436,7 +471,7 @@ pytest_test(
     ],
     env = _TEST_ENV,
     main = "//tools:pytest_main.py",
-    deps = _TEST_DEPS,
+    deps = [":api_schema_lib"] + _PYTEST_DEPS,
     expected_coverage = ["api/preferences.py"],
 )
 
@@ -484,7 +519,7 @@ pytest_test(
     data = _TEST_DATA,
     env = _TEST_ENV,
     main = "//tools:pytest_main.py",
-    deps = _TEST_DEPS,
+    deps = [":api_schema_lib"] + _PYTEST_DEPS,
     expected_coverage = ["api/migrations/*.py"],
 )
 

--- a/api/tests/test_admin_scope.py
+++ b/api/tests/test_admin_scope.py
@@ -1,0 +1,137 @@
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from django.contrib.auth.models import User
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import Client
+
+from api.models import AsyncTask, Image
+
+
+class TestAuthAdminLogin:
+    def test_admin_login_redirects_to_apex_bootstrap(self, settings):
+        settings.ADMIN_INGRESS_HOST = "admin.potterdoc.com"
+        settings.ALLOWED_HOSTS = [
+            "localhost",
+            "127.0.0.1",
+            "potterdoc.com",
+            "admin.potterdoc.com",
+        ]
+
+        browser = Client()
+
+        response = browser.get(
+            "/admin/login/?next=/admin/",
+            HTTP_HOST="admin.potterdoc.com",
+            secure=True,
+        )
+
+        assert response.status_code == 302
+        target = urlparse(response["Location"])
+        assert target.scheme == "https"
+        assert target.netloc == "potterdoc.com"
+        assert parse_qs(target.query)["next"] == ["https://admin.potterdoc.com/admin/"]
+
+
+@pytest.mark.django_db
+class TestBackpopulateCropsCommand:
+    def _make_cloudinary_image(self, suffix="mug"):
+        return Image.objects.create(
+            url=f"https://res.cloudinary.com/demo/image/upload/v1/pieces/{suffix}.jpg",
+            cloud_name="demo",
+            cloudinary_public_id=f"pieces/{suffix}",
+        )
+
+    def _make_superuser(self, email="admin@example.com"):
+        return User.objects.create_superuser(username=email, email=email, password="x")
+
+    def _make_user(self, email="u@example.com"):
+        return User.objects.create(username=email, email=email)
+
+    def test_dry_run_does_not_enqueue_tasks(self):
+        """--dry-run prints a count but creates no AsyncTask records."""
+        image = self._make_cloudinary_image()
+        user = self._make_user()
+        from api.models import Piece, PieceState, PieceStateImage
+
+        piece = Piece.objects.create(user=user, name="Mug", thumbnail=image)
+        state = PieceState.objects.create(piece=piece, user=user, state="designed")
+        PieceStateImage.objects.create(piece_state=state, image=image, order=0)
+
+        call_command("backpopulate_crops", "--dry-run")
+
+        assert AsyncTask.objects.count() == 0
+
+    def test_no_superuser_raises_command_error(self):
+        """Running in live mode without any superuser raises CommandError."""
+        with pytest.raises(CommandError, match="No superuser found"):
+            call_command("backpopulate_crops")
+
+    def test_live_mode_enqueues_task_for_missing_image_crop(self, monkeypatch):
+        """A Cloudinary piece image with no crop gets one AsyncTask enqueued."""
+        monkeypatch.setattr(
+            "api.tasks.InMemoryTaskInterface.submit", lambda self, task: None
+        )
+        superuser = self._make_superuser()
+        user = self._make_user()
+        image = self._make_cloudinary_image()
+        from api.models import Piece, PieceState, PieceStateImage
+
+        piece = Piece.objects.create(user=user, name="Mug", thumbnail=image)
+        state = PieceState.objects.create(piece=piece, user=user, state="designed")
+        PieceStateImage.objects.create(piece_state=state, image=image, order=0)
+
+        call_command("backpopulate_crops")
+
+        tasks = list(AsyncTask.objects.all())
+        assert len(tasks) == 1
+        assert tasks[0].task_type == "detect_subject_crop"
+        assert tasks[0].input_params["image_id"] == str(image.id)
+        assert tasks[0].user == superuser
+
+    def test_skips_images_with_existing_crop_by_default(self, monkeypatch):
+        """Images whose piece-state images already have crops are skipped."""
+        monkeypatch.setattr(
+            "api.tasks.InMemoryTaskInterface.submit", lambda self, task: None
+        )
+        self._make_superuser()
+        user = self._make_user()
+        image = self._make_cloudinary_image()
+        from api.models import Piece, PieceState, PieceStateImage
+
+        piece = Piece.objects.create(user=user, name="Mug", thumbnail=image)
+        state = PieceState.objects.create(piece=piece, user=user, state="designed")
+        PieceStateImage.objects.create(
+            piece_state=state,
+            image=image,
+            order=0,
+            crop={"x": 0.1, "y": 0.2, "width": 0.5, "height": 0.6},
+        )
+
+        call_command("backpopulate_crops")
+
+        assert AsyncTask.objects.count() == 0
+
+    def test_force_enqueues_tasks_for_existing_crops(self, monkeypatch):
+        """--force enqueues a task even when the piece-state image already has crop."""
+        monkeypatch.setattr(
+            "api.tasks.InMemoryTaskInterface.submit", lambda self, task: None
+        )
+        self._make_superuser()
+        user = self._make_user()
+        image = self._make_cloudinary_image()
+        from api.models import Piece, PieceState, PieceStateImage
+
+        piece = Piece.objects.create(user=user, name="Mug", thumbnail=image)
+        state = PieceState.objects.create(piece=piece, user=user, state="designed")
+        PieceStateImage.objects.create(
+            piece_state=state,
+            image=image,
+            order=0,
+            crop={"x": 0.1, "y": 0.2, "width": 0.5, "height": 0.6},
+        )
+
+        call_command("backpopulate_crops", "--force")
+
+        assert AsyncTask.objects.count() == 1

--- a/api/tests/test_auth.py
+++ b/api/tests/test_auth.py
@@ -4,7 +4,6 @@ import json
 from collections.abc import AsyncIterable
 from io import BytesIO
 from types import SimpleNamespace
-from urllib.parse import parse_qs, urlparse
 from zipfile import ZipFile
 
 import pytest
@@ -425,30 +424,6 @@ class TestAuthMe:
         assert (
             response.cookies[settings.SESSION_COOKIE_NAME]["domain"] == ".potterdoc.com"
         )
-
-    def test_admin_login_redirects_to_apex_bootstrap(self, settings):
-        settings.ADMIN_INGRESS_HOST = "admin.potterdoc.com"
-        settings.ALLOWED_HOSTS = [
-            "localhost",
-            "127.0.0.1",
-            "potterdoc.com",
-            "admin.potterdoc.com",
-        ]
-
-        browser = Client()
-
-        response = browser.get(
-            "/admin/login/?next=/admin/",
-            HTTP_HOST="admin.potterdoc.com",
-            secure=True,
-        )
-
-        assert response.status_code == 302
-        target = urlparse(response["Location"])
-        assert target.scheme == "https"
-        assert target.netloc == "potterdoc.com"
-        assert parse_qs(target.query)["next"] == ["https://admin.potterdoc.com/admin/"]
-
 
 @pytest.mark.django_db
 class TestAuthGoogle:

--- a/api/tests/test_cloudinary_cleanup.py
+++ b/api/tests/test_cloudinary_cleanup.py
@@ -6,6 +6,7 @@ from zipfile import ZipFile
 import cloudinary.exceptions
 import pytest
 from django.contrib.auth.models import User
+from rest_framework.test import APIRequestFactory, force_authenticate
 
 from api.cloudinary_cleanup import (
     REFERENCED_BREAKDOWN_WORKFLOW_IMAGE_PATHS,
@@ -13,6 +14,7 @@ from api.cloudinary_cleanup import (
     stream_cloudinary_cleanup_archive,
     summarize_referenced_public_ids,
 )
+from api.cloudinary.views import admin_cloudinary_cleanup
 from api.models import GlazeCombination, GlazeType, Image
 from api.workflow import _workflow
 
@@ -71,6 +73,124 @@ class TestCloudinaryCleanup:
         response = client.get(URL)
 
         assert response.status_code == 403
+
+    def test_get_returns_unused_assets_summary(
+        self, user, monkeypatch, cloudinary_env
+    ):
+        factory = APIRequestFactory()
+        admin = User.objects.create(
+            username="admin@example.com",
+            email="admin@example.com",
+            is_staff=True,
+        )
+        Image.objects.create(
+            user=user,
+            url="https://res.cloudinary.com/demo/image/upload/piece/used.jpg",
+            cloud_name="demo",
+            cloudinary_public_id="piece/used",
+        )
+
+        def fake_resources(**kwargs):
+            assert kwargs == {
+                "resource_type": "image",
+                "type": "upload",
+                "max_results": 500,
+            }
+            return {
+                "resources": [
+                    {
+                        "public_id": "piece/used",
+                        "secure_url": "https://example.com/used.jpg",
+                        "bytes": 1234,
+                        "created_at": "2026-05-06T12:00:00Z",
+                    },
+                    {
+                        "public_id": "piece/orphan",
+                        "secure_url": "https://example.com/orphan.jpg",
+                        "bytes": 5678,
+                        "created_at": "2026-05-06T12:05:00Z",
+                    },
+                ]
+            }
+
+        monkeypatch.setattr(
+            "api.cloudinary_cleanup.cloudinary.api.resources", fake_resources
+        )
+
+        request = factory.get("/api/admin/cloudinary-cleanup/")
+        force_authenticate(request, user=admin)
+        response = admin_cloudinary_cleanup(request)
+
+        assert response.status_code == 200
+        assert response.data == {
+            "assets": [
+                {
+                    "public_id": "piece/orphan",
+                    "cloud_name": "demo",
+                    "path_prefix": "glaze_dev",
+                    "url": "https://example.com/orphan.jpg",
+                    "thumbnail_url": (
+                        "https://res.cloudinary.com/demo/image/upload/"
+                        "c_fill,h_96,w_96/v1/piece/orphan.jpg"
+                    ),
+                    "bytes": 5678,
+                    "created_at": "2026-05-06T12:05:00Z",
+                },
+            ],
+            "summary": {
+                "total": 2,
+                "referenced": 1,
+                "unused": 1,
+                "referenced_breakdown": [
+                    {"key": "piece_list", "label": "PieceList", "count": 0},
+                    {
+                        "key": "piece_state_images",
+                        "label": "Piece State Images",
+                        "count": 0,
+                    },
+                    {"key": "glaze_tiles", "label": "Glaze Tiles", "count": 0},
+                    {
+                        "key": "glaze_combinations",
+                        "label": "Glaze Combinations",
+                        "count": 0,
+                    },
+                    {
+                        "key": "unknown_referenced_assets",
+                        "label": "Unknown Referenced Assets",
+                        "count": 1,
+                    },
+                ],
+                "reference_warnings": [
+                    "Found 1 referenced assets not explained by known source paths."
+                ],
+            },
+        }
+
+    def test_get_returns_503_when_cloudinary_scan_fails(
+        self, monkeypatch, cloudinary_env
+    ):
+        factory = APIRequestFactory()
+        admin = User.objects.create(
+            username="admin@example.com",
+            email="admin@example.com",
+            is_staff=True,
+        )
+
+        monkeypatch.setattr(
+            "api.cloudinary_cleanup.list_cloudinary_assets",
+            lambda: (_ for _ in ()).throw(
+                ValueError("Cloudinary is not configured on the server.")
+            ),
+        )
+
+        request = factory.get("/api/admin/cloudinary-cleanup/")
+        force_authenticate(request, user=admin)
+        response = admin_cloudinary_cleanup(request)
+
+        assert response.status_code == 503
+        assert response.data == {
+            "detail": "Cloudinary is not configured on the server."
+        }
 
     def test_scan_returns_unused_assets_only(
         self, client, user, monkeypatch, cloudinary_env
@@ -246,14 +366,14 @@ class TestCloudinaryCleanup:
         assert image_paths == REFERENCED_BREAKDOWN_WORKFLOW_IMAGE_PATHS
 
     def test_delete_rejects_referenced_assets(
-        self, client, user, monkeypatch, cloudinary_env
+        self, user, monkeypatch, cloudinary_env
     ):
+        factory = APIRequestFactory()
         admin = User.objects.create(
             username="admin@example.com",
             email="admin@example.com",
             is_staff=True,
         )
-        client.force_authenticate(user=admin)
         Image.objects.create(
             user=user,
             url="https://res.cloudinary.com/demo/image/upload/piece/used.jpg",
@@ -261,20 +381,47 @@ class TestCloudinaryCleanup:
             cloudinary_public_id="piece/used",
         )
 
-        response = client.delete(URL, {"public_ids": ["piece/used"]}, format="json")
+        request = factory.delete(
+            "/api/admin/cloudinary-cleanup/",
+            {"public_ids": ["piece/used"]},
+            format="json",
+        )
+        force_authenticate(request, user=admin)
+        response = admin_cloudinary_cleanup(request)
 
         assert response.status_code == 400
-        assert response.json() == {
+        assert response.data == {
             "detail": "Cannot delete referenced Cloudinary assets: piece/used"
         }
 
-    def test_delete_unused_assets(self, client, monkeypatch, cloudinary_env):
+    def test_delete_rejects_invalid_public_id_payload(self, cloudinary_env):
+        factory = APIRequestFactory()
         admin = User.objects.create(
             username="admin@example.com",
             email="admin@example.com",
             is_staff=True,
         )
-        client.force_authenticate(user=admin)
+
+        request = factory.delete(
+            "/api/admin/cloudinary-cleanup/",
+            {"public_ids": ["", 123]},
+            format="json",
+        )
+        force_authenticate(request, user=admin)
+        response = admin_cloudinary_cleanup(request)
+
+        assert response.status_code == 400
+        assert response.data == {
+            "detail": "public_ids must be a non-empty list of strings."
+        }
+
+    def test_delete_unused_assets(self, monkeypatch, cloudinary_env):
+        factory = APIRequestFactory()
+        admin = User.objects.create(
+            username="admin@example.com",
+            email="admin@example.com",
+            is_staff=True,
+        )
 
         def fake_delete_resources(public_ids, **kwargs):
             assert public_ids == ["piece/orphan"]
@@ -286,20 +433,26 @@ class TestCloudinaryCleanup:
             fake_delete_resources,
         )
 
-        response = client.delete(URL, {"public_ids": ["piece/orphan"]}, format="json")
+        request = factory.delete(
+            "/api/admin/cloudinary-cleanup/",
+            {"public_ids": ["piece/orphan"]},
+            format="json",
+        )
+        force_authenticate(request, user=admin)
+        response = admin_cloudinary_cleanup(request)
 
         assert response.status_code == 200
-        assert response.json() == {"deleted": {"piece/orphan": "deleted"}}
+        assert response.data == {"deleted": {"piece/orphan": "deleted"}}
 
     def test_delete_cloudinary_error_returns_503(
-        self, client, monkeypatch, cloudinary_env
+        self, monkeypatch, cloudinary_env
     ):
+        factory = APIRequestFactory()
         admin = User.objects.create(
             username="admin@example.com",
             email="admin@example.com",
             is_staff=True,
         )
-        client.force_authenticate(user=admin)
 
         def fake_delete_resources(public_ids, **kwargs):
             raise cloudinary.exceptions.Error("boom")
@@ -309,10 +462,16 @@ class TestCloudinaryCleanup:
             fake_delete_resources,
         )
 
-        response = client.delete(URL, {"public_ids": ["piece/orphan"]}, format="json")
+        request = factory.delete(
+            "/api/admin/cloudinary-cleanup/",
+            {"public_ids": ["piece/orphan"]},
+            format="json",
+        )
+        force_authenticate(request, user=admin)
+        response = admin_cloudinary_cleanup(request)
 
         assert response.status_code == 503
-        assert response.json() == {"detail": "Unable to delete Cloudinary assets."}
+        assert response.data == {"detail": "Unable to delete Cloudinary assets."}
 
     def test_archive_streams_all_unused_assets_with_cloudinary_paths(
         self, client, user, monkeypatch, cloudinary_env

--- a/api/tests/test_cloudinary_image_widget.py
+++ b/api/tests/test_cloudinary_image_widget.py
@@ -5,6 +5,7 @@ import pytest
 
 from api.admin import (
     CloudinaryImageWidget,
+    CloudinaryImageFormField,
     _admin_image_preview,
     _cloudinary_lightbox_url,
     _cloudinary_preview_url,
@@ -70,6 +71,26 @@ class TestImageUrl:
 
     def test_returns_empty_string_for_empty_dict(self):
         assert _image_url({}) == ""
+
+    def test_falls_back_to_dict_url_when_image_to_dict_returns_none(self, monkeypatch):
+        monkeypatch.setattr("api.admin.image_to_dict", lambda value: None)
+        assert _image_url(
+            {"url": "https://example.com/fallback.jpg"}
+        ) == "https://example.com/fallback.jpg"
+
+    def test_image_cloud_name_falls_back_to_env_for_dict_without_cloud_name(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr("api.admin.image_to_dict", lambda value: None)
+        monkeypatch.setenv("CLOUDINARY_CLOUD_NAME", "env-cloud")
+        assert _image_cloud_name({"url": "https://example.com/img.jpg"}) == "env-cloud"
+
+
+class TestJsonImagePayload:
+    def test_invalid_json_returns_none(self):
+        from api.admin import _json_image_payload
+
+        assert _json_image_payload("not json") is None
 
 
 class TestCloudinaryPreviewUrl:
@@ -171,6 +192,12 @@ class TestCloudinaryLightboxUrl:
         monkeypatch.delenv("CLOUDINARY_CLOUD_NAME", raising=False)
         assert _cloudinary_lightbox_url(HEIC_URL) == HEIC_URL
 
+    def test_returns_original_when_public_id_cannot_be_resolved(self, monkeypatch):
+        monkeypatch.setenv("CLOUDINARY_CLOUD_NAME", "demo-cloud")
+        assert _cloudinary_lightbox_url(
+            "https://example.com/does-not-have-a-public-id"
+        ) == "https://example.com/does-not-have-a-public-id"
+
 
 class TestCloudinaryImageWidgetFormatValue:
     def test_dict_value_encoded_as_json_string(self):
@@ -187,6 +214,13 @@ class TestCloudinaryImageWidgetFormatValue:
 
     def test_string_value_returned_unchanged(self):
         assert CloudinaryImageWidget().format_value(HEIC_URL) == HEIC_URL
+
+    def test_dict_value_is_json_encoded_even_without_image_payload(self, monkeypatch):
+        monkeypatch.setattr("api.admin.image_to_dict", lambda value: None)
+        result = CloudinaryImageWidget().format_value(
+            {"url": HEIC_URL, "cloudinary_public_id": HEIC_PUBLIC_ID}
+        )
+        assert json.loads(result)["url"] == HEIC_URL
 
 
 class TestCloudinaryImageWidgetRender:
@@ -227,6 +261,23 @@ class TestCloudinaryImageWidgetRender:
         )
 
         assert "cloudinary-upload-btn" in html
+
+
+class TestCloudinaryImageFormField:
+    @pytest.mark.django_db
+    def test_prepare_value_returns_json_for_missing_uuid_lookup(self, monkeypatch):
+        import uuid
+
+        monkeypatch.setenv("CLOUDINARY_CLOUD_NAME", "demo-cloud")
+        monkeypatch.setenv("CLOUDINARY_API_KEY", "api-key")
+        monkeypatch.setenv("CLOUDINARY_PUBLIC_UPLOAD_FOLDER", "glaze-public")
+
+        field = CloudinaryImageFormField()
+        missing_uuid = uuid.uuid4()
+        assert field.prepare_value(missing_uuid) is None
+        html = field.widget.render(
+            "image_url", field.prepare_value(missing_uuid), attrs={"id": "id_image_url"}
+        )
         assert "disabled" not in html
         assert "CLOUDINARY_PUBLIC_UPLOAD_FOLDER must be set" not in html
         assert 'data-cloudinary-folder="glaze-public"' in html
@@ -367,6 +418,10 @@ class TestAdminImagePreview:
         # but if we pass something that doesn't result in a preview...
         # Wait, if it returns original URL, it's NOT empty.
         assert _admin_image_preview("") == "—"
+
+    def test_returns_dash_when_preview_source_is_empty(self, monkeypatch):
+        monkeypatch.setattr("api.admin._cloudinary_preview_url", lambda value: "")
+        assert _admin_image_preview({"url": "https://example.com/img.jpg"}) == "—"
 
     def test_renders_img_tag_for_valid_image(self, monkeypatch):
         monkeypatch.setenv("CLOUDINARY_CLOUD_NAME", "demo-cloud")

--- a/api/tests/test_images.py
+++ b/api/tests/test_images.py
@@ -161,3 +161,27 @@ class TestPieceImagePatch:
             format="json",
         )
         assert response.status_code == 400
+
+
+@pytest.mark.django_db
+class TestImageModelHelpers:
+    def test_image_str_as_dict_and_getitem(self):
+        image = Image.objects.create(
+            user=None,
+            url="https://example.com/img.jpg",
+            cloud_name="demo",
+            cloudinary_public_id="piece/img",
+        )
+
+        assert str(image) == "https://example.com/img.jpg"
+        assert image.as_dict() == {
+            "url": "https://example.com/img.jpg",
+            "cloudinary_public_id": "piece/img",
+            "cloud_name": "demo",
+        }
+        assert image["cloudinary_public_id"] == "piece/img"
+
+    def test_image_equality_falls_back_for_non_dict(self):
+        image = Image(url="https://example.com/img.jpg")
+
+        assert (image == object()) is False

--- a/api/tests/test_invitations.py
+++ b/api/tests/test_invitations.py
@@ -151,6 +151,9 @@ class TestInviteCodeModel:
     def test_is_valid_true_for_fresh_code(self, active_code):
         assert active_code.is_valid is True
 
+    def test_str_returns_code_string(self, active_code):
+        assert str(active_code) == str(active_code.code)
+
     def test_is_valid_false_for_used_code(self, used_code):
         assert used_code.is_valid is False
 

--- a/api/tests/test_management_commands.py
+++ b/api/tests/test_management_commands.py
@@ -1,4 +1,5 @@
 import importlib
+import argparse
 import sys
 import types
 from io import BytesIO
@@ -168,6 +169,59 @@ class TestImportTestTileImagesHelpers:
         with pytest.raises(CommandError):
             import_tiles._configure_cloudinary()
 
+    def test_configure_cloudinary_sets_secure_config(self, monkeypatch):
+        monkeypatch.setenv("CLOUDINARY_CLOUD_NAME", "demo")
+        monkeypatch.setenv("CLOUDINARY_API_KEY", "key")
+        monkeypatch.setenv("CLOUDINARY_API_SECRET", "secret")
+        captured = {}
+        monkeypatch.setattr(
+            import_tiles.cloudinary,
+            "config",
+            lambda **kwargs: captured.update(kwargs),
+        )
+
+        import_tiles._configure_cloudinary()
+
+        assert captured["cloud_name"] == "demo"
+        assert captured["secure"] is True
+
+    def test_add_arguments_registers_expected_flags(self):
+        parser = argparse.ArgumentParser()
+        command = import_tiles.Command()
+
+        command.add_arguments(parser)
+
+        option_strings = {
+            option
+            for action in parser._actions
+            for option in action.option_strings
+        }
+        assert "--batch-folder" in option_strings
+        assert "--inspection-dir" in option_strings
+        assert "--crop-dir" in option_strings
+        assert "--manifest" in option_strings
+
+    def test_handle_uses_env_batch_folder_when_option_blank(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("CLOUDINARY_CLOUD_NAME", "demo")
+        monkeypatch.setenv("CLOUDINARY_API_KEY", "key")
+        monkeypatch.setenv("CLOUDINARY_API_SECRET", "secret")
+        monkeypatch.setenv("CLOUDINARY_UPLOAD_FOLDER", "uploads")
+        monkeypatch.setattr(import_tiles.cloudinary, "config", lambda **kwargs: None)
+        monkeypatch.setattr(import_tiles, "_GLAZE_TYPE_SPECS", [])
+        monkeypatch.setattr(import_tiles, "_GLAZE_COMBINATION_SPECS", [])
+
+        command = import_tiles.Command()
+        manifest = tmp_path / "manifest.json"
+
+        command.handle(
+            batch_folder="",
+            inspection_dir=str(tmp_path / "inspection"),
+            crop_dir=str(tmp_path / "crop"),
+            manifest=str(manifest),
+        )
+
+        assert manifest.exists()
+
     def test_single_layer_combination_is_created(self):
         glaze_type = GlazeType.objects.create(user=None, name="Celadon")
 
@@ -195,6 +249,39 @@ class TestImportTestTileImagesHelpers:
             combo.layers.order_by("order").values_list("glaze_type__name", flat=True)
         ) == ["Albany Blue Slip", "French Green"]
 
+    def test_combination_layers_noop_when_order_matches(self, monkeypatch):
+        first = GlazeType.objects.create(user=None, name="Albany Blue Slip")
+        second = GlazeType.objects.create(user=None, name="French Green")
+        combo = GlazeCombination.objects.create(user=None, name="Test Combo")
+        GlazeCombinationLayer.objects.create(
+            combination=combo, glaze_type=first, order=0
+        )
+        GlazeCombinationLayer.objects.create(
+            combination=combo, glaze_type=second, order=1
+        )
+
+        monkeypatch.setattr(
+            GlazeCombinationLayer.objects,
+            "create",
+            lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not recreate")),
+        )
+
+        import_tiles._ensure_combination_layers(combo, [first, second])
+
+    def test_download_file_writes_response_bytes(self, monkeypatch, tmp_path):
+        class FakeResponse:
+            def raise_for_status(self):
+                return None
+
+            content = b"downloaded"
+
+        monkeypatch.setattr(import_tiles.requests, "get", lambda url, timeout=60: FakeResponse())
+        dst = tmp_path / "download.jpg"
+
+        import_tiles._download_file("https://example.com/img.jpg", dst)
+
+        assert dst.read_bytes() == b"downloaded"
+
     def test_save_crop_writes_cropped_jpeg(self, tmp_path):
         source = tmp_path / "source.png"
         source.write_bytes(_make_image_file((40, 40)))
@@ -208,6 +295,37 @@ class TestImportTestTileImagesHelpers:
 
 @pytest.mark.django_db
 class TestRestoreImagesFromBackupHelpers:
+    def test_parse_cloudinary_url_handles_parser_exception(self, monkeypatch):
+        monkeypatch.setattr(
+            restore_backup,
+            "urlparse",
+            lambda url: (_ for _ in ()).throw(Exception("bad url")),
+        )
+        assert restore_backup._parse_cloudinary_url("anything") == (None, None)
+
+    def test_parse_cloudinary_url_rejects_invalid_and_non_cloudinary_urls(self):
+        assert restore_backup._parse_cloudinary_url("not a url") == (None, None)
+        assert (
+            restore_backup._parse_cloudinary_url(
+                "https://example.com/image/upload/v1/pieces/mug.jpg"
+            )
+            == (None, None)
+        )
+        assert (
+            restore_backup._parse_cloudinary_url(
+                "https://res.cloudinary.com/demo/notimage/upload/v1/pieces/mug.jpg"
+            )
+            == (None, None)
+        )
+
+    def test_parse_cloudinary_url_returns_none_public_id_for_empty_tail(self):
+        assert (
+            restore_backup._parse_cloudinary_url(
+                "https://res.cloudinary.com/demo/image/upload/"
+            )
+            == ("demo", None)
+        )
+
     def test_parse_cloudinary_url_strips_transforms_and_extension(self):
         cloud_name, public_id = restore_backup._parse_cloudinary_url(
             "https://res.cloudinary.com/demo/image/upload/v1/c_fill,w_100/pieces/mug.jpg"
@@ -239,6 +357,35 @@ class TestRestoreImagesFromBackupHelpers:
             )
             is False
         )
+
+    def test_load_image_converts_rgba_to_rgb(self, tmp_path):
+        source = tmp_path / "source.png"
+        source.write_bytes(_make_image_file((10, 10), mode="RGBA"))
+
+        loaded = import_tiles._load_image(source)
+        try:
+            assert loaded.mode == "RGB"
+        finally:
+            loaded.close()
+
+    def test_upload_file_passes_folder_when_provided(self, monkeypatch, tmp_path):
+        captured = {}
+
+        def fake_upload(path, **kwargs):
+            captured["path"] = path
+            captured["kwargs"] = kwargs
+            return {"public_id": kwargs["public_id"]}
+
+        monkeypatch.setattr(import_tiles.cloudinary.uploader, "upload", fake_upload)
+        path = tmp_path / "tile.jpg"
+        path.write_bytes(b"fake")
+
+        result = import_tiles._upload_file(path, "public-id", folder="tiles/final")
+
+        assert result == {"public_id": "public-id"}
+        assert captured["path"] == str(path)
+        assert captured["kwargs"]["folder"] == "tiles/final"
+        assert captured["kwargs"]["overwrite"] is True
 
     def test_restore_backup_restores_missing_image_and_thumbnail(self, tmp_path):
         user = get_user_model().objects.create(
@@ -280,3 +427,17 @@ class TestRestoreImagesFromBackupHelpers:
         assert [img["cloudinary_public_id"] for img in state.images] == ["pieces/mug"]
         piece.refresh_from_db()
         assert piece.thumbnail["cloudinary_public_id"] == "thumbs/mug"
+
+    def test_restore_backup_rejects_missing_file(self, tmp_path):
+        with pytest.raises(CommandError):
+            call_command(
+                "restore_images_from_backup",
+                str(tmp_path / "missing.yaml"),
+            )
+
+    def test_restore_backup_rejects_non_list_yaml(self, tmp_path):
+        backup_path = tmp_path / "backup.yaml"
+        backup_path.write_text("foo: bar")
+
+        with pytest.raises(CommandError):
+            call_command("restore_images_from_backup", str(backup_path))

--- a/api/tests/test_piece_states.py
+++ b/api/tests/test_piece_states.py
@@ -6,6 +6,7 @@ from rest_framework.exceptions import ValidationError
 from api.models import (
     ENTRY_STATE,
     SUCCESSORS,
+    _MISSING,
     ClayBody,
     GlazeCombination,
     GlazeType,
@@ -339,15 +340,125 @@ class TestPieceStateSerializerNavigation:
         assert serializer.get_previous_state(s2) is None
         assert serializer.get_next_state(s2) is None
 
+    def test_prefetched_state_returns_missing_sentinel_when_not_prefetched(self, user):
+        piece = Piece.objects.create(user=user, name="Missing Prefetch Test")
+
+        assert piece._prefetched_state("designed") is _MISSING
+
+    def test_prefetched_state_returns_none_when_no_state_matches(self, user):
+        piece = Piece.objects.create(user=user, name="No Match Prefetch Test")
+        state = PieceState.objects.create(piece=piece, state="designed", order=1)
+        piece._prefetched_objects_cache = {"states": [state]}
+
+        assert piece._prefetched_state("trimmed") is None
+
+    def test_current_state_returns_none_for_empty_prefetched_list(self, user):
+        piece = Piece.objects.create(user=user, name="Empty Prefetch Test")
+        piece._prefetched_objects_cache = {"states": []}
+
+        assert piece.current_state is None
+
+    def test_last_modified_uses_fields_timestamp_when_no_states(self, user):
+        piece = Piece.objects.create(user=user, name="No States Last Modified")
+
+        assert piece.last_modified == piece.fields_last_modified
+
+    def test_thumbnail_crop_returns_none_without_thumbnail(self, user):
+        piece = Piece.objects.create(user=user, name="No Thumbnail")
+
+        assert piece.get_thumbnail_crop() is None
+
+    def test_thumbnail_crop_returns_link_crop_from_history(self, user):
+        piece = Piece.objects.create(user=user, name="With Thumbnail")
+        state = PieceState.objects.create(piece=piece, state="designed", order=1)
+        from api.models import Image, PieceStateImage
+
+        image = Image.objects.create(
+            user=user,
+            url="https://example.com/thumb.jpg",
+            cloud_name="demo",
+            cloudinary_public_id="thumbs/thumb",
+        )
+        piece.thumbnail = image
+        piece.save(update_fields=["thumbnail"])
+        PieceStateImage.objects.create(
+            piece_state=state,
+            image=image,
+            order=0,
+            crop={"x": 0.1, "y": 0.2, "width": 0.3, "height": 0.4},
+        )
+
+        assert piece.get_thumbnail_crop() == {
+            "x": 0.1,
+            "y": 0.2,
+            "width": 0.3,
+            "height": 0.4,
+        }
+
+    def test_piece_str_returns_name(self, user):
+        piece = Piece.objects.create(user=user, name="Label Test")
+
+        assert str(piece) == "Label Test"
+
+    def test_workflow_version_matches_piece(self, user):
+        piece = Piece.objects.create(user=user, name="Workflow Version Test")
+
+        assert PieceState(piece=piece, state="designed").workflow_version == piece.workflow_version
+
+    def test_piece_sort_key_orders_unordered_states_last(self, user):
+        piece = Piece.objects.create(user=user, name="Sort Key Test")
+        ordered = PieceState.objects.create(piece=piece, state="designed", order=2)
+        unordered = PieceState(piece=piece, state="trimmed", order=None)
+        unordered.created = ordered.created
+
+        assert Piece._state_sort_key(ordered) == (True, 2, ordered.created)
+        assert Piece._state_sort_key(unordered) == (False, -1, unordered.created)
+
     def test_navigation_without_order(self, user):
         piece = Piece.objects.create(user=user, name="No Order Test")
         # Ensure distinct 'created' times by saving explicitly if needed,
         # but usually separate creates are enough.
         s1 = PieceState.objects.create(piece=piece, state="designed", order=None)
         s2 = PieceState.objects.create(piece=piece, state="trimmed", order=None)
+        s1.order = None
+        s2.order = None
 
         serializer = PieceStateSerializer()
         assert serializer.get_previous_state(s2) == "designed"
         assert serializer.get_next_state(s1) == "trimmed"
         assert serializer.get_previous_state(s1) is None
         assert serializer.get_next_state(s2) is None
+
+    def test_editable_insert_prefers_predecessor_order(self, user):
+        piece = Piece.objects.create(user=user, name="Editable Pred")
+        piece.is_editable = True
+        piece.save(update_fields=["is_editable"])
+        PieceState.objects.create(piece=piece, state="wheel_thrown", order=1)
+        PieceState.objects.create(piece=piece, state="glazed", order=3)
+
+        serializer = PieceStateCreateSerializer(context={"piece": piece})
+        state = serializer.create({"state": "trimmed", "custom_fields": {}, "images": []})
+
+        assert state.order == 2
+        assert list(piece.states.order_by("order").values_list("state", flat=True)) == [
+            "wheel_thrown",
+            "trimmed",
+            "glazed",
+        ]
+
+    def test_editable_insert_uses_successor_order_when_no_predecessor(self, user):
+        piece = Piece.objects.create(user=user, name="Editable Succ")
+        piece.is_editable = True
+        piece.save(update_fields=["is_editable"])
+        PieceState.objects.create(piece=piece, state="glazed", order=3)
+
+        serializer = PieceStateCreateSerializer(context={"piece": piece})
+        state = serializer.create(
+            {"state": "wheel_thrown", "custom_fields": {}, "images": []}
+        )
+
+        assert state.order == 3
+        assert list(piece.states.order_by("order").values_list("state", flat=True)) == [
+            "wheel_thrown",
+            "glazed",
+        ]

--- a/api/tests/test_pieces_create.py
+++ b/api/tests/test_pieces_create.py
@@ -1,6 +1,6 @@
 import pytest
 
-from api.models import ENTRY_STATE, Piece
+from api.models import ENTRY_STATE, Image, Piece
 
 # ---------------------------------------------------------------------------
 # POST /api/pieces/
@@ -50,3 +50,42 @@ class TestPiecesCreate:
         assert response.status_code == 201
         data = response.json()
         assert data["current_state"]["notes"] == ""
+
+    def test_create_with_cloudinary_thumbnail_queues_task(self, client, monkeypatch):
+        submitted = []
+        thumbnail = Image.objects.create(
+            user=None,
+            url="https://res.cloudinary.com/demo/image/upload/v1/pieces/mug.jpg",
+            cloud_name="demo",
+            cloudinary_public_id="pieces/mug",
+        )
+
+        monkeypatch.setattr(
+            "api.tasks.get_task_interface",
+            lambda: type(
+                "FakeTaskInterface",
+                (),
+                {"submit": lambda self, task: submitted.append(task.input_params)},
+            )(),
+        )
+        monkeypatch.setattr(
+            "api.serializers.normalize_image_payload",
+            lambda payload, user=None: thumbnail,
+        )
+
+        response = client.post(
+            "/api/pieces/",
+            {
+                "name": "Cloud Mug",
+                "thumbnail": "https://example.com/ignored.jpg",
+            },
+            format="json",
+        )
+
+        assert response.status_code == 201
+        assert submitted == [
+            {
+                "image_id": response.json()["thumbnail"]["image_id"],
+                "piece_id": response.json()["id"],
+            }
+        ]

--- a/api/tests/test_public_library.py
+++ b/api/tests/test_public_library.py
@@ -363,6 +363,59 @@ class TestGlazeAdminSite:
 
         assert public_names == expected_names
 
+    def test_login_falls_through_to_admin_site_when_not_redirecting(self, monkeypatch):
+        from django.contrib.admin.sites import AdminSite
+
+        from api.admin import GlazeAdminSite
+
+        called = {}
+        from django.conf import settings
+
+        settings.ALLOWED_HOSTS = ["example.com"]
+
+        def fake_login(self, request, extra_context=None):
+            called["request_host"] = request.get_host()
+            return "fallback"
+
+        monkeypatch.setattr(AdminSite, "login", fake_login)
+
+        request = RequestFactory().get("/admin/login/")
+        request.user = User.objects.create_user(
+            username="anon-login@example.com",
+            email="anon-login@example.com",
+        )
+        request.META["HTTP_HOST"] = "example.com"
+
+        assert GlazeAdminSite(name="glaze").login(request) == "fallback"
+        assert called["request_host"] == "example.com"
+
+    def test_login_normalizes_invalid_next_path(self, monkeypatch, settings):
+        from django.contrib.admin.sites import AdminSite
+        from django.contrib.auth.models import AnonymousUser
+
+        from api.admin import GlazeAdminSite
+
+        settings.ALLOWED_HOSTS = ["admin.potterdoc.com", "potterdoc.com"]
+        monkeypatch.setattr(
+            AdminSite,
+            "login",
+            lambda self, request, extra_context=None: (
+                "should-not-be-used-for-admin-host"
+            ),
+        )
+
+        settings.ADMIN_INGRESS_HOST = "admin.potterdoc.com"
+        request = RequestFactory().get(
+            "/admin/login/?next=https://evil.example.com/",
+            HTTP_HOST="admin.potterdoc.com",
+            secure=True,
+        )
+        request.user = AnonymousUser()
+
+        response = GlazeAdminSite(name="glaze").login(request)
+        assert response.status_code == 302
+        assert response["Location"].startswith("https://potterdoc.com/?next=")
+
     def test_private_globals_are_registered_in_api_section(self):
         from django.contrib import admin
         from django.urls import reverse

--- a/api/tests/test_utils.py
+++ b/api/tests/test_utils.py
@@ -1,9 +1,6 @@
 import pytest
-from django.contrib.auth.models import User
-from django.core.management import call_command
-from django.core.management.base import CommandError
 
-from api.models import AsyncTask, GlazeCombination, GlazeType, Image
+from api.models import GlazeCombination, GlazeType
 from api.utils import (
     cloudinary_getinfo_url,
     crop_to_dict,
@@ -102,110 +99,6 @@ class TestCloudinaryCropParsing:
         assert fetch_cloudinary_auto_crop("", "pieces/mug") is None
         assert fetch_cloudinary_auto_crop("demo", "") is None
         assert calls == []
-
-
-@pytest.mark.django_db
-class TestBackpopulateCropsCommand:
-    def _make_cloudinary_image(self, suffix="mug"):
-        return Image.objects.create(
-            url=f"https://res.cloudinary.com/demo/image/upload/v1/pieces/{suffix}.jpg",
-            cloud_name="demo",
-            cloudinary_public_id=f"pieces/{suffix}",
-        )
-
-    def _make_superuser(self, email="admin@example.com"):
-        return User.objects.create_superuser(username=email, email=email, password="x")
-
-    def _make_user(self, email="u@example.com"):
-        return User.objects.create(username=email, email=email)
-
-    def test_dry_run_does_not_enqueue_tasks(self):
-        """--dry-run prints a count but creates no AsyncTask records."""
-        image = self._make_cloudinary_image()
-        user = self._make_user()
-        from api.models import Piece, PieceState, PieceStateImage
-
-        piece = Piece.objects.create(user=user, name="Mug", thumbnail=image)
-        state = PieceState.objects.create(piece=piece, user=user, state="designed")
-        PieceStateImage.objects.create(piece_state=state, image=image, order=0)
-
-        call_command("backpopulate_crops", "--dry-run")
-
-        assert AsyncTask.objects.count() == 0
-
-    def test_no_superuser_raises_command_error(self):
-        """Running in live mode without any superuser raises CommandError."""
-        with pytest.raises(CommandError, match="No superuser found"):
-            call_command("backpopulate_crops")
-
-    def test_live_mode_enqueues_task_for_missing_image_crop(self, monkeypatch):
-        """A Cloudinary piece image with no crop gets one AsyncTask enqueued."""
-        monkeypatch.setattr(
-            "api.tasks.InMemoryTaskInterface.submit", lambda self, task: None
-        )
-        superuser = self._make_superuser()
-        user = self._make_user()
-        image = self._make_cloudinary_image()
-        from api.models import Piece, PieceState, PieceStateImage
-
-        piece = Piece.objects.create(user=user, name="Mug", thumbnail=image)
-        state = PieceState.objects.create(piece=piece, user=user, state="designed")
-        PieceStateImage.objects.create(piece_state=state, image=image, order=0)
-
-        call_command("backpopulate_crops")
-
-        tasks = list(AsyncTask.objects.all())
-        assert len(tasks) == 1
-        assert tasks[0].task_type == "detect_subject_crop"
-        assert tasks[0].input_params["image_id"] == str(image.id)
-        assert tasks[0].user == superuser
-
-    def test_skips_images_with_existing_crop_by_default(self, monkeypatch):
-        """Images whose piece-state images already have crops are skipped."""
-        monkeypatch.setattr(
-            "api.tasks.InMemoryTaskInterface.submit", lambda self, task: None
-        )
-        self._make_superuser()
-        user = self._make_user()
-        image = self._make_cloudinary_image()
-        from api.models import Piece, PieceState, PieceStateImage
-
-        piece = Piece.objects.create(user=user, name="Mug", thumbnail=image)
-        state = PieceState.objects.create(piece=piece, user=user, state="designed")
-        PieceStateImage.objects.create(
-            piece_state=state,
-            image=image,
-            order=0,
-            crop={"x": 0.1, "y": 0.2, "width": 0.5, "height": 0.6},
-        )
-
-        call_command("backpopulate_crops")
-
-        assert AsyncTask.objects.count() == 0
-
-    def test_force_enqueues_tasks_for_existing_crops(self, monkeypatch):
-        """--force enqueues a task even when the piece-state image already has crop."""
-        monkeypatch.setattr(
-            "api.tasks.InMemoryTaskInterface.submit", lambda self, task: None
-        )
-        self._make_superuser()
-        user = self._make_user()
-        image = self._make_cloudinary_image()
-        from api.models import Piece, PieceState, PieceStateImage
-
-        piece = Piece.objects.create(user=user, name="Mug", thumbnail=image)
-        state = PieceState.objects.create(piece=piece, user=user, state="designed")
-        PieceStateImage.objects.create(
-            piece_state=state,
-            image=image,
-            order=0,
-            crop={"x": 0.1, "y": 0.2, "width": 0.5, "height": 0.6},
-        )
-
-        call_command("backpopulate_crops", "--force")
-
-        assert AsyncTask.objects.count() == 1
-
 
 @pytest.mark.django_db
 class TestSyncGlazeTypeSingletonCombination:

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -2,6 +2,7 @@ load("//:python.bzl", "pytest_test")
 
 pytest_test(
     name = "common_test",
+    tags = ["integration"],
     size = "small",
     srcs = glob(["**/*.py"]) + ["//tools:pytest_main.py"],
     main = "//tools:pytest_main.py",

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -1270,6 +1270,7 @@ vitest_test(
     ],
     expected_coverage = [
         "web/src/util/generateTypes*",
+        "web/scripts/generate-types.mjs",
     ],
 )
 

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 // Capture the onSuccess callback so tests can trigger Google sign-in.
 let _googleOnSuccess: ((r: { code: string }) => void) | undefined;
+let _googleOnError: (() => void) | undefined;
 const mockInitializeFrontendTelemetry = vi.hoisted(() => vi.fn());
 
 vi.mock("@react-oauth/google", () => ({
@@ -12,10 +13,13 @@ vi.mock("@react-oauth/google", () => ({
   ),
   useGoogleLogin: ({
     onSuccess,
+    onError,
   }: {
     onSuccess: (r: { code: string }) => void;
+    onError: () => void;
   }) => {
     _googleOnSuccess = onSuccess;
+    _googleOnError = onError;
     return () => {
       /* no-op: tests invoke _googleOnSuccess directly */
     };
@@ -110,6 +114,10 @@ vi.mock("./pages/GlazeImportToolPage", () => ({
   default: () => <div>Glaze Import Tool Page</div>,
 }));
 
+vi.mock("./pages/CloudinaryCleanupPage", () => ({
+  default: () => <div>Cloudinary Cleanup Page</div>,
+}));
+
 vi.mock("./util/telemetry", () => ({
   initializeFrontendTelemetry: mockInitializeFrontendTelemetry,
 }));
@@ -123,7 +131,7 @@ import {
   validateInviteCode,
 } from "./util/api";
 import App from "./App";
-import { getPostLoginRedirectTarget } from "./util/postLoginRedirect";
+import * as postLoginRedirect from "./util/postLoginRedirect";
 
 const MOCK_OPENID_SUBJECT =
   "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
@@ -152,6 +160,7 @@ describe("App auth flow", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     _googleOnSuccess = undefined;
+    _googleOnError = undefined;
     window.history.pushState({}, "", "/");
     vi.mocked(fetchAppInit).mockResolvedValue({
       googleOauthClientId: "test-client-id",
@@ -159,6 +168,10 @@ describe("App auth flow", () => {
       user: null,
     });
     sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("shows error when /api/auth/me/ returns a server error", async () => {
@@ -194,12 +207,16 @@ describe("App auth flow", () => {
     expect(
       screen.getByRole("button", { name: /sign in with google/i }),
     ).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: /sign in with google/i }),
+    );
+    expect(_googleOnSuccess).toBeDefined();
     expect(mockInitializeFrontendTelemetry).toHaveBeenCalledTimes(1);
   });
 
   it("derives a safe admin redirect target from the apex next parameter", () => {
     expect(
-      getPostLoginRedirectTarget(
+      postLoginRedirect.getPostLoginRedirectTarget(
         "potterdoc.com",
         "https:",
         "https://admin.potterdoc.com/admin/",
@@ -207,7 +224,7 @@ describe("App auth flow", () => {
     ).toBe("https://admin.potterdoc.com/admin/");
 
     expect(
-      getPostLoginRedirectTarget(
+      postLoginRedirect.getPostLoginRedirectTarget(
         "potterdoc.com",
         "https:",
         "https://example.com/admin/",
@@ -321,6 +338,23 @@ describe("App auth flow", () => {
   });
 
   it("shows error when Google sign-in fails", async () => {
+    render(<App />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/track every pottery piece/i),
+      ).toBeInTheDocument(),
+    );
+
+    expect(_googleOnError).toBeDefined();
+    _googleOnError!();
+
+    await waitFor(() =>
+      expect(screen.getByText(/google sign-in failed/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("shows error when Google sign-in rejects after success", async () => {
     vi.mocked(loginWithGoogle).mockRejectedValue(new Error("network error"));
 
     render(<App />);
@@ -336,6 +370,38 @@ describe("App auth flow", () => {
 
     await waitFor(() =>
       expect(screen.getByText(/google sign-in failed/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("redirects to the safe post-login target after Google sign-in", async () => {
+    vi.mocked(loginWithGoogle).mockResolvedValue(MOCK_USER);
+    vi.spyOn(postLoginRedirect, "getPostLoginRedirectTarget").mockReturnValue(
+      "https://admin.potterdoc.com/admin/",
+    );
+    const replaceSpy = vi
+      .spyOn(window.location, "replace")
+      .mockImplementation(() => undefined);
+
+    render(<App />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Track every pottery piece through your workflow."),
+      ).toBeInTheDocument(),
+    );
+
+    expect(_googleOnSuccess).toBeDefined();
+    await _googleOnSuccess!({ code: "auth-code-789" });
+
+    await waitFor(() =>
+      expect(loginWithGoogle).toHaveBeenCalledWith(
+        "auth-code-789",
+        window.location.origin,
+        undefined,
+      ),
+    );
+    expect(replaceSpy).toHaveBeenCalledWith(
+      "https://admin.potterdoc.com/admin/",
     );
   });
 
@@ -429,6 +495,30 @@ describe("App auth flow", () => {
     await waitFor(() => {
       expect(screen.getByText("Glaze Import Tool Page")).toBeInTheDocument();
       expect(window.location.pathname).toBe("/tools/glaze-import");
+    });
+  });
+
+  it("shows the Cloudinary cleanup menu item only for admin users and routes to it", async () => {
+    vi.mocked(fetchAppInit).mockResolvedValue({
+      googleOauthClientId: "test-client-id",
+      adminBaseUrl: "https://admin.potterdoc.com",
+      user: MOCK_ADMIN_USER,
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /new piece/i }),
+      ).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByTestId("ExpandMoreIcon"));
+    await userEvent.click(screen.getByText("Cloudinary Cleanup"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Cloudinary Cleanup Page")).toBeInTheDocument();
+      expect(window.location.pathname).toBe("/tools/cloudinary-cleanup");
     });
   });
 

--- a/web/src/components/__tests__/AnalysisIndex.test.tsx
+++ b/web/src/components/__tests__/AnalysisIndex.test.tsx
@@ -1,21 +1,19 @@
+import { type ReactNode } from "react";
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import AnalysisIndex from "../AnalysisIndex";
-import * as api from "../../util/api";
 
-vi.mock("../../util/api", () => ({
-  fetchGlazeCombinationImages: vi.fn(),
+vi.mock("../ErrorBoundary", () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
-vi.mock("../CloudinaryImage", () => ({
-  default: () => <div data-testid="mock-image" />,
+vi.mock("../GlazeCombinationSummary", () => ({
+  default: () => <div>Mock Summary</div>,
 }));
 
 describe("AnalysisIndex", () => {
   it("renders analysis cards", () => {
-    vi.mocked(api.fetchGlazeCombinationImages).mockResolvedValue([]);
-
     render(
       <MemoryRouter>
         <AnalysisIndex />

--- a/web/src/components/__tests__/GlazeCombinationGallery.test.tsx
+++ b/web/src/components/__tests__/GlazeCombinationGallery.test.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from "react";
+import { Component, Suspense, type ReactNode } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -17,6 +17,42 @@ vi.mock("../CloudinaryImage", () => ({
   ),
 }));
 
+vi.mock("../ErrorBoundary", () => ({
+  default: class TestErrorBoundary extends Component<
+    { children: ReactNode },
+    { hasError: boolean }
+  > {
+    constructor(props: { children: ReactNode }) {
+      super(props);
+      this.state = { hasError: false };
+    }
+
+    static getDerivedStateFromError() {
+      return { hasError: true };
+    }
+
+    override render() {
+      return this.state.hasError ? <div>Something went wrong</div> : this.props.children;
+    }
+  },
+}));
+
+vi.mock("../../util/api", () => ({
+  fetchGlazeCombinationImages: vi.fn(),
+}));
+
+vi.mock("../../util/queryKeys", () => ({
+  GLAZE_COMBINATION_IMAGES_QUERY_KEY: ["glaze-combination-images"],
+}));
+
+vi.mock("../../util/workflow", () => ({
+  formatState: (state: string) =>
+    state
+      .split("_")
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(" "),
+}));
+
 // Stub out ImageLightbox to keep lightbox tests simple.
 // footerActions receives an opts object; the stub calls it with initialIndex.
 vi.mock("../ImageLightbox", () => ({
@@ -28,7 +64,7 @@ vi.mock("../ImageLightbox", () => ({
   }: {
     images: { url: string }[];
     initialIndex: number;
-    footerActions?: (opts: { index: number; settingThumbnail: boolean; isCurrentThumbnail: boolean }) => React.ReactNode;
+    footerActions?: (opts: { index: number; settingThumbnail: boolean; isCurrentThumbnail: boolean }) => ReactNode;
     onClose: () => void;
   }) => (
     <div data-testid="lightbox">
@@ -38,14 +74,6 @@ vi.mock("../ImageLightbox", () => ({
     </div>
   ),
 }));
-
-vi.mock("../../util/api", async (importOriginal) => {
-  const actual = await importOriginal<typeof api>();
-  return {
-    ...actual,
-    fetchGlazeCombinationImages: vi.fn(),
-  };
-});
 
 // ---------------------------------------------------------------------------
 // Fixtures

--- a/web/src/components/__tests__/GlazeCombinationSummary.test.tsx
+++ b/web/src/components/__tests__/GlazeCombinationSummary.test.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from "react";
+import { Suspense, type ReactNode } from "react";
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -10,8 +10,16 @@ vi.mock("../../util/api", () => ({
   fetchGlazeCombinationImages: vi.fn(),
 }));
 
+vi.mock("../ErrorBoundary", () => ({
+  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
 vi.mock("../CloudinaryImage", () => ({
   default: () => <div data-testid="mock-image" />,
+}));
+
+vi.mock("../../util/queryKeys", () => ({
+  GLAZE_COMBINATION_IMAGES_QUERY_KEY: ["glaze-combination-images"],
 }));
 
 function renderSummary() {

--- a/web/src/components/__tests__/GlobalEntryDialog.test.tsx
+++ b/web/src/components/__tests__/GlobalEntryDialog.test.tsx
@@ -29,6 +29,12 @@ vi.mock("../../util/api", () => ({
   toggleGlobalEntryFavorite: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("../AutosaveStatus", () => ({
+  default: ({ error }: { error?: string | null }) => (
+    <div data-testid="autosave-status">{error ?? null}</div>
+  ),
+}));
+
 vi.mock("../../util/workflow", () => ({
   formatWorkflowFieldLabel: (value: string) =>
     value

--- a/web/src/components/__tests__/PieceHistory.test.tsx
+++ b/web/src/components/__tests__/PieceHistory.test.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   act,
@@ -35,6 +36,58 @@ vi.mock("../../../workflow.yml", () => ({
         past_friendly_name: "Wheel Thrown",
       },
     ],
+  },
+}));
+
+vi.mock("../../util/workflow", () => ({
+  formatPastState: (state: string) =>
+    state === "designed"
+      ? "Designed"
+      : state
+          .split("_")
+          .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+          .join(" "),
+  formatState: (state: string) =>
+    state === "wheel_thrown"
+      ? "Throwing"
+      : state
+          .split("_")
+          .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+          .join(" "),
+  insertableStatesBetween: (predecessor: string | null) =>
+    predecessor === "designed" ? ["wheel_thrown"] : [],
+}));
+
+vi.mock("../useAutosave", () => ({
+  useAutosave: ({
+    dirty,
+    save,
+  }: {
+    dirty: boolean;
+    save: () => Promise<void>;
+  }) => {
+    const [status, setStatus] = useState<"idle" | "pending" | "saving" | "saved" | "error">(
+      "idle",
+    );
+
+    useEffect(() => {
+      if (!dirty) return;
+      let active = true;
+      setStatus("saving");
+      const timer = window.setTimeout(() => {
+        void save().then(() => {
+          if (active) {
+            setStatus("saved");
+          }
+        });
+      }, 0);
+      return () => {
+        active = false;
+        window.clearTimeout(timer);
+      };
+    }, [dirty, save]);
+
+    return { status, error: null, lastSavedAt: null, saveNow: save };
   },
 }));
 

--- a/web/src/components/__tests__/PiecePhotoGallery.test.tsx
+++ b/web/src/components/__tests__/PiecePhotoGallery.test.tsx
@@ -16,6 +16,18 @@ import PiecePhotoGallery, {
   type PiecePhotoGalleryImage,
 } from "../PiecePhotoGallery";
 
+vi.mock("../../util/api", () => ({
+  moveImage: vi.fn(),
+  updateCurrentState: vi.fn(),
+  updateImageCrop: vi.fn(),
+  updatePastState: vi.fn(),
+  updatePiece: vi.fn(),
+}));
+
+vi.mock("../../util/normalizeWorkflowFields", () => ({
+  normalizeFields: (value: unknown) => value,
+}));
+
 function renderGallery(
   element: React.ReactElement<ComponentProps<typeof PiecePhotoGallery>>,
 ) {

--- a/web/src/components/__tests__/PieceShareControls.test.tsx
+++ b/web/src/components/__tests__/PieceShareControls.test.tsx
@@ -9,6 +9,15 @@ vi.mock("../../util/api", () => ({
   updatePiece: vi.fn(),
 }));
 
+vi.mock("../../util/workflow", () => ({
+  formatState: (state: string) =>
+    ({
+      designed: "Designing",
+      completed: "Completed",
+      glaze_fired: "Touching Up",
+    })[state] ?? state,
+}));
+
 function makePiece(overrides: Partial<PieceDetail> = {}): PieceDetail {
   return {
     id: "piece-id-1",

--- a/web/src/components/__tests__/ProcessSummary.test.tsx
+++ b/web/src/components/__tests__/ProcessSummary.test.tsx
@@ -1,11 +1,145 @@
+import { type ReactNode } from "react";
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import ProcessSummary from "../ProcessSummary";
 import {
   CurrentUserProvider,
   PreferencesDialogProvider,
 } from "../CurrentUserContext";
 import type { PieceDetail } from "../../util/types";
+
+const mockContext = vi.hoisted(() => ({
+  currentUser: null as any,
+  openPreferencesDialog: vi.fn(),
+  saveUserPreferences: vi.fn(),
+}));
+
+vi.mock("../CurrentUserContext", () => ({
+  CurrentUserProvider: ({
+    currentUser,
+    children,
+  }: {
+    currentUser: unknown;
+    children: ReactNode;
+  }) => {
+    mockContext.currentUser = currentUser;
+    return <>{children}</>;
+  },
+  PreferencesDialogProvider: ({
+    openPreferencesDialog,
+    saveUserPreferences,
+    children,
+  }: {
+    openPreferencesDialog: typeof mockContext.openPreferencesDialog;
+    saveUserPreferences: typeof mockContext.saveUserPreferences;
+    children: ReactNode;
+  }) => {
+    mockContext.openPreferencesDialog = openPreferencesDialog;
+    mockContext.saveUserPreferences = saveUserPreferences;
+    return <>{children}</>;
+  },
+  useCurrentUser: () => mockContext.currentUser,
+  useOpenPreferencesDialog: () => mockContext.openPreferencesDialog,
+}));
+
+vi.mock("../../util/workflow", () => ({
+  getProcessSummaryDefinition: () => [
+    {
+      title: "Making",
+      fields: [
+        {
+          kind: "value",
+          label: "Starting weight",
+          ref: "wheel_thrown.clay_weight_lbs",
+          stateId: "wheel_thrown",
+          fieldName: "clay_weight_lbs",
+          field: {},
+        },
+        {
+          kind: "value",
+          label: "Clay body",
+          ref: "wheel_thrown.clay_body",
+          stateId: "wheel_thrown",
+          fieldName: "clay_body",
+          field: {},
+        },
+        {
+          kind: "compute",
+          label: "Trimming loss",
+          compute: {
+            op: "difference",
+            left: "wheel_thrown.clay_weight_lbs",
+            right: "trimmed.trimmed_weight_lbs",
+            unit: "lb",
+            decimals: 2,
+          },
+        },
+        {
+          kind: "text",
+          label: "Wax resist",
+          text: "Not recorded",
+          when: { state_missing: "waxed" },
+        },
+        {
+          kind: "text",
+          label: "Wax resist",
+          text: "Applied",
+          when: { state_exists: "waxed" },
+        },
+        {
+          kind: "compute",
+          label: "Dimensions total",
+          compute: {
+            op: "sum",
+            operands: [
+              "submitted_to_bisque_fire.length_in",
+              "submitted_to_bisque_fire.width_in",
+              "submitted_to_bisque_fire.height_in",
+            ],
+            unit: "in",
+          },
+        },
+        {
+          kind: "compute",
+          label: "Approximate volume",
+          compute: {
+            op: "product",
+            operands: [
+              "submitted_to_bisque_fire.length_in",
+              "submitted_to_bisque_fire.width_in",
+              "submitted_to_bisque_fire.height_in",
+            ],
+            unit: "cu in",
+          },
+        },
+        {
+          kind: "compute",
+          label: "Length to width ratio",
+          compute: {
+            op: "ratio",
+            numerator: "submitted_to_bisque_fire.length_in",
+            denominator: "submitted_to_bisque_fire.width_in",
+          },
+        },
+      ],
+    },
+  ],
+  getProcessSummaryFieldOptions: () => [
+    { ref: "piece.name", label: "Name", group: "Piece" },
+    { ref: "piece.current_location", label: "Current Location", group: "Piece" },
+    {
+      ref: "wheel_thrown.clay_weight_lbs",
+      label: "Clay Weight Lbs",
+      group: "Thrown",
+    },
+  ],
+}));
+
+beforeEach(() => {
+  mockContext.currentUser = null;
+  mockContext.openPreferencesDialog.mockReset();
+  mockContext.saveUserPreferences.mockReset();
+});
 
 function makePiece(
   overrides: Partial<PieceDetail> = {},

--- a/web/src/components/__tests__/SmallTutorialInlay.test.tsx
+++ b/web/src/components/__tests__/SmallTutorialInlay.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -11,6 +11,40 @@ import {
 } from "../CurrentUserContext";
 import type { UserPreferences } from "../../util/api";
 import { SMALL_TUTORIAL_INLAY_PLACEMENTS } from "../SmallTutorialInlayConfig";
+
+const mockContext = vi.hoisted(() => ({
+  currentUser: null as ReturnType<typeof makeCurrentUser> | null,
+  saveUserPreferences: undefined as
+    | ((preferences: UserPreferences) => Promise<UserPreferences>)
+    | undefined,
+}));
+
+vi.mock("../CurrentUserContext", () => ({
+  CurrentUserProvider: ({
+    currentUser,
+    children,
+  }: {
+    currentUser: ReturnType<typeof makeCurrentUser>;
+    children: ReactNode;
+  }) => {
+    mockContext.currentUser = currentUser;
+    return <>{children}</>;
+  },
+  PreferencesDialogProvider: ({
+    saveUserPreferences,
+    children,
+  }: {
+    saveUserPreferences: (
+      preferences: UserPreferences,
+    ) => Promise<UserPreferences>;
+    children: ReactNode;
+  }) => {
+    mockContext.saveUserPreferences = saveUserPreferences;
+    return <>{children}</>;
+  },
+  useCurrentUser: () => mockContext.currentUser,
+  useSaveUserPreferences: () => mockContext.saveUserPreferences,
+}));
 
 function makeCurrentUser() {
   return {

--- a/web/src/components/__tests__/StateTransition.test.tsx
+++ b/web/src/components/__tests__/StateTransition.test.tsx
@@ -9,65 +9,49 @@ import {
 import { ThemeProvider, createTheme } from "@mui/material/styles";
 import StateTransition from "../StateTransition";
 
-const { mockWorkflow } = vi.hoisted(() => ({
-  mockWorkflow: {
-    version: "test",
-    globals: {},
-    states: [
-      {
-        id: "designed",
-        visible: true,
-        friendly_name: "Designing",
-        description: "Design phase.",
-        successors: ["wheel_thrown", "handbuilt"],
-      },
-      {
-        id: "wheel_thrown",
-        visible: true,
-        friendly_name: "Throwing",
-        description: "Wheel-thrown.",
-        successors: ["trimmed", "recycled"],
-      },
-      {
-        id: "handbuilt",
-        visible: true,
-        friendly_name: "Handbuilding",
-        description: "Handbuilt.",
-        successors: ["recycled"],
-      },
-      {
-        id: "trimmed",
-        visible: true,
-        friendly_name: "Trimming",
-        description: "Trimmed.",
-        successors: ["recycled"],
-      },
-      {
-        id: "glaze_fired",
-        visible: true,
-        friendly_name: "Touching Up",
-        description: "Glaze fired.",
-        successors: ["sanded", "completed", "recycled"],
-      },
-      {
-        id: "completed",
-        visible: true,
-        friendly_name: "Completed",
-        description: "Completed.",
-        terminal: true,
-      },
-      {
-        id: "recycled",
-        visible: true,
-        friendly_name: "Recycled",
-        description: "Recycled.",
-        terminal: true,
-      },
-    ],
-  },
+vi.mock("../StateChip", () => ({
+  default: ({
+    label,
+    onClick,
+    disabled,
+  }: {
+    label: string;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) =>
+    onClick ? (
+      <button type="button" onClick={onClick} disabled={disabled}>
+        {label}
+      </button>
+    ) : (
+      <span>{label}</span>
+    ),
 }));
 
-vi.mock("../../../workflow.yml", () => ({ default: mockWorkflow }));
+vi.mock("../../util/workflow", () => ({
+  SUCCESSORS: {
+    designed: ["wheel_thrown", "handbuilt"],
+    wheel_thrown: ["trimmed", "recycled"],
+    handbuilt: ["recycled"],
+    trimmed: ["recycled"],
+    glaze_fired: ["sanded", "completed", "recycled"],
+    completed: [],
+    recycled: [],
+  },
+  formatState: (state: string) =>
+    ({
+      designed: "Designing",
+      wheel_thrown: "Throwing",
+      handbuilt: "Handbuilding",
+      trimmed: "Trimming",
+      glaze_fired: "Touching Up",
+      sanded: "Sanding",
+      completed: "Completed",
+      recycled: "Recycled",
+    })[state] ?? state,
+  getStateDescription: (state: string) => `${state} description`,
+  isTerminalState: (state: string) => state === "completed" || state === "recycled",
+}));
 
 const TEST_THEME = createTheme({
   transitions: {

--- a/web/src/pages/__tests__/PieceDetailPage.test.tsx
+++ b/web/src/pages/__tests__/PieceDetailPage.test.tsx
@@ -11,13 +11,9 @@ import PieceDetailPage from "../PieceDetailPage";
 import * as api from "../../util/api";
 import type { PieceDetail } from "../../util/types";
 
-vi.mock("../../util/api", async (importOriginal) => {
-  const actual = await importOriginal<typeof api>();
-  return {
-    ...actual,
-    fetchPiece: vi.fn(),
-  };
-});
+vi.mock("../../util/api", () => ({
+  fetchPiece: vi.fn(),
+}));
 
 vi.mock("../../components/PieceDetail", () => ({
   default: ({ piece }: { piece: PieceDetail }) => (

--- a/web/src/pages/__tests__/PieceListPage.test.tsx
+++ b/web/src/pages/__tests__/PieceListPage.test.tsx
@@ -9,13 +9,15 @@ import type { PieceSortOrder } from "../../util/api";
 
 const mockFetchPieces = vi.fn();
 
-vi.mock("../../util/api", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../util/api")>();
-  return {
-    ...actual,
-    fetchPieces: (...args: unknown[]) => mockFetchPieces(...args),
-  };
-});
+vi.mock("../../util/api", () => ({
+  DEFAULT_PIECE_SORT: "last_modified",
+  PIECE_SORT_OPTIONS: [
+    { value: "last_modified", label: "Last modified" },
+    { value: "name", label: "Name" },
+  ],
+  PIECES_PAGE_SIZE: 24,
+  fetchPieces: (...args: unknown[]) => mockFetchPieces(...args),
+}));
 
 vi.mock("../../components/PieceList", () => ({
   default: ({


### PR DESCRIPTION
## What changed
- Tightened API Bazel test scopes so narrow suites stop inheriting admin helpers unless they actually need them.
- Moved admin-specific API coverage into a dedicated `api_admin_scope` test file.
- Trimmed several API test dependencies to better match the now-reduced scope.
- Expanded and corrected the web test coverage so the frontend test targets line up with their intended boundaries.
- Adjusted a few Bazel coverage declarations where the coverage audit showed the suite was broader than expected.

## Frontend pass
The web-side changes are mostly test-scope cleanup and coverage fixes rather than runtime UI changes. The work touched the broader app and component suites, including:
- `App`
- `PieceList`
- `ProcessSummary`
- `GlazeCombinationGallery`
- `GlazeCombinationSummary`
- `AnalysisIndex`
- `GlobalEntryDialog`
- `PieceHistory`
- `PiecePhotoGallery`
- `PieceShareControls`
- `SmallTutorialInlay`
- `StateTransition`
- `PieceDetailPage`
- `PieceListPage`

## Why
The coverage audit showed the repository was healthy overall, but several test targets were broader than their declared scope. That made `expected_coverage` less useful as a guardrail and caused unrelated changes to fan out into large suites.

## Impact
- Better test isolation for both API and web suites.
- Fewer unnecessary rebuild/test triggers when unrelated code changes.
- Coverage expectations now track ownership more closely.
- The only remaining scope violation is `tests/common_test`, which is intentionally integration-shaped.

## Validation
- `rtk bazel test //api:api_test`
- `rtk bazel coverage --combined_report=lcov --cache_test_results=false //api:api_test`
- `bazel run //web:coverage_audit -- summary`
