### PR TITLE
fix: raise worker memory limit to 512Mi for video rendering

### DIFF
--- a/chart/glaze/values.yaml
+++ b/chart/glaze/values.yaml
@@ -98,7 +98,7 @@ worker:
     requests:
       memory: "128Mi"
     limits:
-      memory: "256Mi"
+      memory: "512Mi"
 
 otelcol:
   enabled: true


### PR DESCRIPTION
## Summary
- dmesg confirmed OOMKill at anon-rss ~254Mi (hitting the previous 256Mi limit) just 24 seconds into the render.
- Baseline worker RSS is ~112Mi; the render (image downloads + Pillow canvases + PyAV packet buffers) consumes ~142Mi on top.
- Raising limit to 512Mi to observe actual peak before right-sizing further.

## Evidence
```
oom-kill: Memory cgroup out of memory: Killed process 1494606 (python)
  total-vm:1166756kB, anon-rss:259776kB (~254Mi), oom_score_adj:935
```

## Test plan
- [ ] Deploy and trigger a showcase video render
- [ ] Worker logs a success line with final RSS
- [ ] Check `dmesg` — no further OOMKill
- [ ] Update limit downward once peak RSS is known

🤖 Generated with [Claude Code](https://claude.com/claude-code)