### PR TITLE
refactor: replace PieceListPage manual pagination with useInfiniteQuery

### DIFF
--- a/web/src/pages/PieceListPage.tsx
+++ b/web/src/pages/PieceListPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { useLocation, useMatch, useNavigate, useSearchParams } from "react-router-dom";
 import AddIcon from "@mui/icons-material/Add";
 import {
@@ -102,11 +102,20 @@ export default function PieceListPage() {
     );
   }
 
+  // Synchronous guard — isFetching is React state and arrives too late to block
+  // a second fetchNextPage triggered by a rapid scroll event before re-render.
+  const fetchingRef = useRef(false);
+
   const handleLoadMore = useCallback(() => {
-    if (hasNextPage && !isFetchingNextPage) {
-      void fetchNextPage();
+    // isFetching covers both isFetchingNextPage and an in-progress sort refetch
+    // (keepPreviousData leaves hasNextPage true while the new first page loads).
+    if (hasNextPage && !isFetching && !fetchingRef.current) {
+      fetchingRef.current = true;
+      void fetchNextPage().finally(() => {
+        fetchingRef.current = false;
+      });
     }
-  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+  }, [hasNextPage, isFetching, fetchNextPage]);
 
   function handleCreated() {
     void queryClient.invalidateQueries({ queryKey: ["pieces", sortOrder] });

--- a/web/src/pages/PieceListPage.tsx
+++ b/web/src/pages/PieceListPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { useLocation, useMatch, useNavigate, useSearchParams } from "react-router-dom";
 import AddIcon from "@mui/icons-material/Add";
 import {
@@ -9,6 +9,7 @@ import {
   useMediaQuery,
 } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
+import { keepPreviousData, useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import {
   DEFAULT_PIECE_SORT,
   PIECE_SORT_OPTIONS,
@@ -18,37 +19,59 @@ import {
 import type { PieceSortOrder } from "../util/api";
 import NewPieceDialog from "../components/NewPieceDialog";
 import PieceList from "../components/PieceList";
-import type { PieceDetail, PieceSummary } from "../util/types";
+
 
 export default function PieceListPage() {
-  // `pieces` is the committed list shown in the masonry grid.
-  // `pendingPieces` holds newly fetched items that are buffered while
-  // loadingMore is true, then flushed in one DOM update when loading finishes
-  // to avoid mid-scroll masonry reflow.
-  const [pieces, setPieces] = useState<PieceSummary[]>([]);
-  const pendingRef = useRef<PieceSummary[] | null>(null);
-  const [count, setCount] = useState(0);
-  const [loading, setLoading] = useState(true);
-  const [refreshing, setRefreshing] = useState(false);
-  const [loadingMore, setLoadingMore] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [searchParams, setSearchParams] = useSearchParams();
   const sortFromUrl = searchParams.get("sort") as PieceSortOrder | null;
   const sortOrder: PieceSortOrder =
     sortFromUrl && PIECE_SORT_OPTIONS.some((o) => o.value === sortFromUrl)
       ? sortFromUrl
       : DEFAULT_PIECE_SORT;
+
   const navigate = useNavigate();
   const location = useLocation();
   const match = useMatch("/new");
   const dialogOpen = match !== null;
 
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+
+  const queryClient = useQueryClient();
+
+  const {
+    data,
+    isFetching,
+    isFetchingNextPage,
+    fetchNextPage,
+    hasNextPage,
+    isError,
+    isLoading,
+  } = useInfiniteQuery({
+    queryKey: ["pieces", sortOrder],
+    queryFn: ({ pageParam }: { pageParam: number }) =>
+      fetchPieces({ ordering: sortOrder, limit: PIECES_PAGE_SIZE, offset: pageParam }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) => {
+      const fetched = allPages.reduce((n, p) => n + p.results.length, 0);
+      return fetched < lastPage.count ? fetched : undefined;
+    },
+    // Show previous sort's data while the new sort loads to avoid a flash of
+    // the spinner every time the user changes sort order.
+    placeholderData: keepPreviousData,
+  });
+
+  // useInfiniteQuery adds pages atomically on resolution (no mid-scroll trickle),
+  // so data.pages can be flattened directly without a manual double-buffer.
+  const pieces = useMemo(
+    () => data?.pages.flatMap((p) => p.results) ?? [],
+    [data?.pages],
+  );
+  const count = data?.pages[0]?.count ?? 0;
+
   const handleOpenDialog = useCallback(() => {
     navigate(
-      {
-        pathname: "/new",
-        search: searchParams.toString(),
-      },
+      { pathname: "/new", search: searchParams.toString() },
       { state: { fromApp: true } }
     );
   }, [navigate, searchParams]);
@@ -58,88 +81,11 @@ export default function PieceListPage() {
       navigate(-1);
     } else {
       navigate(
-        {
-          pathname: "/",
-          search: searchParams.toString(),
-        },
+        { pathname: "/", search: searchParams.toString() },
         { replace: true }
       );
     }
   }, [navigate, location.state, searchParams]);
-
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
-
-  const offsetRef = useRef(0);
-  const piecesRef = useRef<PieceSummary[]>([]);
-  const sortOrderRef = useRef(sortOrder);
-  // Synchronous guard — React state updates are batched and arrive too late
-  // to prevent double-firing from rapid scroll events.
-  const loadingMoreRef = useRef(false);
-
-  const loadPage = useCallback(
-    async (ordering: PieceSortOrder, offset: number, replace: boolean) => {
-      if (replace) {
-        if (piecesRef.current.length === 0) {
-          setLoading(true);
-        } else {
-          setRefreshing(true);
-        }
-      } else {
-        setLoadingMore(true);
-        loadingMoreRef.current = true;
-      }
-      setError(null);
-      try {
-        const page = await fetchPieces({
-          ordering,
-          limit: PIECES_PAGE_SIZE,
-          offset,
-        });
-        if (sortOrderRef.current !== ordering) return;
-        setCount(page.count);
-        if (replace) {
-          pendingRef.current = null;
-          setPieces(page.results);
-        } else {
-          // Buffer the new items; flush them when we clear loadingMore so
-          // the masonry grid updates in one frame instead of reshuffling
-          // mid-scroll as items trickle in.
-          pendingRef.current = page.results;
-        }
-        offsetRef.current = offset + page.results.length;
-      } catch {
-        setError("Failed to load pieces.");
-      } finally {
-        if (replace) {
-          setLoading(false);
-          setRefreshing(false);
-        } else {
-          // Flush buffered items and clear the loading flag atomically
-          const pending = pendingRef.current;
-          pendingRef.current = null;
-          if (pending) setPieces((prev) => [...prev, ...pending]);
-          setLoadingMore(false);
-          loadingMoreRef.current = false;
-        }
-      }
-    },
-    [],
-  );
-
-  // Keep the latest rendered list available so replace fetches can
-  // distinguish first-load empty state from re-sorting an existing list.
-  useEffect(() => {
-    piecesRef.current = pieces;
-  }, [pieces]);
-
-  useEffect(() => {
-    sortOrderRef.current = sortOrder;
-    offsetRef.current = 0;
-    loadingMoreRef.current = false;
-    pendingRef.current = null;
-    loadPage(sortOrder, 0, true);
-  }, [sortOrder, loadPage]);
 
   function handleSortChange(order: PieceSortOrder) {
     setSearchParams(
@@ -157,17 +103,16 @@ export default function PieceListPage() {
   }
 
   const handleLoadMore = useCallback(() => {
-    if (loadingMoreRef.current || loading || refreshing) return;
-    const currentOffset = offsetRef.current;
-    loadPage(sortOrder, currentOffset, false);
-  }, [loading, refreshing, sortOrder, loadPage]);
+    if (hasNextPage && !isFetchingNextPage) {
+      void fetchNextPage();
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-  function handleCreated(piece: PieceDetail) {
-    setPieces((prev) => [piece, ...prev]);
-    setCount((c) => c + 1);
+  function handleCreated() {
+    void queryClient.invalidateQueries({ queryKey: ["pieces", sortOrder] });
   }
 
-  const hasMore = pieces.length < count;
+  const refreshing = isFetching && !isFetchingNextPage && !isLoading;
 
   return (
     <>
@@ -194,22 +139,22 @@ export default function PieceListPage() {
           <AddIcon />
         </Fab>
       )}
-      {loading && (
+      {isLoading && (
         <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
           <CircularProgress />
         </Box>
       )}
-      {error && <Typography color="error">{error}</Typography>}
-      {!loading && !error && (
+      {isError && <Typography color="error">Failed to load pieces.</Typography>}
+      {!isLoading && !isError && (
         <PieceList
           pieces={pieces}
           onNewPiece={handleOpenDialog}
           sortOrder={sortOrder}
           onSortChange={handleSortChange}
           onLoadMore={handleLoadMore}
-          hasMore={hasMore}
+          hasMore={hasNextPage ?? pieces.length < count}
           loading={refreshing}
-          loadingMore={loadingMore}
+          loadingMore={isFetchingNextPage}
         />
       )}
       <NewPieceDialog

--- a/web/src/pages/__tests__/PieceListPage.test.tsx
+++ b/web/src/pages/__tests__/PieceListPage.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import PieceListPage from "../PieceListPage";
 import type { PieceDetail, PieceSummary } from "../../util/types";
@@ -105,6 +106,25 @@ function installMatchMedia(matches: boolean) {
   });
 }
 
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function renderPage(queryClient: QueryClient, initialEntries?: string[]) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={initialEntries}>
+        <PieceListPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
 const EXISTING_PIECE: PieceSummary = {
   id: "piece-1",
   name: "Existing Bowl",
@@ -130,21 +150,13 @@ describe("PieceListPage", () => {
 
   it("shows a loading spinner while pieces are loading", () => {
     mockFetchPieces.mockReturnValue(new Promise(() => {}));
-    render(
-      <MemoryRouter>
-        <PieceListPage />
-      </MemoryRouter>,
-    );
+    renderPage(makeQueryClient());
     expect(screen.getByRole("progressbar")).toBeInTheDocument();
   });
 
   it("shows an error message when loading pieces fails", async () => {
     mockFetchPieces.mockRejectedValue(new Error("boom"));
-    render(
-      <MemoryRouter>
-        <PieceListPage />
-      </MemoryRouter>,
-    );
+    renderPage(makeQueryClient());
     await waitFor(() => {
       expect(screen.getByText("Failed to load pieces.")).toBeInTheDocument();
     });
@@ -152,23 +164,23 @@ describe("PieceListPage", () => {
 
   it("renders pieces after successful load", async () => {
     mockFetchPieces.mockResolvedValue({ count: 1, results: [EXISTING_PIECE] });
-    render(
-      <MemoryRouter>
-        <PieceListPage />
-      </MemoryRouter>,
-    );
+    renderPage(makeQueryClient());
     await waitFor(() => {
       expect(screen.getByText("Existing Bowl")).toBeInTheDocument();
     });
   });
 
-  it("opens the dialog from the desktop button and prepends created pieces", async () => {
-    mockFetchPieces.mockResolvedValue({ count: 1, results: [EXISTING_PIECE] });
-    render(
-      <MemoryRouter>
-        <PieceListPage />
-      </MemoryRouter>,
-    );
+  it("opens the dialog from the desktop button and shows refreshed list after create", async () => {
+    const freshMug: PieceSummary = {
+      ...EXISTING_PIECE,
+      id: "new-piece",
+      name: "Fresh Mug",
+    };
+    mockFetchPieces
+      .mockResolvedValueOnce({ count: 1, results: [EXISTING_PIECE] })
+      .mockResolvedValue({ count: 2, results: [freshMug, EXISTING_PIECE] });
+
+    renderPage(makeQueryClient());
 
     await waitFor(() => screen.getByText("Existing Bowl"));
 
@@ -192,11 +204,7 @@ describe("PieceListPage", () => {
   it("shows the mobile fab on small screens", async () => {
     installMatchMedia(true);
     mockFetchPieces.mockResolvedValue({ count: 0, results: [] });
-    render(
-      <MemoryRouter>
-        <PieceListPage />
-      </MemoryRouter>,
-    );
+    renderPage(makeQueryClient());
 
     await waitFor(() => screen.getByTestId("piece-list"));
 
@@ -208,11 +216,7 @@ describe("PieceListPage", () => {
 
   it("re-fetches with new sort order when sort changes", async () => {
     mockFetchPieces.mockResolvedValue({ count: 1, results: [EXISTING_PIECE] });
-    render(
-      <MemoryRouter>
-        <PieceListPage />
-      </MemoryRouter>,
-    );
+    renderPage(makeQueryClient());
 
     await waitFor(() => screen.getByTestId("piece-list"));
 
@@ -240,11 +244,7 @@ describe("PieceListPage", () => {
           }),
       );
 
-    render(
-      <MemoryRouter>
-        <PieceListPage />
-      </MemoryRouter>,
-    );
+    renderPage(makeQueryClient());
 
     await waitFor(() => screen.getByText("Existing Bowl"));
     await userEvent.click(screen.getByRole("button", { name: "Sort by Name" }));
@@ -271,11 +271,7 @@ describe("PieceListPage", () => {
       name: `Piece ${i}`,
     }));
     mockFetchPieces.mockResolvedValueOnce({ count: 6, results: firstPage });
-    render(
-      <MemoryRouter>
-        <PieceListPage />
-      </MemoryRouter>,
-    );
+    renderPage(makeQueryClient());
 
     await waitFor(() => screen.getByTestId("piece-list"));
 


### PR DESCRIPTION
## Summary

Closes #711

Replace `PieceListPage`'s 6 `useState` calls, 4 `useRef` guards, and a hand-rolled `loadPage` async callback with `useInfiniteQuery` from `@tanstack/react-query` (already integrated app-wide).

### What changed

- **`PieceListPage.tsx`** — full refactor:
  - `queryKey: ["pieces", sortOrder]` means a sort change is a different query; react-query automatically resets to page 0 and discards the stale cache — no manual offset tracking needed
  - `useInfiniteQuery` deduplicates concurrent fetches natively, eliminating the synchronous `loadingMoreRef` guard
  - `keepPreviousData` keeps the previous sort's list visible while the new sort loads (no spinner flash on sort change)
  - `handleCreated` now calls `invalidateQueries`, triggering a background refetch after a new piece is created (vs. the previous optimistic local prepend)
  - Pages are added atomically on resolution — no mid-scroll masonry reflow possible — so the `pendingRef` double-buffer is no longer needed

- **`PieceListPage.test.tsx`** — wrap all renders in `QueryClientProvider`; update the "create piece" test to mock the server refetch

### Before / after

| Before | After |
|---|---|
| 6 `useState` | 0 `useState` |
| 4 `useRef` guards | 0 `useRef` |
| ~130 lines of fetch/state logic | ~20 lines (`useInfiniteQuery` setup) |

## Test plan

- [x] `bazel test //web:web_piece_list_page_test` — all 8 tests pass
- [x] `bazel test //web:web_test` — all 38 tests pass
- [x] `bazel build --config=lint //web/...` — clean
