### PR TITLE
[codex] add piece detail clickthrough to smoke jobs

### DIFF
--- a/.github/actions/setup-bazel-ci/action.yml
+++ b/.github/actions/setup-bazel-ci/action.yml
@@ -11,6 +11,10 @@ inputs:
   buildbuddy-api-key:
     description: BuildBuddy remote API key. The caller must read this from secrets and pass it explicitly — composite actions cannot access secrets directly.
     required: true
+  workdir:
+    description: Directory where repo-local files should be updated. Defaults to the current workspace root.
+    required: false
+    default: .
 
 runs:
   using: composite
@@ -33,6 +37,7 @@ runs:
 
     - name: Inject BuildBuddy API key into .bazelrc
       shell: bash
+      working-directory: ${{ inputs.workdir }}
       run: |
         echo "" >> .bazelrc
         echo "common:ci --remote_header=x-buildbuddy-api-key=${{ inputs.buildbuddy-api-key }}" >> .bazelrc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,11 +184,28 @@ jobs:
         with:
           fetch-depth: 0
           lfs: true
+      - name: Create isolated worktree
+        id: worktree
+        shell: bash
+        run: |
+          set -euo pipefail
+          worktree="$RUNNER_TEMP/glaze-dev-smoke-${GITHUB_RUN_ID}-${GITHUB_JOB}"
+          git worktree add --detach "$worktree" HEAD
+          echo "path=$worktree" >> "$GITHUB_OUTPUT"
       - uses: ./.github/actions/setup-bazel-ci
         with:
           cache-key-prefix: dev-smoke
           deps-key: ${{ needs.preflight.outputs.deps_key }}
           buildbuddy-api-key: ${{ secrets.BAZEL_REMOTE_API_KEY }}
+          workdir: ${{ steps.worktree.outputs.path }}
+      - name: Install web dependencies for browser clickthrough
+        shell: bash
+        working-directory: ${{ steps.worktree.outputs.path }}
+        run: |
+          source env.sh
+          cd web
+          corepack prepare pnpm@10.34.1 --activate
+          corepack pnpm install --frozen-lockfile
 
       # Verifies the developer bootstrap end to end: the documented
       # `source env.sh` → `gz_start` flow must bring up the dev stack on a
@@ -199,6 +216,7 @@ jobs:
       # when the step's shell exits (which also cleans up on failure).
       - name: Bootstrap, log in via mock IdP, verify pieces, stop
         shell: bash
+        working-directory: ${{ steps.worktree.outputs.path }}
         run: |
           # No `set -u`: env.sh / env-agent.sh are not nounset-safe (they read
           # $_GLAZE_AGENT_ENV_LOADED before it is set). -e and pipefail are
@@ -246,6 +264,144 @@ jobs:
           echo "pieces count: $COUNT"
           [ "$COUNT" -gt 0 ] || fail "expected seeded pieces after login, got $COUNT"
 
+          FIRST_ID=$(curl -fsS -b "$JAR" "${BASE}/api/pieces/" \
+            | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["results"][0]["id"] if d["results"] else "")') \
+            || fail "could not determine the first piece id"
+          [ -n "$FIRST_ID" ] || fail "expected at least one seeded piece"
+
+          SESSION_COOKIE=$(awk -F $'\t' '$6=="sessionid"{print $7; exit}' "$JAR")
+          [ -n "$SESSION_COOKIE" ] || fail "mock-IdP login did not set a session cookie"
+
+          WEB_URL="http://localhost:$(cat .dev-pids/web.port)"
+          echo "::group::piece detail clickthrough"
+          (
+            cd web
+            corepack pnpm exec playwright install chromium
+            node scripts/dev-smoke-piece-detail-clickthrough.mjs \
+              --web-url "$WEB_URL" \
+              --piece-id "$FIRST_ID" \
+              --session-cookie "$SESSION_COOKIE"
+          )
+          echo "::endgroup::"
+
+          echo "::group::gz_stop"
+          gz_stop
+          echo "::endgroup::"
+
+      - if: failure()
+        uses: ./.github/actions/collect-failure-diagnostics
+
+      - name: Remove isolated worktree
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          git worktree remove --force "${{ steps.worktree.outputs.path }}"
+
+  dev-smoke-macos:
+    name: Dev bootstrap smoke on macOS (env.sh → gz_start → login → gz_stop)
+    needs: preflight
+    if: ${{ github.event_name == 'pull_request' || needs.preflight.outputs.skip_main != 'true' }}
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Create isolated worktree
+        id: worktree
+        shell: bash
+        run: |
+          set -euo pipefail
+          worktree="$RUNNER_TEMP/glaze-dev-smoke-${GITHUB_RUN_ID}-${GITHUB_JOB}"
+          git worktree add --detach "$worktree" HEAD
+          echo "path=$worktree" >> "$GITHUB_OUTPUT"
+      - uses: ./.github/actions/setup-bazel-ci
+        with:
+          cache-key-prefix: dev-smoke-macos
+          deps-key: ${{ needs.preflight.outputs.deps_key }}
+          buildbuddy-api-key: ${{ secrets.BAZEL_REMOTE_API_KEY }}
+          workdir: ${{ steps.worktree.outputs.path }}
+      - name: Install web dependencies for browser clickthrough
+        shell: bash
+        working-directory: ${{ steps.worktree.outputs.path }}
+        run: |
+          source env.sh
+          cd web
+          corepack prepare pnpm@10.34.1 --activate
+          corepack pnpm install --frozen-lockfile
+
+      # Mirrors the Linux bootstrap smoke test on macOS so the documented
+      # developer workflow stays covered on both supported local platforms.
+      - name: Bootstrap, log in via mock IdP, verify pieces, stop
+        shell: bash
+        working-directory: ${{ steps.worktree.outputs.path }}
+        run: |
+          # No `set -u`: env.sh / env-agent.sh are not nounset-safe (they read
+          # $_GLAZE_AGENT_ENV_LOADED before it is set). -e and pipefail are
+          # already applied by the Actions bash wrapper; keep them explicit.
+          set -eo pipefail
+          source env.sh
+
+          fail() {
+            echo "::error::dev-smoke-macos: $1" >&2
+            echo "--- backend log ---" >&2
+            cat .dev-logs/backend.log 2>/dev/null >&2 || true
+            exit 1
+          }
+
+          echo "::group::gz_start"
+          gz_start || fail "gz_start failed to bring up the dev stack"
+          echo "::endgroup::"
+
+          BASE="http://localhost:$(cat .dev-pids/backend.port)"
+          JAR="$(mktemp)"
+
+          # Dev login flow: POST the mock-IdP authorize endpoint (CSRF-exempt),
+          # capture the relative redirect to complete/, then GET it to land the
+          # session cookie. A single `curl -L` is unreliable here because cookies
+          # written at the intermediate hop are not flushed when the final hop
+          # returns a redirect — so we do the two steps explicitly.
+          echo "::group::mock-IdP login"
+          LOCATION=$(curl -fsS --retry 5 --retry-connrefused -c "$JAR" -b "$JAR" -D - -X POST \
+            --data "redirect_uri=/api/auth/mock-idp/complete/&state=ci&login_hint=dev@localhost" \
+            "${BASE}/api/auth/mock-idp/authorize/" \
+            | grep -i '^location:' | sed 's/[Ll]ocation: //' | tr -d '\r\n')
+          [ -n "$LOCATION" ] || fail "mock-IdP authorize did not return a redirect (is DEV_BOOTSTRAP_ENABLED set?)"
+          curl -fsS -c "$JAR" -b "$JAR" "${BASE}${LOCATION}" -o /dev/null
+          echo "::endgroup::"
+
+          # Confirm we have an authenticated session.
+          curl -fsS -b "$JAR" "${BASE}/api/auth/me/" \
+            | python3 -c 'import json,sys; d=json.load(sys.stdin); assert d.get("user"), "no authenticated user"; print("authenticated:", d["user"]["openid_subject"][:16])' \
+            || fail "session was not authenticated after mock-IdP login"
+
+          # The freshly bootstrapped dev user is seeded with sample pieces.
+          COUNT=$(curl -fsS -b "$JAR" "${BASE}/api/pieces/" \
+            | python3 -c 'import json,sys; print(json.load(sys.stdin)["count"])') \
+            || fail "could not read /api/pieces/"
+          echo "pieces count: $COUNT"
+          [ "$COUNT" -gt 0 ] || fail "expected seeded pieces after login, got $COUNT"
+
+          FIRST_ID=$(curl -fsS -b "$JAR" "${BASE}/api/pieces/" \
+            | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["results"][0]["id"] if d["results"] else "")') \
+            || fail "could not determine the first piece id"
+          [ -n "$FIRST_ID" ] || fail "expected at least one seeded piece"
+
+          SESSION_COOKIE=$(awk -F $'\t' '$6=="sessionid"{print $7; exit}' "$JAR")
+          [ -n "$SESSION_COOKIE" ] || fail "mock-IdP login did not set a session cookie"
+
+          WEB_URL="http://localhost:$(cat .dev-pids/web.port)"
+          echo "::group::piece detail clickthrough"
+          (
+            cd web
+            corepack pnpm exec playwright install chromium
+            node scripts/dev-smoke-piece-detail-clickthrough.mjs \
+              --web-url "$WEB_URL" \
+              --piece-id "$FIRST_ID" \
+              --session-cookie "$SESSION_COOKIE"
+          )
+          echo "::endgroup::"
+
           echo "::group::gz_stop"
           gz_stop
           echo "::endgroup::"
@@ -260,6 +416,13 @@ jobs:
 
       - if: failure()
         uses: ./.github/actions/collect-failure-diagnostics
+
+      - name: Remove isolated worktree
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          git worktree remove --force "${{ steps.worktree.outputs.path }}"
 
   compose-smoke:
     name: Docker Compose smoke test

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -292,7 +292,7 @@
         "bzlTransitiveDigest": "3GB+HVbmUfi1gaE0kWIzYPstolh7vaSq+4B96AikLiA=",
         "usagesDigest": "ZXxKBmt+bDvqYeAjgAl/x/xI/QLW5EbehLOG2a9mYMM=",
         "recordedFileInputs": {
-          "@@//web/package.json": "44a5fa722df67ea011be943b35e4c86e79f0e5915b1f77d31ad3c5452d4ee908"
+          "@@//web/package.json": "845ec1905352bdfe23cdd68924fd24e7d2f143b165d14b202b5d12fc47de0d20"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/api/showcase/music.py
+++ b/api/showcase/music.py
@@ -135,6 +135,7 @@ def resolve_track_id(track_id: str | None) -> str:
     """
     if track_id is None:
         return DEFAULT_TRACK_ID
-    if track_id not in _catalog():
+    catalog = _catalog()
+    if track_id not in catalog:
         raise ValueError(f"Unknown music track id: {track_id!r}")
     return track_id

--- a/tools/gz_start_launcher.py
+++ b/tools/gz_start_launcher.py
@@ -312,6 +312,31 @@ def wait_for_backend(port: int, timeout_seconds: float = 60.0) -> None:
         time.sleep(0.5)
 
 
+def wait_for_web(port: int, timeout_seconds: float = 60.0) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    url = f"http://127.0.0.1:{port}/"
+    sys.stdout.write("Waiting for web to be ready")
+    sys.stdout.flush()
+    while True:
+        try:
+            with urllib.request.urlopen(url, timeout=1) as response:
+                if response.status == 200:
+                    sys.stdout.write(" ready.\n")
+                    sys.stdout.flush()
+                    return
+        except Exception:
+            pass
+
+        if time.monotonic() >= deadline:
+            sys.stdout.write(" timed out!\n")
+            sys.stdout.flush()
+            raise TimeoutError(f"web did not become ready on port {port}")
+
+        sys.stdout.write(".")
+        sys.stdout.flush()
+        time.sleep(0.5)
+
+
 def open_browser(url: str) -> None:
     if os.environ.get("CI") == "1" or os.environ.get("GLAZE_NO_BROWSER") == "1":
         return
@@ -628,6 +653,7 @@ def start_stack(no_browser: bool = False) -> int:
             web_port = read_int_file(web_portfile) or port_from_log(web_log) or web_port
 
         wait_for_backend(backend_port)
+        wait_for_web(web_port)
 
         url = f"http://localhost:{web_port}"
         if not no_browser:

--- a/tools/gz_start_launcher.py
+++ b/tools/gz_start_launcher.py
@@ -318,7 +318,11 @@ def wait_for_web(port: int, timeout_seconds: float = 60.0) -> None:
     sys.stdout.flush()
     while True:
         try:
-            with socket.create_connection(("127.0.0.1", port), timeout=1):
+            # Match the browser URL (`http://localhost:<port>`) instead of
+            # probing IPv4 only. GitHub-hosted runners can expose the dev
+            # server on an IPv6 loopback address even when the browser works
+            # fine via `localhost`.
+            with socket.create_connection(("localhost", port), timeout=1):
                 sys.stdout.write(" ready.\n")
                 sys.stdout.flush()
                 return
@@ -403,7 +407,7 @@ def terminate_process_group(pid: int, timeout_seconds: float = 3.0) -> None:
         return
     try:
         os.killpg(pid, signal.SIGTERM)
-    except ProcessLookupError:
+    except (ProcessLookupError, PermissionError):
         return
     deadline = time.monotonic() + timeout_seconds
     while time.monotonic() < deadline:
@@ -412,7 +416,7 @@ def terminate_process_group(pid: int, timeout_seconds: float = 3.0) -> None:
         time.sleep(0.1)
     try:
         os.killpg(pid, signal.SIGKILL)
-    except ProcessLookupError:
+    except (ProcessLookupError, PermissionError):
         return
     deadline = time.monotonic() + 1.0
     while time.monotonic() < deadline:

--- a/tools/gz_start_launcher.py
+++ b/tools/gz_start_launcher.py
@@ -253,7 +253,8 @@ def ensure_local_web_node_modules(roots: Roots) -> None:
 def sync_generated_types(roots: Roots, env: dict[str, str]) -> None:
     print("web: regenerating TypeScript types...")
     generated_types_env = env.copy()
-    generated_types_env.setdefault("BAZEL_BINDIR", ".")
+    if not generated_types_env.get("BAZEL_BINDIR"):
+        generated_types_env["BAZEL_BINDIR"] = "."
     subprocess.run(
         ["bazel", "build", "//web:generated_types"],
         cwd=str(roots.workspace),
@@ -607,7 +608,8 @@ def start_web(
     # from the execroot after the launcher has exited. Make the environment look
     # like a non-build action so aspect_rules_js can resolve paths consistently
     # on both Linux and macOS runners.
-    web_env.setdefault("BAZEL_BINDIR", ".")
+    if not web_env.get("BAZEL_BINDIR"):
+        web_env["BAZEL_BINDIR"] = "."
 
     # Worktrees must keep their own npm install so Vite/Babel resolve package
     # paths against the active checkout rather than borrowing another worktree's

--- a/tools/gz_start_launcher.py
+++ b/tools/gz_start_launcher.py
@@ -312,18 +312,16 @@ def wait_for_backend(port: int, timeout_seconds: float = 60.0) -> None:
         time.sleep(0.5)
 
 
-def wait_for_web(port: int, timeout_seconds: float = 180.0) -> None:
+def wait_for_web(log_path: Path, port: int, timeout_seconds: float = 60.0) -> None:
     deadline = time.monotonic() + timeout_seconds
-    url = f"http://127.0.0.1:{port}/"
     sys.stdout.write("Waiting for web to be ready")
     sys.stdout.flush()
     while True:
         try:
-            with urllib.request.urlopen(url, timeout=1) as response:
-                if response.status == 200:
-                    sys.stdout.write(" ready.\n")
-                    sys.stdout.flush()
-                    return
+            if port_from_log(log_path) == port:
+                sys.stdout.write(" ready.\n")
+                sys.stdout.flush()
+                return
         except Exception:
             pass
 
@@ -654,7 +652,7 @@ def start_stack(no_browser: bool = False) -> int:
             print(f"web: already running (PID {pid})")
             web_port = read_int_file(web_portfile) or port_from_log(web_log) or web_port
 
-        wait_for_web(web_port)
+        wait_for_web(web_log, web_port)
 
         url = f"http://localhost:{web_port}"
         if not no_browser:

--- a/tools/gz_start_launcher.py
+++ b/tools/gz_start_launcher.py
@@ -603,10 +603,11 @@ def start_web(
     web_env = env.copy()
     web_env["BACKEND_PORT"] = str(backend_port)
 
-    # Behavioral: aspect_rules_js[js_binary] FATAL error occurs on Linux if BAZEL_BINDIR is unset
-    # when running as a non-build action. We provide a fallback to '.' to suppress this.
-    if sys.platform.startswith("linux"):
-        web_env.setdefault("BAZEL_BINDIR", ".")
+    # `bazel run` sets BAZEL_BINDIR, but `gz_start` launches the web `js_binary`
+    # from the execroot after the launcher has exited. Make the environment look
+    # like a non-build action so aspect_rules_js can resolve paths consistently
+    # on both Linux and macOS runners.
+    web_env.setdefault("BAZEL_BINDIR", ".")
 
     # Worktrees must keep their own npm install so Vite/Babel resolve package
     # paths against the active checkout rather than borrowing another worktree's

--- a/tools/gz_start_launcher.py
+++ b/tools/gz_start_launcher.py
@@ -393,6 +393,18 @@ def open_browser(url: str) -> None:
             continue
 
 
+def dump_log_tail(log_path: Path, *, label: str, max_lines: int = 80) -> None:
+    if not log_path.is_file():
+        print(f"{label}: log file missing: {log_path}")
+        return
+
+    lines = log_path.read_text(encoding="utf-8", errors="ignore").splitlines()
+    tail = lines[-max_lines:]
+    print(f"{label}: showing last {len(tail)} lines from {log_path}")
+    for line in tail:
+        print(f"{label}: {line}")
+
+
 def shutil_which(command: str) -> str | None:
     from shutil import which
 
@@ -681,7 +693,11 @@ def start_stack(no_browser: bool = False) -> int:
             print(f"web: already running (PID {pid})")
             web_port = read_int_file(web_portfile) or port_from_log(web_log) or web_port
 
-        wait_for_web(web_port)
+        try:
+            wait_for_web(web_port)
+        except Exception:
+            dump_log_tail(web_log, label="web")
+            raise
 
         url = f"http://localhost:{web_port}"
         if not no_browser:

--- a/tools/gz_start_launcher.py
+++ b/tools/gz_start_launcher.py
@@ -250,6 +250,27 @@ def ensure_local_web_node_modules(roots: Roots) -> None:
     subprocess.run(["npm", "install"], cwd=str(roots.workspace / "web"), check=True)
 
 
+def sync_generated_types(roots: Roots, env: dict[str, str]) -> None:
+    print("web: regenerating TypeScript types...")
+    subprocess.run(
+        ["bazel", "build", "//web:generated_types"],
+        cwd=str(roots.workspace),
+        env=env,
+        check=True,
+    )
+
+    source_dir = roots.workspace / "web" / "src" / "util"
+    source_dir.mkdir(parents=True, exist_ok=True)
+    generated_dir = roots.workspace / "bazel-bin" / "web" / "src" / "util"
+    for filename in ("generated-types.ts", "types.ts"):
+        source_path = source_dir / filename
+        target_path = generated_dir / filename
+        if source_path.exists() or source_path.is_symlink():
+            source_path.unlink()
+        source_path.symlink_to(target_path)
+        print(f"Generated: {source_path} -> {target_path}")
+
+
 def backend_ready_payload(port: int) -> dict[str, object]:
     url = f"http://127.0.0.1:{port}/api/health/ready/"
     try:
@@ -639,6 +660,8 @@ def start_stack(no_browser: bool = False) -> int:
             )
 
         wait_for_backend(backend_port)
+
+        sync_generated_types(roots, env)
 
         pid, running = ensure_running(web_pidfile)
         if not (running and pid is not None):

--- a/tools/gz_start_launcher.py
+++ b/tools/gz_start_launcher.py
@@ -252,10 +252,12 @@ def ensure_local_web_node_modules(roots: Roots) -> None:
 
 def sync_generated_types(roots: Roots, env: dict[str, str]) -> None:
     print("web: regenerating TypeScript types...")
+    generated_types_env = env.copy()
+    generated_types_env.setdefault("BAZEL_BINDIR", ".")
     subprocess.run(
         ["bazel", "build", "//web:generated_types"],
         cwd=str(roots.workspace),
-        env=env,
+        env=generated_types_env,
         check=True,
     )
 

--- a/tools/gz_start_launcher.py
+++ b/tools/gz_start_launcher.py
@@ -312,7 +312,7 @@ def wait_for_backend(port: int, timeout_seconds: float = 60.0) -> None:
         time.sleep(0.5)
 
 
-def wait_for_web(port: int, timeout_seconds: float = 60.0) -> None:
+def wait_for_web(port: int, timeout_seconds: float = 180.0) -> None:
     deadline = time.monotonic() + timeout_seconds
     url = f"http://127.0.0.1:{port}/"
     sys.stdout.write("Waiting for web to be ready")
@@ -636,6 +636,8 @@ def start_stack(no_browser: bool = False) -> int:
                 or backend_port
             )
 
+        wait_for_backend(backend_port)
+
         pid, running = ensure_running(web_pidfile)
         if not (running and pid is not None):
             start_web(
@@ -652,7 +654,6 @@ def start_stack(no_browser: bool = False) -> int:
             print(f"web: already running (PID {pid})")
             web_port = read_int_file(web_portfile) or port_from_log(web_log) or web_port
 
-        wait_for_backend(backend_port)
         wait_for_web(web_port)
 
         url = f"http://localhost:{web_port}"

--- a/tools/gz_start_launcher.py
+++ b/tools/gz_start_launcher.py
@@ -335,20 +335,22 @@ def wait_for_backend(port: int, timeout_seconds: float = 60.0) -> None:
 
 def wait_for_web(port: int, timeout_seconds: float = 60.0) -> None:
     deadline = time.monotonic() + timeout_seconds
+    loopback_hosts = ("localhost", "127.0.0.1", "::1")
     sys.stdout.write("Waiting for web to be ready")
     sys.stdout.flush()
     while True:
-        try:
-            # Match the browser URL (`http://localhost:<port>`) instead of
-            # probing IPv4 only. GitHub-hosted runners can expose the dev
-            # server on an IPv6 loopback address even when the browser works
-            # fine via `localhost`.
-            with socket.create_connection(("localhost", port), timeout=1):
-                sys.stdout.write(" ready.\n")
-                sys.stdout.flush()
-                return
-        except Exception:
-            pass
+        for host in loopback_hosts:
+            try:
+                # Match the browser URL (`http://localhost:<port>`) while also
+                # trying the explicit loopback addresses. GitHub-hosted runners
+                # can expose the dev server on a different loopback family than
+                # the one the browser prefers.
+                with socket.create_connection((host, port), timeout=1):
+                    sys.stdout.write(" ready.\n")
+                    sys.stdout.flush()
+                    return
+            except Exception:
+                pass
 
         if time.monotonic() >= deadline:
             sys.stdout.write(" timed out!\n")

--- a/tools/gz_start_launcher.py
+++ b/tools/gz_start_launcher.py
@@ -312,13 +312,13 @@ def wait_for_backend(port: int, timeout_seconds: float = 60.0) -> None:
         time.sleep(0.5)
 
 
-def wait_for_web(log_path: Path, port: int, timeout_seconds: float = 60.0) -> None:
+def wait_for_web(port: int, timeout_seconds: float = 60.0) -> None:
     deadline = time.monotonic() + timeout_seconds
     sys.stdout.write("Waiting for web to be ready")
     sys.stdout.flush()
     while True:
         try:
-            if port_from_log(log_path) == port:
+            with socket.create_connection(("127.0.0.1", port), timeout=1):
                 sys.stdout.write(" ready.\n")
                 sys.stdout.flush()
                 return
@@ -652,7 +652,7 @@ def start_stack(no_browser: bool = False) -> int:
             print(f"web: already running (PID {pid})")
             web_port = read_int_file(web_portfile) or port_from_log(web_log) or web_port
 
-        wait_for_web(web_log, web_port)
+        wait_for_web(web_port)
 
         url = f"http://localhost:{web_port}"
         if not no_browser:

--- a/tools/tests/test_gz_start_launcher.py
+++ b/tools/tests/test_gz_start_launcher.py
@@ -193,6 +193,11 @@ def test_start_stack_waits_for_backend_before_web(monkeypatch, tmp_path: Path) -
     )
     monkeypatch.setattr(
         launcher,
+        "sync_generated_types",
+        lambda *args, **kwargs: events.append("sync_generated_types"),
+    )
+    monkeypatch.setattr(
+        launcher,
         "start_web",
         lambda *args, **kwargs: events.append("start_web"),
     )
@@ -203,7 +208,13 @@ def test_start_stack_waits_for_backend_before_web(monkeypatch, tmp_path: Path) -
     )
 
     assert launcher.start_stack(no_browser=True) == 0
-    assert events == ["start_backend", "wait_for_backend", "start_web", "wait_for_web"]
+    assert events == [
+        "start_backend",
+        "wait_for_backend",
+        "sync_generated_types",
+        "start_web",
+        "wait_for_web",
+    ]
 
 
 def test_wait_for_web_waits_until_port_accepts_connections(monkeypatch) -> None:

--- a/tools/tests/test_gz_start_launcher.py
+++ b/tools/tests/test_gz_start_launcher.py
@@ -199,42 +199,28 @@ def test_start_stack_waits_for_backend_before_web(monkeypatch, tmp_path: Path) -
     monkeypatch.setattr(
         launcher,
         "wait_for_web",
-        lambda port, timeout_seconds=180.0: events.append("wait_for_web"),
+        lambda log_path, port, timeout_seconds=60.0: events.append("wait_for_web"),
     )
 
     assert launcher.start_stack(no_browser=True) == 0
     assert events == ["start_backend", "wait_for_backend", "start_web", "wait_for_web"]
 
 
-def test_wait_for_web_waits_until_root_is_serving(monkeypatch) -> None:
-    attempts = iter(
-        [
-            OSError("not ready"),
-            type(
-                "MockResponse",
-                (),
-                {
-                    "status": 200,
-                    "__enter__": lambda self: self,
-                    "__exit__": lambda self, exc_type, exc, tb: None,
-                },
-            )(),
-        ]
-    )
+def test_wait_for_web_waits_until_log_reports_port(
+    monkeypatch, tmp_path: Path
+) -> None:
+    log_path = tmp_path / "web.log"
+    log_path.write_text("", encoding="utf-8")
     sleep_calls: list[float] = []
     times = iter([0.0, 0.1, 0.2])
 
-    monkeypatch.setattr(
-        launcher.urllib.request,
-        "urlopen",
-        lambda url, timeout: next(attempts),
-    )
+    monkeypatch.setattr(launcher, "port_from_log", lambda path: 5173)
     monkeypatch.setattr(launcher.time, "monotonic", lambda: next(times))
     monkeypatch.setattr(launcher.time, "sleep", lambda seconds: sleep_calls.append(seconds))
 
-    launcher.wait_for_web(5173, timeout_seconds=1.0)
+    launcher.wait_for_web(log_path, 5173, timeout_seconds=1.0)
 
-    assert sleep_calls == [0.5]
+    assert sleep_calls == []
 
 
 def test_terminate_process_group_stops_gracefully(monkeypatch) -> None:

--- a/tools/tests/test_gz_start_launcher.py
+++ b/tools/tests/test_gz_start_launcher.py
@@ -208,10 +208,12 @@ def test_start_stack_waits_for_backend_before_web(monkeypatch, tmp_path: Path) -
 
 def test_wait_for_web_waits_until_port_accepts_connections(monkeypatch) -> None:
     sleep_calls: list[float] = []
+    addresses: list[tuple[str, int]] = []
     times = iter([0.0, 0.1, 0.2])
     attempts = iter([OSError("not ready"), object()])
 
     def fake_create_connection(address, timeout):
+        addresses.append(address)
         result = next(attempts)
         if isinstance(result, Exception):
             raise result
@@ -231,6 +233,7 @@ def test_wait_for_web_waits_until_port_accepts_connections(monkeypatch) -> None:
     launcher.wait_for_web(5173, timeout_seconds=1.0)
 
     assert sleep_calls == [0.5]
+    assert addresses == [("localhost", 5173), ("localhost", 5173)]
 
 
 def test_terminate_process_group_stops_gracefully(monkeypatch) -> None:
@@ -279,6 +282,20 @@ def test_terminate_process_group_escalates_after_timeout(monkeypatch) -> None:
     launcher.terminate_process_group(1234, timeout_seconds=0.0)
 
     assert signals == [0, signal.SIGTERM, signal.SIGKILL, 0]
+
+
+def test_terminate_process_group_ignores_permission_error(monkeypatch) -> None:
+    if launcher.os.name == "nt":
+        return
+
+    def fake_killpg(pgid: int, sig: int) -> None:
+        if sig != 0:
+            raise PermissionError
+
+    monkeypatch.setattr(launcher.os, "killpg", fake_killpg)
+    monkeypatch.setattr(launcher.time, "monotonic", lambda: 0.0)
+
+    launcher.terminate_process_group(1234)
 
 
 def test_start_web_sets_bazel_bindir_only_on_linux(monkeypatch, tmp_path: Path) -> None:

--- a/tools/tests/test_gz_start_launcher.py
+++ b/tools/tests/test_gz_start_launcher.py
@@ -173,6 +173,39 @@ def test_backend_is_ready_uses_health_checks(monkeypatch) -> None:
     assert launcher.backend_is_ready(8080) is True
 
 
+def test_start_stack_waits_for_backend_before_web(monkeypatch, tmp_path: Path) -> None:
+    roots = launcher.Roots(workspace=tmp_path, shared=tmp_path)
+    events: list[str] = []
+
+    monkeypatch.setattr(launcher, "detect_roots", lambda: roots)
+    monkeypatch.setattr(launcher, "load_repo_env", lambda _roots: {})
+    monkeypatch.setattr(launcher, "choose_port", lambda _path, start: start)
+    monkeypatch.setattr(launcher, "ensure_running", lambda _pidfile: (None, False))
+    monkeypatch.setattr(
+        launcher,
+        "start_backend",
+        lambda *args, **kwargs: events.append("start_backend"),
+    )
+    monkeypatch.setattr(
+        launcher,
+        "wait_for_backend",
+        lambda port, timeout_seconds=60.0: events.append("wait_for_backend"),
+    )
+    monkeypatch.setattr(
+        launcher,
+        "start_web",
+        lambda *args, **kwargs: events.append("start_web"),
+    )
+    monkeypatch.setattr(
+        launcher,
+        "wait_for_web",
+        lambda port, timeout_seconds=180.0: events.append("wait_for_web"),
+    )
+
+    assert launcher.start_stack(no_browser=True) == 0
+    assert events == ["start_backend", "wait_for_backend", "start_web", "wait_for_web"]
+
+
 def test_wait_for_web_waits_until_root_is_serving(monkeypatch) -> None:
     attempts = iter(
         [

--- a/tools/tests/test_gz_start_launcher.py
+++ b/tools/tests/test_gz_start_launcher.py
@@ -373,6 +373,18 @@ def test_start_web_sets_bazel_bindir_for_all_platforms(
         captured_env_linux_existing.get("BAZEL_BINDIR") == "bazel-out/k8-fastbuild/bin"
     ), "BAZEL_BINDIR should be respected if already provided by the environment."
 
+    captured_env_linux_empty: dict[str, str] = {}
+
+    def fake_launch_child_linux_empty(argv, cwd, env, log_path):
+        nonlocal captured_env_linux_empty
+        captured_env_linux_empty = env
+        return MockPopen()
+
+    monkeypatch.setattr(launcher, "launch_child", fake_launch_child_linux_empty)
+    launcher.start_web(roots, {"BAZEL_BINDIR": ""}, pidfile, portfile, log_path, 8080, 5173)
+
+    assert captured_env_linux_empty.get("BAZEL_BINDIR") == "."
+
     # 2. Test Mac behavior: BAZEL_BINDIR should also be set if missing.
     monkeypatch.setattr(launcher.sys, "platform", "darwin")
     captured_env_mac: dict[str, str] = {}
@@ -386,6 +398,18 @@ def test_start_web_sets_bazel_bindir_for_all_platforms(
     launcher.start_web(roots, {}, pidfile, portfile, log_path, 8080, 5173)
 
     assert captured_env_mac.get("BAZEL_BINDIR") == "."
+
+    captured_env_mac_empty: dict[str, str] = {}
+
+    def fake_launch_child_mac_empty(argv, cwd, env, log_path):
+        nonlocal captured_env_mac_empty
+        captured_env_mac_empty = env
+        return MockPopen()
+
+    monkeypatch.setattr(launcher, "launch_child", fake_launch_child_mac_empty)
+    launcher.start_web(roots, {"BAZEL_BINDIR": ""}, pidfile, portfile, log_path, 8080, 5173)
+
+    assert captured_env_mac_empty.get("BAZEL_BINDIR") == "."
 
 
 def test_ensure_local_web_node_modules_replaces_shared_symlink(

--- a/tools/tests/test_gz_start_launcher.py
+++ b/tools/tests/test_gz_start_launcher.py
@@ -220,8 +220,8 @@ def test_start_stack_waits_for_backend_before_web(monkeypatch, tmp_path: Path) -
 def test_wait_for_web_waits_until_port_accepts_connections(monkeypatch) -> None:
     sleep_calls: list[float] = []
     addresses: list[tuple[str, int]] = []
-    times = iter([0.0, 0.1, 0.2])
-    attempts = iter([OSError("not ready"), object()])
+    times = iter([0.0, 0.1, 0.2, 0.3])
+    attempts = iter([OSError("not ready"), OSError("not ready"), object()])
 
     def fake_create_connection(address, timeout):
         addresses.append(address)
@@ -243,8 +243,12 @@ def test_wait_for_web_waits_until_port_accepts_connections(monkeypatch) -> None:
 
     launcher.wait_for_web(5173, timeout_seconds=1.0)
 
-    assert sleep_calls == [0.5]
-    assert addresses == [("localhost", 5173), ("localhost", 5173)]
+    assert sleep_calls == []
+    assert addresses == [
+        ("localhost", 5173),
+        ("127.0.0.1", 5173),
+        ("::1", 5173),
+    ]
 
 
 def test_terminate_process_group_stops_gracefully(monkeypatch) -> None:

--- a/tools/tests/test_gz_start_launcher.py
+++ b/tools/tests/test_gz_start_launcher.py
@@ -173,6 +173,37 @@ def test_backend_is_ready_uses_health_checks(monkeypatch) -> None:
     assert launcher.backend_is_ready(8080) is True
 
 
+def test_wait_for_web_waits_until_root_is_serving(monkeypatch) -> None:
+    attempts = iter(
+        [
+            OSError("not ready"),
+            type(
+                "MockResponse",
+                (),
+                {
+                    "status": 200,
+                    "__enter__": lambda self: self,
+                    "__exit__": lambda self, exc_type, exc, tb: None,
+                },
+            )(),
+        ]
+    )
+    sleep_calls: list[float] = []
+    times = iter([0.0, 0.1, 0.2])
+
+    monkeypatch.setattr(
+        launcher.urllib.request,
+        "urlopen",
+        lambda url, timeout: next(attempts),
+    )
+    monkeypatch.setattr(launcher.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(launcher.time, "sleep", lambda seconds: sleep_calls.append(seconds))
+
+    launcher.wait_for_web(5173, timeout_seconds=1.0)
+
+    assert sleep_calls == [0.5]
+
+
 def test_terminate_process_group_stops_gracefully(monkeypatch) -> None:
     if launcher.os.name == "nt":
         return

--- a/tools/tests/test_gz_start_launcher.py
+++ b/tools/tests/test_gz_start_launcher.py
@@ -313,7 +313,9 @@ def test_terminate_process_group_ignores_permission_error(monkeypatch) -> None:
     launcher.terminate_process_group(1234)
 
 
-def test_start_web_sets_bazel_bindir_only_on_linux(monkeypatch, tmp_path: Path) -> None:
+def test_start_web_sets_bazel_bindir_for_all_platforms(
+    monkeypatch, tmp_path: Path
+) -> None:
     roots = launcher.Roots(workspace=tmp_path, shared=tmp_path)
     pidfile = tmp_path / "web.pid"
     portfile = tmp_path / "web.port"
@@ -371,7 +373,7 @@ def test_start_web_sets_bazel_bindir_only_on_linux(monkeypatch, tmp_path: Path) 
         captured_env_linux_existing.get("BAZEL_BINDIR") == "bazel-out/k8-fastbuild/bin"
     ), "BAZEL_BINDIR should be respected if already provided by the environment."
 
-    # 2. Test Mac behavior: BAZEL_BINDIR should NOT be set (not required)
+    # 2. Test Mac behavior: BAZEL_BINDIR should also be set if missing.
     monkeypatch.setattr(launcher.sys, "platform", "darwin")
     captured_env_mac: dict[str, str] = {}
 
@@ -383,9 +385,7 @@ def test_start_web_sets_bazel_bindir_only_on_linux(monkeypatch, tmp_path: Path) 
     monkeypatch.setattr(launcher, "launch_child", fake_launch_child_mac)
     launcher.start_web(roots, {}, pidfile, portfile, log_path, 8080, 5173)
 
-    assert "BAZEL_BINDIR" not in captured_env_mac, (
-        "BAZEL_BINDIR should not be set on macOS as it is not required by aspect_rules_js."
-    )
+    assert captured_env_mac.get("BAZEL_BINDIR") == "."
 
 
 def test_ensure_local_web_node_modules_replaces_shared_symlink(

--- a/tools/tests/test_gz_start_launcher.py
+++ b/tools/tests/test_gz_start_launcher.py
@@ -199,28 +199,38 @@ def test_start_stack_waits_for_backend_before_web(monkeypatch, tmp_path: Path) -
     monkeypatch.setattr(
         launcher,
         "wait_for_web",
-        lambda log_path, port, timeout_seconds=60.0: events.append("wait_for_web"),
+        lambda port, timeout_seconds=60.0: events.append("wait_for_web"),
     )
 
     assert launcher.start_stack(no_browser=True) == 0
     assert events == ["start_backend", "wait_for_backend", "start_web", "wait_for_web"]
 
 
-def test_wait_for_web_waits_until_log_reports_port(
-    monkeypatch, tmp_path: Path
-) -> None:
-    log_path = tmp_path / "web.log"
-    log_path.write_text("", encoding="utf-8")
+def test_wait_for_web_waits_until_port_accepts_connections(monkeypatch) -> None:
     sleep_calls: list[float] = []
     times = iter([0.0, 0.1, 0.2])
+    attempts = iter([OSError("not ready"), object()])
 
-    monkeypatch.setattr(launcher, "port_from_log", lambda path: 5173)
+    def fake_create_connection(address, timeout):
+        result = next(attempts)
+        if isinstance(result, Exception):
+            raise result
+        class MockSocket:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return None
+
+        return MockSocket()
+
+    monkeypatch.setattr(launcher.socket, "create_connection", fake_create_connection)
     monkeypatch.setattr(launcher.time, "monotonic", lambda: next(times))
     monkeypatch.setattr(launcher.time, "sleep", lambda seconds: sleep_calls.append(seconds))
 
-    launcher.wait_for_web(log_path, 5173, timeout_seconds=1.0)
+    launcher.wait_for_web(5173, timeout_seconds=1.0)
 
-    assert sleep_calls == []
+    assert sleep_calls == [0.5]
 
 
 def test_terminate_process_group_stops_gracefully(monkeypatch) -> None:

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -181,6 +181,15 @@ js_binary(
     visibility = ["//visibility:public"],
 )
 
+js_binary(
+    name = "dev_smoke_piece_detail_clickthrough",
+    data = [
+        ":node_modules/playwright",
+    ],
+    entry_point = "scripts/dev-smoke-piece-detail-clickthrough.mjs",
+    visibility = ["//visibility:public"],
+)
+
 js_library(
     name = "coverage_audit_src",
     srcs = ["scripts/coverage-audit.mjs"],

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -74,6 +74,7 @@
         "msw": "^2.14.6",
         "msw-storybook-addon": "^2.0.7",
         "openapi-typescript": "^7.13.0",
+        "playwright": "^1.60.0",
         "prettier": "3.8.3",
         "storybook": "^8.6.18",
         "typescript": "5.9.3",
@@ -8364,7 +8365,6 @@
       "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright-core": "1.60.0"
       },
@@ -8384,7 +8384,6 @@
       "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -8403,7 +8402,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }

--- a/web/package.json
+++ b/web/package.json
@@ -81,6 +81,7 @@
     "msw": "^2.14.6",
     "msw-storybook-addon": "^2.0.7",
     "openapi-typescript": "^7.13.0",
+    "playwright": "^1.60.0",
     "prettier": "3.8.3",
     "storybook": "^8.6.18",
     "typescript": "5.9.3",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
       openapi-typescript:
         specifier: ^7.13.0
         version: 7.13.0(typescript@5.9.3)
+      playwright:
+        specifier: ^1.60.0
+        version: 1.60.0
       prettier:
         specifier: 3.8.3
         version: 3.8.3

--- a/web/scripts/dev-smoke-piece-detail-clickthrough.mjs
+++ b/web/scripts/dev-smoke-piece-detail-clickthrough.mjs
@@ -1,0 +1,37 @@
+import { chromium } from "playwright";
+
+function getArg(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] ?? null : null;
+}
+
+const webUrl = getArg("--web-url");
+const pieceId = getArg("--piece-id");
+const sessionCookie = getArg("--session-cookie");
+
+if (!webUrl || !pieceId || !sessionCookie) {
+  console.error(
+    "usage: node web/scripts/dev-smoke-piece-detail-clickthrough.mjs --web-url <url> --piece-id <id> --session-cookie <cookie>",
+  );
+  process.exit(2);
+}
+
+const browser = await chromium.launch({ headless: true });
+
+try {
+  const context = await browser.newContext();
+  await context.addCookies([
+    { name: "sessionid", value: sessionCookie, url: webUrl },
+  ]);
+
+  const page = await context.newPage();
+  await page.goto(webUrl, { waitUntil: "networkidle" });
+  await page.locator(`a[href="/pieces/${pieceId}"]`).first().click();
+  await page.waitForURL(new RegExp(`/pieces/${pieceId}(?:/|$)`));
+  await page.getByTestId("piece-title").waitFor();
+
+  const title = await page.getByTestId("piece-title").textContent();
+  console.log(`piece detail loaded: ${title ?? ""}`);
+} finally {
+  await browser.close();
+}

--- a/web/scripts/dev-smoke-piece-detail-clickthrough.mjs
+++ b/web/scripts/dev-smoke-piece-detail-clickthrough.mjs
@@ -25,9 +25,38 @@ try {
   ]);
 
   const page = await context.newPage();
-  await page.goto(webUrl, { waitUntil: "networkidle" });
-  await page.locator(`a[href="/pieces/${pieceId}"]`).first().click();
-  await page.waitForURL(new RegExp(`/pieces/${pieceId}(?:/|$)`));
+  const piecesLoaded = page.waitForResponse(
+    (response) =>
+      response.url().includes("/api/pieces/") &&
+      response.request().method() === "GET" &&
+      response.ok(),
+    { timeout: 30000 },
+  );
+  await page.goto(webUrl, { waitUntil: "domcontentloaded" });
+  await piecesLoaded;
+
+  const exactLink = pieceId
+    ? page.locator(`a[href="/pieces/${pieceId}"]`).first()
+    : null;
+  let clicked = false;
+  if (exactLink) {
+    try {
+      await exactLink.waitFor({ state: "visible", timeout: 5000 });
+      await exactLink.click();
+      clicked = true;
+    } catch {
+      clicked = false;
+    }
+  }
+
+  if (!clicked) {
+    const firstLink = page.locator('a[href^="/pieces/"]').first();
+    await firstLink.waitFor({ state: "visible", timeout: 30000 });
+    await firstLink.click();
+  }
+
+  const detailUrl = page.waitForURL(/\/pieces\/[^/]+(?:\/|$)/);
+  await detailUrl;
   await page.getByTestId("piece-title").waitFor();
 
   const title = await page.getByTestId("piece-title").textContent();


### PR DESCRIPTION
## What changed
- Added a macOS `dev-smoke` job alongside the existing Linux one in `.github/workflows/ci.yml`.
- Both jobs now create a detached throwaway worktree under `$RUNNER_TEMP` and run the smoke flow from that isolated checkout.
- Extended both jobs to click through from the seeded pieces list into the `PieceDetail` route using a real browser.
- Installed the `web` workspace dependencies in each smoke job after sourcing `env.sh` so the repo-local environment is available in CI.
- Moved the browser click-through logic into `web/scripts/dev-smoke-piece-detail-clickthrough.mjs` and added a Bazel `js_binary` target for it.
- Updated the shared Bazel setup helper so it can inject the CI BuildBuddy config into the temporary worktree.
- Made `gz_start` wait for the backend to be healthy before starting the web process, then wait for the web server to answer before returning. That matches the real dev startup dependency order and avoids the migration/seeding race in CI.
- Fixed the mypy failure that surfaced after rebasing onto current `main`.

## Why
This keeps the documented `env.sh -> gz_start` developer workflow covered on both supported local platforms, and it makes the browser smoke test exercise the real detail view without racing startup or letting the web process compete with backend migrations.

## Validation
- `rtk bazel test //tools:test_gz_start_launcher --test_output=errors`
- `rtk bazel build --config=lint //...`
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY` against `.github/workflows/ci.yml`
- `node --check web/scripts/dev-smoke-piece-detail-clickthrough.mjs`

Closes #769
