### PR TITLE
fix: upgrade rules_shell version in MODULE.bazel to 0.6.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,7 @@ bazel_dep(name = "aspect_rules_lint", version = "2.5.0")
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "rules_oci", version = "2.3.0")
 bazel_dep(name = "rules_pkg", version = "1.1.0")
-bazel_dep(name = "rules_shell", version = "0.3.0")
+bazel_dep(name = "rules_shell", version = "0.6.1")
 bazel_dep(name = "rules_helm", version = "0.27.0")
 # rules_distroless is beta (no stable API). Test celery_worker_image builds
 # manually after any version bump — do not upgrade blindly.

--- a/tests/test_bazel_deps.py
+++ b/tests/test_bazel_deps.py
@@ -1,0 +1,23 @@
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_rules_shell_version():
+    """Assert that the direct dependency version of rules_shell in MODULE.bazel is 0.6.1."""
+    module_bazel_path = ROOT / "MODULE.bazel"
+    assert module_bazel_path.exists(), "MODULE.bazel file does not exist"
+
+    content = module_bazel_path.read_text()
+    # Match: bazel_dep(name = "rules_shell", version = "X.Y.Z")
+    match = re.search(
+        r"bazel_dep\(\s*name\s*=\s*[\"']rules_shell[\"']\s*,\s*version\s*=\s*[\"']([^\"']+)[\"']\s*\)",
+        content,
+    )
+    assert match is not None, "Could not find rules_shell dependency in MODULE.bazel"
+
+    version = match.group(1)
+    assert version == "0.6.1", (
+        f"Expected rules_shell version to be '0.6.1', but got '{version}'"
+    )


### PR DESCRIPTION
## Problem
Direct dependency resolution checks fail/warn because the root module requires `rules_shell@0.3.0` while transitive dependencies in the resolved graph (such as `aspect_rules_lint` and `aspect_rules_py`) require `rules_shell@0.6.1`.

## Fix
Upgraded `rules_shell` to version `0.6.1` in `MODULE.bazel`.

## Regression Test
Added `tests/test_bazel_deps.py` with `test_rules_shell_version` to assert that the direct dependency version of `rules_shell` matches the resolved version (`0.6.1`). This test successfully failed on the baseline and passes after the fix is applied.

## Verification
- Verified that `rtk bazel test //tests:common_test` passes cleanly (both the new regression test and the existing integration tests).
- Verified that all workspace linters and builds pass with `rtk bazel build --config=lint //...` and `gz_format`.

Closes #765
