### PR TITLE
feat: create-piece tutorial as sequential SmallTutorialInlay steps

### DIFF
--- a/tutorials.schema.yml
+++ b/tutorials.schema.yml
@@ -24,6 +24,12 @@ $defs:
     required: [preference, inlay, attachment]
     additionalProperties: false
     properties:
+      depends_on:
+        type: array
+        items:
+          type: string
+          pattern: "^[a-z][a-z0-9_]*$"
+        description: Tutorial IDs that must be dismissed before this tutorial is shown.
       preference:
         type: object
         required: [label, hint]
@@ -65,7 +71,7 @@ $defs:
             properties:
               type:
                 type: string
-                enum: [open-preferences]
+                enum: [open-preferences, dismiss-only]
               section:
                 type: string
                 description: The preference section ID to open when the tutorial is clicked.

--- a/tutorials.yml
+++ b/tutorials.yml
@@ -31,3 +31,72 @@ tutorials:
       action:
         type: "open-preferences"
         section: "identity"
+
+  create_piece_step_1:
+    preference:
+      label: "Show step 1: create your first piece"
+      hint: "Points to the New Piece button on the piece list."
+    inlay:
+      label: "Start here — create your first piece."
+      dismiss_label: "Dismiss create-piece step 1"
+    attachment:
+      selector: '[data-testid="new-piece-button"]'
+      placement: "right"
+      action:
+        type: "dismiss-only"
+
+  create_piece_step_2:
+    depends_on: [create_piece_step_1]
+    preference:
+      label: "Show step 2: name your piece"
+      hint: "Points to the name field in the New Piece dialog."
+    inlay:
+      label: "Give your piece a name."
+      dismiss_label: "Dismiss create-piece step 2"
+    attachment:
+      selector: '[data-testid="name-input"]'
+      placement: "right"
+      action:
+        type: "dismiss-only"
+
+  create_piece_step_3:
+    depends_on: [create_piece_step_2]
+    preference:
+      label: "Show step 3: advance to your first making step"
+      hint: "Points to the state transition controls on the piece detail page."
+    inlay:
+      label: "Advance to your first making step — wheel thrown or handbuilt."
+      dismiss_label: "Dismiss create-piece step 3"
+    attachment:
+      selector: '[data-testid="state-transition-group"]'
+      placement: "top"
+      action:
+        type: "dismiss-only"
+
+  create_piece_step_4:
+    depends_on: [create_piece_step_3]
+    preference:
+      label: "Show step 4: fill in the details"
+      hint: "Points to the Clay Body field on the piece detail page."
+    inlay:
+      label: "Fill in the details as you work."
+      dismiss_label: "Dismiss create-piece step 4"
+    attachment:
+      selector: '[data-testid="global-entry-field-clay_body"]'
+      placement: "right"
+      action:
+        type: "dismiss-only"
+
+  create_piece_step_5:
+    depends_on: [create_piece_step_4]
+    preference:
+      label: "Show step 5: completion tip"
+      hint: "Completion message shown on the piece detail page."
+    inlay:
+      label: "You're tracking your first piece!"
+      dismiss_label: "Dismiss create-piece step 5"
+    attachment:
+      selector: '[data-testid="piece-title"]'
+      placement: "top"
+      action:
+        type: "dismiss-only"

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -649,6 +649,15 @@ js_library(
 )
 
 js_library(
+    name = "tutorial_manager_src",
+    srcs = ["src/components/TutorialManager.tsx"],
+    deps = [
+        ":piece_detail_src",
+        ":process_summary_src",
+    ],
+)
+
+js_library(
     name = "public_piece_shell_src",
     srcs = ["src/components/PublicPieceShell.tsx"],
     deps = [
@@ -1075,6 +1084,14 @@ vitest_test(
 )
 
 vitest_test(
+    name = "web_tutorial_manager_test",
+    srcs = ["src/components/__tests__/TutorialManager.test.tsx"],
+    tags = ["ibazel_notify_changes"],
+    deps = [":tutorial_manager_src"],
+    expected_coverage = ["web/src/components/TutorialManager*"],
+)
+
+vitest_test(
     name = "web_public_piece_shell_test",
     srcs = [
         "src/components/__tests__/PublicPieceShell.test.tsx",
@@ -1409,6 +1426,7 @@ test_suite(
         ":web_generate_types_test",
         ":web_telemetry_test",
         ":web_workflow_state_test",
+        ":web_tutorial_manager_test",
         ":web_workflow_summary_test",
         ":workflow_test",
     ],

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -899,6 +899,7 @@ const PieceList = (props: PieceListProps) => {
               <Box
                 component="button"
                 type="button"
+                data-testid="new-piece-button"
                 onClick={onNewPiece}
                 sx={{
                   display: "inline-flex",

--- a/web/src/components/PieceNameEditor.tsx
+++ b/web/src/components/PieceNameEditor.tsx
@@ -130,6 +130,7 @@ export default function PieceNameEditor({
           <Typography
             variant="h3"
             component="h2"
+            data-testid="piece-title"
             sx={{
               fontSize: { xs: "2rem", sm: "2.6rem", md: "2rem" },
               lineHeight: 1.05,

--- a/web/src/components/StateTransition.tsx
+++ b/web/src/components/StateTransition.tsx
@@ -170,7 +170,7 @@ export default function StateTransition({
 
   return (
     <>
-      <Box aria-label="State flow" role="group" sx={{ mb: 0.75 }}>
+      <Box aria-label="State flow" role="group" data-testid="state-transition-group" sx={{ mb: 0.75 }}>
         <Box sx={{ minWidth: 0, flex: 1 }}>
           <Box
             sx={{

--- a/web/src/components/TutorialManager.tsx
+++ b/web/src/components/TutorialManager.tsx
@@ -9,6 +9,7 @@ import SmallTutorialInlay from "./SmallTutorialInlay";
 import { type SmallTutorialInlayPlacement } from "./SmallTutorialInlayConfig";
 
 export interface TutorialDefinition {
+  depends_on?: string[];
   preference: {
     label: string;
     hint?: string;
@@ -72,7 +73,10 @@ export default function TutorialManager() {
       {Object.entries(config.tutorials).map(([key, tutorial]) => {
         const element = elements[key];
         const isDismissed = currentUser.preferences[key] === false;
-        if (!element || isDismissed) return null;
+        const dependenciesNotMet = (tutorial.depends_on ?? []).some(
+          (dep) => currentUser.preferences[dep] !== false,
+        );
+        if (!element || isDismissed || dependenciesNotMet) return null;
 
         const handleAction = () => {
           if (

--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -257,30 +257,31 @@ export default function WorkflowState({
             }
             if (field.isGlobalRef && field.globalName) {
               return (
-                <GlobalEntryField
-                  key={field.name}
-                  globalName={field.globalName}
-                  label={label}
-                  value={value}
-                  onSelect={(entry) => {
-                    if (readOnly) return;
-                    handleFieldChange(field.name, entryNameOrEmpty(entry));
-                    dispatch({
-                      type: "set_global_ref_pks",
-                      globalRefPks: entry
-                        ? { ...globalRefPks, [field.name]: entry.id }
-                        : Object.fromEntries(
-                            Object.entries(globalRefPks).filter(
-                              ([key]) => key !== field.name,
+                <Box key={field.name} data-testid={`global-entry-field-${field.globalName}`}>
+                  <GlobalEntryField
+                    globalName={field.globalName}
+                    label={label}
+                    value={value}
+                    onSelect={(entry) => {
+                      if (readOnly) return;
+                      handleFieldChange(field.name, entryNameOrEmpty(entry));
+                      dispatch({
+                        type: "set_global_ref_pks",
+                        globalRefPks: entry
+                          ? { ...globalRefPks, [field.name]: entry.id }
+                          : Object.fromEntries(
+                              Object.entries(globalRefPks).filter(
+                                ([key]) => key !== field.name,
+                              ),
                             ),
-                          ),
-                    });
-                  }}
-                  canCreate={Boolean(field.canCreate)}
-                  disabled={readOnly}
-                  helperText={helperText}
-                  required={field.required}
-                />
+                      });
+                    }}
+                    canCreate={Boolean(field.canCreate)}
+                    disabled={readOnly}
+                    helperText={helperText}
+                    required={field.required}
+                  />
+                </Box>
               );
             }
             if (field.enum?.length) {

--- a/web/src/components/__tests__/TutorialManager.test.tsx
+++ b/web/src/components/__tests__/TutorialManager.test.tsx
@@ -1,0 +1,160 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+import TutorialManager from "../TutorialManager";
+import type { UserPreferences } from "../../util/api";
+
+// Mock tutorials.yml with two fake tutorials for dependency tests
+vi.mock("../../../../tutorials.yml", () => ({
+  default: {
+    version: "1.0",
+    tutorials: {
+      tutorial_a: {
+        preference: {
+          label: "Show tutorial A",
+          hint: "Tutorial A hint",
+        },
+        inlay: {
+          label: "Tutorial A label",
+          dismiss_label: "Dismiss tutorial A",
+        },
+        attachment: {
+          selector: '[data-testid="anchor-a"]',
+          placement: "right",
+          action: { type: "dismiss-only" },
+        },
+      },
+      tutorial_b: {
+        depends_on: ["tutorial_a"],
+        preference: {
+          label: "Show tutorial B",
+          hint: "Tutorial B hint",
+        },
+        inlay: {
+          label: "Tutorial B label",
+          dismiss_label: "Dismiss tutorial B",
+        },
+        attachment: {
+          selector: '[data-testid="anchor-b"]',
+          placement: "right",
+          action: { type: "dismiss-only" },
+        },
+      },
+    },
+  },
+}));
+
+const mockContext = vi.hoisted(() => ({
+  currentUser: null as {
+    id: number;
+    is_staff: boolean;
+    openid_subject: string;
+    alias: string;
+    preferences: UserPreferences;
+  } | null,
+}));
+
+vi.mock("../CurrentUserContext", () => ({
+  useCurrentUser: () => mockContext.currentUser,
+  useOpenPreferencesDialog: () => null,
+  useSaveUserPreferences: () => async (prefs: UserPreferences) => prefs,
+}));
+
+function makeCurrentUser(overrides: Partial<UserPreferences> = {}) {
+  return {
+    id: 1,
+    is_staff: false,
+    openid_subject: "",
+    alias: "potter",
+    preferences: {
+      process_summary_fields: [],
+      ...overrides,
+    } as UserPreferences,
+  };
+}
+
+function renderHarness(children: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
+  );
+}
+
+describe("TutorialManager depends_on sequencing", () => {
+  it("renders a tutorial with no depends_on when its anchor is present", async () => {
+    // Set up DOM anchors
+    const anchorA = document.createElement("div");
+    anchorA.setAttribute("data-testid", "anchor-a");
+    document.body.appendChild(anchorA);
+
+    const anchorB = document.createElement("div");
+    anchorB.setAttribute("data-testid", "anchor-b");
+    document.body.appendChild(anchorB);
+
+    mockContext.currentUser = makeCurrentUser();
+
+    renderHarness(<TutorialManager />);
+
+    // tutorial_a has no depends_on — it should render
+    await waitFor(() => {
+      expect(screen.queryByText("Tutorial A label")).toBeInTheDocument();
+    });
+
+    anchorA.remove();
+    anchorB.remove();
+  });
+
+  it("suppresses a tutorial whose depends_on prerequisite has not been dismissed", async () => {
+    // Set up DOM anchors
+    const anchorA = document.createElement("div");
+    anchorA.setAttribute("data-testid", "anchor-a");
+    document.body.appendChild(anchorA);
+
+    const anchorB = document.createElement("div");
+    anchorB.setAttribute("data-testid", "anchor-b");
+    document.body.appendChild(anchorB);
+
+    // tutorial_a preference is still true (not yet dismissed)
+    mockContext.currentUser = makeCurrentUser({ tutorial_a: true });
+
+    renderHarness(<TutorialManager />);
+
+    // tutorial_b depends on tutorial_a which is not dismissed → should not render
+    await waitFor(() => {
+      expect(screen.queryByText("Tutorial B label")).not.toBeInTheDocument();
+    });
+
+    anchorA.remove();
+    anchorB.remove();
+  });
+
+  it("renders a tutorial once its depends_on prerequisite has been dismissed", async () => {
+    // Set up DOM anchors
+    const anchorA = document.createElement("div");
+    anchorA.setAttribute("data-testid", "anchor-a");
+    document.body.appendChild(anchorA);
+
+    const anchorB = document.createElement("div");
+    anchorB.setAttribute("data-testid", "anchor-b");
+    document.body.appendChild(anchorB);
+
+    // tutorial_a preference is false (dismissed) — tutorial_b's dep is satisfied
+    mockContext.currentUser = makeCurrentUser({
+      tutorial_a: false,
+    });
+
+    renderHarness(<TutorialManager />);
+
+    // tutorial_b depends on tutorial_a which IS dismissed → should render
+    await waitFor(() => {
+      expect(screen.queryByText("Tutorial B label")).toBeInTheDocument();
+    });
+
+    anchorA.remove();
+    anchorB.remove();
+  });
+});

--- a/web/src/components/__tests__/UserPreferencesDialog.test.tsx
+++ b/web/src/components/__tests__/UserPreferencesDialog.test.tsx
@@ -179,11 +179,11 @@ describe("UserPreferencesDialog", () => {
 
     await waitFor(() => {
       expect(saveUserPreferences).toHaveBeenCalledWith(
-        {
+        expect.objectContaining({
           process_summary_fields: ["piece.name"],
           summary_customize_popover: false,
           change_alias_prompt: true,
-        },
+        }),
         "",
       );
       expect(onClose).toHaveBeenCalled();
@@ -234,11 +234,11 @@ describe("UserPreferencesDialog", () => {
 
     await waitFor(() => {
       expect(saveUserPreferences).toHaveBeenCalledWith(
-        {
+        expect.objectContaining({
           process_summary_fields: ["piece.name"],
           summary_customize_popover: true,
           change_alias_prompt: false,
-        },
+        }),
         "",
       );
       expect(onClose).toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- Adds a `depends_on` field to the tutorial infrastructure so steps only appear after their prerequisite is dismissed — prevents multiple inlays showing simultaneously.
- Defines the 5-step create-piece onboarding tutorial in `tutorials.yml` with the original copy from #458, each step attaching to a stable DOM element.
- Adds `data-testid` anchors to four components (`PieceList`, `StateTransition`, `WorkflowState` per global field, `PieceNameEditor`) so the CSS selectors resolve correctly.
- No backend changes needed — `preferences.py` dynamic serializer auto-picks up the 5 new keys from `tutorials.yml`.

## Test plan

- [ ] `//web:web_tutorial_manager_test` — new, 3 tests covering: no-dep renders, unsatisfied dep suppresses, satisfied dep shows
- [ ] `//web:web_workflow_summary_test` — existing SmallTutorialInlay tests pass (regression)
- [ ] `//web:tsc_typecheck` — passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Closes #752
