### PR TITLE
fix: allow Cloudinary showcase video playback

### DIFF
--- a/chart/glaze/templates/middleware-security-headers.yaml
+++ b/chart/glaze/templates/middleware-security-headers.yaml
@@ -12,6 +12,7 @@ spec:
       script-src 'self' https://accounts.google.com https://apis.google.com https://upload-widget.cloudinary.com;
       style-src 'self' 'unsafe-inline' https://accounts.google.com https://fonts.googleapis.com;
       img-src 'self' data: https://res.cloudinary.com;
+      media-src 'self' https://res.cloudinary.com;
       connect-src 'self' https://api.cloudinary.com;
       font-src 'self' https://fonts.gstatic.com;
       frame-src https://accounts.google.com https://widget.cloudinary.com https://upload-widget.cloudinary.com;

--- a/tests/test_admin_access.py
+++ b/tests/test_admin_access.py
@@ -40,3 +40,12 @@ def test_public_admin_ingress_remains_explicitly_public():
         "default-{{ $fullName }}-tailscale-only@kubernetescrd"
         not in admin_public_ingress
     )
+
+
+def test_security_headers_allow_cloudinary_video_media():
+    repo_root = Path(__file__).resolve().parents[1]
+    security_headers = (
+        repo_root / "chart/glaze/templates/middleware-security-headers.yaml"
+    ).read_text()
+
+    assert "media-src 'self' https://res.cloudinary.com;" in security_headers


### PR DESCRIPTION
## Problem
The showcase video preview was blocked in production because the page CSP only allowed `default-src 'self'`, so the Cloudinary MP4 request for the `<video>` element was rejected as a media load.

## Fix
Added a `media-src` directive to the Helm security-headers middleware so Cloudinary video URLs from `https://res.cloudinary.com` are allowed for showcase playback, while keeping the rest of the CSP unchanged.

## Regression Test
`tests/test_admin_access.py:test_security_headers_allow_cloudinary_video_media` asserts the security-headers template includes the Cloudinary `media-src` allowance. It fails before the template change and passes after it.

## Verification
- `rtk bazel test //tests:common_test --test_output=errors`

Closes #785
