### PR TITLE
fix: move ShowcaseVideoPanel to full-width post-grid flow

### DIFF
--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -7,14 +7,17 @@ import {
   alpha,
   Box,
   Chip,
+  Collapse,
   Divider,
   Button,
   CircularProgress,
+  IconButton,
   LinearProgress,
   Stack,
   Typography,
 } from "@mui/material";
 import HistoryIcon from "@mui/icons-material/History";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { useBlocker, useLocation, useNavigate } from "react-router-dom";
 import type { PieceDetail as PieceDetailType } from "../util/types";
 import { DEFAULT_TRACK_ID } from "../util/music";
@@ -511,6 +514,7 @@ function ArtifactActions({ artifact, pieceName }: ArtifactActionsProps) {
 
 function ShowcaseVideoPanel({ piece }: { piece: PieceDetailType }) {
   const queryClient = useQueryClient();
+  const [userExpanded, setUserExpanded] = useState<boolean | null>(null);
   const [selection, setSelection] = useState<ShowcaseVideoInputSelection>({
     excludedImageKeys: [],
     excludedNoteKeys: [],
@@ -566,6 +570,9 @@ function ShowcaseVideoPanel({ piece }: { piece: PieceDetailType }) {
     currentStatus === "running" ? (showcaseVideo?.progress ?? 0) : null;
 
   const artifact = showcaseVideo?.artifact ?? null;
+  // Default: expanded when no artifact exists (needs action), collapsed when one does.
+  // userExpanded overrides once the user manually toggles.
+  const expanded = userExpanded ?? (artifact === null);
   const errorMessage = rawGenerateError
     ? extractErrorMessage(
         rawGenerateError,
@@ -582,7 +589,18 @@ function ShowcaseVideoPanel({ piece }: { piece: PieceDetailType }) {
     <SectionCard
       title="Showcase Video"
       subtitle="Render a deterministic Keepsake slideshow from the piece history."
+      titleAdornment={
+        <IconButton
+          size="small"
+          onClick={() => setUserExpanded(!expanded)}
+          aria-label={expanded ? "Collapse showcase video" : "Expand showcase video"}
+          sx={{ transform: expanded ? "rotate(180deg)" : "rotate(0deg)", transition: "transform 0.2s" }}
+        >
+          <ExpandMoreIcon fontSize="small" />
+        </IconButton>
+      }
     >
+      <Collapse in={expanded} unmountOnExit>
       <Stack spacing={2}>
         <ShowcaseVideoInputPicker
           piece={piece}
@@ -687,6 +705,7 @@ function ShowcaseVideoPanel({ piece }: { piece: PieceDetailType }) {
           </Stack>
         </Box>
       </Stack>
+      </Collapse>
     </SectionCard>
   );
 }

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -237,11 +237,6 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
                 <ShareControls piece={piece} onPieceUpdated={onPieceUpdated} />
               </Box>
             )}
-            {canEdit && isTerminal && (
-              <Box sx={{ mb: 1.5 }}>
-                <ShowcaseVideoPanel piece={piece} />
-              </Box>
-            )}
             {canEdit && (
               <Box sx={{ mb: 1.5 }}>
                 <EditableToggle piece={piece} onPieceUpdated={onPieceUpdated} />
@@ -399,6 +394,12 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
             <strong>{formatState(currentState.state)}</strong>). No further
             transitions are possible.
           </Alert>
+        )}
+
+        {canEdit && isTerminal && (
+          <Box sx={{ mb: 2.5 }}>
+            <ShowcaseVideoPanel piece={piece} />
+          </Box>
         )}
 
         <Box sx={{ mb: 2.5 }}>

--- a/web/src/components/__tests__/PieceDetail.test.tsx
+++ b/web/src/components/__tests__/PieceDetail.test.tsx
@@ -274,6 +274,7 @@ beforeEach(() => {
   vi.useRealTimers();
   vi.mocked(api.fetchGlobalEntries).mockResolvedValue([]);
   vi.mocked(api.fetchGlobalEntriesWithFilters).mockResolvedValue([]);
+  vi.mocked(api.fetchPieceShowcaseVideo).mockResolvedValue(null);
 });
 
 describe("PieceDetail", () => {
@@ -448,6 +449,49 @@ describe("PieceDetail", () => {
       alert.compareDocumentPosition(showcaseHeading) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+  });
+
+  it("collapses ShowcaseVideoPanel by default when a video artifact exists", async () => {
+    vi.mocked(api.fetchPieceShowcaseVideo).mockResolvedValue({
+      piece_id: "piece-id-1",
+      task_id: null,
+      status: "succeeded",
+      task_status: "success",
+      enabled: true,
+      disabled_reason: null,
+      eligible: true,
+      current_input_hash: "abc",
+      stored_input_hash: "abc",
+      is_stale: false,
+      stale_reason: null,
+      music_track_id: null,
+      storyboard: null,
+      artifact: {
+        url: "https://example.com/video.mp4",
+        download_url: "https://example.com/video.mp4?dl=1",
+        filename: "showcase.mp4",
+        content_type: "video/mp4",
+      },
+      error: null,
+    });
+    await renderPieceDetail(
+      makePiece({
+        current_state: makeState({ state: "completed" }),
+        history: [makeState({ state: "completed" })],
+      }),
+    );
+
+    // Panel header visible, but body content collapsed
+    expect(screen.getByText("Showcase Video")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: "Generate video" }),
+      ).not.toBeInTheDocument(),
+    );
+    // Expand button present
+    expect(
+      screen.getByRole("button", { name: "Expand showcase video" }),
+    ).toBeInTheDocument();
   });
 
   it("shares an editable terminal piece through the PieceDetail API interaction", async () => {

--- a/web/src/components/__tests__/PieceDetail.test.tsx
+++ b/web/src/components/__tests__/PieceDetail.test.tsx
@@ -148,6 +148,8 @@ vi.mock("../../util/api", () => ({
   toggleGlobalEntryFavorite: vi.fn().mockResolvedValue(undefined),
   hasCloudinaryUploadConfig: vi.fn().mockReturnValue(false),
   uploadImageToCloudinary: vi.fn(),
+  fetchPieceShowcaseVideo: vi.fn().mockResolvedValue(null),
+  requestPieceShowcaseVideo: vi.fn(),
   extractErrorMessage: vi.fn((err) => {
     if (err && typeof err === "object" && "response" in err) {
       const data = (err as any).response?.data;
@@ -427,6 +429,25 @@ describe("PieceDetail", () => {
     );
 
     expect(screen.getByRole("button", { name: "Share" })).toBeInTheDocument();
+  });
+
+  it("renders ShowcaseVideoPanel after the header grid, not inside the info column", async () => {
+    await renderPieceDetail(
+      makePiece({
+        current_state: makeState({ state: "completed" }),
+        history: [makeState({ state: "completed" })],
+      }),
+    );
+
+    // The terminal-state alert lives in the post-grid flow (after the two-column grid).
+    // ShowcaseVideoPanel must appear AFTER it in the DOM, proving it is outside the
+    // narrow info column.
+    const alert = screen.getByText(/terminal state/i).closest("[role='alert']")!;
+    const showcaseHeading = screen.getByText("Showcase Video");
+    expect(
+      alert.compareDocumentPosition(showcaseHeading) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it("shares an editable terminal piece through the PieceDetail API interaction", async () => {


### PR DESCRIPTION
## Problem

On desktop, [#793](https://github.com/shaoster/glaze/issues/793): `ShowcaseVideoPanel` was placed inside the narrow "info" column of the two-column header grid, causing layout breakage for completed pieces with a video player, input picker, and progress bar. Additionally, even once moved to full width, the large panel dominates the page when a video already exists.

## Fix

1. **Placement:** Removed the panel from the "info" grid column and relocated it to the full-width post-grid flow in `PieceDetail.tsx`, after the terminal-state alert and before the `ProcessSummary` section.

2. **Collapsibility:** Added an expand/collapse toggle (chevron `IconButton` via `SectionCard`'s `titleAdornment` slot). Default state is driven by data:
   - **Expanded** when no video artifact exists (needs user action)
   - **Collapsed** when an artifact already exists (video is ready, panel doesn't dominate)
   - User can manually toggle at any time; their choice overrides the default.

## Regression Tests

`web/src/components/__tests__/PieceDetail.test.tsx`:

- *renders ShowcaseVideoPanel after the header grid, not inside the info column* — uses `compareDocumentPosition` to assert the heading follows the terminal alert in DOM order.
- *collapses ShowcaseVideoPanel by default when a video artifact exists* — mocks a succeeded video status and asserts the generate button is not rendered (panel is collapsed, content unmounted).

## Verification

```
rtk bazel test //web:web_test  →  38/38 pass (54 PieceDetail tests)
rtk bazel build --config=lint //web/...  →  success
```

Closes #793
