### PR TITLE
[codex] showcase video pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 1
+          lfs: true
 
       - id: fingerprint
         name: Compute CI fingerprint
@@ -130,6 +131,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          lfs: true
       - uses: ./.github/actions/setup-bazel-ci
         with:
           cache-key-prefix: lint
@@ -152,6 +154,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          lfs: true
       - uses: ./.github/actions/setup-bazel-ci
         with:
           cache-key-prefix: coverage
@@ -180,6 +183,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          lfs: true
       - uses: ./.github/actions/setup-bazel-ci
         with:
           cache-key-prefix: dev-smoke
@@ -264,6 +268,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          lfs: true
 
       - name: Configure test environment
         run: |
@@ -337,6 +343,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
+          lfs: true
           # Pin to the exact SHA on main so the image build uses the same
           # commit that lint/coverage validated. Omit on PRs — the default
           # merge-commit ref is fine there and avoids replication-race failures.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,44 +279,12 @@ jobs:
 
       - name: Generate self-signed SSL certificates for Nginx
         run: |
-          retry() {
-            local attempts="$1"
-            shift
-            local delay=5
-            local attempt=1
-            until "$@"; do
-              if [ "$attempt" -ge "$attempts" ]; then
-                return 1
-              fi
-              echo "::warning::Compose command failed on attempt $attempt/$attempts; retrying in ${delay}s..."
-              sleep "$delay"
-              attempt=$((attempt + 1))
-              delay=$((delay * 2))
-            done
-          }
-
-          retry 3 docker compose -f infra/custom/docker-compose.yml -f infra/custom/docker-compose.smoke.yml run --rm --entrypoint "/bin/sh -c" certbot \
+          docker compose -f infra/custom/docker-compose.yml -f infra/custom/docker-compose.smoke.yml run --rm --entrypoint "/bin/sh -c" certbot \
             "mkdir -p /etc/letsencrypt/live/glaze.local && openssl req -x509 -nodes -newkey rsa:2048 -days 1 -keyout /etc/letsencrypt/live/glaze.local/privkey.pem -out /etc/letsencrypt/live/glaze.local/fullchain.pem -subj '/CN=glaze.local'"
 
       - name: Start Docker Compose stack and wait for health
         run: |
-          retry() {
-            local attempts="$1"
-            shift
-            local delay=5
-            local attempt=1
-            until "$@"; do
-              if [ "$attempt" -ge "$attempts" ]; then
-                return 1
-              fi
-              echo "::warning::Compose command failed on attempt $attempt/$attempts; retrying in ${delay}s..."
-              sleep "$delay"
-              attempt=$((attempt + 1))
-              delay=$((delay * 2))
-            done
-          }
-
-          retry 3 docker compose -f infra/custom/docker-compose.yml -f infra/custom/docker-compose.smoke.yml up --build -d --wait nginx certbot
+          docker compose -f infra/custom/docker-compose.yml -f infra/custom/docker-compose.smoke.yml up --build -d --wait nginx certbot
 
       - name: Verify application readiness and data seeding
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,12 +279,44 @@ jobs:
 
       - name: Generate self-signed SSL certificates for Nginx
         run: |
-          docker compose -f infra/custom/docker-compose.yml -f infra/custom/docker-compose.smoke.yml run --rm --entrypoint "/bin/sh -c" certbot \
+          retry() {
+            local attempts="$1"
+            shift
+            local delay=5
+            local attempt=1
+            until "$@"; do
+              if [ "$attempt" -ge "$attempts" ]; then
+                return 1
+              fi
+              echo "::warning::Compose command failed on attempt $attempt/$attempts; retrying in ${delay}s..."
+              sleep "$delay"
+              attempt=$((attempt + 1))
+              delay=$((delay * 2))
+            done
+          }
+
+          retry 3 docker compose -f infra/custom/docker-compose.yml -f infra/custom/docker-compose.smoke.yml run --rm --entrypoint "/bin/sh -c" certbot \
             "mkdir -p /etc/letsencrypt/live/glaze.local && openssl req -x509 -nodes -newkey rsa:2048 -days 1 -keyout /etc/letsencrypt/live/glaze.local/privkey.pem -out /etc/letsencrypt/live/glaze.local/fullchain.pem -subj '/CN=glaze.local'"
 
       - name: Start Docker Compose stack and wait for health
         run: |
-          docker compose -f infra/custom/docker-compose.yml -f infra/custom/docker-compose.smoke.yml up --build -d --wait nginx certbot
+          retry() {
+            local attempts="$1"
+            shift
+            local delay=5
+            local attempt=1
+            until "$@"; do
+              if [ "$attempt" -ge "$attempts" ]; then
+                return 1
+              fi
+              echo "::warning::Compose command failed on attempt $attempt/$attempts; retrying in ${delay}s..."
+              sleep "$delay"
+              attempt=$((attempt + 1))
+              delay=$((delay * 2))
+            done
+          }
+
+          retry 3 docker compose -f infra/custom/docker-compose.yml -f infra/custom/docker-compose.smoke.yml up --build -d --wait nginx certbot
 
       - name: Verify application readiness and data seeding
         shell: bash

--- a/api/BUILD.bazel
+++ b/api/BUILD.bazel
@@ -38,6 +38,7 @@ py_library(
         "piece/views.py",
         "piece/helpers.py",
         "piece/image_views.py",
+        "piece/showcase_views.py",
         "cloudinary/__init__.py",
         "cloudinary/views.py",
         "cloudinary/admin_views.py",
@@ -58,6 +59,7 @@ py_library(
         "serializers.py",
         "showcase/__init__.py",
         "showcase/music.py",
+        "showcase/render.py",
         "showcase/storyboard.py",
         "tasks.py",
         "task_views.py",
@@ -73,6 +75,10 @@ py_library(
     deps = [
         ":api_workflow_lib",
         "//backend:backend_lib",
+        "@pypi//cloudinary",
+        "@pypi//av",
+        "@pypi//numpy",
+        "@pypi//pillow_heif",
     ],
 )
 
@@ -335,6 +341,7 @@ pytest_test(
         "tests/test_analysis.py",
         "tests/test_keepsake_storyboard.py",
         "tests/test_music_catalog.py",
+        "tests/test_showcase_video.py",
         "tests/test_patch_current_state.py",
         "tests/test_piece_detail.py",
         "tests/test_piece_showcase_validation.py",
@@ -358,6 +365,7 @@ pytest_test(
         "api/tests/test_analysis.py",
         "api/tests/test_keepsake_storyboard.py",
         "api/tests/test_music_catalog.py",
+        "api/tests/test_showcase_video.py",
         "api/tests/test_piece_showcase_validation.py",
         "api/tests/test_piece_state_admin_relational.py",
         "api/tests/test_editable_mode.py",
@@ -371,9 +379,12 @@ pytest_test(
     deps = [":api_schema_lib", ":api_admin_lib"] + _PYTEST_DEPS,
     expected_coverage = [
         "api/piece/views.py",
+        "api/piece/showcase_views.py",
         "api/analysis_views.py",
         "api/workflow_views.py",
         "api/showcase/storyboard.py",
+        "api/showcase/render.py",
+        "api/tasks.py",
     ],
 )
 

--- a/api/piece/showcase_views.py
+++ b/api/piece/showcase_views.py
@@ -219,6 +219,9 @@ def piece_showcase_video(request: Request, piece_id: str) -> Response:
                 storyboard = cast(dict[str, Any], storyboard_candidate)
             else:
                 storyboard = _requested_storyboard(piece, task_input)
+            # `storyboard` is the snapshot that was submitted with the task
+            # (what was rendered).  `current_input_hash` reflects the piece as
+            # it stands today.  Comparing them is how stale detection works.
             current_storyboard = _requested_storyboard(piece, task_input)
             current_input_hash = compute_storyboard_hash(current_storyboard)
         payload = _status_payload(

--- a/api/piece/showcase_views.py
+++ b/api/piece/showcase_views.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from typing import Any, cast
+
+from django.contrib.auth.models import User
 from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers as drf_serializers
@@ -210,9 +213,11 @@ def piece_showcase_video(request: Request, piece_id: str) -> Response:
             storyboard = _requested_storyboard(piece, None)
             current_input_hash = compute_storyboard_hash(storyboard)
         else:
-            task_input = task.input_params if isinstance(task.input_params, dict) else {}
-            storyboard = task_input.get("storyboard")
-            if not isinstance(storyboard, dict):
+            task_input = cast(dict[str, Any], task.input_params or {})
+            storyboard_candidate = task_input.get("storyboard")
+            if isinstance(storyboard_candidate, dict):
+                storyboard = cast(dict[str, Any], storyboard_candidate)
+            else:
                 storyboard = _requested_storyboard(piece, task_input)
             current_storyboard = _requested_storyboard(piece, task_input)
             current_input_hash = compute_storyboard_hash(current_storyboard)
@@ -263,7 +268,7 @@ def piece_showcase_video(request: Request, piece_id: str) -> Response:
     storyboard = storyboard_obj.to_dict()
     input_hash = compute_storyboard_hash(storyboard)
     task = AsyncTask.objects.create(
-        user=request.user,
+        user=cast(User, request.user),
         task_type=SHOWCASE_VIDEO_TASK_TYPE,
         input_params={
             "piece_id": str(piece.id),

--- a/api/piece/showcase_views.py
+++ b/api/piece/showcase_views.py
@@ -1,0 +1,287 @@
+"""Piece-scoped Showcase video API endpoints."""
+
+from __future__ import annotations
+
+from django.shortcuts import get_object_or_404
+from drf_spectacular.utils import extend_schema
+from rest_framework import serializers as drf_serializers
+from rest_framework import status
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from backend.otel import traced
+
+from ..models import AsyncTask, Piece
+from ..showcase import (
+    build_keepsake_storyboard,
+    compute_storyboard_hash,
+    is_showcase_video_cloudinary_enabled,
+    SHOWCASE_VIDEO_RENDER_VERSION,
+)
+from ..showcase.render import SHOWCASE_VIDEO_TASK_TYPE
+from ..tasks import get_task_interface
+from ..workflow import TERMINAL_STATES
+from .helpers import piece_queryset
+
+
+class ShowcaseVideoRequestSerializer(drf_serializers.Serializer):
+    excluded_image_keys = drf_serializers.ListField(
+        child=drf_serializers.CharField(),
+        required=False,
+        default=list,
+    )
+    excluded_note_keys = drf_serializers.ListField(
+        child=drf_serializers.CharField(),
+        required=False,
+        default=list,
+    )
+    music_track_id = drf_serializers.CharField(
+        required=False, allow_blank=True, allow_null=True, default=None
+    )
+
+
+class ShowcaseVideoArtifactSerializer(drf_serializers.Serializer):
+    url = drf_serializers.CharField()
+    download_url = drf_serializers.CharField()
+    filename = drf_serializers.CharField()
+    content_type = drf_serializers.CharField()
+
+
+class ShowcaseVideoStatusSerializer(drf_serializers.Serializer):
+    piece_id = drf_serializers.UUIDField()
+    task_id = drf_serializers.UUIDField(allow_null=True, required=False)
+    status = drf_serializers.CharField()
+    task_status = drf_serializers.CharField(allow_null=True, required=False)
+    enabled = drf_serializers.BooleanField()
+    disabled_reason = drf_serializers.CharField(allow_null=True, required=False)
+    eligible = drf_serializers.BooleanField()
+    current_input_hash = drf_serializers.CharField(allow_null=True, required=False)
+    stored_input_hash = drf_serializers.CharField(allow_null=True, required=False)
+    is_stale = drf_serializers.BooleanField()
+    stale_reason = drf_serializers.CharField(allow_null=True, required=False)
+    music_track_id = drf_serializers.CharField(allow_null=True, required=False)
+    storyboard = drf_serializers.JSONField(allow_null=True, required=False)
+    artifact = ShowcaseVideoArtifactSerializer(allow_null=True, required=False)
+    error = drf_serializers.CharField(allow_null=True, required=False)
+
+
+def _piece_with_showcase_prefetch(request: Request, piece_id: str) -> Piece:
+    return get_object_or_404(
+        piece_queryset(request).prefetch_related("states__image_links__image"),
+        pk=piece_id,
+    )
+
+
+def _requested_storyboard(piece: Piece, request_data: dict | None) -> dict:
+    payload = request_data or {}
+    excluded_image_keys = payload.get("excluded_image_keys") or []
+    excluded_note_keys = payload.get("excluded_note_keys") or []
+    music_track_id = payload.get("music_track_id")
+    storyboard = build_keepsake_storyboard(
+        piece,
+        excluded_image_keys=excluded_image_keys,
+        excluded_note_keys=excluded_note_keys,
+        music_track_id=music_track_id,
+    )
+    return storyboard.to_dict()
+
+
+def _latest_showcase_task(piece: Piece) -> AsyncTask | None:
+    return (
+        AsyncTask.objects.filter(
+            user=piece.user,
+            task_type=SHOWCASE_VIDEO_TASK_TYPE,
+            input_params__piece_id=str(piece.id),
+        )
+        .order_by("-created")
+        .first()
+    )
+
+
+def _video_disabled_reason() -> str | None:
+    if is_showcase_video_cloudinary_enabled():
+        return None
+    return "Cloudinary showcase video uploads are not configured."
+
+
+def _status_payload(
+    *,
+    piece: Piece,
+    task: AsyncTask | None,
+    storyboard: dict,
+    current_input_hash: str,
+    request: Request,
+) -> dict:
+    enabled = is_showcase_video_cloudinary_enabled()
+    disabled_reason = _video_disabled_reason()
+    task_data = task.input_params if task is not None else {}
+    stored_input_hash = None
+    if isinstance(task_data, dict):
+        stored_input_hash = task_data.get("input_hash")
+
+    artifact = None
+    task_status = None
+    error = None
+    status_label = "idle"
+    task_id = None
+    is_stale = False
+    stale_reason = None
+
+    if task is not None:
+        task_id = task.id
+        task_status = task.status
+        error = task.error
+        if task.status == AsyncTask.Status.PENDING:
+            status_label = "pending"
+        elif task.status == AsyncTask.Status.RUNNING:
+            status_label = "running"
+        elif task.status == AsyncTask.Status.FAILURE:
+            status_label = "failed"
+        else:
+            status_label = "succeeded"
+
+        if task.status == AsyncTask.Status.SUCCESS and stored_input_hash:
+            is_stale = stored_input_hash != current_input_hash
+            if is_stale:
+                status_label = "stale-needs-regeneration"
+                stale_reason = (
+                    "The piece has changed since this video was rendered."
+                )
+
+        if task.status == AsyncTask.Status.SUCCESS:
+            result = task.result if isinstance(task.result, dict) else {}
+            artifact = {
+                "url": result.get("artifact_url"),
+                "download_url": result.get("download_url"),
+                "filename": result.get("artifact_filename")
+                or f"{current_input_hash}.mp4",
+                "content_type": result.get("content_type") or "video/mp4",
+            }
+    elif not enabled:
+        status_label = "disabled"
+
+    return {
+        "piece_id": piece.id,
+        "task_id": task_id,
+        "status": status_label,
+        "task_status": task_status,
+        "enabled": enabled,
+        "disabled_reason": disabled_reason,
+        "eligible": storyboard.get("eligible", False),
+        "current_input_hash": current_input_hash,
+        "stored_input_hash": stored_input_hash,
+        "is_stale": is_stale,
+        "stale_reason": stale_reason,
+        "music_track_id": storyboard.get("music_track_id"),
+        "storyboard": storyboard,
+        "artifact": artifact,
+        "error": error,
+    }
+
+
+@extend_schema(
+    methods=["GET"],
+    responses={200: ShowcaseVideoStatusSerializer},
+    description=(
+        "Return the most recent showcase video task for the piece, including "
+        "stale-input detection and artifact metadata."
+    ),
+)
+@extend_schema(
+    methods=["POST"],
+    request=ShowcaseVideoRequestSerializer,
+    responses={202: ShowcaseVideoStatusSerializer},
+    description=(
+        "Submit a Keepsake showcase video render. The request is enqueued on "
+        "the AsyncTask framework so the browser never blocks on rendering."
+    ),
+)
+@api_view(["GET", "POST"])
+@permission_classes([IsAuthenticated])
+@traced
+def piece_showcase_video(request: Request, piece_id: str) -> Response:
+    piece = _piece_with_showcase_prefetch(request, piece_id)
+
+    if request.method == "GET":
+        task = _latest_showcase_task(piece)
+        if task is None:
+            storyboard = _requested_storyboard(piece, None)
+            current_input_hash = compute_storyboard_hash(storyboard)
+        else:
+            task_input = task.input_params if isinstance(task.input_params, dict) else {}
+            storyboard = task_input.get("storyboard")
+            if not isinstance(storyboard, dict):
+                storyboard = _requested_storyboard(piece, task_input)
+            current_storyboard = _requested_storyboard(piece, task_input)
+            current_input_hash = compute_storyboard_hash(current_storyboard)
+        payload = _status_payload(
+            piece=piece,
+            task=task,
+            storyboard=storyboard,
+            current_input_hash=current_input_hash,
+            request=request,
+        )
+        return Response(payload)
+
+    serializer = ShowcaseVideoRequestSerializer(data=request.data)
+    serializer.is_valid(raise_exception=True)
+
+    if not is_showcase_video_cloudinary_enabled():
+        return Response(
+            {
+                "detail": (
+                    "Cloudinary showcase video uploads are not configured."
+                )
+            },
+            status=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    if piece.current_state is None:
+        return Response(
+            {"detail": "Piece has no states."}, status=status.HTTP_400_BAD_REQUEST
+        )
+    if piece.current_state.state not in TERMINAL_STATES:
+        return Response(
+            {"detail": "Piece must be in a terminal state to generate a video."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    storyboard_obj = build_keepsake_storyboard(
+        piece,
+        excluded_image_keys=serializer.validated_data["excluded_image_keys"],
+        excluded_note_keys=serializer.validated_data["excluded_note_keys"],
+        music_track_id=serializer.validated_data["music_track_id"],
+    )
+    if not storyboard_obj.eligible:
+        return Response(
+            {"detail": storyboard_obj.ineligible_reason or "Piece is ineligible."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    storyboard = storyboard_obj.to_dict()
+    input_hash = compute_storyboard_hash(storyboard)
+    task = AsyncTask.objects.create(
+        user=request.user,
+        task_type=SHOWCASE_VIDEO_TASK_TYPE,
+        input_params={
+            "piece_id": str(piece.id),
+            "excluded_image_keys": serializer.validated_data["excluded_image_keys"],
+            "excluded_note_keys": serializer.validated_data["excluded_note_keys"],
+            "music_track_id": serializer.validated_data["music_track_id"],
+            "input_hash": input_hash,
+            "storyboard": storyboard,
+            "render_version": SHOWCASE_VIDEO_RENDER_VERSION,
+        },
+    )
+    get_task_interface().submit(task)
+
+    payload = _status_payload(
+        piece=piece,
+        task=task,
+        storyboard=storyboard,
+        current_input_hash=input_hash,
+        request=request,
+    )
+    return Response(payload, status=status.HTTP_202_ACCEPTED)

--- a/api/showcase/__init__.py
+++ b/api/showcase/__init__.py
@@ -27,6 +27,17 @@ from .storyboard import (
     build_keepsake_storyboard,
     validate_storyboard,
 )
+from .render import (
+    SHOWCASE_VIDEO_CANVAS_SIZE,
+    SHOWCASE_VIDEO_FORMAT,
+    SHOWCASE_VIDEO_FPS,
+    SHOWCASE_VIDEO_RENDER_VERSION,
+    SHOWCASE_VIDEO_TASK_TYPE,
+    compute_storyboard_hash,
+    is_showcase_video_cloudinary_enabled,
+    render_storyboard_to_mp4,
+    upload_storyboard_video_to_cloudinary,
+)
 
 __all__ = [
     "COVER_SLIDE_MS",
@@ -38,13 +49,22 @@ __all__ = [
     "MusicAudio",
     "MusicTrack",
     "NOTE_SLIDE_MS",
+    "SHOWCASE_VIDEO_CANVAS_SIZE",
+    "SHOWCASE_VIDEO_FORMAT",
+    "SHOWCASE_VIDEO_FPS",
+    "SHOWCASE_VIDEO_RENDER_VERSION",
+    "SHOWCASE_VIDEO_TASK_TYPE",
     "STORYBOARD_SCHEMA",
     "STORYBOARD_VERSION",
     "Storyboard",
     "StoryboardSlide",
     "build_keepsake_storyboard",
+    "compute_storyboard_hash",
+    "is_showcase_video_cloudinary_enabled",
     "get_catalog",
     "get_track",
     "resolve_track_id",
+    "render_storyboard_to_mp4",
+    "upload_storyboard_video_to_cloudinary",
     "validate_storyboard",
 ]

--- a/api/showcase/render.py
+++ b/api/showcase/render.py
@@ -18,13 +18,13 @@ import tempfile
 import textwrap
 import unicodedata
 from fractions import Fraction
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
 import av
 import numpy as np
 import requests
-from functools import lru_cache
 from av.audio.resampler import AudioResampler
 from PIL import Image as PILImage
 from PIL import ImageDraw, ImageFont, ImageOps
@@ -678,7 +678,7 @@ def render_storyboard_to_mp4(storyboard: dict) -> Path:
     transition_seconds = min(
         SHOWCASE_VIDEO_FADE_SECONDS,
         *(duration / 2 for duration in durations),
-    ) if len(durations) > 1 else 0.0
+    )
     fade_seconds = min(SHOWCASE_VIDEO_FADE_SECONDS, durations[-1] / 2)
 
     slide_canvases = _render_slide_canvases(storyboard)
@@ -699,6 +699,9 @@ def render_storyboard_to_mp4(storyboard: dict) -> Path:
             fade_seconds,
         )
 
+        # AAC encoders emit a few priming frames with negative DTS before the
+        # first real sample, which breaks muxing.  Compute the shift needed to
+        # bring the earliest timestamp to zero, then apply it to all packets.
         audio_offset = 0
         for packet in audio_packets:
             timestamp = packet.dts if packet.dts is not None else packet.pts

--- a/api/showcase/render.py
+++ b/api/showcase/render.py
@@ -1,0 +1,789 @@
+"""Deterministic Showcase video rendering helpers.
+
+This module turns a render-ready storyboard snapshot into a playable MP4 file.
+The render pipeline is intentionally boring: it uses a fixed canvas size, fixed
+frame rate, and fixed slide durations so the same storyboard always yields the
+same output bytes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import math
+import os
+import re
+import tempfile
+import textwrap
+import unicodedata
+from fractions import Fraction
+from pathlib import Path
+from typing import Any
+
+import av
+import numpy as np
+import requests
+from functools import lru_cache
+from av.audio.resampler import AudioResampler
+from PIL import Image as PILImage
+from PIL import ImageDraw, ImageFont, ImageOps
+from pillow_heif import register_heif_opener
+
+from .music import get_track
+from .storyboard import validate_storyboard
+
+SHOWCASE_VIDEO_TASK_TYPE = "generate_showcase_video"
+SHOWCASE_VIDEO_RENDER_VERSION = "4"
+SHOWCASE_VIDEO_FORMAT = "mp4"
+SHOWCASE_VIDEO_CANVAS_SIZE = (1280, 720)
+SHOWCASE_VIDEO_FPS = 24
+SHOWCASE_VIDEO_FADE_SECONDS = 0.75
+SHOWCASE_VIDEO_CLOSING_SECONDS = 3.0
+_BRAND_LOCKUP_SCALE = 4
+_BRAND_ICON_VIEWBOX = 128
+_BRAND_ICON_FILL = "#C66A3D"
+_BRAND_ICON_STROKE = "#8A3F1D"
+_BRAND_ICON_WHEEL_FILL = "#E6C3A0"
+
+_BACKGROUND = (0, 0, 0)
+_ACCENT = (122, 79, 58)
+_INK = (54, 38, 28)
+_MUTED = (108, 90, 78)
+_WHITE = (255, 250, 246)
+_FONT_PATH = Path("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf")
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+register_heif_opener()
+
+
+def _canonical_json(data: Any) -> str:
+    return json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+@lru_cache(maxsize=None)
+def _load_font(size: int) -> ImageFont.ImageFont:
+    if _FONT_PATH.exists():
+        return ImageFont.truetype(str(_FONT_PATH), size=size)
+    return ImageFont.load_default()
+
+
+def compute_storyboard_hash(storyboard: dict) -> str:
+    """Return a stable content hash for a storyboard snapshot."""
+    payload = {
+        "render_version": SHOWCASE_VIDEO_RENDER_VERSION,
+        "storyboard": storyboard,
+    }
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def _load_image(image_dict: dict | None) -> PILImage.Image | None:
+    if not image_dict:
+        return None
+    url = str(image_dict.get("url") or "").strip()
+    if not url:
+        return None
+
+    try:
+        if url.startswith(("http://", "https://")):
+            response = requests.get(url, timeout=15)
+            response.raise_for_status()
+            raw = response.content
+        else:
+            raw = Path(url).read_bytes()
+        image = PILImage.open(io.BytesIO(raw))
+        image.load()
+        return ImageOps.exif_transpose(image).convert("RGB")
+    except Exception:
+        return None
+
+
+def _fit_image(
+    image: PILImage.Image,
+    *,
+    crop: dict | None = None,
+    preserve_aspect: bool = False,
+) -> PILImage.Image:
+    width, height = SHOWCASE_VIDEO_CANVAS_SIZE
+    if crop:
+        try:
+            crop_x = float(crop.get("x", 0.0))
+            crop_y = float(crop.get("y", 0.0))
+            crop_w = float(crop.get("width", 1.0))
+            crop_h = float(crop.get("height", 1.0))
+        except (TypeError, ValueError, AttributeError):
+            crop_x = crop_y = 0.0
+            crop_w = crop_h = 1.0
+        left = max(0, min(image.width - 1, round(image.width * crop_x)))
+        top = max(0, min(image.height - 1, round(image.height * crop_y)))
+        right = max(left + 1, min(image.width, round(image.width * (crop_x + crop_w))))
+        bottom = max(top + 1, min(image.height, round(image.height * (crop_y + crop_h))))
+        image = image.crop((left, top, right, bottom))
+    if preserve_aspect:
+        canvas = PILImage.new("RGB", (width, height), _BACKGROUND)
+        contained = ImageOps.contain(
+            image,
+            (width, height),
+            method=PILImage.Resampling.LANCZOS,
+        )
+        left = (width - contained.width) // 2
+        top = (height - contained.height) // 2
+        canvas.paste(contained, (left, top))
+        return canvas
+    return ImageOps.fit(
+        image,
+        (width, height),
+        method=PILImage.Resampling.LANCZOS,
+        centering=(0.5, 0.5),
+    )
+
+
+def _wrap_text(text: str, *, width: int) -> list[str]:
+    if not text:
+        return []
+    lines: list[str] = []
+    for paragraph in text.splitlines():
+        if not paragraph.strip():
+            lines.append("")
+            continue
+        lines.extend(textwrap.wrap(paragraph, width=width))
+    return lines or [text]
+
+
+def _ascii_text(text: str | None) -> str:
+    if not text:
+        return ""
+    normalized = (
+        text.replace("→", " -> ")
+        .replace("←", " <- ")
+        .replace("↔", " <-> ")
+        .replace("—", "-")
+        .replace("–", "-")
+    )
+    ascii_text = unicodedata.normalize("NFKD", normalized).encode("ascii", "ignore").decode("ascii")
+    return re.sub(r"\s+", " ", ascii_text).strip()
+
+
+def _draw_text_block(
+    draw: ImageDraw.ImageDraw,
+    text: str,
+    *,
+    box: tuple[int, int, int, int],
+    fill: tuple[int, int, int] = _INK,
+    font: ImageFont.ImageFont,
+    line_spacing: int = 8,
+    stroke_width: int = 0,
+    stroke_fill: tuple[int, int, int] | None = None,
+) -> None:
+    left, top, right, bottom = box
+    max_chars = max(10, (right - left) // 18)
+    lines = _wrap_text(text, width=max_chars)
+    y = top
+    for line in lines:
+        draw.text(
+            (left, y),
+            line,
+            fill=fill,
+            font=font,
+            stroke_width=stroke_width,
+            stroke_fill=stroke_fill,
+        )
+        y += font.size + line_spacing
+        if y > bottom:
+            break
+
+
+def _placeholder_canvas() -> PILImage.Image:
+    width, height = SHOWCASE_VIDEO_CANVAS_SIZE
+    canvas = PILImage.new("RGB", (width, height), _BACKGROUND)
+    draw = ImageDraw.Draw(canvas)
+    font = _load_font(36)
+    draw.rectangle((0, 0, width, height), fill=_BACKGROUND)
+    draw.rounded_rectangle((72, 72, width - 72, height - 72), radius=32, fill=_WHITE)
+    draw.text((112, 112), "PotterDoc", fill=_ACCENT, font=font)
+    return canvas
+
+
+def _render_potterdoc_icon(size: int) -> PILImage.Image:
+    """Render the favicon-style PotterDoc icon at a square size."""
+    canvas = PILImage.new("RGBA", (size, size), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(canvas)
+    scale = size / _BRAND_ICON_VIEWBOX
+    stroke_width = max(1, round(scale))
+
+    wheel_cx = 64 * scale
+    wheel_cy = 93.2143 * scale
+    wheel_rx = 42 * scale
+    wheel_ry = 12 * scale
+    draw.ellipse(
+        (
+            wheel_cx - wheel_rx,
+            wheel_cy - wheel_ry,
+            wheel_cx + wheel_rx,
+            wheel_cy + wheel_ry,
+        ),
+        fill=_BRAND_ICON_WHEEL_FILL,
+        outline=_BRAND_ICON_STROKE,
+        width=stroke_width,
+    )
+
+    body_left = 42 * scale
+    body_top = 29.2143 * scale
+    body_right = 86 * scale
+    body_bottom = 93.2143 * scale
+    draw.rounded_rectangle(
+        (body_left, body_top, body_right, body_bottom),
+        radius=max(1, round(3.0 * scale)),
+        fill=_BRAND_ICON_FILL,
+        outline=_BRAND_ICON_STROKE,
+        width=stroke_width,
+    )
+
+    rim_cx = 64 * scale
+    rim_cy = 29.2143 * scale
+    rim_rx = 22.5 * scale
+    rim_ry = 6.4286 * scale
+    draw.ellipse(
+        (
+            rim_cx - rim_rx,
+            rim_cy - rim_ry,
+            rim_cx + rim_rx,
+            rim_cy + rim_ry,
+        ),
+        fill=_BRAND_ICON_STROKE,
+    )
+    return canvas
+
+
+def _brand_lockup_layout(scale: int) -> dict[str, int]:
+    width, height = SHOWCASE_VIDEO_CANVAS_SIZE
+    work_width = width * scale
+    work_height = height * scale
+    title_font = _load_font(56 * scale)
+    measurement_canvas = PILImage.new("RGBA", (1, 1), (0, 0, 0, 0))
+    measurement_draw = ImageDraw.Draw(measurement_canvas)
+
+    text = "PotterDoc"
+    text_bbox = measurement_draw.textbbox((0, 0), text, font=title_font)
+    text_width = text_bbox[2] - text_bbox[0]
+
+    icon_size = int(96 * scale)
+    gap = int(30 * scale)
+    total_width = icon_size + gap + text_width
+    center_x = work_width // 2
+    center_y = work_height // 2
+    left_x = center_x - total_width // 2
+    icon_y = center_y - icon_size // 2
+    text_x = left_x + icon_size + gap
+    text_y = center_y - (text_bbox[1] + text_bbox[3]) // 2
+    return {
+        "icon_size": icon_size,
+        "gap": gap,
+        "icon_x": left_x,
+        "icon_y": icon_y,
+        "text_x": text_x,
+        "text_y": text_y,
+        "center_y": center_y,
+    }
+
+
+def _render_closing_frame() -> PILImage.Image:
+    width, height = SHOWCASE_VIDEO_CANVAS_SIZE
+    scale = _BRAND_LOCKUP_SCALE
+    work = PILImage.new("RGBA", (width * scale, height * scale), "#000000")
+    draw = ImageDraw.Draw(work)
+
+    title_font = _load_font(56 * scale)
+    text = "PotterDoc"
+    layout = _brand_lockup_layout(scale)
+    icon = _render_potterdoc_icon(layout["icon_size"])
+    work.alpha_composite(icon, (layout["icon_x"], layout["icon_y"]))
+    draw.text(
+        (layout["text_x"], layout["text_y"]),
+        text,
+        fill="#F1E4D2",
+        font=title_font,
+    )
+
+    return work.resize((width, height), resample=PILImage.Resampling.LANCZOS).convert("RGB")
+
+
+def _fade_background_frame(frame: PILImage.Image, alpha: float) -> PILImage.Image:
+    alpha = max(0.0, min(1.0, alpha))
+    if alpha <= 0.0:
+        return frame
+    background = PILImage.new("RGB", SHOWCASE_VIDEO_CANVAS_SIZE, _BACKGROUND)
+    return PILImage.blend(frame, background, alpha)
+
+
+def _render_cover_frame(storyboard: dict, slide: dict) -> PILImage.Image:
+    canvas = _placeholder_canvas()
+    source = _load_image(slide.get("image"))
+    if source is not None:
+        source = _fit_image(
+            source,
+            crop=slide.get("image", {}).get("crop"),
+            preserve_aspect=bool(slide.get("image", {}).get("crop")),
+        )
+        canvas.paste(source, (0, 0))
+        overlay = PILImage.new("RGBA", SHOWCASE_VIDEO_CANVAS_SIZE, (0, 0, 0, 0))
+        overlay_draw = ImageDraw.Draw(overlay)
+        overlay_draw.rectangle(
+            (0, 440, SHOWCASE_VIDEO_CANVAS_SIZE[0], SHOWCASE_VIDEO_CANVAS_SIZE[1]),
+            fill=(0, 0, 0, 120),
+        )
+        canvas = PILImage.alpha_composite(canvas.convert("RGBA"), overlay).convert("RGB")
+    draw = ImageDraw.Draw(canvas)
+    title_font = _load_font(42)
+    body_font = _load_font(28)
+    draw.rounded_rectangle((72, 540, 1208, 648), radius=24, fill=_WHITE)
+    draw.text((110, 572), slide.get("heading") or "Untitled piece", fill=_ACCENT, font=title_font)
+    story = (slide.get("text") or "").strip()
+    if story:
+        _draw_text_block(
+            draw,
+            story,
+            box=(110, 606, 1120, 640),
+            fill=_MUTED,
+            font=body_font,
+        )
+    return canvas
+
+
+def _render_image_frame(slide: dict) -> PILImage.Image:
+    canvas = _placeholder_canvas()
+    source = _load_image(slide.get("image"))
+    if source is not None:
+        source = _fit_image(
+            source,
+            crop=slide.get("image", {}).get("crop"),
+            preserve_aspect=bool(slide.get("image", {}).get("crop")),
+        )
+        canvas.paste(source, (0, 0))
+    draw = ImageDraw.Draw(canvas)
+    header_font = _load_font(30)
+    body_font = _load_font(28)
+    draw.text(
+        (72, 44),
+        _ascii_text(slide.get("state_label") or "State"),
+        fill=_WHITE,
+        font=header_font,
+        stroke_width=3,
+        stroke_fill=_INK,
+    )
+    caption = _ascii_text((slide.get("caption") or "").strip())
+    if caption:
+        _draw_text_block(
+            draw,
+            caption,
+            box=(72, 594, 1208, 680),
+            fill=_WHITE,
+            font=body_font,
+            stroke_width=2,
+            stroke_fill=_INK,
+        )
+    return canvas
+
+
+def _render_note_frame(slide: dict) -> PILImage.Image:
+    canvas = _placeholder_canvas()
+    draw = ImageDraw.Draw(canvas)
+    title_font = _load_font(36)
+    body_font = _load_font(28)
+    draw.rounded_rectangle((72, 72, 1208, 648), radius=32, fill=_WHITE)
+    draw.text(
+        (112, 120),
+        _ascii_text(slide.get("state_label") or "Note"),
+        fill=_ACCENT,
+        font=title_font,
+    )
+    note = _ascii_text((slide.get("text") or "").strip())
+    if note:
+        _draw_text_block(
+            draw,
+            note,
+            box=(112, 180, 1140, 612),
+            fill=_INK,
+            font=body_font,
+            line_spacing=10,
+        )
+    return canvas
+
+
+def _slide_duration_seconds(slide: dict) -> float:
+    duration_ms = float(slide.get("duration_ms", 0) or 0)
+    return max(0.1, duration_ms / 1000.0)
+
+
+def _resolve_music_audio_path(storyboard: dict) -> Path:
+    track = get_track(storyboard.get("music_track_id"))
+    if track is None:
+        raise ValueError(f"Unknown music track id: {storyboard.get('music_track_id')!r}")
+    audio_url = track.audio.url
+    if not audio_url:
+        raise ValueError(f"Track {track.track_id!r} does not have a local audio asset.")
+    audio_path = Path(audio_url)
+    if not audio_path.is_absolute():
+        audio_path = _REPO_ROOT / audio_path
+    if not audio_path.exists():
+        raise FileNotFoundError(f"Music asset not found: {audio_path}")
+    return audio_path
+
+
+def _slide_start_times(durations: list[float], transition_seconds: float) -> list[float]:
+    starts = [0.0]
+    for duration in durations[:-1]:
+        starts.append(starts[-1] + duration - transition_seconds)
+    return starts
+
+
+def _render_slide_canvases(storyboard: dict) -> list[PILImage.Image]:
+    canvases: list[PILImage.Image] = []
+    for slide in storyboard.get("slides", []):
+        kind = slide.get("kind")
+        if kind == "cover":
+            canvases.append(_render_cover_frame(storyboard, slide))
+        elif kind == "image":
+            canvases.append(_render_image_frame(slide))
+        else:
+            canvases.append(_render_note_frame(slide))
+    canvases.append(_render_closing_frame())
+    return canvases
+
+
+def _iter_video_frames(
+    slide_canvases: list[PILImage.Image],
+    durations: list[float],
+    transition_seconds: float,
+    fade_seconds: float,
+):
+    if not slide_canvases:
+        return
+
+    if len(slide_canvases) == 1:
+        frame_count = max(1, math.ceil(durations[0] * SHOWCASE_VIDEO_FPS))
+        total_duration = durations[0]
+        for index in range(frame_count):
+            t = index / SHOWCASE_VIDEO_FPS
+            yield _fade_background_frame(
+                slide_canvases[0],
+                _fade_alpha(t=t, total_duration=total_duration, fade_seconds=fade_seconds),
+            )
+        return
+
+    starts = _slide_start_times(durations, transition_seconds)
+    total_duration = starts[-1] + durations[-1]
+    frame_count = max(1, math.ceil(total_duration * SHOWCASE_VIDEO_FPS))
+    for index in range(frame_count):
+        t = index / SHOWCASE_VIDEO_FPS
+        slide_index = len(slide_canvases) - 1
+        for candidate, start in enumerate(starts):
+            if t < start + durations[candidate]:
+                slide_index = candidate
+                break
+        if slide_index < len(slide_canvases) - 1:
+            transition_start = starts[slide_index + 1]
+            if t >= transition_start:
+                alpha = min(1.0, (t - transition_start) / transition_seconds)
+                frame = PILImage.blend(
+                    slide_canvases[slide_index],
+                    slide_canvases[slide_index + 1],
+                    alpha,
+                )
+                yield _fade_background_frame(
+                    frame,
+                    _fade_alpha(
+                        t=t,
+                        total_duration=total_duration,
+                        fade_seconds=fade_seconds,
+                    ),
+                )
+                continue
+        yield _fade_background_frame(
+            slide_canvases[slide_index],
+            _fade_alpha(t=t, total_duration=total_duration, fade_seconds=fade_seconds),
+        )
+
+
+def _fade_alpha(*, t: float, total_duration: float, fade_seconds: float) -> float:
+    if fade_seconds <= 0:
+        return 0.0
+    fade_start = max(0.0, total_duration - fade_seconds)
+    if t < fade_start:
+        return 0.0
+    return min(1.0, (t - fade_start) / fade_seconds)
+
+
+def _write_video_stream(
+    container: av.container.output.OutputContainer,
+    slide_canvases: list[PILImage.Image],
+    durations: list[float],
+    transition_seconds: float,
+    fade_seconds: float,
+) -> tuple[list[Any], float]:
+    video_stream = container.add_stream("libx264", rate=SHOWCASE_VIDEO_FPS)
+    video_stream.width = SHOWCASE_VIDEO_CANVAS_SIZE[0]
+    video_stream.height = SHOWCASE_VIDEO_CANVAS_SIZE[1]
+    video_stream.pix_fmt = "yuv420p"
+    video_stream.time_base = Fraction(1, SHOWCASE_VIDEO_FPS)
+
+    packets: list[Any] = []
+    frame_count = 0
+    for frame in _iter_video_frames(
+        slide_canvases,
+        durations,
+        transition_seconds,
+        fade_seconds,
+    ):
+        video_frame = av.VideoFrame.from_image(frame)
+        video_frame.pts = frame_count
+        video_frame.time_base = Fraction(1, SHOWCASE_VIDEO_FPS)
+        for packet in video_stream.encode(video_frame):
+            packets.append(packet)
+        frame_count += 1
+
+    for packet in video_stream.encode():
+        packets.append(packet)
+
+    return packets, frame_count / SHOWCASE_VIDEO_FPS
+
+
+def _write_audio_stream(
+    container: av.container.output.OutputContainer,
+    audio_path: Path,
+    video_duration_seconds: float,
+    fade_seconds: float,
+) -> list[Any]:
+    with av.open(str(audio_path)) as audio_container:
+        source_stream = audio_container.streams.audio[0]
+        sample_rate = int(source_stream.rate or 44100)
+        layout = source_stream.layout.name if source_stream.layout else "stereo"
+        audio_stream = container.add_stream("aac", rate=sample_rate)
+        audio_stream.layout = layout
+        audio_stream.sample_rate = sample_rate
+        audio_stream.time_base = Fraction(1, sample_rate)
+        audio_stream.codec_context.time_base = Fraction(1, sample_rate)
+        resampler = AudioResampler(format="fltp", layout=layout, rate=sample_rate)
+        packet_time_base = Fraction(1, sample_rate)
+        packets: list[Any] = []
+
+        target_samples = int(round(video_duration_seconds * sample_rate))
+        fade_samples = int(round(fade_seconds * sample_rate))
+        samples_written = 0
+
+        def _encode_audio_frame(frame: av.AudioFrame) -> None:
+            nonlocal samples_written
+            arr = frame.to_ndarray()
+            if arr.ndim == 1:
+                arr = arr[np.newaxis, :]
+            frame_samples = arr.shape[-1]
+            if samples_written >= target_samples:
+                return
+            remaining = target_samples - samples_written
+            if frame_samples > remaining:
+                arr = arr[:, :remaining]
+                frame_samples = remaining
+            arr = _apply_audio_fade(
+                arr,
+                samples_written=samples_written,
+                target_samples=target_samples,
+                fade_samples=fade_samples,
+            )
+            frame = av.AudioFrame.from_ndarray(arr, format="fltp", layout=layout)
+            frame.sample_rate = sample_rate
+            frame.pts = samples_written
+            frame.time_base = Fraction(1, sample_rate)
+            for packet in audio_stream.encode(frame):
+                packet.time_base = packet_time_base
+                packets.append(packet)
+            samples_written += frame_samples
+
+        for packet in audio_container.demux(source_stream):
+            for decoded in packet.decode():
+                for resampled in resampler.resample(decoded):
+                    _encode_audio_frame(resampled)
+                    if samples_written >= target_samples:
+                        break
+                if samples_written >= target_samples:
+                    break
+            if samples_written >= target_samples:
+                break
+
+        for resampled in resampler.resample(None):
+            _encode_audio_frame(resampled)
+            if samples_written >= target_samples:
+                break
+
+        if samples_written < target_samples:
+            remaining = target_samples - samples_written
+            silence = av.AudioFrame(format="fltp", layout=layout, samples=remaining)
+            silence.sample_rate = sample_rate
+            silence.pts = samples_written
+            silence.time_base = Fraction(1, sample_rate)
+            for plane in silence.planes:
+                plane.update(b"\x00" * plane.buffer_size)
+            for packet in audio_stream.encode(silence):
+                packet.time_base = packet_time_base
+                packets.append(packet)
+
+        for packet in audio_stream.encode():
+            packet.time_base = packet_time_base
+            packets.append(packet)
+
+        return packets
+
+
+def _apply_audio_fade(
+    samples: np.ndarray,
+    *,
+    samples_written: int,
+    target_samples: int,
+    fade_samples: int,
+) -> np.ndarray:
+    if fade_samples <= 0 or samples_written >= target_samples:
+        return samples
+
+    frame_samples = samples.shape[-1]
+    positions = samples_written + np.arange(frame_samples, dtype=np.float32)
+    gain = np.clip((target_samples - positions) / max(1, fade_samples), 0.0, 1.0)
+    if np.all(gain >= 1.0):
+        return samples
+    return samples * gain[np.newaxis, :]
+
+
+def render_storyboard_to_mp4(storyboard: dict) -> Path:
+    """Render a storyboard snapshot to a deterministic MP4 file."""
+    validate_storyboard(storyboard)
+    input_hash = compute_storyboard_hash(storyboard)
+    temp_file = tempfile.NamedTemporaryFile(
+        delete=False,
+        suffix=f".{SHOWCASE_VIDEO_FORMAT}",
+        prefix=f"{input_hash}-",
+    )
+    output_path = Path(temp_file.name)
+    temp_file.close()
+
+    slides = list(storyboard.get("slides", []))
+    if not slides:
+        raise ValueError("Storyboard did not contain any slides to render.")
+
+    durations = [_slide_duration_seconds(slide) for slide in slides]
+    durations.append(SHOWCASE_VIDEO_CLOSING_SECONDS)
+    transition_seconds = min(
+        SHOWCASE_VIDEO_FADE_SECONDS,
+        *(duration / 2 for duration in durations),
+    ) if len(durations) > 1 else 0.0
+    fade_seconds = min(SHOWCASE_VIDEO_FADE_SECONDS, durations[-1] / 2)
+
+    slide_canvases = _render_slide_canvases(storyboard)
+    video_duration_seconds = 0.0
+    with av.open(str(output_path), mode="w", format="mp4") as container:
+        video_packets, video_duration_seconds = _write_video_stream(
+            container,
+            slide_canvases,
+            durations,
+            transition_seconds,
+            fade_seconds,
+        )
+        audio_path = _resolve_music_audio_path(storyboard)
+        audio_packets = _write_audio_stream(
+            container,
+            audio_path,
+            video_duration_seconds,
+            fade_seconds,
+        )
+
+        audio_offset = 0
+        for packet in audio_packets:
+            timestamp = packet.dts if packet.dts is not None else packet.pts
+            if timestamp is None:
+                continue
+            audio_offset = max(audio_offset, -int(timestamp))
+        if audio_offset:
+            for packet in audio_packets:
+                if packet.pts is not None:
+                    packet.pts += audio_offset
+                if packet.dts is not None:
+                    packet.dts += audio_offset
+
+        def _packet_timestamp(packet: Any) -> float:
+            timestamp = packet.dts if packet.dts is not None else packet.pts
+            if timestamp is None or packet.time_base is None:
+                return 0.0
+            return float(timestamp * packet.time_base)
+
+        for packet in sorted(
+            [*video_packets, *audio_packets],
+            key=lambda packet: (
+                _packet_timestamp(packet),
+                0 if packet.stream and packet.stream.type == "video" else 1,
+            ),
+        ):
+            container.mux(packet)
+
+    return output_path
+
+
+def _cloudinary_video_folder() -> str:
+    return os.environ.get("CLOUDINARY_VIDEO_UPLOAD_FOLDER", "").strip().strip("/")
+
+
+def is_showcase_video_cloudinary_enabled() -> bool:
+    return all(
+        [
+            os.environ.get("CLOUDINARY_CLOUD_NAME", "").strip(),
+            os.environ.get("CLOUDINARY_API_KEY", "").strip(),
+            os.environ.get("CLOUDINARY_API_SECRET", "").strip(),
+            _cloudinary_video_folder(),
+            os.environ.get("CLOUDINARY_VIDEO_UPLOAD_PRESET", "").strip(),
+        ]
+    )
+
+
+def upload_storyboard_video_to_cloudinary(
+    video_path: Path,
+    *,
+    input_hash: str,
+) -> dict[str, Any] | None:
+    """Upload a rendered video to Cloudinary when credentials are available.
+
+    The upload is optional. If Cloudinary is not configured, or the upload
+    fails, callers should keep using the local artifact path.
+    """
+
+    if not is_showcase_video_cloudinary_enabled():
+        return None
+    cloud_name = os.environ.get("CLOUDINARY_CLOUD_NAME", "").strip()
+    api_key = os.environ.get("CLOUDINARY_API_KEY", "").strip()
+    api_secret = os.environ.get("CLOUDINARY_API_SECRET", "").strip()
+
+    import cloudinary  # noqa: PLC0415
+    import cloudinary.uploader  # noqa: PLC0415
+
+    cloudinary.config(
+        cloud_name=cloud_name,
+        api_key=api_key,
+        api_secret=api_secret,
+        secure=True,
+    )
+
+    upload_kwargs: dict[str, Any] = {
+        "public_id": input_hash,
+        "folder": _cloudinary_video_folder(),
+        "overwrite": True,
+        "resource_type": "video",
+        "format": SHOWCASE_VIDEO_FORMAT,
+    }
+    upload_kwargs["upload_preset"] = os.environ.get(
+        "CLOUDINARY_VIDEO_UPLOAD_PRESET", ""
+    ).strip()
+
+    result = cloudinary.uploader.upload(str(video_path), **upload_kwargs)
+    return {
+        "cloud_name": result.get("cloud_name") or cloud_name,
+        "public_id": result.get("public_id") or input_hash,
+        "secure_url": result.get("secure_url") or result.get("url"),
+        "asset_id": result.get("asset_id"),
+        "version": result.get("version"),
+        "resource_type": result.get("resource_type") or "video",
+    }

--- a/api/showcase/render.py
+++ b/api/showcase/render.py
@@ -62,7 +62,7 @@ def _canonical_json(data: Any) -> str:
 
 
 @lru_cache(maxsize=None)
-def _load_font(size: int) -> ImageFont.ImageFont:
+def _load_font(size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
     if _FONT_PATH.exists():
         return ImageFont.truetype(str(_FONT_PATH), size=size)
     return ImageFont.load_default()
@@ -170,7 +170,7 @@ def _draw_text_block(
     *,
     box: tuple[int, int, int, int],
     fill: tuple[int, int, int] = _INK,
-    font: ImageFont.ImageFont,
+    font: ImageFont.FreeTypeFont | ImageFont.ImageFont,
     line_spacing: int = 8,
     stroke_width: int = 0,
     stroke_fill: tuple[int, int, int] | None = None,
@@ -180,6 +180,12 @@ def _draw_text_block(
     lines = _wrap_text(text, width=max_chars)
     y = top
     for line in lines:
+        bbox = draw.textbbox(
+            (left, y),
+            line,
+            font=font,
+            stroke_width=stroke_width,
+        )
         draw.text(
             (left, y),
             line,
@@ -188,7 +194,7 @@ def _draw_text_block(
             stroke_width=stroke_width,
             stroke_fill=stroke_fill,
         )
-        y += font.size + line_spacing
+        y = int(bbox[3]) + line_spacing
         if y > bottom:
             break
 
@@ -265,7 +271,7 @@ def _brand_lockup_layout(scale: int) -> dict[str, int]:
 
     text = "PotterDoc"
     text_bbox = measurement_draw.textbbox((0, 0), text, font=title_font)
-    text_width = text_bbox[2] - text_bbox[0]
+    text_width = int(text_bbox[2] - text_bbox[0])
 
     icon_size = int(96 * scale)
     gap = int(30 * scale)
@@ -275,7 +281,7 @@ def _brand_lockup_layout(scale: int) -> dict[str, int]:
     left_x = center_x - total_width // 2
     icon_y = center_y - icon_size // 2
     text_x = left_x + icon_size + gap
-    text_y = center_y - (text_bbox[1] + text_bbox[3]) // 2
+    text_y = int(center_y - ((text_bbox[1] + text_bbox[3]) / 2))
     return {
         "icon_size": icon_size,
         "gap": gap,

--- a/api/showcase/storyboard.py
+++ b/api/showcase/storyboard.py
@@ -218,6 +218,7 @@ def build_keepsake_storyboard(
         )
     elif piece.thumbnail_id:
         thumb = image_to_dict(piece.thumbnail) or {}
+        thumb["crop"] = piece.get_thumbnail_crop()
         cover_key = "cover:thumbnail"
         cover_slide = StoryboardSlide(
             kind="cover",

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -292,6 +292,74 @@ def detect_subject_crop(task: AsyncTask) -> dict | None:
     }
 
 
+@TaskRegistry.register("generate_showcase_video")
+def generate_showcase_video(task: AsyncTask) -> dict:
+    """Render a deterministic Keepsake showcase video from a storyboard snapshot."""
+    from .showcase import (
+        SHOWCASE_VIDEO_RENDER_VERSION,
+        compute_storyboard_hash,
+        is_showcase_video_cloudinary_enabled,
+        render_storyboard_to_mp4,
+        upload_storyboard_video_to_cloudinary,
+        validate_storyboard,
+    )
+
+    params = task.input_params or {}
+    if not isinstance(params, dict):
+        raise ValueError("Missing task input params")
+
+    storyboard = params.get("storyboard")
+    if not isinstance(storyboard, dict):
+        raise ValueError("Missing storyboard snapshot in task params")
+
+    validate_storyboard(storyboard)
+
+    input_hash = compute_storyboard_hash(storyboard)
+    stored_hash = params.get("input_hash")
+    if stored_hash and str(stored_hash) != input_hash:
+        raise ValueError("Storyboard snapshot hash does not match task input hash")
+
+    if not is_showcase_video_cloudinary_enabled():
+        raise ValueError(
+            "Cloudinary showcase video upload is not configured."
+        )
+
+    output_path = render_storyboard_to_mp4(storyboard)
+    try:
+        cloudinary_asset = upload_storyboard_video_to_cloudinary(
+            output_path,
+            input_hash=input_hash,
+        )
+        if not cloudinary_asset:
+            raise ValueError("Cloudinary showcase video upload failed.")
+    except Exception:
+        logger.exception(
+            f"Cloudinary upload failed for showcase video task {task.id}; "
+            "marking the task as failed."
+        )
+        raise
+    finally:
+        try:
+            output_path.unlink(missing_ok=True)
+        except OSError:
+            logger.warning(
+                "Could not remove temporary showcase video file for task %s",
+                task.id,
+            )
+
+    return {
+        "status": "success",
+        "render_version": SHOWCASE_VIDEO_RENDER_VERSION,
+        "input_hash": input_hash,
+        "artifact_filename": f"{input_hash}.mp4",
+        "artifact_url": cloudinary_asset["secure_url"],
+        "download_url": cloudinary_asset["secure_url"],
+        "content_type": "video/mp4",
+        "cloudinary_asset": cloudinary_asset,
+        "storyboard": storyboard,
+    }
+
+
 def fail_stuck_tasks(hours: int = 1) -> int:
     """Find and fail tasks stuck in RUNNING or PENDING for too long."""
     from datetime import timedelta

--- a/api/tests/test_showcase_video.py
+++ b/api/tests/test_showcase_video.py
@@ -1,0 +1,490 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import av
+import numpy as np
+import pytest
+from django.urls import reverse
+from PIL import Image as PILImage
+
+from api.models import AsyncTask, Image, Piece, PieceState, PieceStateImage
+from api.showcase.render import (
+    _BACKGROUND,
+    _BRAND_LOCKUP_SCALE,
+    _ascii_text,
+    _apply_audio_fade,
+    _brand_lockup_layout,
+    _fade_background_frame,
+    _load_image,
+    _render_image_frame,
+    _render_closing_frame,
+)
+from api.showcase.storyboard import build_keepsake_storyboard
+from api.tasks import _execute_task
+from api.workflow import TERMINAL_STATES
+
+
+def _make_local_png(path: Path, color: tuple[int, int, int]) -> str:
+    from PIL import Image as PILImage
+
+    img = PILImage.new("RGB", (96, 96), color)
+    img.save(path, format="PNG")
+    return str(path)
+
+
+def _make_oriented_jpeg(path: Path) -> str:
+    from PIL import Image as PILImage
+
+    img = PILImage.new("RGB", (80, 120), (240, 200, 120))
+    exif = img.getexif()
+    exif[274] = 6  # Rotate 90 degrees clockwise
+    img.save(path, format="JPEG", exif=exif)
+    return str(path)
+
+
+def _make_piece_with_terminal_state(user, *, name: str = "Showcase Bowl") -> Piece:
+    piece = Piece.objects.create(user=user, name=name)
+    terminal_state = sorted(TERMINAL_STATES)[0]
+    PieceState.objects.create(piece=piece, user=user, state=terminal_state)
+    return piece
+
+
+def _attach_image(piece: Piece, *, url: str, caption: str = "Frame") -> Image:
+    image = Image.objects.create(user=piece.user, url=url)
+    state = piece.current_state
+    assert state is not None
+    PieceStateImage.objects.create(
+        piece_state=state,
+        image=image,
+        order=0,
+        caption=caption,
+    )
+    return image
+
+
+@pytest.mark.django_db(transaction=True)
+class TestShowcaseVideoApi:
+    def test_load_image_applies_exif_rotation(self, tmp_path):
+        image_path = tmp_path / "rotated.jpg"
+        loaded = _load_image({"url": _make_oriented_jpeg(image_path)})
+
+        assert loaded is not None
+        assert loaded.size == (120, 80)
+
+    def test_load_image_opens_heic_files(self, tmp_path):
+        from pillow_heif import register_heif_opener
+
+        register_heif_opener()
+
+        from PIL import Image as PILImage
+
+        source = PILImage.new("RGB", (48, 72), (30, 120, 210))
+        path = tmp_path / "source.heif"
+        source.save(path, format="HEIF")
+
+        loaded = _load_image({"url": str(path)})
+
+        assert loaded is not None
+        assert loaded.size == (48, 72)
+
+    def test_render_image_frame_uses_ascii_state_labels_without_framing_bars(
+        self, tmp_path
+    ):
+        image_path = tmp_path / "frame.png"
+        source_color = (90, 150, 210)
+        slide = {
+            "image": {"url": _make_local_png(image_path, source_color)},
+            "state_label": "Queued → Glaze",
+            "caption": "First pass → second pass",
+        }
+
+        frame = _render_image_frame(slide)
+
+        assert _ascii_text("Queued → Glaze") == "Queued -> Glaze"
+        assert frame.getpixel((1200, 50)) == source_color
+
+    def test_fit_image_preserves_crop_aspect_with_letterboxing(self, tmp_path):
+        image_path = tmp_path / "wide.png"
+        source = PILImage.new("RGB", (240, 120), (120, 80, 40))
+        source.save(image_path, format="PNG")
+
+        from api.showcase.render import _fit_image
+
+        fitted = _fit_image(
+            _load_image({"url": str(image_path)}),
+            crop={"x": 0.0, "y": 0.0, "width": 0.5, "height": 1.0},
+            preserve_aspect=True,
+        )
+
+        assert fitted.size == (1280, 720)
+        assert fitted.getpixel((10, 10)) == _BACKGROUND
+        assert fitted.getpixel((640, 360)) == (120, 80, 40)
+
+    def test_fade_background_frame_does_not_leave_the_last_slide_hanging(
+        self,
+    ):
+        frame = PILImage.new("RGB", (1280, 720), (200, 40, 40))
+
+        faded = _fade_background_frame(frame, 1.0)
+
+        assert faded.getpixel((640, 360)) == _BACKGROUND
+
+    def test_render_closing_frame_keeps_brand_lockup_separated(self):
+        frame = _render_closing_frame()
+        layout = _brand_lockup_layout(_BRAND_LOCKUP_SCALE)
+        gap_mid_x = ((layout["icon_x"] + layout["icon_size"] + layout["text_x"]) // 2) // _BRAND_LOCKUP_SCALE
+        gap_mid_y = layout["center_y"] // _BRAND_LOCKUP_SCALE
+
+        assert frame.getpixel((gap_mid_x, gap_mid_y)) == (0, 0, 0)
+
+    def test_apply_audio_fade_scales_tail_samples(self):
+        samples = np.ones((2, 8), dtype=np.float32)
+
+        faded = _apply_audio_fade(
+            samples,
+            samples_written=4,
+            target_samples=8,
+            fade_samples=4,
+        )
+
+        assert faded.shape == samples.shape
+        assert faded[0, 0] == pytest.approx(1.0)
+        assert faded[0, 1] < faded[0, 0]
+        assert faded[0, 2] < faded[0, 1]
+        assert faded[0, 3] == pytest.approx(0.25)
+        assert faded[0, 4] == pytest.approx(0.0)
+
+    def test_thumbnail_fallback_preserves_crop(self, user):
+        piece = Piece.objects.create(user=user, name="Thumbnail Crop")
+        state = PieceState.objects.create(piece=piece, user=user, state=sorted(TERMINAL_STATES)[0])
+        image = Image.objects.create(
+            user=user,
+            url="https://example.com/thumb.jpg",
+            cloud_name="demo",
+            cloudinary_public_id="pieces/thumb",
+        )
+        PieceStateImage.objects.create(
+            piece_state=state,
+            image=image,
+            crop={"x": 0.2, "y": 0.1, "width": 0.6, "height": 0.5},
+            order=0,
+        )
+        piece.thumbnail = image
+        piece.save(update_fields=["thumbnail"])
+
+        storyboard = build_keepsake_storyboard(piece).to_dict()
+
+        assert storyboard["slides"][0]["image"]["crop"] == {
+            "x": 0.2,
+            "y": 0.1,
+            "width": 0.6,
+            "height": 0.5,
+        }
+
+    def test_render_storyboard_includes_audio_and_crossfade(self, user, tmp_path):
+        piece = _make_piece_with_terminal_state(user, name="Audio Piece")
+        cover_path = tmp_path / "cover.png"
+        detail_path = tmp_path / "detail.png"
+        piece.thumbnail = _attach_image(
+            piece,
+            url=_make_local_png(cover_path, (200, 120, 80)),
+            caption="Cover",
+        )
+        piece.save()
+
+        PieceState.objects.create(
+            piece=piece,
+            user=user,
+            state=sorted(TERMINAL_STATES)[0],
+        )
+        _attach_image(
+            piece,
+            url=_make_local_png(detail_path, (80, 140, 200)),
+            caption="Detail",
+        )
+
+        from api.showcase.storyboard import build_keepsake_storyboard
+        from api.showcase.render import render_storyboard_to_mp4
+
+        storyboard = build_keepsake_storyboard(piece)
+        output_path = render_storyboard_to_mp4(storyboard.to_dict())
+        with av.open(str(output_path)) as container:
+            assert any(stream.type == "audio" for stream in container.streams)
+            assert any(stream.type == "video" for stream in container.streams)
+            duration = container.duration / 1_000_000 if container.duration else 0.0
+
+        assert duration > (
+            storyboard.total_duration_ms / 1000.0
+        )
+
+    def test_submit_enqueues_async_task_and_streams_artifact(
+        self, client, user, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("CLOUDINARY_CLOUD_NAME", "demo-cloud")
+        monkeypatch.setenv("CLOUDINARY_API_KEY", "public-api-key")
+        monkeypatch.setenv("CLOUDINARY_API_SECRET", "super-secret")
+        monkeypatch.setenv("CLOUDINARY_VIDEO_UPLOAD_FOLDER", "showcase-videos")
+        monkeypatch.setenv("CLOUDINARY_VIDEO_UPLOAD_PRESET", "glaze_video_signed")
+
+        piece = _make_piece_with_terminal_state(user)
+        cover_path = tmp_path / "cover.png"
+        piece.thumbnail = _attach_image(
+            piece,
+            url=_make_local_png(cover_path, (200, 120, 80)),
+            caption="Cover",
+        )
+        piece.save()
+
+        client.force_authenticate(user=user)
+        url = reverse("piece-showcase-video", kwargs={"piece_id": piece.id})
+
+        with patch(
+            "api.tasks.InMemoryTaskInterface.submit",
+            autospec=True,
+            side_effect=lambda self_obj, task_obj: _execute_task(task_obj.id),
+        ), patch(
+            "api.showcase.upload_storyboard_video_to_cloudinary",
+            autospec=True,
+            return_value={
+                "cloud_name": "demo-cloud",
+                "public_id": "video-hash",
+                "secure_url": "https://res.cloudinary.com/demo-cloud/video/upload/v1/showcase-videos/video-hash.mp4",
+                "resource_type": "video",
+            },
+        ):
+            response = client.post(url, {}, format="json")
+
+        assert response.status_code == 202
+        body = response.json()
+        assert body["status"] == "pending"
+
+        task = AsyncTask.objects.get(id=body["task_id"])
+        assert task.status == AsyncTask.Status.SUCCESS
+        assert task.result["input_hash"] == task.input_params["input_hash"]
+        assert task.result["storyboard"]["slides"][0]["heading"] == piece.name
+
+        status_response = client.get(url)
+        assert status_response.status_code == 200
+        status_body = status_response.json()
+        assert status_body["status"] == "succeeded"
+        assert status_body["artifact"]["url"] == (
+            "https://res.cloudinary.com/demo-cloud/video/upload/"
+            "v1/showcase-videos/video-hash.mp4"
+        )
+        assert status_body["artifact"]["download_url"] == (
+            "https://res.cloudinary.com/demo-cloud/video/upload/"
+            "v1/showcase-videos/video-hash.mp4"
+        )
+
+    def test_task_uses_storyboard_snapshot_even_if_piece_changes_before_execution(
+        self, client, user, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("CLOUDINARY_CLOUD_NAME", "demo-cloud")
+        monkeypatch.setenv("CLOUDINARY_API_KEY", "public-api-key")
+        monkeypatch.setenv("CLOUDINARY_API_SECRET", "super-secret")
+        monkeypatch.setenv("CLOUDINARY_VIDEO_UPLOAD_FOLDER", "showcase-videos")
+        monkeypatch.setenv("CLOUDINARY_VIDEO_UPLOAD_PRESET", "glaze_video_signed")
+
+        piece = _make_piece_with_terminal_state(user, name="Original Name")
+        cover_path = tmp_path / "cover.png"
+        piece.thumbnail = _attach_image(
+            piece,
+            url=_make_local_png(cover_path, (90, 150, 200)),
+            caption="Cover",
+        )
+        piece.save()
+
+        client.force_authenticate(user=user)
+        url = reverse("piece-showcase-video", kwargs={"piece_id": piece.id})
+
+        submitted: list[AsyncTask] = []
+
+        def _capture_submit(self_obj, task_obj):
+            submitted.append(task_obj)
+
+        with patch(
+            "api.tasks.InMemoryTaskInterface.submit",
+            autospec=True,
+            side_effect=_capture_submit,
+        ), patch(
+            "api.showcase.upload_storyboard_video_to_cloudinary",
+            autospec=True,
+            return_value={
+                "cloud_name": "demo-cloud",
+                "public_id": "video-hash",
+                "secure_url": "https://res.cloudinary.com/demo-cloud/video/upload/v1/showcase-videos/video-hash.mp4",
+                "resource_type": "video",
+            },
+        ):
+            response = client.post(url, {}, format="json")
+
+        assert response.status_code == 202
+        assert submitted
+        task = submitted[0]
+
+        piece.name = "Mutated Name"
+        piece.save(update_fields=["name"])
+
+        with patch(
+            "api.showcase.upload_storyboard_video_to_cloudinary",
+            autospec=True,
+            return_value={
+                "cloud_name": "demo-cloud",
+                "public_id": "video-hash",
+                "secure_url": "https://res.cloudinary.com/demo-cloud/video/upload/v1/showcase-videos/video-hash.mp4",
+                "resource_type": "video",
+            },
+        ):
+            _execute_task(task.id)
+
+        task.refresh_from_db()
+        assert task.status == AsyncTask.Status.SUCCESS
+        assert task.result["storyboard"]["slides"][0]["heading"] == "Original Name"
+
+    def test_get_marks_render_stale_after_piece_changes(
+        self, client, user, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("CLOUDINARY_CLOUD_NAME", "demo-cloud")
+        monkeypatch.setenv("CLOUDINARY_API_KEY", "public-api-key")
+        monkeypatch.setenv("CLOUDINARY_API_SECRET", "super-secret")
+        monkeypatch.setenv("CLOUDINARY_VIDEO_UPLOAD_FOLDER", "showcase-videos")
+        monkeypatch.setenv("CLOUDINARY_VIDEO_UPLOAD_PRESET", "glaze_video_signed")
+
+        piece = _make_piece_with_terminal_state(user, name="Stable")
+        cover_path = tmp_path / "cover.png"
+        piece.thumbnail = _attach_image(
+            piece,
+            url=_make_local_png(cover_path, (120, 90, 140)),
+            caption="Cover",
+        )
+        piece.save()
+
+        client.force_authenticate(user=user)
+        url = reverse("piece-showcase-video", kwargs={"piece_id": piece.id})
+
+        with patch(
+            "api.tasks.InMemoryTaskInterface.submit",
+            autospec=True,
+            side_effect=lambda self_obj, task_obj: _execute_task(task_obj.id),
+        ), patch(
+            "api.showcase.upload_storyboard_video_to_cloudinary",
+            autospec=True,
+            return_value={
+                "cloud_name": "demo-cloud",
+                "public_id": "video-hash",
+                "secure_url": "https://res.cloudinary.com/demo-cloud/video/upload/v1/showcase-videos/video-hash.mp4",
+                "resource_type": "video",
+            },
+        ):
+            response = client.post(url, {}, format="json")
+
+        assert response.status_code == 202
+        task_id = response.json()["task_id"]
+
+        piece.name = "Changed"
+        piece.save(update_fields=["name"])
+
+        status_response = client.get(url)
+        assert status_response.status_code == 200
+        body = status_response.json()
+        assert body["task_id"] == task_id
+        assert body["status"] == "stale-needs-regeneration"
+        assert body["is_stale"] is True
+        assert body["stored_input_hash"] != body["current_input_hash"]
+
+    def test_other_user_cannot_access_piece_showcase_video(self, client, user, other_user):
+        piece = _make_piece_with_terminal_state(user)
+        client.force_authenticate(user=other_user)
+        url = reverse("piece-showcase-video", kwargs={"piece_id": piece.id})
+
+        response = client.get(url)
+
+        assert response.status_code == 404
+
+    def test_artifact_redirects_to_cloudinary_when_uploaded(
+        self, client, user, tmp_path, monkeypatch
+    ):
+        piece = _make_piece_with_terminal_state(user, name="Cloudinary Ready")
+        cover_path = tmp_path / "cover.png"
+        piece.thumbnail = _attach_image(
+            piece,
+            url=_make_local_png(cover_path, (70, 160, 110)),
+            caption="Cover",
+        )
+        piece.save()
+
+        monkeypatch.setenv("CLOUDINARY_CLOUD_NAME", "demo-cloud")
+        monkeypatch.setenv("CLOUDINARY_API_KEY", "public-api-key")
+        monkeypatch.setenv("CLOUDINARY_API_SECRET", "super-secret")
+        monkeypatch.setenv("CLOUDINARY_VIDEO_UPLOAD_FOLDER", "showcase-videos")
+        monkeypatch.setenv("CLOUDINARY_VIDEO_UPLOAD_PRESET", "glaze_video_signed")
+
+        client.force_authenticate(user=user)
+        url = reverse("piece-showcase-video", kwargs={"piece_id": piece.id})
+
+        with patch(
+            "api.tasks.InMemoryTaskInterface.submit",
+            autospec=True,
+            side_effect=lambda self_obj, task_obj: _execute_task(task_obj.id),
+        ), patch(
+            "api.showcase.upload_storyboard_video_to_cloudinary",
+            autospec=True,
+            return_value={
+                "cloud_name": "demo-cloud",
+                "public_id": "video-hash",
+                "secure_url": "https://res.cloudinary.com/demo-cloud/video/upload/v1/showcase-videos/video-hash.mp4",
+                "resource_type": "video",
+            },
+        ) as upload_mock:
+            response = client.post(url, {}, format="json")
+
+        assert response.status_code == 202
+        task_id = response.json()["task_id"]
+        upload_mock.assert_called_once()
+        assert upload_mock.call_args.kwargs["input_hash"] == AsyncTask.objects.get(
+            id=task_id
+        ).input_params["input_hash"]
+
+        status_response = client.get(url)
+        assert status_response.status_code == 200
+        artifact_url = status_response.json()["artifact"]["url"]
+        assert artifact_url == (
+            "https://res.cloudinary.com/demo-cloud/video/upload/"
+            "v1/showcase-videos/video-hash.mp4"
+        )
+
+        task = AsyncTask.objects.get(id=task_id)
+        assert task.result["cloudinary_asset"]["secure_url"] == (
+            "https://res.cloudinary.com/demo-cloud/video/upload/"
+            "v1/showcase-videos/video-hash.mp4"
+        )
+
+    def test_submit_rejected_when_cloudinary_video_is_not_configured(
+        self, client, user, tmp_path, monkeypatch
+    ):
+        piece = _make_piece_with_terminal_state(user, name="Disabled")
+        cover_path = tmp_path / "cover.png"
+        piece.thumbnail = _attach_image(
+            piece,
+            url=_make_local_png(cover_path, (220, 180, 90)),
+            caption="Cover",
+        )
+        piece.save()
+
+        monkeypatch.delenv("CLOUDINARY_VIDEO_UPLOAD_FOLDER", raising=False)
+        monkeypatch.delenv("CLOUDINARY_VIDEO_UPLOAD_PRESET", raising=False)
+
+        client.force_authenticate(user=user)
+        url = reverse("piece-showcase-video", kwargs={"piece_id": piece.id})
+
+        response = client.post(url, {}, format="json")
+
+        assert response.status_code == 503
+        assert response.json()["detail"] == (
+            "Cloudinary showcase video uploads are not configured."
+        )
+
+        status_response = client.get(url)
+        assert status_response.status_code == 200
+        assert status_response.json()["status"] == "disabled"
+        assert status_response.json()["enabled"] is False

--- a/api/urls.py
+++ b/api/urls.py
@@ -82,6 +82,11 @@ urlpatterns = [
         name="piece-current-state",
     ),
     path(
+        "pieces/<uuid:piece_id>/showcase-video/",
+        views.piece_showcase_video,
+        name="piece-showcase-video",
+    ),
+    path(
         "uploads/cloudinary/widget-config/",
         views.cloudinary_widget_config,
         name="cloudinary-widget-config",

--- a/api/views.py
+++ b/api/views.py
@@ -38,6 +38,9 @@ from .health_views import (
 )
 from .import_views import admin_manual_square_crop_import
 from .piece.image_views import patch_image_crop, piece_image_detail
+from .piece.showcase_views import (
+    piece_showcase_video,
+)
 from .piece.views import (
     piece_current_state,
     piece_current_state_detail,
@@ -80,6 +83,7 @@ __all__ = [
     "piece_detail",
     "piece_image_detail",
     "piece_past_state",
+    "piece_showcase_video",
     "piece_states",
     "pieces",
     "send_invite",

--- a/docs/agents/glaze-domain.md
+++ b/docs/agents/glaze-domain.md
@@ -305,6 +305,8 @@ All API endpoints are registered in `backend/urls.py`.
 | `GOOGLE_OAUTH_CLIENT_ID`                           | `GOOGLE_OAUTH_CLIENT_ID`      | Empty string — Google sign-in disabled      | Set to enable Google OAuth JWT verification                       |
 | `CLOUDINARY_CLOUD_NAME` / `API_KEY` / `API_SECRET` | _(same names)_                | Empty — widget-config returns 503           | Set to enable Cloudinary uploads                                  |
 | `CLOUDINARY_UPLOAD_FOLDER`                         | `CLOUDINARY_UPLOAD_FOLDER`    | Not set                                     | Optional subfolder for uploaded images                            |
+| `CLOUDINARY_VIDEO_UPLOAD_FOLDER`                   | `CLOUDINARY_VIDEO_UPLOAD_FOLDER` | Not set                                  | Required subfolder for generated showcase videos; disables the feature when absent |
+| `CLOUDINARY_VIDEO_UPLOAD_PRESET`                   | `CLOUDINARY_VIDEO_UPLOAD_PRESET` | Not set                                  | Required upload preset for generated showcase videos; disables the feature when absent |
 
 **Image FK normalization (`ImageForeignKey` / `ImageForwardDescriptor`):** `type: image` fields on global models are stored as FKs to the `api.Image` table, not as raw JSON. `ImageForeignKey` (defined in `api/model_factories.py`) swaps in `ImageForwardDescriptor` as its accessor, which intercepts every assignment and calls `normalize_image_payload` when the incoming value is a `str` or `dict`:
 
@@ -359,6 +361,9 @@ Name uniqueness for public globals is enforced with two conditional DB constrain
 - `POST /api/pieces/<id>/states/` → record a new state transition
 - `PATCH /api/pieces/<id>/` → update piece-level editable fields (currently location)
 - `PATCH /api/pieces/<id>/state/` → update current state's editable fields
+- `GET /api/pieces/<id>/showcase-video/` → latest showcase video task status, stale detection, and artifact metadata
+- `POST /api/pieces/<id>/showcase-video/` → enqueue a deterministic Keepsake slideshow render for a terminal piece
+- `Showcase video artifacts are served directly from Cloudinary once upload succeeds; there is no local fallback artifact route.`
 
 **Piece vs. current-state access pattern:**
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -63,9 +63,13 @@ All scoped to the `glaze-droplet` environment in **Settings → Environments**.
 | `CLOUDINARY_CLOUD_NAME` | Variable | Cloudinary cloud name |
 | `CLOUDINARY_UPLOAD_FOLDER` | Variable | Cloudinary folder for user-uploaded images |
 | `CLOUDINARY_UPLOAD_PRESET` | Variable | Cloudinary upload preset |
+| `CLOUDINARY_VIDEO_UPLOAD_FOLDER` | Variable | Cloudinary folder for generated showcase videos |
+| `CLOUDINARY_VIDEO_UPLOAD_PRESET` | Variable | Cloudinary upload preset for generated showcase videos |
 | `CLOUDINARY_PUBLIC_UPLOAD_FOLDER` | Variable | Cloudinary folder for public library images |
 
 All other app secrets (Django `SECRET_KEY`, Postgres password, Cloudinary API key/secret, Grafana OTLP token) are managed in Infisical and synced into the cluster by ESO — CD does not need them directly.
+
+Showcase video generation stays disabled until both `CLOUDINARY_VIDEO_UPLOAD_FOLDER` and `CLOUDINARY_VIDEO_UPLOAD_PRESET` are set.
 
 ---
 

--- a/infra/custom/Dockerfile
+++ b/infra/custom/Dockerfile
@@ -47,6 +47,7 @@ COPY web/ ./
 COPY tutorials.yml /app/
 COPY user_preferences.yml /app/
 COPY workflow.yml /app/
+COPY music_catalog.yml /app/
 
 # Generate TypeScript types from the local schema.json file
 ENV GLAZE_SCHEMA_SOURCE=/app/schema.json

--- a/infra/custom/Dockerfile
+++ b/infra/custom/Dockerfile
@@ -20,6 +20,7 @@ COPY user_preferences.yml ./
 COPY workflow.yml ./
 COPY music_catalog.yml ./
 COPY music_catalog.schema.yml ./
+COPY assets/showcase_music/ ./assets/showcase_music/
 
 # Generate the OpenAPI schema.json
 RUN python manage.py spectacular --file schema.json --format openapi-json
@@ -90,6 +91,7 @@ COPY user_preferences.yml ./
 COPY workflow.yml ./
 COPY music_catalog.yml ./
 COPY music_catalog.schema.yml ./
+COPY assets/showcase_music/ ./assets/showcase_music/
 
 # Make the entrypoint executable
 RUN chmod +x docker-entrypoint.sh

--- a/infra/custom/Dockerfile
+++ b/infra/custom/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.12-slim AS schema-builder
 WORKDIR /app
 
 # Install uv for high-speed package management
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+RUN python -m pip install --no-cache-dir uv
 
 # Copy python dependencies
 COPY pyproject.toml uv.lock ./
@@ -65,7 +65,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 # Install uv for high-speed package management
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+RUN python -m pip install --no-cache-dir uv
 
 # Copy python dependencies
 COPY pyproject.toml uv.lock ./

--- a/infra/custom/Dockerfile
+++ b/infra/custom/Dockerfile
@@ -18,6 +18,7 @@ COPY manage.py ./
 COPY tutorials.yml ./
 COPY user_preferences.yml ./
 COPY workflow.yml ./
+COPY music_catalog.schema.yml ./
 
 # Generate the OpenAPI schema.json
 RUN python manage.py spectacular --file schema.json --format openapi-json
@@ -86,6 +87,7 @@ COPY docker-entrypoint.sh ./
 COPY tutorials.yml ./
 COPY user_preferences.yml ./
 COPY workflow.yml ./
+COPY music_catalog.schema.yml ./
 
 # Make the entrypoint executable
 RUN chmod +x docker-entrypoint.sh

--- a/infra/custom/Dockerfile
+++ b/infra/custom/Dockerfile
@@ -18,6 +18,7 @@ COPY manage.py ./
 COPY tutorials.yml ./
 COPY user_preferences.yml ./
 COPY workflow.yml ./
+COPY storyboard.schema.yml ./
 COPY music_catalog.yml ./
 COPY music_catalog.schema.yml ./
 COPY assets/showcase_music/ ./assets/showcase_music/
@@ -89,6 +90,7 @@ COPY docker-entrypoint.sh ./
 COPY tutorials.yml ./
 COPY user_preferences.yml ./
 COPY workflow.yml ./
+COPY storyboard.schema.yml ./
 COPY music_catalog.yml ./
 COPY music_catalog.schema.yml ./
 COPY assets/showcase_music/ ./assets/showcase_music/

--- a/infra/custom/Dockerfile
+++ b/infra/custom/Dockerfile
@@ -18,6 +18,7 @@ COPY manage.py ./
 COPY tutorials.yml ./
 COPY user_preferences.yml ./
 COPY workflow.yml ./
+COPY music_catalog.yml ./
 COPY music_catalog.schema.yml ./
 
 # Generate the OpenAPI schema.json
@@ -87,6 +88,7 @@ COPY docker-entrypoint.sh ./
 COPY tutorials.yml ./
 COPY user_preferences.yml ./
 COPY workflow.yml ./
+COPY music_catalog.yml ./
 COPY music_catalog.schema.yml ./
 
 # Make the entrypoint executable

--- a/infra/custom/Dockerfile
+++ b/infra/custom/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.12-slim AS schema-builder
 WORKDIR /app
 
 # Install uv for high-speed package management
-RUN python -m pip install --no-cache-dir uv
+RUN python -m pip install --no-cache-dir "uv==0.11.18"
 
 # Copy python dependencies
 COPY pyproject.toml uv.lock ./
@@ -67,7 +67,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 # Install uv for high-speed package management
-RUN python -m pip install --no-cache-dir uv
+RUN python -m pip install --no-cache-dir "uv==0.11.18"
 
 # Copy python dependencies
 COPY pyproject.toml uv.lock ./

--- a/music_catalog.yml
+++ b/music_catalog.yml
@@ -13,7 +13,7 @@
 # how the files were produced and their attribution.
 #
 version: "1.0"
-default_track_id: adventures-a-himitsu
+default_track_id: we-are-one-vexento
 tracks:
   adventures-a-himitsu:
     title: Adventures

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "anyio==4.13.0",
     "asgiref==3.11.1",
     "attrs==26.1.0",
+    "av>=17.0.1",
     "brotli==1.2.0",
     "celery>=5.6.3",
     "certifi==2026.4.22",

--- a/uv.lock
+++ b/uv.lock
@@ -79,6 +79,22 @@ wheels = [
 ]
 
 [[package]]
+name = "av"
+version = "17.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/f0/8c8dca97ae0cf00e8e2a53bb5cb9aca5fd484f585ef3e9b412200aff3ebd/av-17.0.1.tar.gz", hash = "sha256:fbcbd4aa43bca6a8691816283112d1659a27f407bbeb66d1397023691339f5d4", size = 4411938, upload-time = "2026-04-18T17:12:34.29Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/82/e7007dcef7bd2d2c377e2e85977701384f42d19fc808c2ccb3a99eaf58f2/av-17.0.1-cp311-abi3-macosx_11_0_x86_64.whl", hash = "sha256:987f4f46ceae4da6c614dcbd2b8149be9dbf680c3bb7a6841c58af9cff4d9230", size = 23238802, upload-time = "2026-04-18T17:11:51.166Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/aa/858b09a08ea6f83f91be44b5a5adad13ae8d9ac8b80fda27e73c24bfb160/av-17.0.1-cp311-abi3-macosx_14_0_arm64.whl", hash = "sha256:d97f54e55b18a74912f479c1978aadd1341d38d892dee95bb5c2f2dccfa72f32", size = 18709338, upload-time = "2026-04-18T17:11:53.286Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/8b/8de3fd21c4b0b74d44337421abeab0e71462337fb6a28fff888e0c356cbd/av-17.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e6eee84afa48d0e9321047cd3e4facd44b401493f6bdc753e2e1d1e7c9e6d13e", size = 34007351, upload-time = "2026-04-18T17:11:56.116Z" },
+    { url = "https://files.pythonhosted.org/packages/02/28/167b291356c2cc315a2d62a95b0ceace72b5b0bf547de30b89313110f032/av-17.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:c58c71bffd9383908c85695ac61d3184c668accb04a5bd1b262e0fb8d09f60a5", size = 36345295, upload-time = "2026-04-18T17:11:59.125Z" },
+    { url = "https://files.pythonhosted.org/packages/04/fa/aae56f2ff2c204c408641e1120f5ca5ce9c3390cf5362245c6f1158704b5/av-17.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:42d6745d30a410ec9b22aef79a52a7ab5a001eb8f5adfd952946606a30983318", size = 35183754, upload-time = "2026-04-18T17:12:01.697Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/bd/776046f27093aef80155a204ca7d82a887ae4ee72ba4ef8411b46ea7898c/av-17.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3ed6bcd7021fe55832f95b8ef78dd01a4cb21faf3cd71f1e1bf4f20bf100b278", size = 37430809, upload-time = "2026-04-18T17:12:04.231Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/d5/3261bd2c6b7f6c0aa8379fc970d1ecf496330990b992ad28607785074268/av-17.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:9af524e8632a54032e361d6b88895bd3e7c6212ca560de60f5ccc525323c764c", size = 28889649, upload-time = "2026-04-18T17:12:07.04Z" },
+    { url = "https://files.pythonhosted.org/packages/98/39/381104e427a0c7231d2ec0d25d538d58fc20fc0458846b95860d3ef8073b/av-17.0.1-cp311-abi3-win_arm64.whl", hash = "sha256:50e58a473d65ea29b645e45c9fd8518a6783737135683ecc40571a91592bdfe4", size = 21918412, upload-time = "2026-04-18T17:12:09.312Z" },
+]
+
+[[package]]
 name = "billiard"
 version = "4.2.4"
 source = { registry = "https://pypi.org/simple" }
@@ -531,6 +547,7 @@ dependencies = [
     { name = "anyio" },
     { name = "asgiref" },
     { name = "attrs" },
+    { name = "av" },
     { name = "brotli" },
     { name = "celery" },
     { name = "certifi" },
@@ -630,6 +647,7 @@ requires-dist = [
     { name = "anyio", specifier = "==4.13.0" },
     { name = "asgiref", specifier = "==3.11.1" },
     { name = "attrs", specifier = "==26.1.0" },
+    { name = "av", specifier = ">=17.0.1" },
     { name = "brotli", specifier = "==1.2.0" },
     { name = "celery", specifier = ">=5.6.3" },
     { name = "certifi", specifier = "==2026.4.22" },

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -679,6 +679,7 @@ js_library(
         "src/components/PieceNameEditor.tsx",
         "src/components/SectionCard.tsx",
         "src/components/ShowcaseVideoInputPicker.tsx",
+        "src/components/SelectablePhotoMasonry.tsx",
         "src/components/SmallTutorialInlay.tsx",
         "src/components/SmallTutorialInlayConfig.ts",
     ],

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -8,14 +8,27 @@ import {
   Box,
   Chip,
   Divider,
+  Button,
+  CircularProgress,
+  Stack,
   Typography,
 } from "@mui/material";
 import HistoryIcon from "@mui/icons-material/History";
 import { useBlocker, useLocation, useNavigate } from "react-router-dom";
 import type { PieceDetail as PieceDetailType } from "../util/types";
+import { DEFAULT_TRACK_ID } from "../util/music";
 import { formatState, isTerminalState, getCustomFieldDefinitions } from "../util/workflow";
-import { useMutation } from "@tanstack/react-query";
-import { updatePiece, updatePastState, updateCurrentState, moveImage, extractErrorMessage, addPieceState } from "../util/api";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  fetchPieceShowcaseVideo,
+  requestPieceShowcaseVideo,
+  updatePiece,
+  updatePastState,
+  updateCurrentState,
+  moveImage,
+  extractErrorMessage,
+  addPieceState,
+} from "../util/api";
 import CloudinaryImage from "./CloudinaryImage";
 
 import NavigationBlocker from "./NavigationBlocker";
@@ -29,6 +42,9 @@ import PiecePhotoGallery, {
   PiecePhotoGalleryButton,
   type PiecePhotoGalleryImage,
 } from "./PiecePhotoGallery";
+import ShowcaseVideoInputPicker, {
+  type ShowcaseVideoInputSelection,
+} from "./ShowcaseVideoInputPicker";
 import { PieceDetailSaveStatusProvider } from "./PieceDetailSaveStatusContext";
 import { usePieceDetailSaveStatus } from "./usePieceDetailSaveStatus";
 import ShareControls from "./PieceShareControls";
@@ -218,6 +234,11 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
             {canEdit && isTerminal && (
               <Box sx={{ mb: 1.5 }}>
                 <ShareControls piece={piece} onPieceUpdated={onPieceUpdated} />
+              </Box>
+            )}
+            {canEdit && isTerminal && (
+              <Box sx={{ mb: 1.5 }}>
+                <ShowcaseVideoPanel piece={piece} />
               </Box>
             )}
             {canEdit && (
@@ -410,5 +431,181 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
         />
       )}
     </Box>
+  );
+}
+
+function ShowcaseVideoPanel({ piece }: { piece: PieceDetailType }) {
+  const queryClient = useQueryClient();
+  const [selection, setSelection] = useState<ShowcaseVideoInputSelection>({
+    excludedImageKeys: [],
+    excludedNoteKeys: [],
+    musicTrackId: DEFAULT_TRACK_ID,
+  });
+
+  const {
+    data: showcaseVideo,
+    error: rawStatusError,
+    isLoading,
+  } = useQuery({
+    queryKey: ["showcase-video", piece.id],
+    queryFn: () => fetchPieceShowcaseVideo(piece.id),
+    refetchInterval: (query) =>
+      query.state.data?.status === "pending" ||
+      query.state.data?.status === "running"
+        ? 2500
+        : false,
+  });
+
+  const {
+    mutate: generateVideo,
+    isPending: generating,
+    error: rawGenerateError,
+  } = useMutation({
+    mutationFn: () => requestPieceShowcaseVideo(piece.id, selection),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(["showcase-video", piece.id], updated);
+    },
+  });
+
+  const currentStatus = showcaseVideo?.status ?? "idle";
+  const canGenerate =
+    !generating &&
+    (showcaseVideo?.enabled ?? true) &&
+    currentStatus !== "pending" &&
+    currentStatus !== "running" &&
+    (showcaseVideo?.eligible ?? true);
+  const statusLabel =
+    currentStatus === "idle"
+      ? "No render has been requested yet."
+      : currentStatus === "disabled"
+        ? "Showcase video generation is unavailable."
+      : currentStatus === "pending"
+        ? "Queued for rendering."
+        : currentStatus === "running"
+          ? "Rendering in the background."
+          : currentStatus === "failed"
+            ? "The latest render failed."
+            : currentStatus === "stale-needs-regeneration"
+              ? "The latest render is stale."
+              : "The latest render is ready.";
+
+  const artifact = showcaseVideo?.artifact ?? null;
+  const errorMessage = rawGenerateError
+    ? extractErrorMessage(
+        rawGenerateError,
+        "Failed to request a video render. Please try again.",
+      )
+    : rawStatusError
+      ? extractErrorMessage(
+          rawStatusError,
+          "Failed to load showcase video status.",
+        )
+      : null;
+
+  return (
+    <SectionCard
+      title="Showcase Video"
+      subtitle="Render a deterministic Keepsake slideshow from the piece history."
+    >
+      <Stack spacing={2}>
+        <ShowcaseVideoInputPicker
+          piece={piece}
+          selection={selection}
+          onSelectionChange={setSelection}
+          disabled={generating || currentStatus === "pending" || currentStatus === "running"}
+        />
+
+        <Box
+          sx={(theme) => ({
+            borderRadius: 2,
+            border: "1px solid",
+            borderColor: "divider",
+            backgroundColor: theme.palette.background.paper,
+            p: 1.5,
+          })}
+        >
+          <Stack spacing={1.25}>
+            <Typography variant="body2" sx={{ fontWeight: 600 }}>
+              {statusLabel}
+            </Typography>
+            {isLoading && !showcaseVideo ? (
+              <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                <CircularProgress size={16} />
+                <Typography variant="body2" color="text.secondary">
+                  Checking for the latest render...
+                </Typography>
+              </Box>
+            ) : null}
+            {showcaseVideo?.stale_reason ? (
+              <Alert severity="warning" variant="outlined">
+                {showcaseVideo.stale_reason}
+              </Alert>
+            ) : null}
+            {showcaseVideo?.disabled_reason ? (
+              <Alert severity="info" variant="outlined">
+                {showcaseVideo.disabled_reason}
+              </Alert>
+            ) : null}
+            {showcaseVideo?.error ? (
+              <Alert severity="error" variant="outlined">
+                {showcaseVideo.error}
+              </Alert>
+            ) : null}
+            {errorMessage ? (
+              <Typography variant="body2" color="error">
+                {errorMessage}
+              </Typography>
+            ) : null}
+            {artifact ? (
+              <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
+                <Button
+                  component="a"
+                  href={artifact.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  variant="outlined"
+                >
+                  Open video
+                </Button>
+                <Button
+                  component="a"
+                  href={artifact.download_url}
+                  download={artifact.filename}
+                  variant="outlined"
+                >
+                  Download MP4
+                </Button>
+              </Stack>
+            ) : null}
+            <Stack
+              direction={{ xs: "column", sm: "row" }}
+              spacing={1}
+              alignItems={{ xs: "stretch", sm: "center" }}
+            >
+                <Button
+                  variant="contained"
+                  onClick={() => generateVideo()}
+                  disabled={!canGenerate}
+                  startIcon={generating ? <CircularProgress size={16} /> : undefined}
+                >
+                  {currentStatus === "succeeded" ||
+                  currentStatus === "stale-needs-regeneration"
+                    ? "Render again"
+                    : currentStatus === "disabled"
+                      ? "Unavailable"
+                      : "Generate video"}
+                </Button>
+                <Typography variant="caption" color="text.secondary">
+                {showcaseVideo?.enabled === false
+                  ? "Set CLOUDINARY_VIDEO_UPLOAD_FOLDER and CLOUDINARY_VIDEO_UPLOAD_PRESET to enable showcase videos."
+                  : showcaseVideo?.eligible === false
+                  ? "This piece is not eligible for video generation yet."
+                  : "The request is queued immediately and continues in the background."}
+                </Typography>
+            </Stack>
+          </Stack>
+        </Box>
+      </Stack>
+    </SectionCard>
   );
 }

--- a/web/src/util/api.ts
+++ b/web/src/util/api.ts
@@ -452,6 +452,69 @@ export async function addPieceState(
   return mapPieceDetail(data);
 }
 
+export type ShowcaseVideoArtifact = {
+  url: string;
+  download_url: string;
+  filename: string;
+  content_type: string;
+};
+
+export type ShowcaseVideoStatus = {
+  piece_id: string;
+  task_id: string | null;
+  status:
+    | "idle"
+    | "disabled"
+    | "pending"
+    | "running"
+    | "succeeded"
+    | "failed"
+    | "stale-needs-regeneration";
+  task_status: "pending" | "running" | "success" | "failure" | null;
+  enabled: boolean;
+  disabled_reason: string | null;
+  eligible: boolean;
+  current_input_hash: string | null;
+  stored_input_hash: string | null;
+  is_stale: boolean;
+  stale_reason: string | null;
+  music_track_id: string | null;
+  storyboard: Record<string, unknown> | null;
+  artifact: ShowcaseVideoArtifact | null;
+  error: string | null;
+};
+
+export type ShowcaseVideoRequestPayload = {
+  excludedImageKeys?: string[];
+  excludedNoteKeys?: string[];
+  musicTrackId?: string | null;
+};
+
+export async function fetchPieceShowcaseVideo(
+  pieceId: string,
+): Promise<ShowcaseVideoStatus> {
+  const { data } = await client.get<ShowcaseVideoStatus>(
+    `pieces/${pieceId}/showcase-video/`,
+  );
+  return data;
+}
+
+export async function requestPieceShowcaseVideo(
+  pieceId: string,
+  payload: ShowcaseVideoRequestPayload = {},
+): Promise<ShowcaseVideoStatus> {
+  await ensureCsrfCookie();
+  const { data } = await client.post<ShowcaseVideoStatus>(
+    `pieces/${pieceId}/showcase-video/`,
+    {
+      excluded_image_keys: payload.excludedImageKeys ?? [],
+      excluded_note_keys: payload.excludedNoteKeys ?? [],
+      music_track_id: payload.musicTrackId ?? null,
+    },
+  );
+  return data;
+}
+
 export type UpdateStatePayload = {
   notes?: string;
   created?: string;


### PR DESCRIPTION
Closes #232
Closes #329
Closes #745
Closes #747

## What changed

- Added the showcase video render pipeline for finished pieces, including async task execution, storyboard snapshot hashing, and stale-render detection.
- Switched the renderer to PyAV so we can mux audio, add slide crossfades, and apply an end fade.
- Fixed crop handling so the video respects the website crop behavior, including framing gaps when the crop aspect ratio does not match 16:9.
- Added a closing PotterDoc end card and standardized the render background to black.
- Wired the piece detail UI to enqueue and poll the showcase video task, with input selection for excluding images/notes and choosing a music track.
- Added Web Share API button that appears on mobile browsers; tries file-share first and falls back to URL share.
- Added review feedback fixes: import ordering, dead-code removal, pinned uv version in Dockerfile, and clarifying comments.

## Why

We wanted a production-safe way to generate slideshow videos for finished pieces without blocking the request thread. The old path rendered silently, without music or transitions, and did not visually match the crop presentation on the website.

## Validation

- `rtk bazel test //api:api_piece_test --test_output=errors`
- `rtk bazel coverage --config=ci --combined_report=lcov --nocache_test_results //api:api_piece_test --test_output=errors` ran 4 times locally and passed each time
- `rtk bazel test --config=ci //api:api_mypy --test_output=errors`
- `rtk bazel test //web:web_test --test_output=errors`
- `git diff --check`

## Cloudinary setup

Before enabling the flow in production, create a separate Cloudinary video preset and folder for these renders.

1. Create a signed upload preset for videos in Cloudinary.
2. Set the preset to accept `resource_type=video`.
3. Choose or create a dedicated folder for showcase renders, for example `showcase-videos`.
4. Set these production env vars:
   - `CLOUDINARY_VIDEO_UPLOAD_PRESET=<your signed video preset>`
   - `CLOUDINARY_VIDEO_UPLOAD_FOLDER=<your showcase folder>`
5. Keep the existing Cloudinary credentials in place:
   - `CLOUDINARY_CLOUD_NAME`
   - `CLOUDINARY_API_KEY`
   - `CLOUDINARY_API_SECRET`

The feature stays disabled unless both the video preset and folder are set.