### PR TITLE
fix: surface desktop New Piece action

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -67,7 +67,11 @@ vi.mock("./components/NewPieceDialog", () => ({
 vi.mock("./components/PieceList", () => ({
   default: ({ onNewPiece }: { onNewPiece?: () => void }) => (
     <div>
-      {onNewPiece && <button onClick={onNewPiece}>New Piece</button>}
+      {onNewPiece && (
+        <button data-testid="new-piece-button" onClick={onNewPiece}>
+          New Piece
+        </button>
+      )}
       <div>Piece List Content</div>
     </div>
   ),
@@ -613,6 +617,28 @@ describe("App auth flow", () => {
       expect(screen.getByText("Active Section: identity")).toBeInTheDocument();
       expect(window.location.pathname).toBe("/preferences/identity");
     });
+  });
+
+  it("shows the create-piece tutorial inlay on the desktop New Piece button", async () => {
+    vi.mocked(fetchAppInit).mockResolvedValue({
+      googleOauthClientId: "test-client-id",
+      adminBaseUrl: null,
+      user: MOCK_USER,
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /new piece/i }),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole("button", {
+        name: "Start here — create your first piece.",
+      }),
+    ).toBeInTheDocument();
   });
 
   it("opens the identity preferences route directly", async () => {

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -685,6 +685,36 @@ const PieceList = (props: PieceListProps) => {
           </Box>
         </Box>
 
+        {!isMobile && onNewPiece && (
+          <Box
+            component="button"
+            type="button"
+            data-testid="new-piece-button"
+            onClick={onNewPiece}
+            sx={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 0.5,
+              mt: 1,
+              px: 1.5,
+              py: 0.75,
+              alignSelf: "flex-start",
+              borderRadius: 1.5,
+              bgcolor: "primary.main",
+              color: "primary.contrastText",
+              border: "none",
+              fontSize: "0.8125rem",
+              fontWeight: 600,
+              fontFamily: "inherit",
+              cursor: "pointer",
+              "&:hover": { filter: "brightness(1.1)" },
+            }}
+          >
+            <AddIcon sx={{ fontSize: 16 }} />
+            New Piece
+          </Box>
+        )}
+
         {/* Absolutely positioned so the panel overlays the masonry without
             pushing it down or triggering a page scroll. */}
         {filterOpen && (
@@ -895,34 +925,6 @@ const PieceList = (props: PieceListProps) => {
             )}
 
             {/* New Piece button (desktop only) */}
-            {!isMobile && onNewPiece && (
-              <Box
-                component="button"
-                type="button"
-                data-testid="new-piece-button"
-                onClick={onNewPiece}
-                sx={{
-                  display: "inline-flex",
-                  alignItems: "center",
-                  gap: 0.5,
-                  px: 1.5,
-                  py: 0.75,
-                  alignSelf: "flex-start",
-                  borderRadius: 1.5,
-                  bgcolor: "primary.main",
-                  color: "primary.contrastText",
-                  border: "none",
-                  fontSize: "0.8125rem",
-                  fontWeight: 600,
-                  fontFamily: "inherit",
-                  cursor: "pointer",
-                  "&:hover": { filter: "brightness(1.1)" },
-                }}
-              >
-                <AddIcon sx={{ fontSize: 16 }} />
-                New Piece
-              </Box>
-            )}
           </Box>
         )}
       </Box>

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -176,9 +176,17 @@ function makePiece(overrides: Partial<PieceSummary> = {}): PieceSummary {
   };
 }
 
-function renderPieceList(pieces: PieceSummary[]) {
+function renderPieceList(
+  pieces: PieceSummary[],
+  onNewPiece?: () => void,
+) {
   const router = createMemoryRouter(
-    [{ path: "/", element: <PieceList pieces={pieces} /> }],
+    [
+      {
+        path: "/",
+        element: <PieceList pieces={pieces} onNewPiece={onNewPiece} />,
+      },
+    ],
     { initialEntries: ["/"] },
   );
   return render(<RouterProvider router={router} />);
@@ -220,6 +228,13 @@ describe("PieceList", () => {
   });
 
   describe("MasonryScroller container-width guard", () => {
+    it("shows the desktop New Piece button before filters are expanded", () => {
+      renderPieceList([makePiece()], vi.fn());
+      expect(
+        screen.getByRole("button", { name: /new piece/i }),
+      ).toBeInTheDocument();
+    });
+
     it("does not render the masonry grid when container width is zero", () => {
       // Root cause of the prod-only initial-overlap bug: useContainerPosition
       // returns width=0 on the first React commit. If MasonryScroller renders


### PR DESCRIPTION
## Problem
Fixes [#751](https://github.com/shaoster/glaze/issues/751). On desktop, the New Piece action was hidden inside the collapsed filter/sort strip and only became visible after expanding filters.

## Fix
Moved the desktop New Piece button out of the collapsed panel and into the always-visible sticky strip so it is present by default. Mobile still uses the floating action button.

## Regression Test
- `web/src/components/__tests__/PieceList.test.tsx` adds `shows the desktop New Piece button before filters are expanded`, which renders `PieceList` with `onNewPiece` and asserts the button is visible before any filter interaction.
- `web/src/App.test.tsx` adds `shows the create-piece tutorial inlay on the desktop New Piece button`, which confirms the onboarding inlay still attaches to the button's `data-testid` in the app shell.

## Verification
- `rtk bazel test //web:web_piece_list_test --test_output=all` ✅
- `rtk bazel test //web:web_test --test_output=summary` ✅
- `rtk bazel build --config=lint //web/...` ✅
- `rtk bazel test //web:web_app_test --test_output=all` ✅

Closes #751
