### PR TITLE
fix: install DejaVu fonts in Docker image; raise on missing font

### DIFF
--- a/api/showcase/render.py
+++ b/api/showcase/render.py
@@ -63,10 +63,13 @@ def _canonical_json(data: Any) -> str:
 
 
 @lru_cache(maxsize=None)
-def _load_font(size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
-    if _FONT_PATH.exists():
-        return ImageFont.truetype(str(_FONT_PATH), size=size)
-    return ImageFont.load_default()
+def _load_font(size: int) -> ImageFont.FreeTypeFont:
+    if not _FONT_PATH.exists():
+        raise RuntimeError(
+            f"Required font not found: {_FONT_PATH}. "
+            "Install fonts-dejavu-core (apt) or equivalent."
+        )
+    return ImageFont.truetype(str(_FONT_PATH), size=size)
 
 
 class _SlideCanvas:

--- a/infra/custom/Dockerfile
+++ b/infra/custom/Dockerfile
@@ -59,9 +59,10 @@ RUN npx tsc -p tsconfig.app.json && npx vite build
 # Stage 3: Create the Python/Django backend & final runner
 FROM python:3.12-slim
 
-# Install system utilities (curl for health check probes)
+# Install system utilities and fonts required for video rendering
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
+    fonts-dejavu-core \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
## Summary

- Install `fonts-dejavu-core` in the production Docker image so `/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf` is present at runtime
- Replace the silent `load_default()` fallback in `_load_font` with a `RuntimeError` so a missing font is caught immediately rather than producing unreadable videos

## Root Cause

The production image (`python:3.12-slim`) had no fonts installed. `_load_font` silently fell back to `ImageFont.load_default()`, which ignores the requested size and always returns a fixed ~10pt bitmap font. With the old 1× rendering this produced tiny-but-visible text (~8px in a 720px frame). After the `_SlideCanvas` 4× super-sampling change (#791), that same 10pt font is drawn on a 5120×2880 canvas then downsampled — producing ~2px text, effectively invisible.

## Test plan

- [ ] Build the Docker image and confirm `/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf` is present
- [ ] Generate a showcase video on the deployed image and confirm text is legible
- [ ] All backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
