### PR TITLE
fix: add humanize for helpdesk dashboard

### DIFF
--- a/api/tests/test_host_settings.py
+++ b/api/tests/test_host_settings.py
@@ -67,6 +67,24 @@ def test_backend_production_settings_enable_hsts_preload(monkeypatch):
     assert settings.SECURE_SSL_REDIRECT is True
 
 
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "backend.settings",
+        "backend.test_settings",
+    ],
+)
+def test_helpdesk_dashboard_tag_library_is_installed(monkeypatch, module_name):
+    if module_name == "backend.settings":
+        monkeypatch.setenv("PRODUCTION", "1")
+        monkeypatch.setenv("SECRET_KEY", "test-secret")
+        monkeypatch.setenv("DATABASE_URL", "sqlite:///db.sqlite3")
+
+    settings = _reload_settings_module(module_name)
+
+    assert "django.contrib.humanize" in settings.INSTALLED_APPS
+
+
 def test_backend_test_settings_includes_admin_ingress_host(monkeypatch):
     monkeypatch.setenv("ALLOWED_HOST", "potterdoc.com")
     monkeypatch.setenv("ADMIN_INGRESS_HOST", "admin.potterdoc.com")

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -95,6 +95,7 @@ INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
+    "django.contrib.humanize",
     "django.contrib.sites",
     "django.contrib.sessions",
     "django.contrib.messages",

--- a/backend/test_settings.py
+++ b/backend/test_settings.py
@@ -78,6 +78,7 @@ INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
+    "django.contrib.humanize",
     "django.contrib.sites",
     "django.contrib.sessions",
     "django.contrib.messages",


### PR DESCRIPTION
Fix the staff `/support/dashboard/` 500 by registering `django.contrib.humanize` in both runtime and test settings.

Why:
- `django-helpdesk` renders `helpdesk/templates/helpdesk/include/tickets.html`
- That template loads the `humanize` tag library
- Without `django.contrib.humanize` in `INSTALLED_APPS`, staff users get a TemplateSyntaxError and a 500

What changed:
- Added `django.contrib.humanize` to `backend/settings.py`
- Added `django.contrib.humanize` to `backend/test_settings.py`
- Added a regression test that asserts both settings modules include the tag library

Validation:
- `rtk bazel test //api:api_test //web:web_test --test_output=errors`
- `rtk bazel build --config=lint //...`
