### PR TITLE
feat: plan deterministic Keepsake storyboards

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -76,6 +76,17 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+# Schema-only filegroup: the storyboard schema is read at import time by
+# api/showcase/storyboard.py (there is no companion .yml config — storyboards
+# are produced in code).
+filegroup(
+    name = "storyboard_files",
+    srcs = [
+        "storyboard.schema.yml",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 js_library(
     name = "tutorials_js",
     srcs = ["tutorials.yml"],
@@ -171,6 +182,7 @@ pkg_tar(
         "user_preferences.schema.yml",
         "tutorials.yml",
         "tutorials.schema.yml",
+        "storyboard.schema.yml",
         "docker-entrypoint.sh",
         "//api:api_runtime_files",
         "//backend:backend_runtime_files",

--- a/api/BUILD.bazel
+++ b/api/BUILD.bazel
@@ -56,6 +56,8 @@ py_library(
         "serializer_factories.py",
         "serializer_registry.py",
         "serializers.py",
+        "showcase/__init__.py",
+        "showcase/storyboard.py",
         "tasks.py",
         "task_views.py",
         "telemetry_views.py",
@@ -63,6 +65,7 @@ py_library(
         "views.py",
         "workflow_views.py",
     ],
+    data = ["//:storyboard_files"],
     deps = [
         ":api_workflow_lib",
         "//backend:backend_lib",
@@ -189,6 +192,8 @@ filegroup(
         "serializer_factories.py",
         "serializer_registry.py",
         "serializers.py",
+        "showcase/__init__.py",
+        "showcase/storyboard.py",
         "task_views.py",
         "telemetry_views.py",
         "tasks.py",
@@ -216,6 +221,7 @@ _PYTEST_DEPS = [
 
 _TEST_DATA = [
     "//:workflow_files",
+    "//:storyboard_files",
     "//:fixtures",
     "//:pytest_ini",
     "//backend:backend_test_settings",
@@ -321,6 +327,7 @@ pytest_test(
     size = "medium",
     srcs = _CONFTEST + [
         "tests/test_analysis.py",
+        "tests/test_keepsake_storyboard.py",
         "tests/test_patch_current_state.py",
         "tests/test_piece_detail.py",
         "tests/test_piece_showcase_validation.py",
@@ -342,6 +349,7 @@ pytest_test(
         "api/tests/test_patch_current_state.py",
         "api/tests/test_sealed_state.py",
         "api/tests/test_analysis.py",
+        "api/tests/test_keepsake_storyboard.py",
         "api/tests/test_piece_showcase_validation.py",
         "api/tests/test_piece_state_admin_relational.py",
         "api/tests/test_editable_mode.py",
@@ -353,7 +361,12 @@ pytest_test(
     env = _TEST_ENV,
     main = "//tools:pytest_main.py",
     deps = [":api_schema_lib", ":api_admin_lib"] + _PYTEST_DEPS,
-    expected_coverage = ["api/piece/views.py", "api/analysis_views.py", "api/workflow_views.py"],
+    expected_coverage = [
+        "api/piece/views.py",
+        "api/analysis_views.py",
+        "api/workflow_views.py",
+        "api/showcase/storyboard.py",
+    ],
 )
 
 pytest_test(

--- a/api/showcase/__init__.py
+++ b/api/showcase/__init__.py
@@ -1,0 +1,34 @@
+"""Showcase video planning.
+
+The Storyboard is the render-ready, style-agnostic description of a showcase
+slideshow video. Style builders (the first is "keepsake") turn a piece's
+effective inputs into a Storyboard deterministically.
+"""
+
+from .storyboard import (
+    COVER_SLIDE_MS,
+    IMAGE_SLIDE_MS,
+    KEEPSAKE_STYLE,
+    KEEPSAKE_STYLE_VERSION,
+    NOTE_SLIDE_MS,
+    STORYBOARD_SCHEMA,
+    STORYBOARD_VERSION,
+    Storyboard,
+    StoryboardSlide,
+    build_keepsake_storyboard,
+    validate_storyboard,
+)
+
+__all__ = [
+    "COVER_SLIDE_MS",
+    "IMAGE_SLIDE_MS",
+    "KEEPSAKE_STYLE",
+    "KEEPSAKE_STYLE_VERSION",
+    "NOTE_SLIDE_MS",
+    "STORYBOARD_SCHEMA",
+    "STORYBOARD_VERSION",
+    "Storyboard",
+    "StoryboardSlide",
+    "build_keepsake_storyboard",
+    "validate_storyboard",
+]

--- a/api/showcase/storyboard.py
+++ b/api/showcase/storyboard.py
@@ -1,0 +1,286 @@
+"""Deterministic Keepsake storyboard planning.
+
+Given a piece's effective inputs — metadata, the workflow-backed state timeline,
+included images and notes, the potter's narrative, and a selected music track —
+``build_keepsake_storyboard`` produces a render-ready :class:`Storyboard`.
+
+The function is pure and deterministic: the same effective inputs always produce
+an identical Storyboard. There is no randomness and no wall-clock dependence;
+slide ordering is derived entirely from stored fields, and workflow state names
+are never hardcoded (labels come from :func:`get_state_friendly_name`).
+
+The authoritative contract is ``storyboard.schema.yml`` at the repo root; every
+Storyboard validates against it via :func:`validate_storyboard`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import yaml
+
+from ..models import Piece
+from ..utils import image_to_dict
+from ..workflow import get_state_friendly_name
+
+# ── Versions (consumed by the input-hash layer, issue #747) ───────────────────
+# Bump STORYBOARD_VERSION when the Storyboard data shape changes; bump
+# KEEPSAKE_STYLE_VERSION when the Keepsake builder's output changes for the same
+# inputs. They are independent so future styles can reuse the same data shape.
+STORYBOARD_VERSION = "1"
+KEEPSAKE_STYLE = "keepsake"
+KEEPSAKE_STYLE_VERSION = "1"
+
+# ── Deterministic slide durations (milliseconds) ──────────────────────────────
+COVER_SLIDE_MS = 4000
+IMAGE_SLIDE_MS = 3500
+NOTE_SLIDE_MS = 5000
+
+_IMAGE_FIT = "cover"
+
+# Load the JSON Schema once at import. __file__ is api/showcase/storyboard.py, so
+# parent.parent.parent is the repo root where the schema lives.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+STORYBOARD_SCHEMA: dict = yaml.safe_load(
+    (_REPO_ROOT / "storyboard.schema.yml").read_text()
+)
+
+
+def validate_storyboard(data: dict) -> None:
+    """Validate a serialized Storyboard against ``storyboard.schema.yml``.
+
+    Raises ``jsonschema.ValidationError`` if the data does not conform.
+    """
+    jsonschema.validate(instance=data, schema=STORYBOARD_SCHEMA)
+
+
+# ── Contract dataclasses ──────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class StoryboardSlide:
+    kind: str  # "cover" | "image" | "note"
+    key: str
+    duration_ms: int
+    state_label: str
+    image: dict | None = None
+    heading: str | None = None
+    caption: str | None = None
+    text: str | None = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class Storyboard:
+    piece_id: str
+    eligible: bool
+    ineligible_reason: str | None = None
+    music_track_id: str | None = None
+    slides: list[StoryboardSlide] = field(default_factory=list)
+    storyboard_version: str = STORYBOARD_VERSION
+    style: str = KEEPSAKE_STYLE
+    style_version: str = KEEPSAKE_STYLE_VERSION
+
+    @property
+    def total_duration_ms(self) -> int:
+        return sum(slide.duration_ms for slide in self.slides)
+
+    @property
+    def slide_count(self) -> int:
+        return len(self.slides)
+
+    def to_dict(self) -> dict:
+        return {
+            "storyboard_version": self.storyboard_version,
+            "style": self.style,
+            "style_version": self.style_version,
+            "piece_id": self.piece_id,
+            "eligible": self.eligible,
+            "ineligible_reason": self.ineligible_reason,
+            "music_track_id": self.music_track_id,
+            "total_duration_ms": self.total_duration_ms,
+            "slide_count": self.slide_count,
+            "slides": [slide.to_dict() for slide in self.slides],
+        }
+
+
+# ── Builder ───────────────────────────────────────────────────────────────────
+
+
+def _ordered_states(piece: Piece) -> list:
+    """Return the piece's states in ascending timeline order.
+
+    Uses the same sort key as ``Piece.current_state`` so ordering is consistent
+    with the rest of the app and never depends on workflow state names.
+    """
+    return sorted(piece.states.all(), key=Piece._state_sort_key)
+
+
+def _image_key(state_id: str, image: dict, index: int) -> str:
+    """Mirror the frontend picker's image key scheme so exclusions line up."""
+    ident = image.get("image_id") or image.get("cloudinary_public_id") or str(index)
+    return ":".join(part for part in (str(state_id), str(ident)) if part)
+
+
+def _slide_image(image: dict) -> dict:
+    return {
+        "url": image.get("url") or "",
+        "image_id": image.get("image_id"),
+        "cloudinary_public_id": image.get("cloudinary_public_id"),
+        "cloud_name": image.get("cloud_name"),
+        "crop": image.get("crop"),
+        "fit": _IMAGE_FIT,
+    }
+
+
+def _thumbnail_public_id(piece: Piece) -> str:
+    if not piece.thumbnail_id:
+        return ""
+    return (piece.thumbnail.cloudinary_public_id or "").strip()
+
+
+def build_keepsake_storyboard(
+    piece: Piece,
+    *,
+    excluded_image_keys: Any = (),
+    excluded_note_keys: Any = (),
+    music_track_id: str | None = None,
+) -> Storyboard:
+    """Build a deterministic Keepsake :class:`Storyboard` for ``piece``.
+
+    ``excluded_image_keys`` / ``excluded_note_keys`` use the same key schemes as
+    the frontend ``ShowcaseVideoInputPicker`` so the potter's exclusions apply
+    directly. The piece's thumbnail is the locked cover and cannot be excluded.
+    """
+    excluded_images = set(excluded_image_keys)
+    excluded_notes = set(excluded_note_keys)
+    thumb_pid = _thumbnail_public_id(piece)
+
+    # Walk the timeline once, collecting included images (with their captions and
+    # state labels) and the included note per state.
+    timeline: list[dict] = []
+    cover_key: str | None = None
+    for state in _ordered_states(piece):
+        label = get_state_friendly_name(state.state)
+        images: list[dict] = []
+        for index, image in enumerate(state.images):
+            key = _image_key(state.id, image, index)
+            is_thumbnail = (
+                bool(thumb_pid)
+                and (image.get("cloudinary_public_id") or "").strip() == thumb_pid
+            )
+            # The thumbnail is the locked cover and is never excluded.
+            if not is_thumbnail and key in excluded_images:
+                continue
+            item = {
+                "key": key,
+                "image": image,
+                "label": label,
+                "caption": (image.get("caption") or "").strip() or None,
+                "is_thumbnail": is_thumbnail,
+            }
+            if is_thumbnail and cover_key is None:
+                cover_key = key
+            images.append(item)
+
+        note_text = (state.notes or "").strip()
+        note = (
+            {"key": str(state.id), "label": label, "text": note_text}
+            if note_text and str(state.id) not in excluded_notes
+            else None
+        )
+        timeline.append({"label": label, "images": images, "note": note})
+
+    all_images = [item for entry in timeline for item in entry["images"]]
+
+    # Resolve the cover slide: prefer the thumbnail-matching state image, then the
+    # thumbnail Image directly, then the first included image.
+    cover_slide: StoryboardSlide | None = None
+    if cover_key is not None:
+        cover_item = next(item for item in all_images if item["key"] == cover_key)
+        cover_slide = StoryboardSlide(
+            kind="cover",
+            key=cover_item["key"],
+            duration_ms=COVER_SLIDE_MS,
+            state_label=cover_item["label"],
+            image=_slide_image(cover_item["image"]),
+            heading=piece.name,
+            text=(piece.showcase_story or "").strip() or None,
+        )
+    elif piece.thumbnail_id:
+        thumb = image_to_dict(piece.thumbnail) or {}
+        cover_key = "cover:thumbnail"
+        cover_slide = StoryboardSlide(
+            kind="cover",
+            key=cover_key,
+            duration_ms=COVER_SLIDE_MS,
+            state_label=get_state_friendly_name(piece.current_state.state)
+            if piece.current_state
+            else "",
+            image=_slide_image(thumb),
+            heading=piece.name,
+            text=(piece.showcase_story or "").strip() or None,
+        )
+    elif all_images:
+        first = all_images[0]
+        cover_key = first["key"]
+        cover_slide = StoryboardSlide(
+            kind="cover",
+            key=first["key"],
+            duration_ms=COVER_SLIDE_MS,
+            state_label=first["label"],
+            image=_slide_image(first["image"]),
+            heading=piece.name,
+            text=(piece.showcase_story or "").strip() or None,
+        )
+
+    if cover_slide is None:
+        # Sparse-data fallback: no usable imagery, so there is nothing to show.
+        return Storyboard(
+            piece_id=str(piece.id),
+            eligible=False,
+            ineligible_reason="This piece has no included images to build a video.",
+            music_track_id=music_track_id,
+            slides=[],
+        )
+
+    slides: list[StoryboardSlide] = [cover_slide]
+    for entry in timeline:
+        for item in entry["images"]:
+            # The cover image is already shown; do not repeat it.
+            if item["key"] == cover_key:
+                continue
+            slides.append(
+                StoryboardSlide(
+                    kind="image",
+                    key=item["key"],
+                    duration_ms=IMAGE_SLIDE_MS,
+                    state_label=item["label"],
+                    image=_slide_image(item["image"]),
+                    caption=item["caption"],
+                )
+            )
+        note = entry["note"]
+        if note is not None:
+            slides.append(
+                StoryboardSlide(
+                    kind="note",
+                    key=note["key"],
+                    duration_ms=NOTE_SLIDE_MS,
+                    state_label=note["label"],
+                    text=note["text"],
+                )
+            )
+
+    return Storyboard(
+        piece_id=str(piece.id),
+        eligible=True,
+        ineligible_reason=None,
+        music_track_id=music_track_id,
+        slides=slides,
+    )

--- a/api/tests/test_keepsake_storyboard.py
+++ b/api/tests/test_keepsake_storyboard.py
@@ -1,0 +1,216 @@
+"""Tests for the deterministic Keepsake storyboard planner (issue #744)."""
+
+import jsonschema
+import pytest
+from jsonschema import Draft202012Validator
+
+from api.models import ENTRY_STATE, Image, Piece, PieceState, PieceStateImage
+from api.showcase import (
+    COVER_SLIDE_MS,
+    KEEPSAKE_STYLE,
+    NOTE_SLIDE_MS,
+    STORYBOARD_SCHEMA,
+    Storyboard,
+    build_keepsake_storyboard,
+    validate_storyboard,
+)
+from api.showcase.storyboard import IMAGE_SLIDE_MS
+from api.workflow import get_state_friendly_name
+
+SECOND_STATE = "wheel_thrown"
+
+
+def _add_image(state, *, url, order, public_id=None, caption="", crop=None):
+    img = Image.objects.create(
+        user=state.user,
+        url=url,
+        cloudinary_public_id=public_id,
+    )
+    PieceStateImage.objects.create(
+        piece_state=state,
+        image=img,
+        order=order,
+        caption=caption,
+        crop=crop,
+    )
+    return img
+
+
+@pytest.fixture
+def rich_piece(user, db):
+    """A two-state piece with a thumbnail, several images, and notes."""
+    piece = Piece.objects.create(
+        user=user, name="Speckled Bowl", showcase_story="Made over a slow week."
+    )
+    s1 = PieceState.objects.create(
+        piece=piece, state=ENTRY_STATE, order=1, notes="First sketch."
+    )
+    thumb = _add_image(
+        s1,
+        url="https://ex.com/cover.jpg",
+        order=0,
+        public_id="cover_pid",
+        caption="The cover",
+    )
+    _add_image(s1, url="https://ex.com/a.jpg", order=1, public_id="a_pid", caption="A")
+    s2 = PieceState.objects.create(
+        piece=piece, state=SECOND_STATE, order=2, notes="Thrown on the wheel."
+    )
+    _add_image(s2, url="https://ex.com/b.jpg", order=0, public_id="b_pid", caption="B")
+    piece.thumbnail = thumb
+    piece.save()
+    return piece
+
+
+@pytest.mark.django_db
+def test_normal_piece_cover_first_and_deterministic_durations(rich_piece):
+    sb = build_keepsake_storyboard(rich_piece)
+
+    assert isinstance(sb, Storyboard)
+    assert sb.eligible is True
+    assert sb.ineligible_reason is None
+    assert sb.style == KEEPSAKE_STYLE
+
+    # Cover is first, is the thumbnail image, and carries the piece name + story.
+    cover = sb.slides[0]
+    assert cover.kind == "cover"
+    assert cover.duration_ms == COVER_SLIDE_MS
+    assert cover.heading == "Speckled Bowl"
+    assert cover.text == "Made over a slow week."
+    assert cover.image["cloudinary_public_id"] == "cover_pid"
+    assert cover.image["fit"] == "cover"
+
+    kinds = [s.kind for s in sb.slides]
+    # cover, then image A + note(s1), then image B + note(s2).
+    assert kinds == ["cover", "image", "note", "image", "note"]
+
+    # The cover image is not repeated as an image slide.
+    image_pids = [
+        s.image["cloudinary_public_id"] for s in sb.slides if s.kind == "image"
+    ]
+    assert image_pids == ["a_pid", "b_pid"]
+
+    # Durations are derived from constants only.
+    assert sb.total_duration_ms == (
+        COVER_SLIDE_MS + IMAGE_SLIDE_MS + NOTE_SLIDE_MS + IMAGE_SLIDE_MS + NOTE_SLIDE_MS
+    )
+    assert sb.slide_count == len(sb.slides)
+
+
+@pytest.mark.django_db
+def test_state_labels_are_derived_not_hardcoded(rich_piece):
+    sb = build_keepsake_storyboard(rich_piece)
+    labels = {s.state_label for s in sb.slides}
+    assert get_state_friendly_name(ENTRY_STATE) in labels
+    assert get_state_friendly_name(SECOND_STATE) in labels
+
+
+@pytest.mark.django_db
+def test_excluded_images_and_notes_are_omitted(rich_piece):
+    s2 = rich_piece.states.get(state=SECOND_STATE)
+    # Image keys use the image UUID when present, mirroring the frontend picker.
+    image_b_id = s2.image_links.get().image_id
+    sb = build_keepsake_storyboard(
+        rich_piece,
+        excluded_image_keys=[f"{s2.id}:{image_b_id}"],
+        excluded_note_keys=[str(s2.id)],
+    )
+    image_pids = [
+        s.image["cloudinary_public_id"] for s in sb.slides if s.kind == "image"
+    ]
+    assert image_pids == ["a_pid"]  # b excluded
+    note_keys = [s.key for s in sb.slides if s.kind == "note"]
+    assert str(s2.id) not in note_keys
+
+
+@pytest.mark.django_db
+def test_thumbnail_cannot_be_excluded(rich_piece):
+    s1 = rich_piece.states.get(state=ENTRY_STATE)
+    cover_id = s1.image_links.get(image__cloudinary_public_id="cover_pid").image_id
+    # Attempt to exclude the cover image's key; it must remain as the cover.
+    sb = build_keepsake_storyboard(
+        rich_piece, excluded_image_keys=[f"{s1.id}:{cover_id}"]
+    )
+    assert sb.eligible is True
+    assert sb.slides[0].kind == "cover"
+    assert sb.slides[0].image["cloudinary_public_id"] == "cover_pid"
+
+
+@pytest.mark.django_db
+def test_sparse_piece_without_images_is_ineligible(user, db):
+    piece = Piece.objects.create(user=user, name="Empty")
+    PieceState.objects.create(piece=piece, state=ENTRY_STATE, order=1, notes="A note.")
+    sb = build_keepsake_storyboard(piece)
+    assert sb.eligible is False
+    assert sb.ineligible_reason
+    assert sb.slides == []
+    assert sb.total_duration_ms == 0
+
+
+@pytest.mark.django_db
+def test_single_image_no_notes_is_degraded_but_valid(user, db):
+    piece = Piece.objects.create(user=user, name="Solo")
+    s1 = PieceState.objects.create(piece=piece, state=ENTRY_STATE, order=1)
+    img = _add_image(s1, url="https://ex.com/only.jpg", order=0, public_id="only_pid")
+    piece.thumbnail = img
+    piece.save()
+    sb = build_keepsake_storyboard(piece)
+    assert sb.eligible is True
+    assert [s.kind for s in sb.slides] == ["cover"]
+
+
+@pytest.mark.django_db
+def test_identical_inputs_produce_identical_storyboard(rich_piece):
+    a = build_keepsake_storyboard(rich_piece, music_track_id="track-1").to_dict()
+    b = build_keepsake_storyboard(rich_piece, music_track_id="track-1").to_dict()
+    assert a == b
+    assert a["music_track_id"] == "track-1"
+
+
+@pytest.mark.django_db
+def test_slide_order_follows_state_order_not_creation_order(user, db):
+    """States created out of timeline order still play back in `order` sequence,
+    so data reordered at rest does not change the effective Storyboard."""
+    piece = Piece.objects.create(user=user, name="Stable")
+    # Create the later state first to decouple creation order from `order`.
+    s2 = PieceState.objects.create(piece=piece, state=SECOND_STATE, order=2)
+    s1 = PieceState.objects.create(piece=piece, state=ENTRY_STATE, order=1)
+    thumb = _add_image(s1, url="https://ex.com/c.jpg", order=0, public_id="c_pid")
+    _add_image(s2, url="https://ex.com/d.jpg", order=0, public_id="d_pid")
+    piece.thumbnail = thumb
+    piece.save()
+
+    sb = build_keepsake_storyboard(piece)
+    # Cover (s1 thumbnail) first, then the s2 image — ordered by `order`.
+    image_pids = [
+        s.image["cloudinary_public_id"] for s in sb.slides if s.kind == "image"
+    ]
+    assert image_pids == ["d_pid"]
+    assert sb.slides[0].image["cloudinary_public_id"] == "c_pid"
+    assert sb.slides[0].state_label == get_state_friendly_name(ENTRY_STATE)
+
+
+@pytest.mark.django_db
+def test_every_storyboard_validates_against_schema(rich_piece, user):
+    cases = [
+        build_keepsake_storyboard(rich_piece),
+        build_keepsake_storyboard(rich_piece, music_track_id="track-9"),
+        build_keepsake_storyboard(
+            rich_piece, excluded_image_keys=["nope"], excluded_note_keys=["nope"]
+        ),
+    ]
+    empty = Piece.objects.create(user=user, name="Empty2")
+    PieceState.objects.create(piece=empty, state=ENTRY_STATE, order=1)
+    cases.append(build_keepsake_storyboard(empty))
+
+    for sb in cases:
+        validate_storyboard(sb.to_dict())  # raises on failure
+
+
+def test_schema_document_is_valid_draft_2020_12():
+    Draft202012Validator.check_schema(STORYBOARD_SCHEMA)
+
+
+def test_validate_storyboard_rejects_malformed():
+    with pytest.raises(jsonschema.ValidationError):
+        validate_storyboard({"storyboard_version": "1"})

--- a/storyboard.schema.yml
+++ b/storyboard.schema.yml
@@ -1,0 +1,143 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: PotterDoc Showcase Video Storyboard
+description: >-
+  Render-ready, style-agnostic description of a showcase slideshow video.
+  A Storyboard is produced deterministically from a piece's effective inputs by a
+  style builder (the first style is "keepsake"). The same effective inputs always
+  produce the same Storyboard. This document is the authoritative contract; the
+  renderer and the input-hash layer both consume it.
+type: object
+additionalProperties: false
+required:
+  - storyboard_version
+  - style
+  - style_version
+  - piece_id
+  - eligible
+  - ineligible_reason
+  - music_track_id
+  - total_duration_ms
+  - slide_count
+  - slides
+
+properties:
+  storyboard_version:
+    type: string
+    description: Version of the Storyboard data shape (style-agnostic).
+    pattern: '^\d+$'
+  style:
+    type: string
+    description: Identifier of the style that produced this Storyboard.
+    enum: [keepsake]
+  style_version:
+    type: string
+    description: Version of the style builder logic that produced this Storyboard.
+    pattern: '^\d+$'
+  piece_id:
+    type: string
+    description: UUID of the piece this Storyboard was built from.
+  eligible:
+    type: boolean
+    description: >-
+      Whether the piece had enough usable content to produce a playable video.
+      When false, `slides` is empty and `ineligible_reason` explains why.
+  ineligible_reason:
+    type: [string, "null"]
+    description: Human-readable reason the piece is ineligible, or null when eligible.
+  music_track_id:
+    type: [string, "null"]
+    description: >-
+      Selected royalty-free music track identifier, passed through to the
+      renderer. Null when no track is selected. The catalog is defined elsewhere.
+  total_duration_ms:
+    type: integer
+    minimum: 0
+    description: Sum of all slide durations in milliseconds.
+  slide_count:
+    type: integer
+    minimum: 0
+    description: Number of slides. Equals the length of `slides`.
+  slides:
+    type: array
+    description: Ordered list of slides, played front to back.
+    items:
+      $ref: "#/$defs/slide"
+
+$defs:
+  slide:
+    type: object
+    additionalProperties: false
+    required:
+      - kind
+      - key
+      - duration_ms
+      - state_label
+      - image
+      - heading
+      - caption
+      - text
+    properties:
+      kind:
+        type: string
+        description: >-
+          Slide role. "cover" is the locked thumbnail title slide, "image" is a
+          piece photo, "note" is a text-only slide carrying a state note.
+        enum: [cover, image, note]
+      key:
+        type: string
+        description: >-
+          Stable source key. For image slides this matches the picker's image key
+          scheme (`<state_id>:<image_id|cloudinary_public_id|index>`); for note
+          slides it is the source state id.
+      duration_ms:
+        type: integer
+        minimum: 1
+        description: How long the slide is shown, in milliseconds.
+      state_label:
+        type: string
+        description: >-
+          Friendly workflow state label this slide came from, derived from the
+          workflow definition (never a hardcoded state name).
+      image:
+        description: Image to display, or null for text-only slides.
+        oneOf:
+          - type: "null"
+          - $ref: "#/$defs/image"
+      heading:
+        type: [string, "null"]
+        description: Optional primary text overlay (e.g. piece name on the cover).
+      caption:
+        type: [string, "null"]
+        description: Optional image caption overlay.
+      text:
+        type: [string, "null"]
+        description: Optional body text (e.g. the note content on a note slide).
+
+  image:
+    type: object
+    additionalProperties: false
+    required:
+      - url
+      - image_id
+      - cloudinary_public_id
+      - cloud_name
+      - crop
+      - fit
+    properties:
+      url:
+        type: string
+        description: Source image URL.
+      image_id:
+        type: [string, "null"]
+        description: Image model UUID when available.
+      cloudinary_public_id:
+        type: [string, "null"]
+      cloud_name:
+        type: [string, "null"]
+      crop:
+        description: Crop rectangle when one is stored, otherwise null.
+        type: [object, "null"]
+      fit:
+        type: string
+        description: Deterministic fitting instruction for the renderer.
+        enum: [cover]


### PR DESCRIPTION
## Summary

Adds a deterministic, backend planning layer for showcase videos: given a piece's effective inputs (metadata, the workflow-backed state timeline, included images/notes, the potter's narrative, and a selected music track), it produces a render-ready **Storyboard**.

"Storyboard" is the style-agnostic intermediate data structure — future video styles beyond Keepsake reuse it; "Keepsake" is the first style that produces one.

Closes [#744](https://github.com/shaoster/glaze/issues/744). Foundation for [#745](https://github.com/shaoster/glaze/issues/745) (review/export), [#746](https://github.com/shaoster/glaze/issues/746) (music catalog), and [#747](https://github.com/shaoster/glaze/issues/747) (input hashing).

## What's included

- **`storyboard.schema.yml`** — a validatable JSON Schema (draft 2020-12, mirroring `user_preferences.schema.yml`) that is the authoritative Storyboard contract.
- **`api/showcase/storyboard.py`** — `Storyboard` / `StoryboardSlide` dataclasses with stable `to_dict()`, version constants (`STORYBOARD_VERSION`, `KEEPSAKE_STYLE_VERSION`) for the future input hash, deterministic duration constants, `validate_storyboard()`, and the pure builder `build_keepsake_storyboard()`.
- **`api/tests/test_keepsake_storyboard.py`** — normal / excluded / sparse / ineligible cases, output stability, order-derivation, and schema validity.
- **BUILD.bazel** wiring for the schema file and new sources/tests.

## Behavior

- State timeline ordering is derived from `order`/`created` (state names never hardcoded; labels via `get_state_friendly_name`).
- Image/note exclusion keys match the existing `ShowcaseVideoInputPicker` scheme so the potter's choices apply directly, and align with the future input hash (#747).
- The piece thumbnail is the locked cover and cannot be excluded.
- A piece with no usable images yields a clear `eligible=False` Storyboard with a reason; otherwise a degraded-but-valid Storyboard.
- Fully deterministic — no randomness, no wall-clock; durations from constants.

## Out of scope (per the issue)

API/preview endpoint (#745), music catalog (#746) — the track id is passed through, input hashing (#747), AI/random sequencing, user-configurable pacing.

## Security

No security-sensitive surface: pure in-process function, no new endpoints, auth, permissions, serializer fields, tokens, email, or settings changes.

## Testing

- `rtk bazel test //...` — all 61 targets pass
- `rtk bazel build --config=lint //...` and `//api:api_mypy` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
