### PR TITLE
fix: delete accounts with protected image refs

### DIFF
--- a/api/auth/account_views.py
+++ b/api/auth/account_views.py
@@ -6,23 +6,35 @@ behavior remains observable as a stable contract.
 
 from django.contrib.auth import logout
 from django.db import transaction
+from django.db.models import Q
+from django.http import HttpResponse
 from rest_framework import status
 from rest_framework.request import Request
-from rest_framework.response import Response
 
 from backend.otel import traced
 
+from ..models import CropRun, PieceStateImage
+
 
 @traced
-def delete_account_impl(request: Request, *, logout_fn=logout) -> Response:
+def delete_account_impl(request: Request, *, logout_fn=logout) -> HttpResponse:
     """Delete the current user after invalidating their session."""
     user = getattr(request, "user", None)
     if user is None or not getattr(user, "is_authenticated", False):
-        return Response(status=status.HTTP_403_FORBIDDEN)
+        return HttpResponse(status=status.HTTP_403_FORBIDDEN)
     assert user is not None
     # Invalidate the session before deleting the user to avoid dangling session
     # references to a now-deleted User row.
     logout_fn(request)
     with transaction.atomic():
+        # Remove protected image-adjacent rows first so the subsequent user
+        # deletion can cascade through pieces and images without hitting a
+        # database-level ProtectedError.
+        CropRun.objects.filter(
+            Q(image__user=user) | Q(piece_state_image__piece_state__piece__user=user)
+        ).delete()
+        PieceStateImage.objects.filter(
+            Q(image__user=user) | Q(piece_state__piece__user=user)
+        ).delete()
         user.delete()
-    return Response(status=status.HTTP_204_NO_CONTENT)
+    return HttpResponse(status=status.HTTP_204_NO_CONTENT)

--- a/api/auth/views.py
+++ b/api/auth/views.py
@@ -6,6 +6,7 @@ while the actual implementations live in focused feature submodules.
 
 from django.conf import settings
 from django.contrib.auth import logout
+from django.http import HttpResponse
 from django.views.decorators.csrf import ensure_csrf_cookie
 from drf_spectacular.utils import extend_schema, inline_serializer
 from rest_framework import serializers as drf_serializers
@@ -18,7 +19,7 @@ from rest_framework.response import Response
 from backend.otel import traced
 
 from ..serializers import AuthUserSerializer
-from .account_views import delete_account_impl as auth_delete_account
+from .account_views import delete_account_impl
 from .export_views import auth_export
 from .google_views import auth_google
 from .invite_views import (
@@ -71,6 +72,19 @@ def auth_logout(request: Request) -> Response:
     """Log the current user out of the active session."""
     logout(request)
     return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+@extend_schema(
+    request=None,
+    responses={204: None},
+    description="Delete the current user account and all owned content.",
+)
+@api_view(["DELETE"])
+@permission_classes([IsAuthenticated])
+@traced
+def auth_delete_account(request: Request) -> HttpResponse:
+    """Delete the current user account after cleaning up protected refs."""
+    return delete_account_impl(request, logout_fn=logout)
 
 
 @extend_schema(

--- a/api/tests/test_auth.py
+++ b/api/tests/test_auth.py
@@ -13,7 +13,16 @@ from django.test import Client
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory, force_authenticate
 
-from api.models import Image, InviteCode, Piece, UserProfile
+from api.models import (
+    ENTRY_STATE,
+    CropRun,
+    Image,
+    InviteCode,
+    Piece,
+    PieceState,
+    PieceStateImage,
+    UserProfile,
+)
 
 FAKE_SUB = "google-subject-12345"
 FAKE_HASHED_SUB = hashlib.sha256(FAKE_SUB.encode()).hexdigest()
@@ -765,6 +774,71 @@ class TestAuthDeleteAccount:
 
         assert response.status_code == 204
         assert not User.objects.filter(id=user_id).exists()
+
+    def test_delete_account_removes_user_with_protected_image_refs(self, user):
+        from rest_framework.test import APIClient
+
+        piece = Piece.objects.create(user=user, name="Protected Bowl")
+        state = PieceState.objects.create(piece=piece, state=ENTRY_STATE, order=0)
+        image = Image.objects.create(
+            user=user,
+            url="https://example.com/protected.jpg",
+        )
+        piece_state_image = PieceStateImage.objects.create(
+            piece_state=state,
+            image=image,
+            order=0,
+        )
+        CropRun.objects.create(
+            image=image,
+            piece_state_image=piece_state_image,
+            source={
+                "type": "automated",
+                "backend": "test",
+                "deployment": "local",
+                "version": "1",
+            },
+            status=CropRun.Status.SUCCESS,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        response = client.delete("/api/auth/account/")
+
+        assert response.status_code == 204
+        assert not User.objects.filter(id=user.id).exists()
+        assert not Piece.objects.filter(id=piece.id).exists()
+        assert not Image.objects.filter(id=image.id).exists()
+        assert not PieceStateImage.objects.filter(id=piece_state_image.id).exists()
+        assert not CropRun.objects.filter(image=image).exists()
+
+    def test_delete_account_removes_piece_state_images_for_owned_images(
+        self, user, other_user
+    ):
+        from rest_framework.test import APIClient
+
+        piece = Piece.objects.create(user=other_user, name="Other Bowl")
+        state = PieceState.objects.create(piece=piece, state=ENTRY_STATE, order=0)
+        image = Image.objects.create(
+            user=user,
+            url="https://example.com/shared.jpg",
+        )
+        piece_state_image = PieceStateImage.objects.create(
+            piece_state=state,
+            image=image,
+            order=0,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        response = client.delete("/api/auth/account/")
+
+        assert response.status_code == 204
+        assert not User.objects.filter(id=user.id).exists()
+        assert not Image.objects.filter(id=image.id).exists()
+        assert not PieceStateImage.objects.filter(id=piece_state_image.id).exists()
 
     def test_delete_account_invalidates_session_before_deletion(self, user):
         from api.auth.account_views import delete_account_impl


### PR DESCRIPTION
## Problem
`DELETE /api/auth/account/` returned a 500 for users who owned pieces and image-linked records. The failure surfaced as `ProtectedError` from `user.delete()` and blocked account deletion entirely. See [issue #753](https://github.com/shaoster/glaze/issues/753).

## Fix
- Clean up protected `CropRun` rows before deleting the current user, so the user delete can cascade through pieces and images without hitting `ProtectedError`.
- Clean up `PieceStateImage` rows that reference either the user’s pieces or the user’s images, so account deletion also works when images are referenced from another owner’s piece state.
- Expose `/api/auth/account/` as a real DELETE DRF endpoint that delegates to the shared helper, preserving the expected authenticated API contract.

## Regression Test
- Added `TestAuthDeleteAccount.test_delete_account_removes_user_with_protected_image_refs` in `api/tests/test_auth.py`.
- Added `TestAuthDeleteAccount.test_delete_account_removes_piece_state_images_for_owned_images` in `api/tests/test_auth.py`.
- The tests create the protected reference shapes that previously blocked deletion and assert the DELETE endpoint returns 204 and removes the owned rows.

## Verification
- `rtk bazel test //api:api_auth_test --test_output=errors`
- `rtk bazel test //api:api_test --test_output=errors`
- `rtk bazel build --config=lint //api/...`
- `source env-agent.sh && gz_format`

Closes #753
