### PR TITLE
fix: force browser download for MP4 instead of in-tab playback

### DIFF
--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -450,6 +450,17 @@ function ArtifactActions({ artifact, pieceName }: ArtifactActionsProps) {
     typeof navigator.share === "function" &&
     typeof navigator.canShare === "function";
 
+  async function handleDownload() {
+    const response = await fetch(artifact.download_url);
+    const blob = await response.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = artifact.filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
   async function handleShare() {
     setSharing(true);
     try {
@@ -490,10 +501,8 @@ function ArtifactActions({ artifact, pieceName }: ArtifactActionsProps) {
       />
       <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
         <Button
-          component="a"
-          href={artifact.download_url}
-          download={artifact.filename}
           variant="outlined"
+          onClick={handleDownload}
         >
           Download MP4
         </Button>


### PR DESCRIPTION
## Problem

The "Download MP4" button was rendered as an `<a download="...">` anchor. Browsers respect the `download` attribute only for same-origin URLs; for cross-origin URLs (Cloudinary in our case) it is silently ignored, so clicking the button navigated to the video URL and played it in the tab instead of downloading it — redundant given the embedded player directly above.

## Fix

Replace the anchor with a `Button onClick` handler that:
1. Fetches the video via `fetch()` (already done in `handleShare`)
2. Creates a temporary `Blob` object URL
3. Programmatically clicks a hidden `<a download>` pointing at the blob URL
4. Revokes the object URL immediately after

This forces a download regardless of the video's origin.

## Testing

- Lint: `bazel build --config=lint //web/...` ✅
- Tests: `bazel test //web/...` — 41/41 pass ✅
