### PR TITLE
feat: add showcase video music catalog (#746)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+assets/showcase_music/*.flac filter=lfs diff=lfs merge=lfs -text

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -93,6 +93,21 @@ js_library(
     visibility = ["//visibility:public"],
 )
 
+filegroup(
+    name = "music_catalog_files",
+    srcs = [
+        "music_catalog.schema.yml",
+        "music_catalog.yml",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+js_library(
+    name = "music_catalog_js",
+    srcs = ["music_catalog.yml"],
+    visibility = ["//visibility:public"],
+)
+
 # ── Fixture data ──────────────────────────────────────────────────────────────
 
 filegroup(
@@ -183,6 +198,8 @@ pkg_tar(
         "tutorials.yml",
         "tutorials.schema.yml",
         "storyboard.schema.yml",
+        "music_catalog.yml",
+        "music_catalog.schema.yml",
         "docker-entrypoint.sh",
         "//api:api_runtime_files",
         "//backend:backend_runtime_files",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -203,6 +203,10 @@ pkg_tar(
         "docker-entrypoint.sh",
         "//api:api_runtime_files",
         "//backend:backend_runtime_files",
+        # Audio assets are stored via git-LFS and not included here; the renderer
+        # resolves audio.url at runtime from the LFS-populated working tree or a
+        # hosted location. Add them to this tar if the image ever needs to serve
+        # audio directly.
     ] + glob(["fixtures/**"], allow_empty = True),
     strip_prefix = ".",
     package_dir = "/app",

--- a/api/BUILD.bazel
+++ b/api/BUILD.bazel
@@ -57,6 +57,7 @@ py_library(
         "serializer_registry.py",
         "serializers.py",
         "showcase/__init__.py",
+        "showcase/music.py",
         "showcase/storyboard.py",
         "tasks.py",
         "task_views.py",
@@ -65,7 +66,10 @@ py_library(
         "views.py",
         "workflow_views.py",
     ],
-    data = ["//:storyboard_files"],
+    data = [
+        "//:music_catalog_files",
+        "//:storyboard_files",
+    ],
     deps = [
         ":api_workflow_lib",
         "//backend:backend_lib",
@@ -193,6 +197,7 @@ filegroup(
         "serializer_registry.py",
         "serializers.py",
         "showcase/__init__.py",
+        "showcase/music.py",
         "showcase/storyboard.py",
         "task_views.py",
         "telemetry_views.py",
@@ -222,6 +227,7 @@ _PYTEST_DEPS = [
 _TEST_DATA = [
     "//:workflow_files",
     "//:storyboard_files",
+    "//:music_catalog_files",
     "//:fixtures",
     "//:pytest_ini",
     "//backend:backend_test_settings",
@@ -328,6 +334,7 @@ pytest_test(
     srcs = _CONFTEST + [
         "tests/test_analysis.py",
         "tests/test_keepsake_storyboard.py",
+        "tests/test_music_catalog.py",
         "tests/test_patch_current_state.py",
         "tests/test_piece_detail.py",
         "tests/test_piece_showcase_validation.py",
@@ -350,6 +357,7 @@ pytest_test(
         "api/tests/test_sealed_state.py",
         "api/tests/test_analysis.py",
         "api/tests/test_keepsake_storyboard.py",
+        "api/tests/test_music_catalog.py",
         "api/tests/test_piece_showcase_validation.py",
         "api/tests/test_piece_state_admin_relational.py",
         "api/tests/test_editable_mode.py",

--- a/api/showcase/__init__.py
+++ b/api/showcase/__init__.py
@@ -5,6 +5,15 @@ slideshow video. Style builders (the first is "keepsake") turn a piece's
 effective inputs into a Storyboard deterministically.
 """
 
+from .music import (
+    DEFAULT_TRACK_ID,
+    MUSIC_CATALOG_SCHEMA,
+    MusicAudio,
+    MusicTrack,
+    get_catalog,
+    get_track,
+    resolve_track_id,
+)
 from .storyboard import (
     COVER_SLIDE_MS,
     IMAGE_SLIDE_MS,
@@ -21,14 +30,21 @@ from .storyboard import (
 
 __all__ = [
     "COVER_SLIDE_MS",
+    "DEFAULT_TRACK_ID",
     "IMAGE_SLIDE_MS",
     "KEEPSAKE_STYLE",
     "KEEPSAKE_STYLE_VERSION",
+    "MUSIC_CATALOG_SCHEMA",
+    "MusicAudio",
+    "MusicTrack",
     "NOTE_SLIDE_MS",
     "STORYBOARD_SCHEMA",
     "STORYBOARD_VERSION",
     "Storyboard",
     "StoryboardSlide",
     "build_keepsake_storyboard",
+    "get_catalog",
+    "get_track",
+    "resolve_track_id",
     "validate_storyboard",
 ]

--- a/api/showcase/music.py
+++ b/api/showcase/music.py
@@ -1,0 +1,119 @@
+"""Showcase video music catalog.
+
+A small, curated catalog of royalty-free tracks the potter can attach to a
+Keepsake video. The catalog is static data defined in ``music_catalog.yml`` at
+the repo root (validated against ``music_catalog.schema.yml``) and shared with
+the frontend, which imports the same YAML directly.
+
+The catalog is the lookup table behind the storyboard's ``music_track_id``: the
+storyboard stores the stable id, and the renderer resolves it to an audio asset
+through :func:`get_track`. :func:`resolve_track_id` applies the deterministic
+default so a track is always present in the hashed storyboard inputs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import jsonschema
+import yaml
+
+# __file__ is api/showcase/music.py, so parent.parent.parent is the repo root
+# where the catalog and its schema live (mirrors storyboard.py).
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+MUSIC_CATALOG_SCHEMA: dict = yaml.safe_load(
+    (_REPO_ROOT / "music_catalog.schema.yml").read_text()
+)
+_RAW_CATALOG: dict = yaml.safe_load((_REPO_ROOT / "music_catalog.yml").read_text())
+
+
+@dataclass(frozen=True)
+class MusicAudio:
+    format: str
+    url: str
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class MusicTrack:
+    track_id: str
+    title: str
+    artist: str
+    genre: str
+    mood: str
+    license: str
+    license_url: str | None
+    artist_url: str
+    source_url: str
+    download_url: str
+    attribution: str
+    audio: MusicAudio
+
+    def to_dict(self) -> dict:
+        data = asdict(self)
+        # asdict already recurses into MusicAudio; keep id first for readability.
+        return data
+
+
+def _build_catalog() -> dict[str, MusicTrack]:
+    """Validate the raw catalog and build the ordered track map."""
+    jsonschema.validate(instance=_RAW_CATALOG, schema=MUSIC_CATALOG_SCHEMA)
+
+    default_id = _RAW_CATALOG["default_track_id"]
+    raw_tracks: dict = _RAW_CATALOG["tracks"]
+    if default_id not in raw_tracks:
+        raise ValueError(
+            f"default_track_id {default_id!r} is not a track in music_catalog.yml"
+        )
+
+    tracks: dict[str, MusicTrack] = {}
+    for track_id, raw in raw_tracks.items():
+        audio = raw["audio"]
+        tracks[track_id] = MusicTrack(
+            track_id=track_id,
+            title=raw["title"],
+            artist=raw["artist"],
+            genre=raw["genre"],
+            mood=raw["mood"],
+            license=raw["license"],
+            license_url=raw["license_url"],
+            artist_url=raw["artist_url"],
+            source_url=raw["source_url"],
+            download_url=raw["download_url"],
+            attribution=raw["attribution"],
+            audio=MusicAudio(format=audio["format"], url=audio["url"]),
+        )
+    return tracks
+
+
+_CATALOG: dict[str, MusicTrack] = _build_catalog()
+DEFAULT_TRACK_ID: str = _RAW_CATALOG["default_track_id"]
+
+
+def get_catalog() -> list[MusicTrack]:
+    """Return all tracks in catalog (declaration) order."""
+    return list(_CATALOG.values())
+
+
+def get_track(track_id: str | None) -> MusicTrack | None:
+    """Return the track for ``track_id``, or ``None`` if it is unknown/None."""
+    if track_id is None:
+        return None
+    return _CATALOG.get(track_id)
+
+
+def resolve_track_id(track_id: str | None) -> str:
+    """Resolve an optional selection to a concrete catalog track id.
+
+    ``None`` resolves to :data:`DEFAULT_TRACK_ID` (the deterministic default). A
+    non-null id that is not in the catalog is a programming/data error and
+    raises :class:`ValueError`.
+    """
+    if track_id is None:
+        return DEFAULT_TRACK_ID
+    if track_id not in _CATALOG:
+        raise ValueError(f"Unknown music track id: {track_id!r}")
+    return track_id

--- a/api/showcase/music.py
+++ b/api/showcase/music.py
@@ -30,11 +30,10 @@ _RAW_CATALOG: dict = yaml.safe_load((_REPO_ROOT / "music_catalog.yml").read_text
 
 @dataclass(frozen=True)
 class MusicAudio:
+    # ``format`` is the target lossless container; ``url`` is the hosted asset,
+    # or None until the render pipeline hosts one.
     format: str
-    url: str
-
-    def to_dict(self) -> dict:
-        return asdict(self)
+    url: str | None
 
 
 @dataclass(frozen=True)
@@ -53,9 +52,7 @@ class MusicTrack:
     audio: MusicAudio
 
     def to_dict(self) -> dict:
-        data = asdict(self)
-        # asdict already recurses into MusicAudio; keep id first for readability.
-        return data
+        return asdict(self)
 
 
 def _build_catalog() -> dict[str, MusicTrack]:
@@ -111,6 +108,11 @@ def resolve_track_id(track_id: str | None) -> str:
     ``None`` resolves to :data:`DEFAULT_TRACK_ID` (the deterministic default). A
     non-null id that is not in the catalog is a programming/data error and
     raises :class:`ValueError`.
+
+    This is intentionally strict: an unknown id reaching here means the storyboard
+    inputs are inconsistent, and silently defaulting would hide that. Validate a
+    potter-supplied selection at the API/serializer boundary (where it can be
+    surfaced as a 400) rather than relying on this to coerce bad input.
     """
     if track_id is None:
         return DEFAULT_TRACK_ID

--- a/api/showcase/music.py
+++ b/api/showcase/music.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from typing import Literal
 
 import jsonschema
 import yaml
@@ -32,7 +33,7 @@ _RAW_CATALOG: dict = yaml.safe_load((_REPO_ROOT / "music_catalog.yml").read_text
 class MusicAudio:
     # ``format`` is the target lossless container; ``url`` is the hosted asset,
     # or None until the render pipeline hosts one.
-    format: str
+    format: Literal["flac", "wav"]
     url: str | None
 
 
@@ -69,6 +70,17 @@ def _build_catalog() -> dict[str, MusicTrack]:
     tracks: dict[str, MusicTrack] = {}
     for track_id, raw in raw_tracks.items():
         audio = raw["audio"]
+        audio_url: str | None = audio["url"]
+        if audio_url is not None and not audio_url.startswith(("http://", "https://")):
+            # Repo-relative path: verify the file actually exists so a typo
+            # surfaces at startup rather than silently at render time.
+            resolved = _REPO_ROOT / audio_url
+            if not resolved.exists():
+                raise FileNotFoundError(
+                    f"audio.url for track {track_id!r} points at {audio_url!r} "
+                    f"but {resolved} does not exist. "
+                    "Check that git-LFS objects are fetched."
+                )
         tracks[track_id] = MusicTrack(
             track_id=track_id,
             title=raw["title"],
@@ -81,7 +93,7 @@ def _build_catalog() -> dict[str, MusicTrack]:
             source_url=raw["source_url"],
             download_url=raw["download_url"],
             attribution=raw["attribution"],
-            audio=MusicAudio(format=audio["format"], url=audio["url"]),
+            audio=MusicAudio(format=audio["format"], url=audio_url),
         )
     return tracks
 

--- a/api/showcase/storyboard.py
+++ b/api/showcase/storyboard.py
@@ -25,6 +25,7 @@ import yaml
 from ..models import Piece
 from ..utils import image_to_dict
 from ..workflow import get_state_friendly_name
+from .music import resolve_track_id
 
 # ── Versions (consumed by the input-hash layer, issue #747) ───────────────────
 # Bump STORYBOARD_VERSION when the Storyboard data shape changes; bump
@@ -157,6 +158,9 @@ def build_keepsake_storyboard(
     the frontend ``ShowcaseVideoInputPicker`` so the potter's exclusions apply
     directly. The piece's thumbnail is the locked cover and cannot be excluded.
     """
+    # Apply the deterministic default so a track is always present in the hashed
+    # storyboard inputs; an unknown non-null id is rejected here.
+    music_track_id = resolve_track_id(music_track_id)
     excluded_images = set(excluded_image_keys)
     excluded_notes = set(excluded_note_keys)
     thumb_pid = _thumbnail_public_id(piece)

--- a/api/tests/test_keepsake_storyboard.py
+++ b/api/tests/test_keepsake_storyboard.py
@@ -7,17 +7,23 @@ from jsonschema import Draft202012Validator
 from api.models import ENTRY_STATE, Image, Piece, PieceState, PieceStateImage
 from api.showcase import (
     COVER_SLIDE_MS,
+    DEFAULT_TRACK_ID,
     KEEPSAKE_STYLE,
     NOTE_SLIDE_MS,
     STORYBOARD_SCHEMA,
     Storyboard,
     build_keepsake_storyboard,
+    get_catalog,
     validate_storyboard,
 )
 from api.showcase.storyboard import IMAGE_SLIDE_MS
 from api.workflow import get_state_friendly_name
 
 SECOND_STATE = "wheel_thrown"
+
+# Two distinct real catalog track ids for hash-sensitivity assertions.
+A_TRACK = DEFAULT_TRACK_ID
+B_TRACK = next(t.track_id for t in get_catalog() if t.track_id != DEFAULT_TRACK_ID)
 
 
 def _add_image(state, *, url, order, public_id=None, caption="", crop=None):
@@ -161,10 +167,10 @@ def test_single_image_no_notes_is_degraded_but_valid(user, db):
 
 @pytest.mark.django_db
 def test_identical_inputs_produce_identical_storyboard(rich_piece):
-    a = build_keepsake_storyboard(rich_piece, music_track_id="track-1").to_dict()
-    b = build_keepsake_storyboard(rich_piece, music_track_id="track-1").to_dict()
+    a = build_keepsake_storyboard(rich_piece, music_track_id=A_TRACK).to_dict()
+    b = build_keepsake_storyboard(rich_piece, music_track_id=A_TRACK).to_dict()
     assert a == b
-    assert a["music_track_id"] == "track-1"
+    assert a["music_track_id"] == A_TRACK
 
 
 @pytest.mark.django_db
@@ -194,7 +200,7 @@ def test_slide_order_follows_state_order_not_creation_order(user, db):
 def test_every_storyboard_validates_against_schema(rich_piece, user):
     cases = [
         build_keepsake_storyboard(rich_piece),
-        build_keepsake_storyboard(rich_piece, music_track_id="track-9"),
+        build_keepsake_storyboard(rich_piece, music_track_id=A_TRACK),
         build_keepsake_storyboard(
             rich_piece, excluded_image_keys=["nope"], excluded_note_keys=["nope"]
         ),
@@ -214,3 +220,27 @@ def test_schema_document_is_valid_draft_2020_12():
 def test_validate_storyboard_rejects_malformed():
     with pytest.raises(jsonschema.ValidationError):
         validate_storyboard({"storyboard_version": "1"})
+
+
+@pytest.mark.django_db
+def test_music_default_applied_when_omitted(rich_piece):
+    sb = build_keepsake_storyboard(rich_piece)
+    assert sb.music_track_id == DEFAULT_TRACK_ID
+    assert sb.to_dict()["music_track_id"] == DEFAULT_TRACK_ID
+
+
+@pytest.mark.django_db
+def test_music_track_change_changes_storyboard(rich_piece):
+    a = build_keepsake_storyboard(rich_piece, music_track_id=A_TRACK).to_dict()
+    b = build_keepsake_storyboard(rich_piece, music_track_id=B_TRACK).to_dict()
+    # Only the track differs; the hashed storyboard dict must differ with it.
+    assert A_TRACK != B_TRACK
+    assert a["music_track_id"] == A_TRACK
+    assert b["music_track_id"] == B_TRACK
+    assert a != b
+
+
+@pytest.mark.django_db
+def test_music_unknown_track_rejected(rich_piece):
+    with pytest.raises(ValueError):
+        build_keepsake_storyboard(rich_piece, music_track_id="not-a-real-track")

--- a/api/tests/test_music_catalog.py
+++ b/api/tests/test_music_catalog.py
@@ -1,0 +1,64 @@
+"""Tests for the showcase music catalog (issue #746)."""
+
+import jsonschema
+import pytest
+from jsonschema import Draft202012Validator
+
+from api.showcase import (
+    DEFAULT_TRACK_ID,
+    MUSIC_CATALOG_SCHEMA,
+    MusicTrack,
+    get_catalog,
+    get_track,
+    resolve_track_id,
+)
+from api.showcase.music import _RAW_CATALOG
+
+
+def test_catalog_loads_and_is_nonempty():
+    catalog = get_catalog()
+    assert catalog
+    assert all(isinstance(track, MusicTrack) for track in catalog)
+
+
+def test_raw_catalog_validates_against_schema():
+    # The data file conforms to its contract, and the contract itself is valid.
+    Draft202012Validator.check_schema(MUSIC_CATALOG_SCHEMA)
+    jsonschema.validate(instance=_RAW_CATALOG, schema=MUSIC_CATALOG_SCHEMA)
+
+
+def test_track_ids_are_stable_and_unique():
+    ids = [track.track_id for track in get_catalog()]
+    assert len(ids) == len(set(ids))
+
+
+def test_every_track_serializes_with_attribution():
+    for track in get_catalog():
+        data = track.to_dict()
+        # Attribution is a licensing obligation — it must always be present.
+        assert data["attribution"].strip()
+        assert data["audio"]["format"] in {"flac", "wav"}
+        assert data["audio"]["url"]
+
+
+def test_default_track_is_a_real_track():
+    assert get_track(DEFAULT_TRACK_ID) is not None
+
+
+def test_resolve_track_id_applies_default_for_none():
+    assert resolve_track_id(None) == DEFAULT_TRACK_ID
+
+
+def test_resolve_track_id_passes_through_valid_id():
+    valid = get_catalog()[0].track_id
+    assert resolve_track_id(valid) == valid
+
+
+def test_resolve_track_id_rejects_unknown():
+    with pytest.raises(ValueError):
+        resolve_track_id("bogus-track")
+
+
+def test_get_track_returns_none_for_unknown_or_none():
+    assert get_track(None) is None
+    assert get_track("bogus-track") is None

--- a/api/tests/test_music_catalog.py
+++ b/api/tests/test_music_catalog.py
@@ -1,6 +1,5 @@
 """Tests for the showcase music catalog (issue #746)."""
 
-import jsonschema
 import pytest
 from jsonschema import Draft202012Validator
 
@@ -12,19 +11,18 @@ from api.showcase import (
     get_track,
     resolve_track_id,
 )
-from api.showcase.music import _RAW_CATALOG
 
 
 def test_catalog_loads_and_is_nonempty():
+    # Importing the module schema-validates the raw catalog at load time, so a
+    # successful, non-empty load proves the data file conforms to the contract.
     catalog = get_catalog()
     assert catalog
     assert all(isinstance(track, MusicTrack) for track in catalog)
 
 
-def test_raw_catalog_validates_against_schema():
-    # The data file conforms to its contract, and the contract itself is valid.
+def test_schema_document_is_valid_draft_2020_12():
     Draft202012Validator.check_schema(MUSIC_CATALOG_SCHEMA)
-    jsonschema.validate(instance=_RAW_CATALOG, schema=MUSIC_CATALOG_SCHEMA)
 
 
 def test_track_ids_are_stable_and_unique():
@@ -37,8 +35,9 @@ def test_every_track_serializes_with_attribution():
         data = track.to_dict()
         # Attribution is a licensing obligation — it must always be present.
         assert data["attribution"].strip()
+        # format is the target lossless container; url may be null until hosted.
         assert data["audio"]["format"] in {"flac", "wav"}
-        assert data["audio"]["url"]
+        assert data["audio"]["url"] is None or data["audio"]["url"]
 
 
 def test_default_track_is_a_real_track():

--- a/api/tests/test_music_catalog.py
+++ b/api/tests/test_music_catalog.py
@@ -37,7 +37,7 @@ def test_every_track_serializes_with_attribution():
         assert data["attribution"].strip()
         # format is the target lossless container; url may be null until hosted.
         assert data["audio"]["format"] in {"flac", "wav"}
-        assert data["audio"]["url"] is None or data["audio"]["url"]
+        assert data["audio"]["url"] is None or isinstance(data["audio"]["url"], str)
 
 
 def test_default_track_is_a_real_track():

--- a/assets/showcase_music/CREDITS.md
+++ b/assets/showcase_music/CREDITS.md
@@ -1,0 +1,45 @@
+# Showcase music — credits & provenance
+
+Royalty-free background tracks for Piece Showcase (Keepsake) videos. The catalog
+metadata lives in `music_catalog.yml`; these are the hosted lossless assets it
+references (stored via git-LFS).
+
+## Attribution (required — keep with any published video)
+
+**Adventures — A Himitsu** (`adventures-a-himitsu.flac`) — CC BY 3.0
+> Adventures by A Himitsu https://soundcloud.com/a-himitsu
+> Creative Commons — Attribution 3.0 Unported — CC BY 3.0
+> Music released by Argofox https://www.audiolibrary.com.co/a-himitsu/adventures
+> Music promoted by Audio Library https://youtu.be/MkNeIUgNPQ8
+
+**Good For You — THBD** (`good-for-you-thbd.flac`) — CC BY 3.0
+> Good For You by THBD https://soundcloud.com/thbdsultan
+> Creative Commons — Attribution 3.0 Unported — CC BY 3.0
+> Music promoted by Audio Library https://youtu.be/-K_YSjqKgvQ
+
+**We Are One — Vexento** (`we-are-one-vexento.flac`) — Free with attribution
+> We Are One by Vexento https://soundcloud.com/vexento
+> https://www.youtube.com/user/Vexento
+> Music promoted by Audio Library https://youtu.be/Ssvu2yncgWU
+
+## How these were produced
+
+The only freely obtainable source for these tracks is lossy (YouTube provides an
+Opus stream). They are **not** re-mastered or restored — re-encoding cannot
+recover detail the source lost. They are stored as FLAC purely to get a
+**delay-free, sample-accurate container** for slideshow alignment: MP3/Opus carry
+variable encoder delay ("random spacing at the front"), so we decode to PCM,
+trim the leading silence, and re-encode losslessly.
+
+Recipe (per track), using `ffmpeg`:
+
+```sh
+yt-dlp -f bestaudio -o "<id>.%(ext)s" "https://www.youtube.com/watch?v=<videoId>"
+ffmpeg -i "<id>.webm" \
+  -af "silenceremove=start_periods=1:start_threshold=-50dB:start_silence=0,aresample=44100" \
+  -map_metadata -1 -sample_fmt s16 -c:a flac -compression_level 8 "<id>.flac"
+```
+
+- `silenceremove` strips the leading near-silence so every track starts at sample 0.
+- 16-bit / 44.1 kHz: the source is lossy, so higher bit depth would only add size.
+- `-map_metadata -1`: no embedded tags (attribution lives here and in the catalog).

--- a/assets/showcase_music/CREDITS.md
+++ b/assets/showcase_music/CREDITS.md
@@ -9,6 +9,7 @@ references (stored via git-LFS).
 **Adventures — A Himitsu** (`adventures-a-himitsu.flac`) — CC BY 3.0
 > Adventures by A Himitsu https://soundcloud.com/a-himitsu
 > Creative Commons — Attribution 3.0 Unported — CC BY 3.0
+> Free Download / Stream: http://bit.ly/2Pj0MtT
 > Music released by Argofox https://www.audiolibrary.com.co/a-himitsu/adventures
 > Music promoted by Audio Library https://youtu.be/MkNeIUgNPQ8
 

--- a/assets/showcase_music/adventures-a-himitsu.flac
+++ b/assets/showcase_music/adventures-a-himitsu.flac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae77650d03375fbb70897f59798d82ce3332f0bfc732b7005c22db455947d8dc
+size 24481526

--- a/assets/showcase_music/good-for-you-thbd.flac
+++ b/assets/showcase_music/good-for-you-thbd.flac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da3dbb85e8210095215c3034ddddb6b70b3b8f3e1307e303700bfab729308aa7
+size 25392676

--- a/assets/showcase_music/we-are-one-vexento.flac
+++ b/assets/showcase_music/we-are-one-vexento.flac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28b7a1d79952e0b73c457791f79681b4862b079cae91f75d8e67f1bcdba87c4f
+size 26137540

--- a/music_catalog.schema.yml
+++ b/music_catalog.schema.yml
@@ -93,10 +93,14 @@ $defs:
             type: string
             enum: [flac, wav]
             description: >-
-              Lossless audio container. mp3 is intentionally disallowed because
-              its encoder/decoder delay causes video-alignment drift.
+              Target lossless audio container the render pipeline must supply.
+              mp3 is intentionally disallowed because its encoder/decoder delay
+              causes video-alignment drift.
           url:
-            type: string
+            type: [string, "null"]
             description: >-
-              Pointer to the lossless audio asset the renderer consumes. Hosting
-              of the actual file is handled by the render pipeline.
+              Pointer to the hosted lossless asset (matching `format`) the
+              renderer consumes, or null while the asset has not been hosted yet.
+              This is deliberately distinct from the human-facing `download_url`:
+              `download_url` is the source page (which may only offer mp3),
+              whereas this must resolve to an actual lossless file once hosted.

--- a/music_catalog.schema.yml
+++ b/music_catalog.schema.yml
@@ -1,0 +1,102 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: PotterDoc Showcase Music Catalog
+description: >-
+  Curated royalty-free music catalog for Piece Showcase (Keepsake) videos. Each
+  track has a stable identifier, the metadata the wizard and renderer need, and
+  the verbatim attribution required by its license. This document is the
+  authoritative contract; the backend loader and the frontend selector both
+  consume it. `default_track_id` MUST be a key present in `tracks` — JSON Schema
+  cannot cross-reference keys, so the loader enforces this invariant.
+type: object
+required: [version, default_track_id, tracks]
+additionalProperties: false
+
+properties:
+  version:
+    type: string
+    description: Semantic version of this catalog definition.
+    pattern: '^\d+\.\d+(\.\d+)?$'
+
+  default_track_id:
+    type: string
+    description: >-
+      Track id applied when the potter has not selected one. Must be a key in
+      `tracks`. Keeps storyboard generation deterministic.
+
+  tracks:
+    type: object
+    description: Map of stable track id to track definition.
+    minProperties: 1
+    propertyNames:
+      pattern: "^[a-z][a-z0-9-]*$"
+    additionalProperties:
+      $ref: "#/$defs/track"
+
+$defs:
+  track:
+    type: object
+    required:
+      - title
+      - artist
+      - genre
+      - mood
+      - license
+      - license_url
+      - artist_url
+      - source_url
+      - download_url
+      - attribution
+      - audio
+    additionalProperties: false
+    properties:
+      title:
+        type: string
+        description: Track title (e.g. "Adventures").
+      artist:
+        type: string
+        description: Performing artist credited for the track.
+      genre:
+        type: string
+        description: Genre label from the source listing.
+      mood:
+        type: string
+        description: Mood label from the source listing.
+      license:
+        type: string
+        description: >-
+          Short license name (e.g. "CC BY 3.0"), or a free-text term such as
+          "Free with attribution" when no formal license is published.
+      license_url:
+        type: [string, "null"]
+        description: Canonical license URL, or null when the license has no URL.
+      artist_url:
+        type: string
+        description: Primary artist link used for credit (e.g. SoundCloud).
+      source_url:
+        type: string
+        description: The Audio Library video the track was curated from.
+      download_url:
+        type: string
+        description: Free-download/stream page for the track.
+      attribution:
+        type: string
+        description: >-
+          The exact copy-and-paste attribution block required by the track's
+          license, stored verbatim. Surfaced in the wizard and intended for the
+          published video credits.
+      audio:
+        type: object
+        required: [format, url]
+        additionalProperties: false
+        properties:
+          format:
+            type: string
+            enum: [flac, wav]
+            description: >-
+              Lossless audio container. mp3 is intentionally disallowed because
+              its encoder/decoder delay causes video-alignment drift.
+          url:
+            type: string
+            description: >-
+              Pointer to the lossless audio asset the renderer consumes. Hosting
+              of the actual file is handled by the render pipeline.

--- a/music_catalog.yml
+++ b/music_catalog.yml
@@ -6,8 +6,10 @@
 # attribution text exactly as published by the source — it is a licensing
 # obligation, not editorial copy.
 #
-# `audio.url` is a pointer to a lossless asset the renderer consumes; the actual
-# files are hosted by the render pipeline, not committed here.
+# `audio.format` is the target lossless container the renderer must supply.
+# `audio.url` points to the hosted lossless asset once it exists; it is null
+# until the render pipeline hosts one. It is intentionally distinct from
+# `download_url` (the source page, which may only offer mp3).
 #
 version: "1.0"
 default_track_id: adventures-a-himitsu
@@ -30,7 +32,7 @@ tracks:
       Music promoted by Audio Library https://youtu.be/MkNeIUgNPQ8
     audio:
       format: flac
-      url: https://www.audiolibrary.com.co/a-himitsu/adventures
+      url: null
 
   good-for-you-thbd:
     title: Good For You
@@ -49,7 +51,7 @@ tracks:
       Music promoted by Audio Library https://youtu.be/-K_YSjqKgvQ
     audio:
       format: flac
-      url: https://www.audiolibrary.com.co/thbd/good-for-you
+      url: null
 
   we-are-one-vexento:
     title: We Are One
@@ -68,4 +70,4 @@ tracks:
       Music promoted by Audio Library https://youtu.be/Ssvu2yncgWU
     audio:
       format: flac
-      url: https://www.audiolibrary.com.co/vexento/we-are-one
+      url: null

--- a/music_catalog.yml
+++ b/music_catalog.yml
@@ -1,0 +1,71 @@
+#
+# Curated royalty-free music catalog for Piece Showcase (Keepsake) videos.
+# See `music_catalog.schema.yml` for the validation contract.
+#
+# Each track stores the verbatim attribution required by its license. Keep the
+# attribution text exactly as published by the source — it is a licensing
+# obligation, not editorial copy.
+#
+# `audio.url` is a pointer to a lossless asset the renderer consumes; the actual
+# files are hosted by the render pipeline, not committed here.
+#
+version: "1.0"
+default_track_id: adventures-a-himitsu
+tracks:
+  adventures-a-himitsu:
+    title: Adventures
+    artist: A Himitsu
+    genre: Dance & Electronic
+    mood: Happy
+    license: CC BY 3.0
+    license_url: https://creativecommons.org/licenses/by/3.0/
+    artist_url: https://soundcloud.com/a-himitsu
+    source_url: https://youtu.be/MkNeIUgNPQ8
+    download_url: https://www.audiolibrary.com.co/a-himitsu/adventures
+    attribution: |-
+      Adventures by A Himitsu https://soundcloud.com/a-himitsu
+      Creative Commons — Attribution 3.0 Unported — CC BY 3.0
+      Free Download / Stream: http://bit.ly/2Pj0MtT
+      Music released by Argofox https://www.audiolibrary.com.co/a-himitsu/adventures
+      Music promoted by Audio Library https://youtu.be/MkNeIUgNPQ8
+    audio:
+      format: flac
+      url: https://www.audiolibrary.com.co/a-himitsu/adventures
+
+  good-for-you-thbd:
+    title: Good For You
+    artist: THBD
+    genre: Dance & Electronic
+    mood: Happy
+    license: CC BY 3.0
+    license_url: https://creativecommons.org/licenses/by/3.0/
+    artist_url: https://soundcloud.com/thbdsultan
+    source_url: https://youtu.be/-K_YSjqKgvQ
+    download_url: https://www.audiolibrary.com.co/thbd/good-for-you
+    attribution: |-
+      Good For You by THBD https://soundcloud.com/thbdsultan
+      Creative Commons — Attribution 3.0 Unported — CC BY 3.0
+      Free Download / Stream: https://www.audiolibrary.com.co/thbd/good-for-you
+      Music promoted by Audio Library https://youtu.be/-K_YSjqKgvQ
+    audio:
+      format: flac
+      url: https://www.audiolibrary.com.co/thbd/good-for-you
+
+  we-are-one-vexento:
+    title: We Are One
+    artist: Vexento
+    genre: Dance & Electronic
+    mood: Bright
+    license: Free with attribution
+    license_url: null
+    artist_url: https://soundcloud.com/vexento
+    source_url: https://youtu.be/Ssvu2yncgWU
+    download_url: https://www.audiolibrary.com.co/vexento/we-are-one
+    attribution: |-
+      We Are One by Vexento https://soundcloud.com/vexento
+      https://www.youtube.com/user/Vexento
+      Free Download / Stream: https://www.audiolibrary.com.co/vexento/we-are-one
+      Music promoted by Audio Library https://youtu.be/Ssvu2yncgWU
+    audio:
+      format: flac
+      url: https://www.audiolibrary.com.co/vexento/we-are-one

--- a/music_catalog.yml
+++ b/music_catalog.yml
@@ -6,10 +6,11 @@
 # attribution text exactly as published by the source — it is a licensing
 # obligation, not editorial copy.
 #
-# `audio.format` is the target lossless container the renderer must supply.
-# `audio.url` points to the hosted lossless asset once it exists; it is null
-# until the render pipeline hosts one. It is intentionally distinct from
-# `download_url` (the source page, which may only offer mp3).
+# `audio.format` is the lossless container the renderer consumes. `audio.url` is
+# the committed lossless asset (a repo-relative path under assets/showcase_music/,
+# stored via git-LFS), kept intentionally distinct from `download_url` (the human
+# source page, which may only offer mp3). See assets/showcase_music/CREDITS.md for
+# how the files were produced and their attribution.
 #
 version: "1.0"
 default_track_id: adventures-a-himitsu
@@ -32,7 +33,7 @@ tracks:
       Music promoted by Audio Library https://youtu.be/MkNeIUgNPQ8
     audio:
       format: flac
-      url: null
+      url: assets/showcase_music/adventures-a-himitsu.flac
 
   good-for-you-thbd:
     title: Good For You
@@ -51,7 +52,7 @@ tracks:
       Music promoted by Audio Library https://youtu.be/-K_YSjqKgvQ
     audio:
       format: flac
-      url: null
+      url: assets/showcase_music/good-for-you-thbd.flac
 
   we-are-one-vexento:
     title: We Are One
@@ -70,4 +71,4 @@ tracks:
       Music promoted by Audio Library https://youtu.be/Ssvu2yncgWU
     audio:
       format: flac
-      url: null
+      url: assets/showcase_music/we-are-one-vexento.flac

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -231,6 +231,7 @@ js_library(
         "src/util/optionalValues.ts",
         "src/util/postLoginRedirect.ts",
         "src/util/preferences.ts",
+        "src/util/music.ts",
         "src/util/queryKeys.ts",
         "src/util/telemetry.ts",
         "src/util/workflow.ts",
@@ -247,6 +248,7 @@ js_library(
         ":node_modules/@opentelemetry/sdk-trace-web",
         ":node_modules/@opentelemetry/semantic-conventions",
         ":generated_types",
+        "//:music_catalog_js",
         "//:tutorials_js",
         "//:user_preferences_js",
         "//:workflow_js",
@@ -698,6 +700,7 @@ js_library(
     deps = [
         ":node_modules",
         ":primitive_src",
+        ":util_lib",
     ],
 )
 

--- a/web/src/components/ShowcaseVideoInputPicker.tsx
+++ b/web/src/components/ShowcaseVideoInputPicker.tsx
@@ -3,13 +3,18 @@ import {
   Box,
   Divider,
   Checkbox,
+  FormControl,
   FormControlLabel,
   FormGroup,
+  Link,
+  MenuItem,
+  Select,
   Stack,
   Typography,
 } from "@mui/material";
 import type { PieceDetail } from "../util/types";
 import { formatState } from "../util/workflow";
+import { DEFAULT_TRACK_ID, MUSIC_CATALOG, getTrack } from "../util/music";
 import SelectablePhotoMasonry, {
   type SelectablePhotoItem,
 } from "./SelectablePhotoMasonry";
@@ -17,6 +22,7 @@ import SelectablePhotoMasonry, {
 export type ShowcaseVideoInputSelection = {
   excludedImageKeys: string[];
   excludedNoteKeys: string[];
+  musicTrackId: string;
 };
 
 type ShowcaseVideoInputPickerProps = {
@@ -124,11 +130,16 @@ export default function ShowcaseVideoInputPicker({
       ? undefined
       : () =>
           onSelectionChange({
+            ...selection,
             excludedImageKeys: toggleValue(selection.excludedImageKeys, item.key),
-            excludedNoteKeys: selection.excludedNoteKeys,
           }),
     toggleLabel: item.required ? "Locked as the video cover" : "Include in the video",
   }));
+
+  const selectedTrackId = getTrack(selection.musicTrackId)
+    ? selection.musicTrackId
+    : DEFAULT_TRACK_ID;
+  const selectedTrack = getTrack(selectedTrackId);
 
   return (
     <Stack spacing={1.5}>
@@ -169,7 +180,7 @@ export default function ShowcaseVideoInputPicker({
                       checked={checked}
                       onChange={() =>
                         onSelectionChange({
-                          excludedImageKeys: selection.excludedImageKeys,
+                          ...selection,
                           excludedNoteKeys: toggleValue(
                             selection.excludedNoteKeys,
                             item.key,
@@ -223,6 +234,73 @@ export default function ShowcaseVideoInputPicker({
             disabled={disabled}
           />
         </FormGroup>
+      </Box>
+
+      <Box
+        sx={(theme) => ({
+          border: "1px solid",
+          borderColor: "divider",
+          borderRadius: 2,
+          p: 1.5,
+          backgroundColor: theme.palette.background.paper,
+        })}
+      >
+        <Typography variant="subtitle2" sx={{ mb: 0.75 }}>
+          Music
+        </Typography>
+        <Typography variant="caption" color="text.secondary" sx={{ display: "block", mb: 1 }}>
+          Pick a royalty-free background track for the Keepsake video.
+        </Typography>
+        <FormControl fullWidth size="small">
+          <Select
+            value={selectedTrackId}
+            disabled={disabled}
+            onChange={(event) =>
+              onSelectionChange({
+                ...selection,
+                musicTrackId: event.target.value,
+              })
+            }
+            inputProps={{ "aria-label": "Background music track" }}
+          >
+            {MUSIC_CATALOG.map((track) => (
+              <MenuItem key={track.id} value={track.id}>
+                {track.title} — {track.artist}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        {selectedTrack && (
+          <Box sx={{ mt: 1 }}>
+            <Typography variant="caption" color="text.secondary" sx={{ display: "block" }}>
+              {selectedTrack.license}
+              {selectedTrack.license_url && (
+                <>
+                  {" · "}
+                  <Link
+                    href={selectedTrack.license_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    License
+                  </Link>
+                </>
+              )}
+            </Typography>
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              component="pre"
+              sx={{
+                mt: 0.5,
+                whiteSpace: "pre-wrap",
+                fontFamily: "inherit",
+              }}
+            >
+              {selectedTrack.attribution}
+            </Typography>
+          </Box>
+        )}
       </Box>
 
       <Divider />

--- a/web/src/components/__tests__/ShowcaseVideoInputPicker.test.tsx
+++ b/web/src/components/__tests__/ShowcaseVideoInputPicker.test.tsx
@@ -7,6 +7,7 @@ import ShowcaseVideoInputPicker, {
   type ShowcaseVideoInputSelection,
 } from "../ShowcaseVideoInputPicker";
 import type { PieceDetail } from "../../util/types";
+import { DEFAULT_TRACK_ID, MUSIC_CATALOG } from "../../util/music";
 
 vi.mock("../../util/workflow", () => ({
   formatState: (state: string) =>
@@ -130,6 +131,7 @@ function makeSelection(
   return {
     excludedImageKeys: [],
     excludedNoteKeys: [],
+    musicTrackId: DEFAULT_TRACK_ID,
     ...overrides,
   };
 }
@@ -166,12 +168,14 @@ describe("ShowcaseVideoInputPicker", () => {
     expect(onSelectionChange).toHaveBeenCalledWith({
       excludedImageKeys: [],
       excludedNoteKeys: ["state-id-throwing"],
+      musicTrackId: DEFAULT_TRACK_ID,
     });
 
     await userEvent.click(screen.getByLabelText(/Include in the video: Throwing/));
     expect(onSelectionChange).toHaveBeenLastCalledWith({
       excludedImageKeys: ["state-id-throwing:throwing-image"],
       excludedNoteKeys: [],
+      musicTrackId: DEFAULT_TRACK_ID,
     });
   });
 
@@ -220,5 +224,48 @@ describe("ShowcaseVideoInputPicker", () => {
     fireEvent.click(thumbnailCheckbox);
     expect(onSelectionChange).not.toHaveBeenCalled();
     expect(screen.getByText("2 of 2 frames will be used")).toBeInTheDocument();
+  });
+
+  it("lists catalog tracks and shows the selected track's attribution", () => {
+    const defaultTrack = MUSIC_CATALOG.find((t) => t.id === DEFAULT_TRACK_ID)!;
+    renderWithClient(
+      <ShowcaseVideoInputPicker
+        piece={makePiece()}
+        selection={makeSelection()}
+        onSelectionChange={vi.fn()}
+      />,
+    );
+
+    const select = screen.getByLabelText("Background music track");
+    expect(select).toHaveTextContent(
+      `${defaultTrack.title} — ${defaultTrack.artist}`,
+    );
+    // The verbatim attribution block is surfaced for the selected track.
+    expect(
+      screen.getByText(defaultTrack.attribution.split("\n")[0], { exact: false }),
+    ).toBeInTheDocument();
+  });
+
+  it("emits the chosen music track id", async () => {
+    const onSelectionChange = vi.fn();
+    const other = MUSIC_CATALOG.find((t) => t.id !== DEFAULT_TRACK_ID)!;
+    renderWithClient(
+      <ShowcaseVideoInputPicker
+        piece={makePiece()}
+        selection={makeSelection()}
+        onSelectionChange={onSelectionChange}
+      />,
+    );
+
+    await userEvent.click(screen.getByLabelText("Background music track"));
+    await userEvent.click(
+      screen.getByRole("option", { name: `${other.title} — ${other.artist}` }),
+    );
+
+    expect(onSelectionChange).toHaveBeenLastCalledWith({
+      excludedImageKeys: [],
+      excludedNoteKeys: [],
+      musicTrackId: other.id,
+    });
   });
 });

--- a/web/src/stories/ShowcaseVideoInputPicker.stories.tsx
+++ b/web/src/stories/ShowcaseVideoInputPicker.stories.tsx
@@ -5,6 +5,7 @@ import ShowcaseVideoInputPicker, {
   type ShowcaseVideoInputSelection,
 } from "../components/ShowcaseVideoInputPicker";
 import type { PieceDetail } from "../util/types";
+import { DEFAULT_TRACK_ID } from "../util/music";
 
 /**
  * ShowcaseVideoInputPicker lets a potter exclude individual images and notes
@@ -177,6 +178,7 @@ export const Default: Story = {
     initialSelection: {
       excludedImageKeys: [],
       excludedNoteKeys: [],
+      musicTrackId: DEFAULT_TRACK_ID,
     },
   },
   render: (args) => <ShowcaseVideoInputPickerPreview {...args} />,
@@ -188,6 +190,7 @@ export const WithExclusions: Story = {
     initialSelection: {
       excludedImageKeys: ["s1:img-wheel"],
       excludedNoteKeys: ["s1"],
+      musicTrackId: DEFAULT_TRACK_ID,
     },
   },
   render: (args) => <ShowcaseVideoInputPickerPreview {...args} />,
@@ -206,6 +209,7 @@ export const LockedThumbnail: Story = {
     initialSelection: {
       excludedImageKeys: ["s3:img-current"],
       excludedNoteKeys: [],
+      musicTrackId: DEFAULT_TRACK_ID,
     },
   },
   render: (args) => <ShowcaseVideoInputPickerPreview {...args} />,
@@ -225,6 +229,7 @@ export const EmptyHistory: Story = {
     initialSelection: {
       excludedImageKeys: [],
       excludedNoteKeys: [],
+      musicTrackId: DEFAULT_TRACK_ID,
     },
   },
   render: (args) => <ShowcaseVideoInputPickerPreview {...args} />,

--- a/web/src/util/music.ts
+++ b/web/src/util/music.ts
@@ -10,8 +10,10 @@
 import catalog from "../../../music_catalog.yml";
 
 export interface MusicTrackAudio {
+  /** Target lossless container the render pipeline must supply. */
   format: "flac" | "wav";
-  url: string;
+  /** Hosted lossless asset URL, or null until one has been hosted. */
+  url: string | null;
 }
 
 export interface MusicTrack {

--- a/web/src/util/music.ts
+++ b/web/src/util/music.ts
@@ -1,0 +1,54 @@
+/**
+ * Web interface to the music_catalog.yml configuration.
+ *
+ * The showcase video wizard lets the potter pick a royalty-free track for a
+ * Keepsake video. The catalog is static data defined in `music_catalog.yml` at
+ * the repo root and shared with the backend (`api/showcase/music.py`). This
+ * module is the single frontend source of track metadata — derive the track
+ * list and default from the exports here rather than duplicating them.
+ */
+import catalog from "../../../music_catalog.yml";
+
+export interface MusicTrackAudio {
+  format: "flac" | "wav";
+  url: string;
+}
+
+export interface MusicTrack {
+  id: string;
+  title: string;
+  artist: string;
+  genre: string;
+  mood: string;
+  license: string;
+  license_url: string | null;
+  artist_url: string;
+  source_url: string;
+  download_url: string;
+  attribution: string;
+  audio: MusicTrackAudio;
+}
+
+interface RawCatalog {
+  version: string;
+  default_track_id: string;
+  tracks: Record<string, Omit<MusicTrack, "id">>;
+}
+
+const rawCatalog = catalog as unknown as RawCatalog;
+
+/** All catalog tracks in declaration order. */
+export const MUSIC_CATALOG: MusicTrack[] = Object.entries(rawCatalog.tracks).map(
+  ([id, track]) => ({ id, ...track }),
+);
+
+/** Track applied when the potter has not chosen one (deterministic default). */
+export const DEFAULT_TRACK_ID: string = rawCatalog.default_track_id;
+
+const byId = new Map(MUSIC_CATALOG.map((track) => [track.id, track]));
+
+/** Return the track for `id`, or undefined if it is not in the catalog. */
+export function getTrack(id: string | null | undefined): MusicTrack | undefined {
+  if (!id) return undefined;
+  return byId.get(id);
+}


### PR DESCRIPTION
Closes #746. Part of milestone [Piece Showcase Video](https://github.com/shaoster/glaze/milestone/6).

## What

Adds a curated royalty-free music catalog for Keepsake showcase videos. PR #749 left a \`music_track_id\` passthrough in the storyboard noting *"the catalog is defined elsewhere"* — this is that catalog. Implemented as data shared by backend and frontend, following the existing \`workflow.yml\` / \`tutorials.yml\` pattern (root-level YAML + JSON Schema, Python loader + Vite import).

## Tracks (user-specified; attribution stored verbatim as required by each license)

| id | Title — Artist | License |
|---|---|---|
| \`adventures-a-himitsu\` | Adventures — A Himitsu | CC BY 3.0 |
| \`good-for-you-thbd\` | Good For You — THBD | CC BY 3.0 |
| \`we-are-one-vexento\` | We Are One — Vexento | Free with attribution |

## Changes

- **\`music_catalog.yml\` + \`music_catalog.schema.yml\`** — stable ids, metadata, verbatim attribution, and \`audio: { format, url }\`. \`format\` is constrained to **lossless** (\`flac\`/\`wav\`) — mp3 is disallowed because its codec delay causes video-alignment drift. \`audio.url\` is the hosted lossless asset path (distinct from \`download_url\`, the human source page which may only serve mp3).
- **\`assets/showcase_music/\` (git-LFS, ~72 MB)** — three delay-free, sample-accurate FLAC files for alignment. The only freely obtainable source is lossy (YouTube Opus); these are stored as FLAC not to restore fidelity but to eliminate variable encoder delay. Each was decoded to PCM, had its leading silence trimmed, and re-encoded as 16-bit/44.1 kHz FLAC with metadata stripped. Includes \`CREDITS.md\` with required CC-BY attribution blocks and the exact reproduction recipe.
- **\`api/showcase/music.py\`** — schema-validated loader, \`MusicTrack\` dataclass, \`get_catalog\` / \`get_track\` / \`resolve_track_id\` (deterministic default; intentionally strict — rejects unknown ids so invalid input surfaces at the API boundary, not here). Exported via \`api/showcase/__init__\`.
- **\`build_keepsake_storyboard\`** resolves \`music_track_id\` through the default so the selected track is always present in the hashed storyboard dict (#747 hash layer consumes it).
- **\`web/src/util/music.ts\` + \`ShowcaseVideoInputPicker\`** — typed catalog access and a Music selector showing the chosen track's attribution + license link; \`ShowcaseVideoInputSelection\` gains \`musicTrackId\` defaulting to the catalog default.
- **Bazel** — \`music_catalog_files\` filegroup + \`music_catalog_js\` js_library, wired into api/web libs, tests, and \`app_src_tar\`.

## Acceptance criteria

- [x] Royalty-free catalog with stable track ids
- [x] Wizard displays and selects a track
- [x] Deterministic default applied when none selected
- [x] Selected track included in the generation input hash (via storyboard dict)
- [x] Render pipeline receives the selected audio asset (\`audio.url\` → \`assets/showcase_music/<id>.flac\` via LFS)
- [x] Tests: catalog serialization, default/selected behavior, hash changes when the track changes

## Audio assets — important notes

- **Not lossless masters.** The source is YouTube Opus (lossy). FLAC here buys *alignment determinism*, not restored fidelity. True lossless masters would require the files from the artists (e.g. Bandcamp/Argofox).
- **\`audio.url\` vs \`download_url\`** are intentionally different fields: \`download_url\` is the human-facing source page; \`audio.url\` must resolve to an actual lossless file (currently a relative repo path for the renderer to resolve).
- **\`resolve_track_id\` is intentionally strict** — it raises on an unknown non-null id rather than silently defaulting. Validate potter-supplied selection at the serializer/API boundary.

## Testing

\`bazel test //...\` — 61 tests pass (incl. mypy). \`bazel build --config=lint //api/... //web/...\` clean. New: \`api/tests/test_music_catalog.py\`; extended \`test_keepsake_storyboard.py\` and \`ShowcaseVideoInputPicker.test.tsx\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)