### PR TITLE
fix: gz_test hangs indefinitely on cold Bazel daemon due to FD leak

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -26,6 +26,7 @@ exports_files([
     "mypy.ini",
     "tutorials.yml",
     "tutorials.schema.yml",
+    "env-agent.sh",
 ])
 
 config_setting(

--- a/env-agent.sh
+++ b/env-agent.sh
@@ -1229,8 +1229,12 @@ _gz_cd_complete() {
 _gz_get_all_sources() {
     local profile="$PWD/bazel_query_profile.json"
     echo "DEBUG: Starting ALL_SOURCES query at $(date +%s)"
+    local tmp_err
+    tmp_err=$(mktemp)
     local sources
-    sources=$(${GLAZE_AGENT:+rtk }bazel query --profile="$profile" --output=label 'kind("source file", //...:* )' 2> >(tee -a /dev/stderr) | sed 's|^//||; s|:|/|')
+    sources=$(${GLAZE_AGENT:+rtk }bazel query --profile="$profile" --output=label 'kind("source file", //...:* )' 2> "$tmp_err" | sed 's|^//||; s|:|/|')
+    cat "$tmp_err" >&2
+    rm -f "$tmp_err"
     echo "DEBUG: Finished ALL_SOURCES query at $(date +%s). Sources found: $(echo "$sources" | wc -l)"
     echo "$sources"
 }

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -11,6 +11,7 @@ pytest_test(
         "//:workflow_files",
         "//:pytest_ini",
         "//backend:backend_test_settings",
+        "//:env-agent.sh",
     ],
     deps = [
         "@pypi//pytest_env",

--- a/tests/test_env_agent.py
+++ b/tests/test_env_agent.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_env_agent_no_process_substitution():
+    """Assert that env-agent.sh does not contain process substitutions like '2> >(tee ...)'
+    which can leak file descriptors to background daemons (like Bazel server) and cause hangs.
+    """
+    env_agent_path = ROOT / "env-agent.sh"
+    assert env_agent_path.exists(), (
+        f"env-agent.sh file does not exist at {env_agent_path}"
+    )
+
+    content = env_agent_path.read_text()
+    # Check for the process substitution leak pattern in bazel query redirects
+    assert "2> >(tee" not in content, (
+        "env-agent.sh contains '2> >(tee', which leaks file descriptors to background daemons "
+        "spawned by Bazel, causing commands to hang indefinitely on a cold cache."
+    )


### PR DESCRIPTION
## Problem
Running `gz_test` on a branch checks affected files, which calls `_gz_get_all_sources()` using process substitution `2> >(tee -a /dev/stderr)`. When the Bazel daemon is cold, the client spawns the persistent daemon process in the background, which inherits the stderr pipe from the client. When the client exits, the background daemon keeps the pipe open, preventing the `tee` process from receiving EOF and causing the shell pipeline to hang indefinitely. This issue is described in https://github.com/shaoster/glaze/issues/768.

## Fix
Replaced the process substitution pattern `2> >(tee -a /dev/stderr)` in `_gz_get_all_sources()` in `env-agent.sh` with a redirection of stderr to a temporary file (`mktemp`). The temporary file's content is then output to stderr (`>&2`) and deleted immediately after the query pipeline completes. This prevents background processes spawned by Bazel from inheriting the pipe and causing hangs.

## Regression Test
Added `tests/test_env_agent.py` containing `test_env_agent_no_process_substitution()`, which reads the contents of `env-agent.sh` and asserts that it does not contain the process substitution pattern `2> >(tee`.

## Verification
- Verified that running `rtk bazel shutdown && gz_test --coverage` completes successfully without hanging on a cold Bazel cache.
- Verified that `rtk bazel test //tests:common_test` fails as expected before the fix and passes after.
- Ran all linters `rtk bazel build --config=lint //...` successfully.

Closes #768
