### PR TITLE
feat: migrate showcase music assets from git-LFS to Cloudinary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-assets/showcase_music/*.flac filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 1
-          lfs: true
+          lfs: false
 
       - id: fingerprint
         name: Compute CI fingerprint
@@ -131,7 +131,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          lfs: true
+          lfs: false
       - uses: ./.github/actions/setup-bazel-ci
         with:
           cache-key-prefix: lint
@@ -154,7 +154,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          lfs: true
+          lfs: false
       - uses: ./.github/actions/setup-bazel-ci
         with:
           cache-key-prefix: coverage
@@ -183,7 +183,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          lfs: true
+          lfs: false
       - name: Create isolated worktree
         id: worktree
         shell: bash
@@ -432,7 +432,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          lfs: true
+          lfs: false
 
       - uses: ./.github/actions/setup-bazel-ci
         with:
@@ -515,7 +515,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          lfs: true
+          lfs: false
           # Pin to the exact SHA on main so the image build uses the same
           # commit that lint/coverage validated. Omit on PRs — the default
           # merge-commit ref is fine there and avoids replication-race failures.

--- a/.gitignore
+++ b/.gitignore
@@ -257,3 +257,6 @@ db.bak.*.sqlite3
 
 # Agent / Tool temporary files
 .antigravitycli/
+
+# Showcase music assets (hosted on Cloudinary, not stored in git)
+assets/showcase_music/*.flac

--- a/api/showcase/render.py
+++ b/api/showcase/render.py
@@ -676,10 +676,14 @@ def _music_audio_path(storyboard: dict):
     if audio_url.startswith(("http://", "https://")):
         audio_bytes = _fetch_remote_audio(audio_url)
         suffix = Path(audio_url.split("?")[0]).suffix or ".flac"
-        with tempfile.NamedTemporaryFile(suffix=suffix, delete=True) as tmp:
+        tmp = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
+        try:
             tmp.write(audio_bytes)
             tmp.flush()
+            tmp.close()
             yield Path(tmp.name)
+        finally:
+            Path(tmp.name).unlink(missing_ok=True)
     else:
         audio_path = Path(audio_url)
         if not audio_path.is_absolute():

--- a/api/showcase/render.py
+++ b/api/showcase/render.py
@@ -676,14 +676,10 @@ def _music_audio_path(storyboard: dict):
     if audio_url.startswith(("http://", "https://")):
         audio_bytes = _fetch_remote_audio(audio_url)
         suffix = Path(audio_url.split("?")[0]).suffix or ".flac"
-        tmp = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
-        try:
-            tmp.write(audio_bytes)
-            tmp.flush()
-            tmp.close()
-            yield Path(tmp.name)
-        finally:
-            Path(tmp.name).unlink(missing_ok=True)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            audio_file = Path(tmpdir) / f"audio{suffix}"
+            audio_file.write_bytes(audio_bytes)
+            yield audio_file
     else:
         audio_path = Path(audio_url)
         if not audio_path.is_absolute():

--- a/api/showcase/render.py
+++ b/api/showcase/render.py
@@ -18,6 +18,7 @@ import tempfile
 import time
 import unicodedata
 from collections.abc import Callable
+from contextlib import contextmanager
 from fractions import Fraction
 from functools import lru_cache
 from pathlib import Path
@@ -642,7 +643,27 @@ def _slide_duration_seconds(slide: dict) -> float:
     return max(0.1, duration_ms / 1000.0)
 
 
-def _resolve_music_audio_path(storyboard: dict) -> Path:
+# 7-day TTL — assets are static; long TTL avoids re-downloading on every render job.
+_AUDIO_CACHE_TTL = 60 * 60 * 24 * 7
+
+
+def _fetch_remote_audio(url: str) -> bytes:
+    """Return audio bytes for a remote URL, using Django's cache to avoid re-downloads."""
+    from django.core.cache import cache
+
+    cache_key = f"music_audio:{hashlib.sha256(url.encode()).hexdigest()}"
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return cached
+    response = requests.get(url, timeout=60)
+    response.raise_for_status()
+    cache.set(cache_key, response.content, timeout=_AUDIO_CACHE_TTL)
+    return response.content
+
+
+@contextmanager
+def _music_audio_path(storyboard: dict):
+    """Yield a Path to the audio asset, downloading it first if the URL is remote."""
     track = get_track(storyboard.get("music_track_id"))
     if track is None:
         raise ValueError(
@@ -650,13 +671,22 @@ def _resolve_music_audio_path(storyboard: dict) -> Path:
         )
     audio_url = track.audio.url
     if not audio_url:
-        raise ValueError(f"Track {track.track_id!r} does not have a local audio asset.")
-    audio_path = Path(audio_url)
-    if not audio_path.is_absolute():
-        audio_path = _REPO_ROOT / audio_path
-    if not audio_path.exists():
-        raise FileNotFoundError(f"Music asset not found: {audio_path}")
-    return audio_path
+        raise ValueError(f"Track {track.track_id!r} does not have an audio asset.")
+
+    if audio_url.startswith(("http://", "https://")):
+        audio_bytes = _fetch_remote_audio(audio_url)
+        suffix = Path(audio_url.split("?")[0]).suffix or ".flac"
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=True) as tmp:
+            tmp.write(audio_bytes)
+            tmp.flush()
+            yield Path(tmp.name)
+    else:
+        audio_path = Path(audio_url)
+        if not audio_path.is_absolute():
+            audio_path = _REPO_ROOT / audio_path
+        if not audio_path.exists():
+            raise FileNotFoundError(f"Music asset not found: {audio_path}")
+        yield audio_path
 
 
 def _slide_start_times(
@@ -937,13 +967,13 @@ def render_storyboard_to_mp4(
             fade_seconds,
             on_progress=on_progress,
         )
-        audio_path = _resolve_music_audio_path(storyboard)
-        audio_packets = _write_audio_stream(
-            container,
-            audio_path,
-            video_duration_seconds,
-            fade_seconds,
-        )
+        with _music_audio_path(storyboard) as audio_path:
+            audio_packets = _write_audio_stream(
+                container,
+                audio_path,
+                video_duration_seconds,
+                fade_seconds,
+            )
 
         # AAC encoders emit a few priming frames with negative DTS before the
         # first real sample, which breaks muxing.  Compute the shift needed to

--- a/assets/showcase_music/adventures-a-himitsu.flac
+++ b/assets/showcase_music/adventures-a-himitsu.flac
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ae77650d03375fbb70897f59798d82ce3332f0bfc732b7005c22db455947d8dc
-size 24481526

--- a/assets/showcase_music/good-for-you-thbd.flac
+++ b/assets/showcase_music/good-for-you-thbd.flac
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:da3dbb85e8210095215c3034ddddb6b70b3b8f3e1307e303700bfab729308aa7
-size 25392676

--- a/assets/showcase_music/we-are-one-vexento.flac
+++ b/assets/showcase_music/we-are-one-vexento.flac
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:28b7a1d79952e0b73c457791f79681b4862b079cae91f75d8e67f1bcdba87c4f
-size 26137540

--- a/music_catalog.yml
+++ b/music_catalog.yml
@@ -7,10 +7,9 @@
 # obligation, not editorial copy.
 #
 # `audio.format` is the lossless container the renderer consumes. `audio.url` is
-# the committed lossless asset (a repo-relative path under assets/showcase_music/,
-# stored via git-LFS), kept intentionally distinct from `download_url` (the human
-# source page, which may only offer mp3). See assets/showcase_music/CREDITS.md for
-# how the files were produced and their attribution.
+# the Cloudinary URL for the hosted asset, kept intentionally distinct from
+# `download_url` (the human source page, which may only offer mp3). See
+# assets/showcase_music/CREDITS.md for how the files were produced and their attribution.
 #
 version: "1.0"
 default_track_id: we-are-one-vexento
@@ -33,7 +32,7 @@ tracks:
       Music promoted by Audio Library https://youtu.be/MkNeIUgNPQ8
     audio:
       format: flac
-      url: assets/showcase_music/adventures-a-himitsu.flac
+      url: https://res.cloudinary.com/dxpnyhe1f/video/upload/glaze_public/showcase_music/adventures-a-himitsu.flac
 
   good-for-you-thbd:
     title: Good For You
@@ -52,7 +51,7 @@ tracks:
       Music promoted by Audio Library https://youtu.be/-K_YSjqKgvQ
     audio:
       format: flac
-      url: assets/showcase_music/good-for-you-thbd.flac
+      url: https://res.cloudinary.com/dxpnyhe1f/video/upload/glaze_public/showcase_music/good-for-you-thbd.flac
 
   we-are-one-vexento:
     title: We Are One
@@ -71,4 +70,4 @@ tracks:
       Music promoted by Audio Library https://youtu.be/Ssvu2yncgWU
     audio:
       format: flac
-      url: assets/showcase_music/we-are-one-vexento.flac
+      url: https://res.cloudinary.com/dxpnyhe1f/video/upload/glaze_public/showcase_music/we-are-one-vexento.flac


### PR DESCRIPTION
## Summary

- **Removes git-LFS entirely** — the three FLAC showcase-music assets (~75 MB) are deleted from the repo and re-hosted on Cloudinary under \`glaze_public/showcase_music/\`. Fixes CI being blocked on LFS budget overrun.
- **\`render.py\` now fetches audio by URL** — \`_music_audio_path\` is a context manager that downloads remote audio, writes it to a temp file for \`av.open\`, and cleans it up afterward.
- **Redis cache for audio downloads** — \`_fetch_remote_audio\` caches the raw bytes in Django's Redis cache (key \`music_audio:<sha256>\`, 7-day TTL) so each render worker only pays the ~25 MB download once. Falls back to \`DummyCache\` (no-op) in dev environments without \`REDIS_CACHE_URL\`.
- **CI**: all six \`actions/checkout\` steps set \`lfs: false\`.
- **Bazel**: no change needed — the \`pkg_tar\` glob already uses \`allow_empty=True\`.

## Review findings & fixes

Two correctness issues found and fixed in follow-up commits:

**Commit 2** — `NamedTemporaryFile(delete=True)` unlinks the file when its `with`-block exits, which coincides with the `yield` suspension point. If the caller's `with _music_audio_path(...)` block raises, the OS removes the file before `av.open` finishes reading it. Fixed by switching to `delete=False` with an explicit `finally: unlink(missing_ok=True)`.

**Commit 3** — Replaced the `NamedTemporaryFile` + manual `try/finally` with `tempfile.TemporaryDirectory`. The directory context stays open across the `yield` suspension (execution resumes only when the caller's `with` block exits, after `av.open` has closed the file), so cleanup is guaranteed on both Linux and Windows without any explicit unlink logic.

## Test plan

- [ ] Verify CI passes without LFS budget errors
- [ ] Trigger a showcase video render in staging; confirm audio is present and the Cloudinary URL is fetched (check worker logs for cache miss on first render)
- [ ] Trigger a second render of the same storyboard; confirm cache hit (no outbound request to Cloudinary for the audio)
- [ ] Confirm \`assets/showcase_music/CREDITS.md\` is still present and included in the OCI image

🤖 Generated with [Claude Code](https://claude.com/claude-code)