### PR TITLE
fix: use fetch-based download for showcase video MP4

### DIFF
--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -450,6 +450,17 @@ function ArtifactActions({ artifact, pieceName }: ArtifactActionsProps) {
     typeof navigator.share === "function" &&
     typeof navigator.canShare === "function";
 
+  async function handleDownload() {
+    const response = await fetch(artifact.download_url);
+    const blob = await response.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = artifact.filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
   async function handleShare() {
     setSharing(true);
     try {
@@ -490,10 +501,8 @@ function ArtifactActions({ artifact, pieceName }: ArtifactActionsProps) {
       />
       <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
         <Button
-          component="a"
-          href={artifact.download_url}
-          download={artifact.filename}
           variant="outlined"
+          onClick={handleDownload}
         >
           Download MP4
         </Button>


### PR DESCRIPTION
## Summary

- Replaces the `<Button component="a" href download>` anchor approach with a `fetch` + Blob URL pattern, consistent with how `handleShare` already fetches the video file
- Avoids browser navigation side-effects that can occur with cross-origin `download` attribute links

## Test plan

- [ ] Click "Download MP4" on a piece with a showcase video and confirm the file downloads correctly
- [ ] Confirm the Share button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)