### PR TITLE
ci: verify image starts cleanly before push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,6 +358,13 @@ jobs:
       - name: Build OCI image and load into docker
         run: bazel run --config=ci --stamp //:load
 
+      - name: Verify image starts cleanly (django check)
+        run: |
+          docker run --rm \
+            -e SECRET_KEY=ci-check-placeholder \
+            ghcr.io/shaoster/glaze:ci \
+            python manage.py check
+
       - name: Lint and validate Helm chart
         run: |
           helm lint chart/glaze/ \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,7 +362,7 @@ jobs:
         run: |
           docker run --rm \
             -e SECRET_KEY=ci-check-placeholder \
-            ghcr.io/shaoster/glaze:ci \
+            ghcr.io/shaoster/glaze:latest \
             python manage.py check
 
       - name: Lint and validate Helm chart


### PR DESCRIPTION
## What

Adds a `Verify image starts cleanly (django check)` step to the `image` CI job, immediately after the image is loaded into Docker and before it is pushed to GHCR.

```yaml
- name: Verify image starts cleanly (django check)
  run: |
    docker run --rm \
      -e SECRET_KEY=ci-check-placeholder \
      ghcr.io/shaoster/glaze:ci \
      python manage.py check
```

## Why

Two production outages this week were caused by bugs that passed all unit tests but only surfaced after a failed deploy:

1. `piece/showcase_views.py` and `showcase/render.py` were added to `api_lib` (the test target) but not to `api_runtime_files` (the image filegroup). Tests passed; the deployed image crashed on startup with `ModuleNotFoundError`.

2. `music.py` called `_build_catalog()` at module import time, raising `FileNotFoundError` when LFS audio assets were absent from the image. Same failure mode — undetectable by tests.

`manage.py check` loads all URL patterns and runs Django's system check framework, which transitively imports every view module. It would have failed immediately on both bugs, blocking the push before CD ever ran.

## Why only `SECRET_KEY`

`settings.py` falls back to SQLite when `DATABASE_URL` is absent and `PRODUCTION` is unset, so no live database is needed. No other env var is required to pass `manage.py check`.