### PR TITLE
[codex] Fix PieceList header and worktree startup

### DIFF
--- a/tools/gz_start_launcher.py
+++ b/tools/gz_start_launcher.py
@@ -235,6 +235,21 @@ def web_executable_path(roots: Roots) -> Path:
     return bazel_binary_path(roots, "web/dev_server_/dev_server")
 
 
+def ensure_local_web_node_modules(roots: Roots) -> None:
+    if roots.workspace == roots.shared:
+        return
+
+    worktree_nm = roots.workspace / "web" / "node_modules"
+    if worktree_nm.is_symlink():
+        worktree_nm.unlink()
+
+    if worktree_nm.exists():
+        return
+
+    print("web: installing local node_modules via npm install...")
+    subprocess.run(["npm", "install"], cwd=str(roots.workspace / "web"), check=True)
+
+
 def backend_ready_payload(port: int) -> dict[str, object]:
     url = f"http://127.0.0.1:{port}/api/health/ready/"
     try:
@@ -529,21 +544,10 @@ def start_web(
     if sys.platform.startswith("linux"):
         web_env.setdefault("BAZEL_BINDIR", ".")
 
-    # The js_binary wrapper does `cd web` relative to roots.workspace before starting
-    # Vite. Vite writes a temp .mjs file there to load vite.config.ts, and Node
-    # resolves imports (including 'vite' itself) from that directory. In a worktree
-    # web/node_modules doesn't exist, so we symlink it from the shared checkout so
-    # Node can find packages without a full reinstall.
-    if roots.workspace != roots.shared:
-        worktree_nm = roots.workspace / "web" / "node_modules"
-        shared_nm = roots.shared / "web" / "node_modules"
-        if (
-            not worktree_nm.exists()
-            and not worktree_nm.is_symlink()
-            and shared_nm.exists()
-        ):
-            worktree_nm.symlink_to(shared_nm)
-            print(f"web: symlinked node_modules from {shared_nm}")
+    # Worktrees must keep their own npm install so Vite/Babel resolve package
+    # paths against the active checkout rather than borrowing another worktree's
+    # node_modules tree through a symlink.
+    ensure_local_web_node_modules(roots)
 
     print(f"web: starting on :{web_port} ...")
     web_binary = web_executable_path(roots)

--- a/tools/tests/test_gz_start_launcher.py
+++ b/tools/tests/test_gz_start_launcher.py
@@ -294,3 +294,34 @@ def test_start_web_sets_bazel_bindir_only_on_linux(monkeypatch, tmp_path: Path) 
     assert "BAZEL_BINDIR" not in captured_env_mac, (
         "BAZEL_BINDIR should not be set on macOS as it is not required by aspect_rules_js."
     )
+
+
+def test_ensure_local_web_node_modules_replaces_shared_symlink(
+    monkeypatch, tmp_path: Path
+) -> None:
+    shared = tmp_path / "shared"
+    workspace = tmp_path / "worktree"
+    shared_web = shared / "web"
+    local_web = workspace / "web"
+    shared_nm = shared_web / "node_modules"
+    local_nm = local_web / "node_modules"
+
+    shared_nm.mkdir(parents=True)
+    local_web.mkdir(parents=True)
+    local_nm.symlink_to(shared_nm)
+
+    roots = launcher.Roots(workspace=workspace, shared=shared)
+    install_calls: list[tuple[list[str], str]] = []
+
+    def fake_run(args, cwd, check):
+        install_calls.append((args, cwd))
+        (workspace / "web" / "node_modules").mkdir(exist_ok=True)
+        return object()
+
+    monkeypatch.setattr(launcher.subprocess, "run", fake_run)
+
+    launcher.ensure_local_web_node_modules(roots)
+
+    assert not local_nm.is_symlink()
+    assert local_nm.exists()
+    assert install_calls == [(["npm", "install"], str(local_web))]

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -602,118 +602,120 @@ const PieceList = (props: PieceListProps) => {
           borderColor: "divider",
         }}
       >
-        <Box
-          component="button"
-          type="button"
-          onClick={() => setFilterOpen((o) => !o)}
-          aria-expanded={filterOpen}
-          aria-label="Toggle filters"
-          sx={{
-            width: "100%",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            gap: 1,
-            px: 1.5,
-            py: 1,
-            borderRadius: 2,
-            bgcolor: alpha("#181210", 0.95),
-            border: "1px solid",
-            borderColor: "divider",
-            color: "text.secondary",
-            fontFamily: "inherit",
-            cursor: "pointer",
-            textAlign: "left",
-          }}
-        >
-          <Box
-            sx={{
-              display: "flex",
-              alignItems: "center",
-              gap: 1,
-              overflow: "hidden",
-            }}
-          >
-            <FilterListIcon
-              sx={{ fontSize: 15, flexShrink: 0, color: "text.disabled" }}
-            />
-            <Typography
-              component="span"
-              sx={{
-                fontSize: "0.8125rem",
-                fontWeight: hasActiveFilters ? 600 : 400,
-                color: hasActiveFilters ? "text.primary" : "text.secondary",
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-              }}
-            >
-              {activeFilterLabel}
-            </Typography>
-            <Typography
-              component="span"
-              sx={{
-                fontSize: "0.6875rem",
-                color: "text.disabled",
-                fontFamily: "'JetBrains Mono', 'Fira Mono', monospace",
-                flexShrink: 0,
-              }}
-            >
-              · {filteredPieces.length}
-              {hasMore ? "+" : ""} pieces
-            </Typography>
-          </Box>
-          <Box
-            sx={{
-              display: "flex",
-              alignItems: "center",
-              gap: 0.5,
-              flexShrink: 0,
-            }}
-          >
-            <SortIcon sx={{ fontSize: 13, color: "text.disabled" }} />
-            <Typography
-              component="span"
-              sx={{
-                fontSize: "0.6875rem",
-                color: "text.disabled",
-                fontFamily: "'JetBrains Mono', 'Fira Mono', monospace",
-              }}
-            >
-              {sortLabel}
-            </Typography>
-          </Box>
-        </Box>
-
-        {!isMobile && onNewPiece && (
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
           <Box
             component="button"
             type="button"
-            data-testid="new-piece-button"
-            onClick={onNewPiece}
+            onClick={() => setFilterOpen((o) => !o)}
+            aria-expanded={filterOpen}
+            aria-label="Toggle filters"
             sx={{
-              display: "inline-flex",
+              flex: "1 1 auto",
+              minWidth: 0,
+              display: "flex",
               alignItems: "center",
-              gap: 0.5,
-              mt: 1,
+              justifyContent: "space-between",
+              gap: 1,
               px: 1.5,
-              py: 0.75,
-              alignSelf: "flex-start",
-              borderRadius: 1.5,
-              bgcolor: "primary.main",
-              color: "primary.contrastText",
-              border: "none",
-              fontSize: "0.8125rem",
-              fontWeight: 600,
+              py: 1,
+              borderRadius: 2,
+              bgcolor: alpha("#181210", 0.95),
+              border: "1px solid",
+              borderColor: "divider",
+              color: "text.secondary",
               fontFamily: "inherit",
               cursor: "pointer",
-              "&:hover": { filter: "brightness(1.1)" },
+              textAlign: "left",
             }}
           >
-            <AddIcon sx={{ fontSize: 16 }} />
-            New Piece
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1,
+                overflow: "hidden",
+              }}
+            >
+              <FilterListIcon
+                sx={{ fontSize: 15, flexShrink: 0, color: "text.disabled" }}
+              />
+              <Typography
+                component="span"
+                sx={{
+                  fontSize: "0.8125rem",
+                  fontWeight: hasActiveFilters ? 600 : 400,
+                  color: hasActiveFilters ? "text.primary" : "text.secondary",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {activeFilterLabel}
+              </Typography>
+              <Typography
+                component="span"
+                sx={{
+                  fontSize: "0.6875rem",
+                  color: "text.disabled",
+                  fontFamily: "'JetBrains Mono', 'Fira Mono', monospace",
+                  flexShrink: 0,
+                }}
+              >
+                · {filteredPieces.length}
+                {hasMore ? "+" : ""} pieces
+              </Typography>
+            </Box>
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 0.5,
+                flexShrink: 0,
+              }}
+            >
+              <SortIcon sx={{ fontSize: 13, color: "text.disabled" }} />
+              <Typography
+                component="span"
+                sx={{
+                  fontSize: "0.6875rem",
+                  color: "text.disabled",
+                  fontFamily: "'JetBrains Mono', 'Fira Mono', monospace",
+                }}
+              >
+                {sortLabel}
+              </Typography>
+            </Box>
           </Box>
-        )}
+
+          {!isMobile && onNewPiece && (
+            <Box
+              component="button"
+              type="button"
+              data-testid="new-piece-button"
+              onClick={onNewPiece}
+              sx={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 0.5,
+                px: 1.5,
+                py: 0.75,
+                flexShrink: 0,
+                borderRadius: 1.5,
+                bgcolor: "primary.main",
+                color: "primary.contrastText",
+                border: "none",
+                fontSize: "0.8125rem",
+                fontWeight: 600,
+                fontFamily: "inherit",
+                cursor: "pointer",
+                "&:hover": { filter: "brightness(1.1)" },
+              }}
+            >
+              <AddIcon sx={{ fontSize: 16 }} />
+              New Piece
+            </Box>
+          )}
+        </Box>
 
         {/* Absolutely positioned so the panel overlays the masonry without
             pushing it down or triggering a page scroll. */}
@@ -923,8 +925,6 @@ const PieceList = (props: PieceListProps) => {
                 </Select>
               </Box>
             )}
-
-            {/* New Piece button (desktop only) */}
           </Box>
         )}
       </Box>


### PR DESCRIPTION
Closes #762

Summary:
- Moves the desktop PieceList New Piece action onto the same row as the filter toggle so the sticky header stays compact.
- Replaces the shared `web/node_modules` symlink path in `gz_start` worktrees with a local install check so Vite/Babel resolve against the active checkout.
- Adds a regression test for the launcher behavior that replaces a symlinked `node_modules` tree.

Validation:
- `rtk bazel test //tools:test_gz_start_launcher --test_output=errors`
- `rtk bazel test //web:web_piece_list_test --test_output=errors`
- `rtk bazel test //web:web_test --test_output=errors`
- `rtk bazel test //...`
- `rtk bazel build --config=lint //...`
