### PR TITLE
feat: report frontend errors and stack traces to Grafana

### DIFF
--- a/api/telemetry_views.py
+++ b/api/telemetry_views.py
@@ -6,9 +6,13 @@ import os
 from urllib.parse import urlparse, urlunparse
 
 import httpx
-from django.http import HttpResponse, RawPostDataException
+from django.http import HttpResponse
 from drf_spectacular.utils import extend_schema
-from rest_framework.decorators import api_view, permission_classes
+from rest_framework.decorators import (
+    api_view,
+    authentication_classes,
+    permission_classes,
+)
 from rest_framework.permissions import AllowAny
 from rest_framework.request import Request
 
@@ -48,16 +52,12 @@ def _collector_traces_endpoint() -> str:
     ),
 )
 @api_view(["POST"])
+@authentication_classes([])
 @permission_classes([AllowAny])
 @traced("telemetry.browser_traces")
 def browser_traces(request: Request) -> HttpResponse:
     """Forward a browser OTLP/HTTP trace payload to the collector."""
-    # Cache body locally; guard against RawPostDataException if the stream was
-    # already consumed upstream (e.g. by middleware or DRF content negotiation).
-    try:
-        body = request.body
-    except RawPostDataException:
-        return HttpResponse(status=400)
+    body = request.body
     if not body:
         return HttpResponse(status=400)
 

--- a/api/telemetry_views.py
+++ b/api/telemetry_views.py
@@ -6,7 +6,7 @@ import os
 from urllib.parse import urlparse, urlunparse
 
 import httpx
-from django.http import HttpResponse
+from django.http import HttpResponse, RawPostDataException
 from drf_spectacular.utils import extend_schema
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny
@@ -52,7 +52,13 @@ def _collector_traces_endpoint() -> str:
 @traced("telemetry.browser_traces")
 def browser_traces(request: Request) -> HttpResponse:
     """Forward a browser OTLP/HTTP trace payload to the collector."""
-    if not request.body:
+    # Cache body locally; guard against RawPostDataException if the stream was
+    # already consumed upstream (e.g. by middleware or DRF content negotiation).
+    try:
+        body = request.body
+    except RawPostDataException:
+        return HttpResponse(status=400)
+    if not body:
         return HttpResponse(status=400)
 
     collector_endpoint = _collector_traces_endpoint()
@@ -65,7 +71,7 @@ def browser_traces(request: Request) -> HttpResponse:
     try:
         response = httpx.post(
             collector_endpoint,
-            content=request.body,
+            content=body,
             headers=forward_headers,
             timeout=10.0,
         )

--- a/api/tests/test_telemetry.py
+++ b/api/tests/test_telemetry.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock
 
 import httpx
 import pytest
-from django.test import RequestFactory
+from django.contrib.auth.models import User
 
 
 @pytest.mark.django_db
@@ -47,27 +47,33 @@ class TestTelemetryProxy:
 
         assert response.status_code == 400
 
-    def test_browser_traces_survives_pre_consumed_body(self, monkeypatch):
-        # Regression for #759: RawPostDataException when request stream is read
-        # before the view runs.
-        from api.telemetry_views import browser_traces
-
+    def test_browser_traces_succeeds_for_authenticated_users(self, client, monkeypatch):
+        # Regression for #759: SessionAuthentication.enforce_csrf() accessed
+        # DRF's Request.POST which triggered _load_data_and_files(), consuming
+        # the body stream before browser_traces() could read it.
+        # Fix: @authentication_classes([]) skips SessionAuthentication entirely.
         monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otelcol:4317")
         response_mock = httpx.Response(
             202,
             content=b"",
             headers={"content-type": "text/plain"},
         )
-        monkeypatch.setattr(
-            "api.telemetry_views.httpx.post", Mock(return_value=response_mock)
-        )
+        post_mock = Mock(return_value=response_mock)
+        monkeypatch.setattr("api.telemetry_views.httpx.post", post_mock)
 
-        raw = RequestFactory().post(
+        user = User.objects.create_user(username="tester", password="pass")
+        client.force_login(user)
+
+        response = client.post(
             "/api/telemetry/traces/",
             data=b"trace-bytes",
             content_type="application/x-protobuf",
         )
-        raw.read()  # consume the stream before the view runs
 
-        response = browser_traces(raw)
-        assert response.status_code == 400
+        assert response.status_code == 202
+        post_mock.assert_called_once_with(
+            "http://otelcol:4318/v1/traces",
+            content=b"trace-bytes",
+            headers={"content-type": "application/x-protobuf"},
+            timeout=10.0,
+        )

--- a/api/tests/test_telemetry.py
+++ b/api/tests/test_telemetry.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock
 
 import httpx
 import pytest
+from django.test import RequestFactory
 
 
 @pytest.mark.django_db
@@ -44,4 +45,29 @@ class TestTelemetryProxy:
             content_type="application/x-protobuf",
         )
 
+        assert response.status_code == 400
+
+    def test_browser_traces_survives_pre_consumed_body(self, monkeypatch):
+        # Regression for #759: RawPostDataException when request stream is read
+        # before the view runs.
+        from api.telemetry_views import browser_traces
+
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otelcol:4317")
+        response_mock = httpx.Response(
+            202,
+            content=b"",
+            headers={"content-type": "text/plain"},
+        )
+        monkeypatch.setattr(
+            "api.telemetry_views.httpx.post", Mock(return_value=response_mock)
+        )
+
+        raw = RequestFactory().post(
+            "/api/telemetry/traces/",
+            data=b"trace-bytes",
+            content_type="application/x-protobuf",
+        )
+        raw.read()  # consume the stream before the view runs
+
+        response = browser_traces(raw)
         assert response.status_code == 400

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
-import { Component } from "react";
+import React, { Component } from "react";
 import type { ReactNode } from "react";
 import { Typography } from "@mui/material";
+import { reportFrontendError } from "../util/telemetry";
 
 interface Props {
   children: ReactNode;
@@ -27,6 +28,13 @@ export default class ErrorBoundary extends Component<Props, State> {
 
   static getDerivedStateFromError(): State {
     return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    reportFrontendError(error, {
+      "error.source": "ErrorBoundary",
+      "react.component_stack": info.componentStack ?? "",
+    });
   }
 
   render() {

--- a/web/src/util/telemetry.ts
+++ b/web/src/util/telemetry.ts
@@ -1,3 +1,4 @@
+import { trace, SpanStatusCode } from "@opentelemetry/api";
 import { resourceFromAttributes } from "@opentelemetry/resources";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
 import { registerInstrumentations } from "@opentelemetry/instrumentation";
@@ -9,6 +10,34 @@ import { XMLHttpRequestInstrumentation } from "@opentelemetry/instrumentation-xm
 
 const TRACE_EXPORT_URL = "/api/telemetry/traces/";
 const SERVICE_NAME = "glaze-web";
+
+const _tracer = trace.getTracer(SERVICE_NAME);
+
+/**
+ * Record an error as an OTel error span so it appears in Grafana Tempo.
+ * Safe to call before telemetry is initialized — spans will be no-ops.
+ */
+export function reportFrontendError(
+  error: unknown,
+  context?: Record<string, string>,
+): void {
+  const span = _tracer.startSpan("frontend.error");
+  try {
+    if (error instanceof Error) {
+      span.recordException(error);
+    } else {
+      span.recordException(String(error));
+    }
+    span.setStatus({ code: SpanStatusCode.ERROR });
+    if (context) {
+      for (const [key, value] of Object.entries(context)) {
+        span.setAttribute(key, value);
+      }
+    }
+  } finally {
+    span.end();
+  }
+}
 
 let frontendTelemetryInitialized = false;
 
@@ -56,6 +85,18 @@ export function initializeFrontendTelemetry(): void {
       }),
       new UserInteractionInstrumentation(),
     ],
+  });
+
+  window.addEventListener("error", (event) => {
+    if (event.error) {
+      reportFrontendError(event.error, { "error.source": "window.onerror" });
+    }
+  });
+
+  window.addEventListener("unhandledrejection", (event) => {
+    reportFrontendError(event.reason, {
+      "error.source": "unhandledrejection",
+    });
   });
 
   frontendTelemetryInitialized = true;


### PR DESCRIPTION
## Summary

**Frontend error reporting (new)**
- Adds `reportFrontendError(error, context?)` to `telemetry.ts` — creates a short-lived OTel error span using `recordException()` and `SpanStatusCode.ERROR`, routed through the existing OTLP trace pipeline to Grafana Tempo. No new packages needed.
- `ErrorBoundary.componentDidCatch` now calls `reportFrontendError` with the error and React component stack so render crashes are visible in Grafana.
- `window.error` and `unhandledrejection` listeners registered during `initializeFrontendTelemetry` catch all other uncaught exceptions and unhandled promise rejections.

**Telemetry proxy body-consumed crash fix (#759)**

Root cause: for authenticated users, DRF's `SessionAuthentication.enforce_csrf()` accessed `Request.POST` — DRF's own `POST` property (not Django's), which calls `_load_data_and_files()` → `_parse()` → `_load_stream()`, setting `_stream = request` (the raw Django request). The parser then called `stream.read()`, setting `_read_started = True`. The subsequent `request.body` access in `browser_traces()` raised `RawPostDataException`.

Fix: `@authentication_classes([])` on `browser_traces` skips `SessionAuthentication` entirely — the endpoint is `AllowAny` and sends its own CSRF token, so session auth is not needed. With no authenticator running, `enforce_csrf` is never called and the stream stays intact.

Regression test: authenticated user POST now reaches the collector with 202 instead of 500.

## Test plan

- [ ] Trigger a render error caught by `ErrorBoundary` and verify a `frontend.error` span with `exception.stacktrace` appears in Grafana Tempo
- [ ] Trigger an unhandled promise rejection (e.g. `Promise.reject(new Error("test"))` in the console) and verify a span appears
- [ ] `//api:api_otel_test` passes — includes regression test: authenticated POST to `/api/telemetry/traces/` returns 202

Closes #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)