### PR TITLE
Tighten small tutorial inlay padding

### DIFF
--- a/web/src/components/SmallTutorialInlay.tsx
+++ b/web/src/components/SmallTutorialInlay.tsx
@@ -142,9 +142,10 @@ export default function SmallTutorialInlay({
           position: "relative",
           display: "inline-flex",
           alignItems: "center",
-          gap: 0.75,
-          py: 0.8,
-          px: 1.25,
+          gap: 0.5,
+          py: 0.5,
+          pl: 1,
+          pr: 0.875,
           borderRadius: 2,
           borderColor: "primary.light",
           bgcolor: "rgba(201, 122, 77, 0.24)",
@@ -192,7 +193,10 @@ export default function SmallTutorialInlay({
             boxShadow: "0 0 10px rgba(201, 122, 77, 0.55)",
           }}
         />
-        <Typography variant="caption" sx={{ color: "text.secondary" }}>
+        <Typography
+          variant="caption"
+          sx={{ color: "text.secondary", lineHeight: 1.15 }}
+        >
           {label}
         </Typography>
         <IconButton
@@ -203,7 +207,7 @@ export default function SmallTutorialInlay({
             dismissMutate();
           }}
           disabled={openPending || dismissPending}
-          sx={{ ml: "auto" }}
+          sx={{ p: 0.375 }}
         >
           <CloseIcon fontSize="small" />
         </IconButton>

--- a/web/src/components/__tests__/SmallTutorialInlay.test.tsx
+++ b/web/src/components/__tests__/SmallTutorialInlay.test.tsx
@@ -125,9 +125,16 @@ describe("SmallTutorialInlay", () => {
       name: "Customize this summary!",
     });
     const popper = button.closest("[data-popper-placement]");
+    const dismissButton = screen.getByRole("button", {
+      name: "Dismiss summary customization tip",
+    });
 
     expect(popper).toHaveAttribute("data-popper-placement", placement);
     expect(window.getComputedStyle(popper ?? button).zIndex).toBe("auto");
+    expect(window.getComputedStyle(button).paddingTop).toBe("4px");
+    expect(window.getComputedStyle(button).paddingBottom).toBe("4px");
+    expect(window.getComputedStyle(button).paddingRight).toBe("7px");
+    expect(window.getComputedStyle(dismissButton).paddingTop).toBe("3px");
 
     anchor.remove();
   });


### PR DESCRIPTION
## Summary
Tighten the shared small tutorial inlay so the alias tip reads less bulky near the user chip.

## Changes
- Reduce the inlay's overall padding and gap.
- Trim the close button's padding so the `X` no longer has so much empty space around it.
- Tighten the label line height so the text doesn't add extra vertical bulk.
- Add a regression assertion covering the compact padding values.

## Testing
- `rtk bazel test //web:web_test --test_output=errors`
- `gz_format`

Closes #757
Issue: [#757](https://github.com/shaoster/glaze/issues/757)
