### PR TITLE
feat: make the New Piece dialog routeable

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -868,6 +868,7 @@ function AuthenticatedApp({
           >
             <Route path="/" element={<LandingPage />}>
               <Route index element={<PieceListPage />} />
+              <Route path="new" element={<PieceListPage />} />
               <Route path="analyze/*" element={<AnalyzePage />} />
             </Route>
             <Route path="/pieces/:id/*" element={<PieceDetailPage />} />

--- a/web/src/components/NewPieceDialog.tsx
+++ b/web/src/components/NewPieceDialog.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useBlocker } from "react-router-dom";
 import {
   Box,
   Button,
@@ -38,6 +39,22 @@ export default function NewPieceDialog({
   const [location, setLocation] = useState("");
   const [confirmDiscard, setConfirmDiscard] = useState(false);
 
+  const isProgrammaticCloseRef = useRef(false);
+
+  const isDirty =
+    name.trim() !== "" ||
+    notes !== "" ||
+    selectedThumbnail !== DEFAULT_THUMBNAIL;
+
+  const blocker = useBlocker(
+    ({ currentLocation, nextLocation }) => {
+      if (isProgrammaticCloseRef.current) {
+        return false;
+      }
+      return isDirty && open && currentLocation.pathname !== nextLocation.pathname;
+    }
+  );
+
   function resetState() {
     setName("");
     setNotes("");
@@ -47,23 +64,53 @@ export default function NewPieceDialog({
     setConfirmDiscard(false);
   }
 
-  const isDirty =
-    name.trim() !== "" ||
-    notes !== "" ||
-    selectedThumbnail !== DEFAULT_THUMBNAIL;
+  useEffect(() => {
+    if (!open) {
+      resetState();
+      isProgrammaticCloseRef.current = false;
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || !isDirty) return;
+
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, [open, isDirty]);
 
   function handleAttemptClose() {
     if (isDirty) {
       setConfirmDiscard(true);
     } else {
+      isProgrammaticCloseRef.current = true;
       resetState();
       onClose();
     }
   }
 
   function handleConfirmDiscard() {
-    resetState();
-    onClose();
+    if (blocker.state === "blocked") {
+      blocker.proceed();
+    } else {
+      isProgrammaticCloseRef.current = true;
+      resetState();
+      onClose();
+    }
+  }
+
+  function handleCancelDiscard() {
+    if (blocker.state === "blocked") {
+      blocker.reset();
+    } else {
+      setConfirmDiscard(false);
+    }
   }
 
   async function handleSave() {
@@ -76,6 +123,7 @@ export default function NewPieceDialog({
         notes: notes || undefined,
         current_location: undefinedIfBlank(location),
       });
+      isProgrammaticCloseRef.current = true;
       resetState();
       onClose();
       onCreated(piece);
@@ -86,6 +134,7 @@ export default function NewPieceDialog({
 
   const nameIsInvalid = name !== "" && name.trim() === "";
   const canSave = name.trim() !== "" && !saving;
+  const showDiscard = confirmDiscard || blocker.state === "blocked";
 
   return (
     <>
@@ -167,7 +216,7 @@ export default function NewPieceDialog({
         </DialogActions>
       </Dialog>
 
-      <Dialog open={confirmDiscard} onClose={() => setConfirmDiscard(false)}>
+      <Dialog open={showDiscard} onClose={handleCancelDiscard}>
         <DialogTitle>Discard new piece?</DialogTitle>
         <DialogContent>
           <DialogContentText>
@@ -176,7 +225,7 @@ export default function NewPieceDialog({
           </DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setConfirmDiscard(false)}>Keep editing</Button>
+          <Button onClick={handleCancelDiscard}>Keep editing</Button>
           <Button
             onClick={handleConfirmDiscard}
             color="error"

--- a/web/src/components/__tests__/NewPieceDialog.test.tsx
+++ b/web/src/components/__tests__/NewPieceDialog.test.tsx
@@ -9,14 +9,22 @@ import {
 import type { ReactElement } from "react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { RouterProvider, createMemoryRouter } from "react-router-dom";
 import NewPieceDialog from "../NewPieceDialog";
 
 function render(ui: ReactElement) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
+  const router = createMemoryRouter([
+    { path: "/", element: ui }
+  ], {
+    initialEntries: ["/"]
+  });
   return baseRender(
-    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
   );
 }
 import { CURATED_THUMBNAILS } from "../thumbnailConstants";

--- a/web/src/pages/PieceListPage.tsx
+++ b/web/src/pages/PieceListPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useLocation, useMatch, useNavigate, useSearchParams } from "react-router-dom";
 import AddIcon from "@mui/icons-material/Add";
 import {
   Box,
@@ -38,7 +38,35 @@ export default function PieceListPage() {
     sortFromUrl && PIECE_SORT_OPTIONS.some((o) => o.value === sortFromUrl)
       ? sortFromUrl
       : DEFAULT_PIECE_SORT;
-  const [dialogOpen, setDialogOpen] = useState(false);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const match = useMatch("/new");
+  const dialogOpen = match !== null;
+
+  const handleOpenDialog = useCallback(() => {
+    navigate(
+      {
+        pathname: "/new",
+        search: searchParams.toString(),
+      },
+      { state: { fromApp: true } }
+    );
+  }, [navigate, searchParams]);
+
+  const handleCloseDialog = useCallback(() => {
+    if (location.state?.fromApp) {
+      navigate(-1);
+    } else {
+      navigate(
+        {
+          pathname: "/",
+          search: searchParams.toString(),
+        },
+        { replace: true }
+      );
+    }
+  }, [navigate, location.state, searchParams]);
+
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
@@ -147,7 +175,7 @@ export default function PieceListPage() {
         <Fab
           color="primary"
           aria-label="New Piece"
-          onClick={() => setDialogOpen(true)}
+          onClick={handleOpenDialog}
           sx={{
             position: "fixed",
             right: 16,
@@ -175,7 +203,7 @@ export default function PieceListPage() {
       {!loading && !error && (
         <PieceList
           pieces={pieces}
-          onNewPiece={() => setDialogOpen(true)}
+          onNewPiece={handleOpenDialog}
           sortOrder={sortOrder}
           onSortChange={handleSortChange}
           onLoadMore={handleLoadMore}
@@ -186,7 +214,7 @@ export default function PieceListPage() {
       )}
       <NewPieceDialog
         open={dialogOpen}
-        onClose={() => setDialogOpen(false)}
+        onClose={handleCloseDialog}
         onCreated={handleCreated}
       />
     </>


### PR DESCRIPTION
Closes https://github.com/shaoster/glaze/issues/761

## Summary

This PR makes the "New Piece" dialog routeable via a URL-backed sub-route under the main piece list.

### Changes
1. **Routing Definition:** Map the `/new` path to `PieceListPage` inside the authenticated routes in [App.tsx](file:///home/phil/code/glaze/web/src/App.tsx).
2. **PieceListPage Refactoring:** Read the matching `/new` sub-route via `useMatch` to determine if the dialog should be open, and trigger `onNewPiece` and `onClose` via standard react-router `navigate` triggers.
3. **Dirty-Form Navigation Interception:** Integrated React Router's `useBlocker` hook in [NewPieceDialog.tsx](file:///home/phil/code/glaze/web/src/components/NewPieceDialog.tsx) to intercept route transitions when the form has unsaved modifications. Added a fallback to ensure standard test runners (which mock `onClose`) still correctly display the discard dialog when cancel is clicked.
4. **BeforeUnload Handler**: Registered a `beforeunload` window event listener when the dialog is open and form is dirty to prompt users confirming reload/tab close actions.
5. **Test Adjustments:** Updated [NewPieceDialog.test.tsx](file:///home/phil/code/glaze/web/src/components/__tests__/NewPieceDialog.test.tsx) to run inside a memory router context.

### Verification Results

All unit and integration tests build and execute cleanly under Bazel:
```bash
bazel test //web:web_test
bazel build --config=lint //web/...
```
All 38 test suites pass.
