### PR TITLE
fix: defer sentinel check until masonry container has a measured width

### DIFF
--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -442,8 +442,26 @@ const PieceList = (props: PieceListProps) => {
   }, [onLoadMore]);
   const sentinelRef = useRef<HTMLDivElement>(null);
 
+  // Declare masonry geometry here so masonryWidth is in scope for the sentinel
+  // effect below. The positioner useMemo further down still consumes these same
+  // values — nothing else in the component changes.
+  const windowHeight = useWindowHeight();
+  const masonryRef = useRef<HTMLElement | null>(null);
+  const columnWidth = isMobile
+    ? MASONRY_COLUMN_WIDTH_MOBILE
+    : MASONRY_COLUMN_WIDTH_DESKTOP;
+  const { width: masonryWidth, offset: masonryOffset } = useContainerPosition(
+    masonryRef,
+    [isMobile],
+  );
+
   useEffect(() => {
-    if (!hasMore) return;
+    // When masonryWidth is 0 the ResizeObserver hasn't fired yet: the masonry
+    // grid hasn't rendered so the sentinel sits at top≈0. Calling check() at
+    // that point fires onLoadMore before any cards are visible, triggering an
+    // immediate second-page fetch and the resulting flash. Defer until the
+    // container has a real width so the sentinel is at its true position.
+    if (!hasMore || masonryWidth === 0) return;
     function check() {
       const sentinel = sentinelRef.current;
       if (!sentinel) return;
@@ -453,7 +471,7 @@ const PieceList = (props: PieceListProps) => {
     window.addEventListener("scroll", check, { passive: true });
     check();
     return () => window.removeEventListener("scroll", check);
-  }, [hasMore]);
+  }, [hasMore, masonryWidth]);
 
   const availableTags = useMemo(() => {
     const deduped = new Map<string, TagEntry>();
@@ -505,15 +523,6 @@ const PieceList = (props: PieceListProps) => {
   }, [activeFilters, activeTagIds, activeTags]);
 
   const hasActiveFilters = activeFilters.length > 0 || activeTagIds.length > 0;
-  const windowHeight = useWindowHeight();
-  const masonryRef = useRef<HTMLElement | null>(null);
-  const columnWidth = isMobile
-    ? MASONRY_COLUMN_WIDTH_MOBILE
-    : MASONRY_COLUMN_WIDTH_DESKTOP;
-  const { width: masonryWidth, offset: masonryOffset } = useContainerPosition(
-    masonryRef,
-    [isMobile],
-  );
   const positioner = useMemo(() => {
     const [computedColumnWidth, computedColumnCount] = getMasonryColumns(
       masonryWidth,

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -1166,34 +1166,6 @@ describe("PieceList", () => {
     });
   });
 
-  describe("scroll sentinel", () => {
-    it("does not call onLoadMore before the masonry container has a measured width", () => {
-      // Regression for #734 Bug 1: when hasMore=true, check() fires immediately on
-      // mount. At that moment masonryWidth=0 (ResizeObserver not yet fired), so the
-      // sentinel sits at top≈0 and onLoadMore fires before any cards are visible.
-      // The fix adds masonryWidth to the effect deps and returns early when it is 0.
-      mockContainerPosition.width = 0;
-      const onLoadMore = vi.fn();
-      const router = createMemoryRouter(
-        [
-          {
-            path: "/",
-            element: (
-              <PieceList
-                pieces={[makePiece()]}
-                onLoadMore={onLoadMore}
-                hasMore
-              />
-            ),
-          },
-        ],
-        { initialEntries: ["/"] },
-      );
-      render(<RouterProvider router={router} />);
-      expect(onLoadMore).not.toHaveBeenCalled();
-    });
-  });
-
   describe("loading states", () => {
     it("dims the existing list during replace-style refreshes", () => {
       const router = createMemoryRouter(
@@ -1235,6 +1207,42 @@ describe("PieceList", () => {
       expect(
         screen.getByTestId("piece-list-overlay").getAttribute("style"),
       ).toContain("background-color: transparent");
+    });
+  });
+
+  describe("scroll sentinel", () => {
+    it("does not call onLoadMore while the masonry container width is unmeasured", async () => {
+      // Regression for #734: with the pre-fix code, the sentinel effect fires
+      // check() immediately on mount regardless of masonryWidth. At that moment
+      // masonryWidth=0 (ResizeObserver hasn't fired), the sentinel element sits
+      // at top≈0 in the unmeasured document, and check() calls onLoadMore before
+      // any cards are visible — fetching page 2 prematurely and causing the flash.
+      //
+      // The fix adds masonryWidth to the effect's deps and guards with
+      // `if (masonryWidth === 0) return`, so the effect is a no-op until the
+      // container has been measured.
+      //
+      // We let the event loop run (setTimeout) so React's MessageChannel-based
+      // scheduler has time to fire the mount effect before we assert.
+      mockContainerPosition.width = 0;
+      const onLoadMore = vi.fn();
+      const firstPage = Array.from({ length: 16 }, (_, i) =>
+        makePiece({ id: `piece-${i}` }),
+      );
+      const router = createMemoryRouter(
+        [
+          {
+            path: "/",
+            element: (
+              <PieceList pieces={firstPage} onLoadMore={onLoadMore} hasMore />
+            ),
+          },
+        ],
+        { initialEntries: ["/"] },
+      );
+      render(<RouterProvider router={router} />);
+      await new Promise<void>((resolve) => setTimeout(resolve, 50));
+      expect(onLoadMore).not.toHaveBeenCalled();
     });
   });
 });

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -1166,6 +1166,34 @@ describe("PieceList", () => {
     });
   });
 
+  describe("scroll sentinel", () => {
+    it("does not call onLoadMore before the masonry container has a measured width", () => {
+      // Regression for #734 Bug 1: when hasMore=true, check() fires immediately on
+      // mount. At that moment masonryWidth=0 (ResizeObserver not yet fired), so the
+      // sentinel sits at top≈0 and onLoadMore fires before any cards are visible.
+      // The fix adds masonryWidth to the effect deps and returns early when it is 0.
+      mockContainerPosition.width = 0;
+      const onLoadMore = vi.fn();
+      const router = createMemoryRouter(
+        [
+          {
+            path: "/",
+            element: (
+              <PieceList
+                pieces={[makePiece()]}
+                onLoadMore={onLoadMore}
+                hasMore
+              />
+            ),
+          },
+        ],
+        { initialEntries: ["/"] },
+      );
+      render(<RouterProvider router={router} />);
+      expect(onLoadMore).not.toHaveBeenCalled();
+    });
+  });
+
   describe("loading states", () => {
     it("dims the existing list during replace-style refreshes", () => {
       const router = createMemoryRouter(


### PR DESCRIPTION
## Problem

Fixes #734 (Bug 1). On the PieceList page with 17+ pieces, a second-page fetch fires immediately on mount — before the user has scrolled and before any cards are visible — causing a dark flash as the masonry re-lays out.

**Root cause:** The scroll sentinel `useEffect` called `check()` immediately when `hasMore` became `true`. At that moment `masonryWidth=0` (the `useContainerPosition` ResizeObserver hasn't fired yet), so the sentinel sits at `top≈0` in the unmeasured document. `check()` sees `top ≤ window.innerHeight + 300` → calls `onLoadMore` → page 2 fetch starts before page 1 is painted.

## Fix

Move the `masonryRef` / `columnWidth` / `useContainerPosition` declarations above the sentinel effect so `masonryWidth` is in scope, then add it to the effect's dependency list and return early when `masonryWidth === 0`:

```typescript
if (!hasMore || masonryWidth === 0) return;
```

The sentinel now first runs once the masonry container has a real width — at which point the sentinel is at its true document position and `check()` correctly reflects whether the user actually needs more content.

The `positioner` `useMemo` and all other masonry logic are unchanged.

## Regression Test

`PieceList > scroll sentinel > does not call onLoadMore while the masonry container width is unmeasured`

Renders 16 pieces with `hasMore=true` and `masonryWidth=0`, then waits 50 ms (giving React's `MessageChannel`-based scheduler time to fire mount effects) and asserts `onLoadMore` was never called.

- **Fails on `main`** before this fix — `onLoadMore` is called 1 time
- **Passes with this fix** — effect returns early, `onLoadMore` never called

## Verification

```
rtk bazel test //web:web_piece_list_test  # 52 tests pass
rtk bazel test //web:web_test             # 37 test targets pass
```

Closes #734
