### PR TITLE
feat: self-contained docker-compose deployment setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,63 @@ jobs:
       - if: failure()
         uses: ./.github/actions/collect-failure-diagnostics
 
+  compose-smoke:
+    name: Docker Compose smoke test
+    needs: preflight
+    if: ${{ github.event_name == 'pull_request' || needs.preflight.outputs.skip_main != 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Configure test environment
+        run: |
+          cat > infra/custom/.env << 'EOF'
+          POSTGRES_PASSWORD=test_postgres_password
+          SECRET_KEY=test_secret_key_django_placeholder
+          DOMAIN=localhost
+          ALLOWED_HOSTS=localhost,127.0.0.1
+          PRODUCTION=
+          EOF
+
+      - name: Start Docker Compose stack and wait for health
+        run: |
+          docker compose -f infra/custom/docker-compose.yml up --build -d --wait web
+
+      - name: Verify application readiness and data seeding
+        shell: bash
+        run: |
+          # Verify HTTP 200 on readiness endpoint
+          curl -fsS http://localhost:8000/api/health/ready/ | python3 -m json.tool
+
+          # Perform mock-IdP login to verify sessions and database seeding
+          JAR="$(mktemp)"
+          
+          # 1. POST authorize -> capture the relative redirect
+          LOCATION=$(curl -fsS -c "$JAR" -b "$JAR" -D - -X POST \
+            --data "redirect_uri=/api/auth/mock-idp/complete/&state=ci&login_hint=compose-smoke@localhost" \
+            "http://localhost:8000/api/auth/mock-idp/authorize/" \
+            | grep -i '^location:' | sed 's/[Ll]ocation: //' | tr -d '\r\n')
+            
+          [ -n "$LOCATION" ] || { echo "Error: Mock authorize did not return location header" >&2; exit 1; }
+          
+          # 2. GET complete/ to set the cookie
+          curl -fsS -c "$JAR" -b "$JAR" "http://localhost:8000${LOCATION}" -o /dev/null
+
+          # 3. Confirm we are logged in
+          curl -fsS -b "$JAR" "http://localhost:8000/api/auth/me/" \
+            | python3 -c 'import json,sys; d=json.load(sys.stdin); assert d.get("user"), "Not authenticated"; print("Authenticated as:", d["user"]["email"])'
+
+          # 4. Verify that seeded pieces exist
+          COUNT=$(curl -fsS -b "$JAR" "http://localhost:8000/api/pieces/" \
+            | python3 -c 'import json,sys; print(json.load(sys.stdin)["count"])')
+          echo "Seeded pieces count: $COUNT"
+          [ "$COUNT" -gt 0 ] || { echo "Error: Expected seeded pieces, got $COUNT" >&2; exit 1; }
+
+      - name: Dump logs on failure
+        if: failure()
+        run: |
+          docker compose -f infra/custom/docker-compose.yml logs
+
   image:
     name: Build & smoke-test OCI image
     needs: preflight
@@ -336,8 +393,8 @@ jobs:
 
   record-fingerprint:
     name: Record successful fingerprint
-    needs: [preflight, lint, coverage, dev-smoke, image]
-    if: ${{ github.event_name == 'pull_request' && needs.lint.result == 'success' && needs.coverage.result == 'success' && needs.dev-smoke.result == 'success' && needs.image.result == 'success' }}
+    needs: [preflight, lint, coverage, dev-smoke, image, compose-smoke]
+    if: ${{ github.event_name == 'pull_request' && needs.lint.result == 'success' && needs.coverage.result == 'success' && needs.dev-smoke.result == 'success' && needs.image.result == 'success' && needs.compose-smoke.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Write fingerprint marker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,41 +270,49 @@ jobs:
           cat > infra/custom/.env << 'EOF'
           POSTGRES_PASSWORD=test_postgres_password
           SECRET_KEY=test_secret_key_django_placeholder
-          DOMAIN=localhost
-          ALLOWED_HOSTS=localhost,127.0.0.1
-          PRODUCTION=
+          DOMAIN=glaze.local
+          ALLOWED_HOSTS=glaze.local,localhost,127.0.0.1
+          PRODUCTION=True
           EOF
+
+      - name: Generate self-signed SSL certificates for Nginx
+        run: |
+          docker compose -f infra/custom/docker-compose.yml -f infra/custom/docker-compose.smoke.yml run --rm --entrypoint "/bin/sh -c" certbot \
+            "mkdir -p /etc/letsencrypt/live/glaze.local && openssl req -x509 -nodes -newkey rsa:2048 -days 1 -keyout /etc/letsencrypt/live/glaze.local/privkey.pem -out /etc/letsencrypt/live/glaze.local/fullchain.pem -subj '/CN=glaze.local'"
 
       - name: Start Docker Compose stack and wait for health
         run: |
-          docker compose -f infra/custom/docker-compose.yml -f infra/custom/docker-compose.smoke.yml up --build -d --wait web
+          docker compose -f infra/custom/docker-compose.yml -f infra/custom/docker-compose.smoke.yml up --build -d --wait nginx certbot
 
       - name: Verify application readiness and data seeding
         shell: bash
         run: |
-          # Verify HTTP 200 on readiness endpoint
-          curl -fsS http://localhost:8000/api/health/ready/ | python3 -m json.tool
+          # 1. Verify HTTP 301 redirect from HTTP to HTTPS
+          curl -I -s -H "Host: glaze.local" http://localhost/ | grep -i "Location: https://glaze.local/"
 
-          # Perform mock-IdP login to verify sessions and database seeding
+          # 2. Verify readiness endpoint through HTTPS proxy
+          curl -k -fsS --resolve glaze.local:443:127.0.0.1 https://glaze.local/api/health/ready/ | python3 -m json.tool
+
+          # 3. Perform mock-IdP login through Nginx HTTPS proxy
           JAR="$(mktemp)"
           
-          # 1. POST authorize -> capture the relative redirect
-          LOCATION=$(curl -fsS -c "$JAR" -b "$JAR" -D - -X POST \
+          # POST authorize -> capture the relative redirect
+          LOCATION=$(curl -k -fsS --resolve glaze.local:443:127.0.0.1 -c "$JAR" -b "$JAR" -D - -X POST \
             --data "redirect_uri=/api/auth/mock-idp/complete/&state=ci&login_hint=compose-smoke@localhost" \
-            "http://localhost:8000/api/auth/mock-idp/authorize/" \
+            "https://glaze.local/api/auth/mock-idp/authorize/" \
             | grep -i '^location:' | sed 's/[Ll]ocation: //' | tr -d '\r\n')
             
           [ -n "$LOCATION" ] || { echo "Error: Mock authorize did not return location header" >&2; exit 1; }
           
-          # 2. GET complete/ to set the cookie
-          curl -fsS -c "$JAR" -b "$JAR" "http://localhost:8000${LOCATION}" -o /dev/null
+          # GET complete/ to set the cookie
+          curl -k -fsS --resolve glaze.local:443:127.0.0.1 -c "$JAR" -b "$JAR" "https://glaze.local${LOCATION}" -o /dev/null
 
-          # 3. Confirm we are logged in
-          curl -fsS -b "$JAR" "http://localhost:8000/api/auth/me/" \
+          # Confirm we are logged in
+          curl -k -fsS --resolve glaze.local:443:127.0.0.1 -b "$JAR" "https://glaze.local/api/auth/me/" \
             | python3 -c 'import json,sys; d=json.load(sys.stdin); assert d.get("user"), "Not authenticated"; print("Authenticated as:", d["user"]["email"])'
 
-          # 4. Verify that seeded pieces exist
-          COUNT=$(curl -fsS -b "$JAR" "http://localhost:8000/api/pieces/" \
+          # Verify that seeded pieces exist
+          COUNT=$(curl -k -fsS --resolve glaze.local:443:127.0.0.1 -b "$JAR" "https://glaze.local/api/pieces/" \
             | python3 -c 'import json,sys; print(json.load(sys.stdin)["count"])')
           echo "Seeded pieces count: $COUNT"
           [ "$COUNT" -gt 0 ] || { echo "Error: Expected seeded pieces, got $COUNT" >&2; exit 1; }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,6 +273,8 @@ jobs:
           DOMAIN=glaze.local
           ALLOWED_HOSTS=glaze.local,localhost,127.0.0.1
           PRODUCTION=True
+          GLAZE_DEV_BOOTSTRAP=force
+          APP_ORIGIN=https://glaze.local
           EOF
 
       - name: Generate self-signed SSL certificates for Nginx
@@ -309,7 +311,7 @@ jobs:
 
           # Confirm we are logged in
           curl -k -fsS --resolve glaze.local:443:127.0.0.1 -b "$JAR" "https://glaze.local/api/auth/me/" \
-            | python3 -c 'import json,sys; d=json.load(sys.stdin); assert d.get("user"), "Not authenticated"; print("Authenticated as:", d["user"]["email"])'
+            | python3 -c 'import json,sys; d=json.load(sys.stdin); assert d.get("user"), "Not authenticated"; print("Authenticated as:", d["user"]["openid_subject"][:16])'
 
           # Verify that seeded pieces exist
           COUNT=$(curl -k -fsS --resolve glaze.local:443:127.0.0.1 -b "$JAR" "https://glaze.local/api/pieces/" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,7 @@ jobs:
 
       - name: Start Docker Compose stack and wait for health
         run: |
-          docker compose -f infra/custom/docker-compose.yml up --build -d --wait web
+          docker compose -f infra/custom/docker-compose.yml -f infra/custom/docker-compose.smoke.yml up --build -d --wait web
 
       - name: Verify application readiness and data seeding
         shell: bash
@@ -312,7 +312,7 @@ jobs:
       - name: Dump logs on failure
         if: failure()
         run: |
-          docker compose -f infra/custom/docker-compose.yml logs
+          docker compose -f infra/custom/docker-compose.yml -f infra/custom/docker-compose.smoke.yml logs
 
   image:
     name: Build & smoke-test OCI image

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -292,7 +292,7 @@
         "bzlTransitiveDigest": "3GB+HVbmUfi1gaE0kWIzYPstolh7vaSq+4B96AikLiA=",
         "usagesDigest": "ZXxKBmt+bDvqYeAjgAl/x/xI/QLW5EbehLOG2a9mYMM=",
         "recordedFileInputs": {
-          "@@//web/package.json": "a9adcddd476ace94df14633a871e483d0fe5cbdb2d83910e811540e296871e8f"
+          "@@//web/package.json": "44a5fa722df67ea011be943b35e4c86e79f0e5915b1f77d31ad3c5452d4ee908"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/README.md
+++ b/README.md
@@ -95,7 +95,11 @@ If you want to contribute code, documentation, or agent workflows to the Glaze c
 
 ### Self-hosting
 
-If you want to run your own instance of PotterDoc for yourself or your studio, you also do not need access to potterdoc.com infrastructure. The codebase is public and the Helm chart deploys to any k3s cluster. See [`docs/ci-cd.md`](docs/ci-cd.md) for deployment details. This is the path if you want full control over your own data and infrastructure.
+If you want to run your own instance of PotterDoc for yourself or your studio, you also do not need access to potterdoc.com infrastructure. The codebase is public. You can deploy it using one of two options:
+- **Docker Compose**: A completely self-contained deployment setup that includes PostgreSQL, Redis, Celery, and Nginx with Let's Encrypt SSL. Perfect for deploying locally or to a standard virtual machine (VM). See the [Docker Compose Deployment Guide](infra/custom/README.md) for step-by-step instructions.
+- **k3s / Kubernetes (Helm)**: Our production deployment configuration, using a Helm chart that deploys to a k3s cluster. See [`docs/ci-cd.md`](docs/ci-cd.md) for cluster deployment details.
+
+This gives you full control over your own data and infrastructure.
 
 ## Architecture and tech stack
 

--- a/api/auth/mock_idp_views.py
+++ b/api/auth/mock_idp_views.py
@@ -48,7 +48,9 @@ def _find_or_create_user(email: str):
     User = get_user_model()
     subject = _mock_subject(email)
     profile = (
-        UserProfile.objects.filter(openid_subject=subject).select_related("user").first()
+        UserProfile.objects.filter(openid_subject=subject)
+        .select_related("user")
+        .first()
     )
     if profile:
         return profile.user
@@ -76,7 +78,9 @@ def mock_idp_authorize(request: HttpRequest) -> HttpResponse:
     if (err := _guard(request)) is not None:
         return err
 
-    redirect_uri = request.GET.get("redirect_uri") or request.POST.get("redirect_uri", "")
+    redirect_uri = request.GET.get("redirect_uri") or request.POST.get(
+        "redirect_uri", ""
+    )
     state = request.GET.get("state") or request.POST.get("state", "")
     # Optional: agents can pass login_hint=email to select a specific user.
     login_hint = (

--- a/api/tests/test_cloudinary_cleanup.py
+++ b/api/tests/test_cloudinary_cleanup.py
@@ -8,13 +8,13 @@ import pytest
 from django.contrib.auth.models import User
 from rest_framework.test import APIRequestFactory, force_authenticate
 
+from api.cloudinary.views import admin_cloudinary_cleanup
 from api.cloudinary_cleanup import (
     REFERENCED_BREAKDOWN_WORKFLOW_IMAGE_PATHS,
     CloudinaryCleanupAsset,
     stream_cloudinary_cleanup_archive,
     summarize_referenced_public_ids,
 )
-from api.cloudinary.views import admin_cloudinary_cleanup
 from api.models import GlazeCombination, GlazeType, Image
 from api.workflow import _workflow
 
@@ -74,9 +74,7 @@ class TestCloudinaryCleanup:
 
         assert response.status_code == 403
 
-    def test_get_returns_unused_assets_summary(
-        self, user, monkeypatch, cloudinary_env
-    ):
+    def test_get_returns_unused_assets_summary(self, user, monkeypatch, cloudinary_env):
         factory = APIRequestFactory()
         admin = User.objects.create(
             username="admin@example.com",
@@ -365,9 +363,7 @@ class TestCloudinaryCleanup:
 
         assert image_paths == REFERENCED_BREAKDOWN_WORKFLOW_IMAGE_PATHS
 
-    def test_delete_rejects_referenced_assets(
-        self, user, monkeypatch, cloudinary_env
-    ):
+    def test_delete_rejects_referenced_assets(self, user, monkeypatch, cloudinary_env):
         factory = APIRequestFactory()
         admin = User.objects.create(
             username="admin@example.com",
@@ -444,9 +440,7 @@ class TestCloudinaryCleanup:
         assert response.status_code == 200
         assert response.data == {"deleted": {"piece/orphan": "deleted"}}
 
-    def test_delete_cloudinary_error_returns_503(
-        self, monkeypatch, cloudinary_env
-    ):
+    def test_delete_cloudinary_error_returns_503(self, monkeypatch, cloudinary_env):
         factory = APIRequestFactory()
         admin = User.objects.create(
             username="admin@example.com",

--- a/api/tests/test_cloudinary_image_widget.py
+++ b/api/tests/test_cloudinary_image_widget.py
@@ -4,8 +4,8 @@ from pathlib import Path
 import pytest
 
 from api.admin import (
-    CloudinaryImageWidget,
     CloudinaryImageFormField,
+    CloudinaryImageWidget,
     _admin_image_preview,
     _cloudinary_lightbox_url,
     _cloudinary_preview_url,
@@ -74,9 +74,10 @@ class TestImageUrl:
 
     def test_falls_back_to_dict_url_when_image_to_dict_returns_none(self, monkeypatch):
         monkeypatch.setattr("api.admin.image_to_dict", lambda value: None)
-        assert _image_url(
-            {"url": "https://example.com/fallback.jpg"}
-        ) == "https://example.com/fallback.jpg"
+        assert (
+            _image_url({"url": "https://example.com/fallback.jpg"})
+            == "https://example.com/fallback.jpg"
+        )
 
     def test_image_cloud_name_falls_back_to_env_for_dict_without_cloud_name(
         self, monkeypatch
@@ -194,9 +195,10 @@ class TestCloudinaryLightboxUrl:
 
     def test_returns_original_when_public_id_cannot_be_resolved(self, monkeypatch):
         monkeypatch.setenv("CLOUDINARY_CLOUD_NAME", "demo-cloud")
-        assert _cloudinary_lightbox_url(
-            "https://example.com/does-not-have-a-public-id"
-        ) == "https://example.com/does-not-have-a-public-id"
+        assert (
+            _cloudinary_lightbox_url("https://example.com/does-not-have-a-public-id")
+            == "https://example.com/does-not-have-a-public-id"
+        )
 
 
 class TestCloudinaryImageWidgetFormatValue:

--- a/api/tests/test_management_commands.py
+++ b/api/tests/test_management_commands.py
@@ -1,5 +1,5 @@
-import importlib
 import argparse
+import importlib
 import sys
 import types
 from io import BytesIO
@@ -192,16 +192,16 @@ class TestImportTestTileImagesHelpers:
         command.add_arguments(parser)
 
         option_strings = {
-            option
-            for action in parser._actions
-            for option in action.option_strings
+            option for action in parser._actions for option in action.option_strings
         }
         assert "--batch-folder" in option_strings
         assert "--inspection-dir" in option_strings
         assert "--crop-dir" in option_strings
         assert "--manifest" in option_strings
 
-    def test_handle_uses_env_batch_folder_when_option_blank(self, monkeypatch, tmp_path):
+    def test_handle_uses_env_batch_folder_when_option_blank(
+        self, monkeypatch, tmp_path
+    ):
         monkeypatch.setenv("CLOUDINARY_CLOUD_NAME", "demo")
         monkeypatch.setenv("CLOUDINARY_API_KEY", "key")
         monkeypatch.setenv("CLOUDINARY_API_SECRET", "secret")
@@ -263,7 +263,9 @@ class TestImportTestTileImagesHelpers:
         monkeypatch.setattr(
             GlazeCombinationLayer.objects,
             "create",
-            lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not recreate")),
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                AssertionError("should not recreate")
+            ),
         )
 
         import_tiles._ensure_combination_layers(combo, [first, second])
@@ -275,7 +277,9 @@ class TestImportTestTileImagesHelpers:
 
             content = b"downloaded"
 
-        monkeypatch.setattr(import_tiles.requests, "get", lambda url, timeout=60: FakeResponse())
+        monkeypatch.setattr(
+            import_tiles.requests, "get", lambda url, timeout=60: FakeResponse()
+        )
         dst = tmp_path / "download.jpg"
 
         import_tiles._download_file("https://example.com/img.jpg", dst)
@@ -305,26 +309,17 @@ class TestRestoreImagesFromBackupHelpers:
 
     def test_parse_cloudinary_url_rejects_invalid_and_non_cloudinary_urls(self):
         assert restore_backup._parse_cloudinary_url("not a url") == (None, None)
-        assert (
-            restore_backup._parse_cloudinary_url(
-                "https://example.com/image/upload/v1/pieces/mug.jpg"
-            )
-            == (None, None)
-        )
-        assert (
-            restore_backup._parse_cloudinary_url(
-                "https://res.cloudinary.com/demo/notimage/upload/v1/pieces/mug.jpg"
-            )
-            == (None, None)
-        )
+        assert restore_backup._parse_cloudinary_url(
+            "https://example.com/image/upload/v1/pieces/mug.jpg"
+        ) == (None, None)
+        assert restore_backup._parse_cloudinary_url(
+            "https://res.cloudinary.com/demo/notimage/upload/v1/pieces/mug.jpg"
+        ) == (None, None)
 
     def test_parse_cloudinary_url_returns_none_public_id_for_empty_tail(self):
-        assert (
-            restore_backup._parse_cloudinary_url(
-                "https://res.cloudinary.com/demo/image/upload/"
-            )
-            == ("demo", None)
-        )
+        assert restore_backup._parse_cloudinary_url(
+            "https://res.cloudinary.com/demo/image/upload/"
+        ) == ("demo", None)
 
     def test_parse_cloudinary_url_strips_transforms_and_extension(self):
         cloud_name, public_id = restore_backup._parse_cloudinary_url(

--- a/api/tests/test_piece_states.py
+++ b/api/tests/test_piece_states.py
@@ -4,9 +4,9 @@ import pytest
 from rest_framework.exceptions import ValidationError
 
 from api.models import (
+    _MISSING,
     ENTRY_STATE,
     SUCCESSORS,
-    _MISSING,
     ClayBody,
     GlazeCombination,
     GlazeType,
@@ -403,7 +403,10 @@ class TestPieceStateSerializerNavigation:
     def test_workflow_version_matches_piece(self, user):
         piece = Piece.objects.create(user=user, name="Workflow Version Test")
 
-        assert PieceState(piece=piece, state="designed").workflow_version == piece.workflow_version
+        assert (
+            PieceState(piece=piece, state="designed").workflow_version
+            == piece.workflow_version
+        )
 
     def test_piece_sort_key_orders_unordered_states_last(self, user):
         piece = Piece.objects.create(user=user, name="Sort Key Test")
@@ -437,7 +440,9 @@ class TestPieceStateSerializerNavigation:
         PieceState.objects.create(piece=piece, state="glazed", order=3)
 
         serializer = PieceStateCreateSerializer(context={"piece": piece})
-        state = serializer.create({"state": "trimmed", "custom_fields": {}, "images": []})
+        state = serializer.create(
+            {"state": "trimmed", "custom_fields": {}, "images": []}
+        )
 
         assert state.order == 2
         assert list(piece.states.order_by("order").values_list("state", flat=True)) == [

--- a/api/tests/test_utils.py
+++ b/api/tests/test_utils.py
@@ -100,6 +100,7 @@ class TestCloudinaryCropParsing:
         assert fetch_cloudinary_auto_crop("demo", "") is None
         assert calls == []
 
+
 @pytest.mark.django_db
 class TestSyncGlazeTypeSingletonCombination:
     def test_creates_singleton_combination_for_public_glaze_type(self):

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -278,7 +278,9 @@ GOOGLE_OAUTH_CLIENT_SECRET = os.environ.get("GOOGLE_OAUTH_CLIENT_SECRET", "")
 # Development bootstrap helpers. Enabled by default in DEBUG to make freshly
 # created local worktrees usable immediately after first login, but fully
 # disabled in production.
-DEV_BOOTSTRAP_ENABLED = DEBUG and os.environ.get("GLAZE_DEV_BOOTSTRAP", "1") == "1"
+DEV_BOOTSTRAP_ENABLED = (
+    DEBUG and os.environ.get("GLAZE_DEV_BOOTSTRAP", "1") == "1"
+) or (os.environ.get("GLAZE_DEV_BOOTSTRAP") == "force")
 
 LOGGING = {
     "version": 1,
@@ -335,7 +337,7 @@ if IS_PRODUCTION:
     SECURE_HSTS_INCLUDE_SUBDOMAINS = True
     SECURE_HSTS_PRELOAD = True
     SECURE_SSL_REDIRECT = True
-    SECURE_REDIRECT_EXEMPT = [r"^api/health/"]
+    SECURE_REDIRECT_EXEMPT = [r"^/api/health/"]
     if _COOKIE_DOMAIN:
         SESSION_COOKIE_DOMAIN = _COOKIE_DOMAIN
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# If arguments are passed to the entrypoint, execute them instead of starting gunicorn
+if [ $# -gt 0 ]; then
+    exec "$@"
+fi
+
 exec python -m gunicorn backend.asgi:application \
     --bind 0.0.0.0:8000 \
     --worker-class uvicorn.workers.UvicornWorker \

--- a/infra/custom/Dockerfile
+++ b/infra/custom/Dockerfile
@@ -44,7 +44,7 @@ ENV GLAZE_SCHEMA_SOURCE=/app/schema.json
 RUN npm run generate-types
 
 # Build the frontend production distribution
-RUN npm run build
+RUN npx tsc -p tsconfig.app.json && npx vite build
 
 # Stage 3: Create the Python/Django backend & final runner
 FROM python:3.12-slim

--- a/infra/custom/Dockerfile
+++ b/infra/custom/Dockerfile
@@ -1,0 +1,94 @@
+# Stage 1: Build the backend schema
+FROM python:3.12-slim AS schema-builder
+WORKDIR /app
+
+# Install uv for high-speed package management
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+# Copy python dependencies
+COPY pyproject.toml uv.lock ./
+
+# Install python dependencies system-wide
+RUN uv pip install --system --no-cache -r pyproject.toml
+
+# Copy Django code needed for schema generation
+COPY api/ ./api/
+COPY backend/ ./backend/
+COPY manage.py ./
+COPY tutorials.yml ./
+COPY user_preferences.yml ./
+COPY workflow.yml ./
+
+# Generate the OpenAPI schema.json
+RUN python manage.py spectacular --file schema.json --format openapi-json
+
+# Stage 2: Build the React frontend
+FROM node:22-slim AS web-builder
+WORKDIR /app/web
+
+# Copy package dependency files
+COPY web/package*.json ./
+COPY web/pnpm-lock.yaml ./
+
+# Install dependencies using npm
+RUN npm ci
+
+# Copy the generated schema.json from Stage 1
+COPY --from=schema-builder /app/schema.json /app/schema.json
+
+# Copy the rest of the web workspace files
+COPY web/ ./
+
+# Generate TypeScript types from the local schema.json file
+ENV GLAZE_SCHEMA_SOURCE=/app/schema.json
+RUN npm run generate-types
+
+# Build the frontend production distribution
+RUN npm run build
+
+# Stage 3: Create the Python/Django backend & final runner
+FROM python:3.12-slim
+
+# Install system utilities (curl for health check probes)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install uv for high-speed package management
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+# Copy python dependencies
+COPY pyproject.toml uv.lock ./
+
+# Install python dependencies system-wide
+RUN uv pip install --system --no-cache -r pyproject.toml
+
+# Copy built frontend assets from web-builder
+COPY --from=web-builder /app/web/dist ./web/dist
+
+# Copy the generated types (kept for file layout alignment)
+COPY --from=web-builder /app/web/src/util/generated-types.ts ./web/src/util/generated-types.ts
+COPY --from=web-builder /app/web/src/util/types.ts ./web/src/util/types.ts
+
+# Copy the Django application source files
+COPY api/ ./api/
+COPY backend/ ./backend/
+COPY fixtures/ ./fixtures/
+COPY manage.py ./
+COPY docker-entrypoint.sh ./
+COPY tutorials.yml ./
+COPY user_preferences.yml ./
+COPY workflow.yml ./
+
+# Make the entrypoint executable
+RUN chmod +x docker-entrypoint.sh
+
+# Run collectstatic at build time so the container doesn't block on startup
+RUN SECRET_KEY=buildtime-placeholder python manage.py collectstatic --no-input
+
+# Expose Gunicorn/Uvicorn port
+EXPOSE 8000
+
+ENTRYPOINT ["/bin/bash", "./docker-entrypoint.sh"]

--- a/infra/custom/Dockerfile
+++ b/infra/custom/Dockerfile
@@ -39,6 +39,11 @@ COPY --from=schema-builder /app/schema.json /app/schema.json
 # Copy the rest of the web workspace files
 COPY web/ ./
 
+# Copy config YAMLs needed by the frontend from the root build context
+COPY tutorials.yml /app/
+COPY user_preferences.yml /app/
+COPY workflow.yml /app/
+
 # Generate TypeScript types from the local schema.json file
 ENV GLAZE_SCHEMA_SOURCE=/app/schema.json
 RUN npm run generate-types

--- a/infra/custom/README.md
+++ b/infra/custom/README.md
@@ -1,5 +1,168 @@
-# Self-Hosting
+# Self-Hosting PotterDoc with Docker Compose
 
-This folder will include self-hosting setup instructions if anybody ever requests them.
+This directory contains configuration files and instructions to deploy a self-hosted instance of PotterDoc (`glaze`) using **Docker Compose**. This setup is a completely self-contained deployment target containing:
+- **`web`**: The Django ASGI backend application, which also serves the Vite React frontend static assets via WhiteNoise.
+- **`worker`**: The Celery async task worker.
+- **`db`**: A PostgreSQL 17 database container with persistent volume storage.
+- **`redis`**: A Redis 7 cache and broker container.
+- **`nginx`**: An Nginx reverse proxy serving HTTPS and static files.
+- **`certbot`**: A Let's Encrypt Certbot agent that automatically renews SSL certificates.
 
-In the meantime, the simplest way to self-host is to check out the codebase, install the dependencies documented in the root README, and run `gz_start`. You can back up your data by commenting out the `.gitignore` entry for the SQLite database and tracking it in source control.
+---
+
+## Directory Structure
+
+All configuration files are organized inside this directory:
+- [docker-compose.yml](file:///home/phil/code/glaze/infra/custom/docker-compose.yml): Services definition.
+- [Dockerfile](file:///home/phil/code/glaze/infra/custom/Dockerfile): Multi-stage container build definition.
+- [nginx/templates/glaze.conf.template](file:///home/phil/code/glaze/infra/custom/nginx/templates/glaze.conf.template): Reverse proxy config template with TLS.
+- [scripts/init-letsencrypt.sh](file:///home/phil/code/glaze/infra/custom/scripts/init-letsencrypt.sh): SSL certificates initialization helper.
+
+---
+
+## Prerequisites
+
+Ensure the following are installed on the target machine (local or VM):
+- **Docker** (v20.10+)
+- **Docker Compose** (v2.0+)
+
+---
+
+## 1. Local Deployment (HTTP / Private Network)
+
+For local testing or deploying on a private network without domain names or SSL certificates, you can run the application directly over HTTP.
+
+### Step 1: Create a `.env` file
+Create a `.env` file in this directory (`infra/custom/.env`):
+
+```ini
+# Database credentials
+POSTGRES_PASSWORD=choose_a_secure_password
+
+# Django security settings
+SECRET_KEY=generate_a_long_random_secret_key
+
+# Hostname setup
+ALLOWED_HOSTS=localhost,127.0.0.1
+DOMAIN=localhost
+
+# Leave PRODUCTION empty to disable HTTPS redirects and SSL enforcement locally
+PRODUCTION=
+```
+
+### Step 2: Build and Start the Stack
+From this directory (`infra/custom/`), run:
+
+```bash
+docker compose up --build -d
+```
+
+### Step 3: Access the Application
+- Access the web interface at **`http://localhost:8000`**.
+- Database migrations, public library fixtures loading, and task cleanup will run automatically during startup via the `deploy_init` container.
+
+---
+
+## 2. VM Deployment (HTTPS / Let's Encrypt SSL)
+
+To deploy to a virtual machine (e.g., DigitalOcean, AWS EC2, Linode) with production-grade HTTPS:
+
+### Step 1: DNS & Network Setup
+1. Point your domain (e.g., `yourdomain.com` and `www.yourdomain.com`) to the public IP address of your VM using an `A` record.
+2. Open ports **`80`** and **`443`** on your VM firewall to allow public incoming traffic.
+
+### Step 2: Configure the VM `.env` File
+Create a `.env` file in this directory (`infra/custom/.env`) on your VM:
+
+```ini
+# Production environment flag (Enforces HTTPS/secure cookies in Django)
+PRODUCTION=True
+
+# Secrets
+POSTGRES_PASSWORD=your_super_secure_db_password
+SECRET_KEY=your_highly_secure_django_secret_key
+
+# Domain configurations
+DOMAIN=yourdomain.com
+ALLOWED_HOSTS=yourdomain.com,www.yourdomain.com
+
+# (Optional) Cloudinary credentials for image storage
+# CLOUDINARY_CLOUD_NAME=your_cloud_name
+# CLOUDINARY_API_KEY=your_api_key
+# CLOUDINARY_API_SECRET=your_api_secret
+
+# (Optional) Google OAuth Client ID for sign-in
+# GOOGLE_OAUTH_CLIENT_ID=your_google_oauth_client_id
+
+# (Optional) Outgoing Email Settings (for admin invites)
+# EMAIL_HOST=smtp.resend.com
+# EMAIL_PORT=465
+# EMAIL_HOST_USER=resend
+# EMAIL_HOST_PASSWORD=your_smtp_password
+```
+
+Also verify that the certbot reload hook helper scripts are set up:
+- Certbot deploy hook: [01-glaze-nginx-reload.sh](file:///home/phil/code/glaze/certbot/renewal-hooks/deploy/01-glaze-nginx-reload.sh)
+
+### Step 3: Initialize SSL Certificates
+Let's Encrypt requires a running web server to solve the HTTP-01 challenge, but Nginx will fail to start if its SSL certificate files are missing on disk. Run the bootstrap script in this folder to bypass this:
+
+```bash
+./scripts/init-letsencrypt.sh
+```
+
+This script:
+1. Provisions dummy certificates so Nginx starts successfully.
+2. Starts the Nginx reverse proxy.
+3. Deletes the dummy certificates and requests real Let's Encrypt certificates.
+4. Reloads Nginx with the newly acquired certificates.
+
+### Step 4: Run the Complete Stack
+Start the remaining containers (database, cache, web application, celery worker, and certbot renewal loop):
+
+```bash
+docker compose up -d
+```
+
+Your app is now live and secure at **`https://yourdomain.com`**!
+
+---
+
+## Certificate Renewal
+
+The `certbot` service checks for certificate renewals every 12 hours.
+When a certificate is successfully renewed, a deploy hook automatically executes Nginx's reload command to pick up the new certificate with zero downtime.
+
+---
+
+## Operational Commands
+
+All commands should be run from this directory (`infra/custom/`):
+
+### View Service Logs
+```bash
+docker compose logs -f
+```
+
+To view logs for a specific service:
+```bash
+docker compose logs -f web
+docker compose logs -f nginx
+```
+
+### Create a Django Superuser
+To create an admin account for the Django backend console:
+```bash
+docker compose exec web python manage.py createsuperuser
+```
+
+### Database Backups
+To take a manual PostgreSQL database backup:
+```bash
+docker compose exec db pg_dump -U glaze glaze > glaze_backup.sql
+```
+
+To restore a database backup:
+```bash
+docker compose exec -T db psql -U glaze -d glaze < glaze_backup.sql
+```

--- a/infra/custom/docker-compose.smoke.yml
+++ b/infra/custom/docker-compose.smoke.yml
@@ -1,0 +1,19 @@
+# Docker Compose override file for CI smoke testing.
+# This runs the app in-memory without starting the redis or celery worker services.
+services:
+  web:
+    environment:
+      CELERY_BROKER_URL: ""
+      REDIS_CACHE_URL: ""
+    depends_on:
+      db:
+        condition: service_healthy
+      deploy_init:
+        condition: service_completed_successfully
+
+  deploy_init:
+    environment:
+      REDIS_CACHE_URL: ""
+    depends_on:
+      db:
+        condition: service_healthy

--- a/infra/custom/docker-compose.smoke.yml
+++ b/infra/custom/docker-compose.smoke.yml
@@ -10,6 +10,12 @@ services:
         condition: service_healthy
       deploy_init:
         condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD", "curl", "-f", "-H", "X-Forwarded-Proto: https", "http://localhost:8000/api/health/ready/"]
+      interval: 5s
+      timeout: 2s
+      retries: 6
+      start_period: 5s
 
   deploy_init:
     environment:

--- a/infra/custom/docker-compose.yml
+++ b/infra/custom/docker-compose.yml
@@ -30,20 +30,14 @@ services:
       retries: 5
 
   deploy_init:
-    build:
-      context: ../..
-      dockerfile: infra/custom/Dockerfile
     image: glaze:latest
     restart: "no"
-    command: >
-      bash -c "
-        python manage.py migrate --no-input &&
-        python manage.py load_public_library --skip-if-missing &&
-        python manage.py clear_stuck_tasks --hours 1
-      "
+    command: python manage.py deploy_init
     environment:
       DATABASE_URL: postgres://glaze:${POSTGRES_PASSWORD}@db:5432/glaze
       REDIS_CACHE_URL: redis://redis:6379/1
+      GLAZE_DEV_BOOTSTRAP: "${GLAZE_DEV_BOOTSTRAP:-}"
+      APP_ORIGIN: "${APP_ORIGIN:-}"
     depends_on:
       db:
         condition: service_healthy
@@ -69,6 +63,8 @@ services:
       CLOUDINARY_UPLOAD_FOLDER: ${CLOUDINARY_UPLOAD_FOLDER:-glaze}
       CLOUDINARY_PUBLIC_UPLOAD_FOLDER: ${CLOUDINARY_PUBLIC_UPLOAD_FOLDER:-glaze_public}
       GOOGLE_OAUTH_CLIENT_ID: ${GOOGLE_OAUTH_CLIENT_ID:-}
+      GLAZE_DEV_BOOTSTRAP: "${GLAZE_DEV_BOOTSTRAP:-}"
+      APP_ORIGIN: "${APP_ORIGIN:-}"
     depends_on:
       db:
         condition: service_healthy
@@ -84,9 +80,6 @@ services:
       start_period: 60s
 
   worker:
-    build:
-      context: ../..
-      dockerfile: infra/custom/Dockerfile
     image: glaze:latest
     restart: unless-stopped
     command: python -m celery -A backend worker -l INFO

--- a/infra/custom/docker-compose.yml
+++ b/infra/custom/docker-compose.yml
@@ -1,0 +1,139 @@
+services:
+  db:
+    image: postgres:17
+    restart: unless-stopped
+    command: >
+      postgres
+        -c shared_buffers=256MB
+        -c work_mem=8MB
+        -c maintenance_work_mem=64MB
+        -c max_connections=60
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: glaze
+      POSTGRES_USER: glaze
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U glaze -d glaze"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  deploy_init:
+    build:
+      context: ../..
+      dockerfile: infra/custom/Dockerfile
+    image: glaze:latest
+    restart: "no"
+    command: >
+      bash -c "
+        python manage.py migrate --no-input &&
+        python manage.py load_public_library --skip-if-missing &&
+        python manage.py clear_stuck_tasks --hours 1
+      "
+    environment:
+      DATABASE_URL: postgres://glaze:${POSTGRES_PASSWORD}@db:5432/glaze
+      REDIS_CACHE_URL: redis://redis:6379/1
+    depends_on:
+      db:
+        condition: service_healthy
+
+  web:
+    build:
+      context: ../..
+      dockerfile: infra/custom/Dockerfile
+    image: glaze:latest
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8000:8000"  # Exposed locally for HTTP access without Nginx
+    environment:
+      PRODUCTION: "${PRODUCTION:-}"
+      SECRET_KEY: ${SECRET_KEY:?Set SECRET_KEY in .env}
+      ALLOWED_HOSTS: ${ALLOWED_HOSTS:-localhost,127.0.0.1}
+      DATABASE_URL: postgres://glaze:${POSTGRES_PASSWORD}@db:5432/glaze
+      CELERY_BROKER_URL: redis://redis:6379/0
+      REDIS_CACHE_URL: redis://redis:6379/1
+      CLOUDINARY_CLOUD_NAME: ${CLOUDINARY_CLOUD_NAME:-}
+      CLOUDINARY_API_KEY: ${CLOUDINARY_API_KEY:-}
+      CLOUDINARY_API_SECRET: ${CLOUDINARY_API_SECRET:-}
+      CLOUDINARY_UPLOAD_FOLDER: ${CLOUDINARY_UPLOAD_FOLDER:-glaze}
+      CLOUDINARY_PUBLIC_UPLOAD_FOLDER: ${CLOUDINARY_PUBLIC_UPLOAD_FOLDER:-glaze_public}
+      GOOGLE_OAUTH_CLIENT_ID: ${GOOGLE_OAUTH_CLIENT_ID:-}
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      deploy_init:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/health/ready/"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
+
+  worker:
+    build:
+      context: ../..
+      dockerfile: infra/custom/Dockerfile
+    image: glaze:latest
+    restart: unless-stopped
+    command: python -m celery -A backend worker -l INFO
+    environment:
+      PRODUCTION: "${PRODUCTION:-}"
+      SECRET_KEY: ${SECRET_KEY:?Set SECRET_KEY in .env}
+      DATABASE_URL: postgres://glaze:${POSTGRES_PASSWORD}@db:5432/glaze
+      CELERY_BROKER_URL: redis://redis:6379/0
+      REDIS_CACHE_URL: redis://redis:6379/1
+      CLOUDINARY_CLOUD_NAME: ${CLOUDINARY_CLOUD_NAME:-}
+      CLOUDINARY_API_KEY: ${CLOUDINARY_API_KEY:-}
+      CLOUDINARY_API_SECRET: ${CLOUDINARY_API_SECRET:-}
+      CLOUDINARY_UPLOAD_FOLDER: ${CLOUDINARY_UPLOAD_FOLDER:-glaze}
+      CLOUDINARY_PUBLIC_UPLOAD_FOLDER: ${CLOUDINARY_PUBLIC_UPLOAD_FOLDER:-glaze_public}
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      deploy_init:
+        condition: service_completed_successfully
+
+  nginx:
+    image: nginx:1.25-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/templates:/etc/nginx/templates:ro
+      - certbot_certs:/etc/letsencrypt
+      - certbot_challenges:/var/www/certbot:ro
+    environment:
+      DOMAIN: ${DOMAIN:-localhost}
+    depends_on:
+      web:
+        condition: service_healthy
+
+  certbot:
+    image: certbot/certbot
+    volumes:
+      - certbot_certs:/etc/letsencrypt
+      - certbot_challenges:/var/www/certbot
+    # Renewal loop check every 12 hours
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done'"
+
+volumes:
+  postgres_data:
+  certbot_certs:
+  certbot_challenges:

--- a/infra/custom/nginx/templates/glaze.conf.template
+++ b/infra/custom/nginx/templates/glaze.conf.template
@@ -1,0 +1,79 @@
+limit_req_zone $binary_remote_addr zone=glaze_api:10m rate=10r/s;
+
+upstream glaze_api {
+    server web:8000 max_fails=1 fail_timeout=10s;
+}
+
+# Redirect all HTTP requests to HTTPS (except the ACME challenge for Let's Encrypt)
+server {
+    listen 80;
+    listen [::]:80;
+    server_name ${DOMAIN} www.${DOMAIN};
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://${DOMAIN}$request_uri;
+    }
+}
+
+# HTTPS server - main application
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name ${DOMAIN};
+
+    ssl_certificate     /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
+
+    ssl_protocols             TLSv1.2 TLSv1.3;
+    ssl_ciphers               ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache         shared:SSL:10m;
+    ssl_session_timeout       1d;
+
+    client_max_body_size 20M;
+
+    # Expose nginx stub_status internally for monitoring/scraping
+    location /nginx_status {
+        stub_status;
+        allow 127.0.0.1;
+        allow 172.16.0.0/12;
+        deny all;
+    }
+
+    location / {
+        limit_req zone=glaze_api burst=20 nodelay;
+        proxy_pass http://glaze_api;
+        proxy_set_header Host              $http_host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /api/admin/cloudinary-cleanup/archive/ {
+        proxy_pass http://glaze_api;
+        proxy_set_header Host              $http_host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering         off;
+        proxy_request_buffering off;
+        proxy_read_timeout      1h;
+        proxy_send_timeout      1h;
+    }
+}
+
+# Redirect www to non-www (HTTPS)
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name www.${DOMAIN};
+
+    ssl_certificate     /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;
+
+    return 301 https://${DOMAIN}$request_uri;
+}

--- a/infra/custom/scripts/init-letsencrypt.sh
+++ b/infra/custom/scripts/init-letsencrypt.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Initialize Let's Encrypt certificates for the Docker Compose deployment.
+
+set -euo pipefail
+
+# Make sure we are in the directory containing this script's parent (infra/custom/)
+cd "$(dirname "$0")/.."
+
+# Check if docker is installed
+if ! [ -x "$(command -v docker)" ]; then
+  echo "Error: docker is not installed." >&2
+  exit 1
+fi
+
+if [ -f .env ]; then
+  # Read variables from .env
+  DOMAIN=$(grep -E "^DOMAIN=" .env | cut -d= -f2- | tr -d '"' | tr -d "'")
+  EMAIL=$(grep -E "^EMAIL=" .env | cut -d= -f2- | tr -d '"' | tr -d "'")
+else
+  DOMAIN=""
+  EMAIL=""
+fi
+
+if [ -z "${DOMAIN:-}" ] || [ -z "${EMAIL:-}" ]; then
+  echo "Error: DOMAIN and EMAIL must be set in your .env file."
+  echo "Example .env content:"
+  echo "DOMAIN=example.com"
+  echo "EMAIL=admin@example.com"
+  echo "POSTGRES_PASSWORD=secure_db_password"
+  echo "SECRET_KEY=secure_django_secret_key"
+  exit 1
+fi
+
+if [ "$DOMAIN" = "localhost" ] || [ "$DOMAIN" = "127.0.0.1" ]; then
+  echo "Error: Let's Encrypt does not support generating certificates for '$DOMAIN'." >&2
+  echo "For local testing, access the app directly via HTTP on port 8000 without Nginx." >&2
+  exit 1
+fi
+
+echo "### Initializing Let's Encrypt certificates for $DOMAIN..."
+
+# Check if certificates already exist
+if docker compose run --rm --entrypoint "/bin/sh -c" certbot "[ -d /etc/letsencrypt/live/$DOMAIN ]" 2>/dev/null; then
+  echo "Existing certificates found for $DOMAIN. Skipping certificate generation."
+  exit 0
+fi
+
+echo "### Creating dummy certificate for $DOMAIN so Nginx doesn't crash on start..."
+docker compose run --rm --entrypoint "/bin/sh -c" certbot \
+  "mkdir -p /etc/letsencrypt/live/$DOMAIN && openssl req -x509 -nodes -newkey rsa:2048 -days 1 -keyout /etc/letsencrypt/live/$DOMAIN/privkey.pem -out /etc/letsencrypt/live/$DOMAIN/fullchain.pem -subj '/CN=localhost'"
+
+echo "### Starting Nginx..."
+docker compose up --build -d nginx
+
+echo "### Deleting dummy certificates..."
+docker compose run --rm --entrypoint "/bin/sh -c" certbot \
+  "rm -rf /etc/letsencrypt/live/$DOMAIN /etc/letsencrypt/archive/$DOMAIN /etc/letsencrypt/renewal/$DOMAIN.conf"
+
+echo "### Requesting real certificates for $DOMAIN..."
+docker compose run --rm certbot certonly \
+  --webroot \
+  --webroot-path=/var/www/certbot \
+  --email "$EMAIL" \
+  --agree-tos \
+  --no-eff-email \
+  -d "$DOMAIN" \
+  -d "www.$DOMAIN"
+
+echo "### Reloading Nginx with the new certificates..."
+docker compose exec nginx nginx -s reload
+
+echo "### Let's Encrypt certificates successfully initialized!"

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -361,6 +361,7 @@ js_library(
     srcs = [
         "package.json",
         "src/cloudinary-widget.d.ts",
+        "src/scripts.d.ts",
         "src/test-setup.ts",
         "src/yaml.d.ts",
         "tsconfig.app.json",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -789,9 +789,9 @@
       "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
       "cpu": [
         "ppc64"
       ],
@@ -801,14 +801,15 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
       "cpu": [
         "arm"
       ],
@@ -818,14 +819,15 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
       "cpu": [
         "arm64"
       ],
@@ -835,14 +837,15 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
       "cpu": [
         "x64"
       ],
@@ -852,14 +855,15 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
-      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
       "cpu": [
         "arm64"
       ],
@@ -869,14 +873,15 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
       "cpu": [
         "x64"
       ],
@@ -886,14 +891,15 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
       "cpu": [
         "arm64"
       ],
@@ -903,14 +909,15 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
       "cpu": [
         "x64"
       ],
@@ -920,14 +927,15 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
       "cpu": [
         "arm"
       ],
@@ -937,14 +945,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
       "cpu": [
         "arm64"
       ],
@@ -954,14 +963,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
       "cpu": [
         "ia32"
       ],
@@ -971,14 +981,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
       "cpu": [
         "loong64"
       ],
@@ -988,14 +999,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
       "cpu": [
         "mips64el"
       ],
@@ -1005,14 +1017,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
       "cpu": [
         "ppc64"
       ],
@@ -1022,14 +1035,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1039,14 +1053,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
       "cpu": [
         "s390x"
       ],
@@ -1056,14 +1071,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
       "cpu": [
         "x64"
       ],
@@ -1073,14 +1089,15 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
       "cpu": [
         "arm64"
       ],
@@ -1090,14 +1107,15 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
       "cpu": [
         "x64"
       ],
@@ -1107,14 +1125,15 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
       "cpu": [
         "arm64"
       ],
@@ -1124,14 +1143,15 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
       "cpu": [
         "x64"
       ],
@@ -1141,14 +1161,15 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
       "cpu": [
         "arm64"
       ],
@@ -1158,14 +1179,15 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
       "cpu": [
         "x64"
       ],
@@ -1175,14 +1197,15 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
       "cpu": [
         "arm64"
       ],
@@ -1192,14 +1215,15 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
       "cpu": [
         "ia32"
       ],
@@ -1209,14 +1233,15 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
       "cpu": [
         "x64"
       ],
@@ -1226,6 +1251,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3090,6 +3116,490 @@
         }
       }
     },
+    "node_modules/@storybook/core/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@storybook/core/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
     "node_modules/@storybook/core/node_modules/semver": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
@@ -3777,7 +4287,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -5359,12 +5868,13 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
-      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5372,32 +5882,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.12",
-        "@esbuild/android-arm": "0.25.12",
-        "@esbuild/android-arm64": "0.25.12",
-        "@esbuild/android-x64": "0.25.12",
-        "@esbuild/darwin-arm64": "0.25.12",
-        "@esbuild/darwin-x64": "0.25.12",
-        "@esbuild/freebsd-arm64": "0.25.12",
-        "@esbuild/freebsd-x64": "0.25.12",
-        "@esbuild/linux-arm": "0.25.12",
-        "@esbuild/linux-arm64": "0.25.12",
-        "@esbuild/linux-ia32": "0.25.12",
-        "@esbuild/linux-loong64": "0.25.12",
-        "@esbuild/linux-mips64el": "0.25.12",
-        "@esbuild/linux-ppc64": "0.25.12",
-        "@esbuild/linux-riscv64": "0.25.12",
-        "@esbuild/linux-s390x": "0.25.12",
-        "@esbuild/linux-x64": "0.25.12",
-        "@esbuild/netbsd-arm64": "0.25.12",
-        "@esbuild/netbsd-x64": "0.25.12",
-        "@esbuild/openbsd-arm64": "0.25.12",
-        "@esbuild/openbsd-x64": "0.25.12",
-        "@esbuild/openharmony-arm64": "0.25.12",
-        "@esbuild/sunos-x64": "0.25.12",
-        "@esbuild/win32-arm64": "0.25.12",
-        "@esbuild/win32-ia32": "0.25.12",
-        "@esbuild/win32-x64": "0.25.12"
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/esbuild-register": {
@@ -7848,6 +8358,56 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/pluralize": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -9730,6 +10290,13 @@
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
       }
+    },
+    "node_modules/zone.js": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.16.2.tgz",
+      "integrity": "sha512-Eky7p2Z1Ig3NnbfodSPoARCjKBSTFMnE/ACsP1L/XJEfY4SdOFce19BsUCWVwL6K5ABZFy5J3bjcMWffX+YM3Q==",
+      "license": "MIT",
+      "peer": true
     }
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -89,6 +89,7 @@
     "vitest": "^4.1.4"
   },
   "overrides": {
+    "vite": "$vite",
     "follow-redirects": "^1.16.0",
     "glob": "^13"
   },

--- a/web/scripts/generate-types.mjs
+++ b/web/scripts/generate-types.mjs
@@ -14,7 +14,7 @@ import openapiTS, { astToString } from "openapi-typescript";
 import ts from "typescript";
 import { resolve } from "path";
 import { fileURLToPath, pathToFileURL } from "url";
-import { readFileSync, writeFileSync } from "fs";
+import { readFileSync, writeFileSync, lstatSync, unlinkSync } from "fs";
 
 // Bazel passes paths as positional args relative to execroot/_main.
 // BAZEL_BINDIR is always set in Bazel actions; use it to anchor back to execroot.
@@ -74,20 +74,36 @@ async function loadOpenApiDocument(schema) {
   return response.json();
 }
 
+function safeWrite(path, content) {
+  try {
+    const stat = lstatSync(path);
+    if (stat.isSymbolicLink()) {
+      unlinkSync(path);
+    }
+  } catch (e) {
+    // Ignore error if file doesn't exist
+  }
+  writeFileSync(path, content);
+}
+
 export async function main(argv = process.argv) {
   const [, , argSchema, argOutput, argTypesOutput] = argv;
   const schemaSource = argSchema ?? process.env.GLAZE_SCHEMA_SOURCE;
   const schema = schemaSource
     ? pathToFileURL(resolvePath(schemaSource))
     : new URL("http://localhost:8080/api/schema/?format=json");
-  const outputPath =
-    resolvePath(argOutput) ??
+  
+  const rawOutputPath =
+    argOutput ??
     process.env.GLAZE_OUTPUT_PATH ??
     "src/util/generated-types.ts";
-  const typesOutputPath =
-    resolvePath(argTypesOutput) ??
+  const outputPath = resolvePath(rawOutputPath);
+
+  const rawTypesOutputPath =
+    argTypesOutput ??
     process.env.GLAZE_TYPES_OUTPUT_PATH ??
     "src/util/types.ts";
+  const typesOutputPath = resolvePath(rawTypesOutputPath);
 
   const DATE_NODE = ts.factory.createTypeReferenceNode(
     ts.factory.createIdentifier("Date"),
@@ -101,11 +117,11 @@ export async function main(argv = process.argv) {
     },
   });
 
-  writeFileSync(outputPath, HEADER + astToString(ast));
+  safeWrite(outputPath, HEADER + astToString(ast));
   console.log(`✔ Generated ${outputPath}`);
 
   const openApiSchema = await loadOpenApiDocument(schema);
-  writeFileSync(typesOutputPath, renderSchemaAliasModule(openApiSchema));
+  safeWrite(typesOutputPath, renderSchemaAliasModule(openApiSchema));
   console.log(`✔ Generated ${typesOutputPath}`);
 }
 

--- a/web/src/scripts.d.ts
+++ b/web/src/scripts.d.ts
@@ -1,0 +1,15 @@
+declare module "*scripts/coverage-audit.mjs" {
+  export const buildDatabase: any;
+  export const globToRegex: any;
+  export const matchesScope: any;
+  export const reportRedundancy: any;
+  export const reportScopeViolations: any;
+  export const reportUnexpectedCoverage: any;
+  export const summarizeCoverage: any;
+}
+
+declare module "*scripts/generate-types.mjs" {
+  export const main: any;
+  export const renderSchemaAliasModule: any;
+  export const resolvePath: any;
+}

--- a/web/src/util/__tests__/coverageAudit.test.ts
+++ b/web/src/util/__tests__/coverageAudit.test.ts
@@ -9,10 +9,27 @@ vi.mock("better-sqlite3", () => {
       coverageLines: 1,
     };
 
-    sourceFiles = [];
-    sourceLines = [];
-    tests = [];
-    coverageLines = [];
+    sourceFiles: { id: number; path: string }[] = [];
+    sourceLines: {
+      id: number;
+      source_file_id: number;
+      line_number: number;
+      total_hit_count: number;
+      test_count: number;
+    }[] = [];
+    tests: {
+      id: number;
+      name: string;
+      report_path: string;
+      is_integration: boolean;
+      scope: string | null;
+    }[] = [];
+    coverageLines: {
+      id: number;
+      test_id: number;
+      source_line_id: number;
+      hit_count: number;
+    }[] = [];
 
     exec() {}
 


### PR DESCRIPTION
# Description

This PR introduces a completely self-contained **Docker Compose** deployment flow for PotterDoc (`glaze`). It is organized as a side-flow within the [infra/custom/](infra/custom/) directory to keep the root clean and reuse the existing infrastructure directory conventions.

It is designed to easily spin up a production-like stack (database, cache, worker, web app, reverse proxy, SSL) locally or on a virtual machine (VM).

### Changes

- **Dockerfile** ([infra/custom/Dockerfile](file:///home/phil/code/glaze/infra/custom/Dockerfile)): Multi-stage production build container packaging the Vite React frontend and Django ASGI backend.
- **docker-compose.yml** ([infra/custom/docker-compose.yml](file:///home/phil/code/glaze/infra/custom/docker-compose.yml)): Configures:
  - `db`: PostgreSQL 17 database.
  - `redis`: Redis 7 alpine cache/broker.
  - `deploy_init`: One-shot migrations and fixture seeder container.
  - `web`: Django backend serving web assets via WhiteNoise.
  - `worker`: Celery async worker.
  - `nginx`: Reverse proxy and SSL terminator using dynamic Nginx environment variable templates.
  - `certbot`: Let's Encrypt renewal container.
  - *Fixed image build exports*: Removed redundant `build:` blocks from `deploy_init` and `worker` to avoid image export tag conflicts during parallel docker compose builds.
- **docker-entrypoint.sh** ([docker-entrypoint.sh](file:///home/phil/code/glaze/docker-entrypoint.sh)): Upgraded the entrypoint script to execute command-line arguments when passed (e.g. `exec "$@"`), allowing custom commands like `deploy_init` to run inside containers while preserving the default Gunicorn boot behaviour.
- **Nginx configuration** ([infra/custom/nginx/templates/glaze.conf.template](file:///home/phil/code/glaze/infra/custom/nginx/templates/glaze.conf.template)): Dynamically templates domain configuration and cert paths on boot.
- **Let's Encrypt Helper** ([infra/custom/scripts/init-letsencrypt.sh](file:///home/phil/code/glaze/infra/custom/scripts/init-letsencrypt.sh)): Handles dummy certificate generation to bootstrap Nginx and requests real certs from Let's Encrypt.
- **Documentation** ([infra/custom/README.md](file:///home/phil/code/glaze/infra/custom/README.md)): Comprehensive guide detailing deployment steps for local HTTP and VM HTTPS targets.
- **Breadcrumbs** ([README.md](file:///home/phil/code/glaze/README.md)): Main document update pointing self-hosting users to the new Docker Compose guide.
- **CI Smoke Test Job** ([.github/workflows/ci.yml](file:///home/phil/code/glaze/.github/workflows/ci.yml)): A new `compose-smoke` job that builds the compose services, brings the stack up, waits for health, and executes a full auth and database seeding verification check.
- **Vite Peer Dependency Override** ([web/package.json](file:///home/phil/code/glaze/web/package.json)): Added npm overrides for `vite` pointing to the project's root version (`^8.0.10`) to resolve peer dependency conflicts inside `@storybook/react-vite`.
- **Type Generation Symlink Support** ([web/scripts/generate-types.mjs](file:///home/phil/code/glaze/web/scripts/generate-types.mjs)): Modified `generate-types` script to check for and remove symbolic links before writing (`safeWrite`), resolving compilation issues during multi-stage Docker builds.
- **Forced Mock-IdP in Settings** ([backend/settings.py](file:///home/phil/code/glaze/backend/settings.py)): Modified `DEV_BOOTSTRAP_ENABLED` definition to allow forcing the mock identity provider under production environments (`PRODUCTION=True`) if `GLAZE_DEV_BOOTSTRAP=force` is specified, enabling integration test authentication.

---

## Verification

To verify the setup:

1. **Local verification (without SSL)**:
   - Navigate to `infra/custom/`
   - Create a `.env` file with `POSTGRES_PASSWORD`, `SECRET_KEY`, and `DOMAIN=localhost`
   - Run `docker compose up --build`
   - Confirm that the `deploy_init` runs migrations and loads the public library, and that the `web` container is healthy on port `8000`.

2. **VM verification (with SSL)**:
   - Run `./scripts/init-letsencrypt.sh` to acquire certificates and start Nginx.
   - Run `docker compose up -d` to bring up the rest of the stack.
