### PR TITLE
fix: move MasonryTile to module scope to prevent WeakMap crash on image delete

### DIFF
--- a/web/src/components/PiecePhotoGalleryGrid.tsx
+++ b/web/src/components/PiecePhotoGalleryGrid.tsx
@@ -21,6 +21,17 @@ type PiecePhotoGalleryGridImage = {
   editableCurrentStateIndex: number | null;
 };
 
+// Extends the image with pre-computed per-tile context so MasonryTile can be
+// defined at module scope (stable reference) rather than inside the component.
+// Masonic remounts all tiles when the render prop identity changes, which
+// causes use-resize-observer to crash with a WeakMap error on unmount.
+type MasonryTileData = PiecePhotoGalleryGridImage & {
+  canDelete: boolean;
+  isThumbnail: boolean;
+  onOpen: () => void;
+  onDelete: () => void;
+};
+
 type PiecePhotoGalleryGridProps = {
   images: PiecePhotoGalleryGridImage[];
   canDeleteImages: boolean;
@@ -29,6 +40,107 @@ type PiecePhotoGalleryGridProps = {
   onOpenImage: (index: number) => void;
   onRequestDelete: (index: number) => void;
 };
+
+function MasonryTile({
+  data: image,
+  index,
+  width,
+}: {
+  data: MasonryTileData;
+  index: number;
+  width: number;
+}) {
+  return (
+    <Box
+      sx={{
+        position: "relative",
+        border: "1px solid",
+        borderColor: "divider",
+        borderRadius: "8px",
+        overflow: "hidden",
+      }}
+    >
+      <Box
+        component="button"
+        type="button"
+        onClick={image.onOpen}
+        aria-label={`Open piece photo ${index + 1}`}
+        sx={{
+          p: 0,
+          border: "none",
+          width: "100%",
+          background: "transparent",
+          display: "block",
+          lineHeight: 0,
+          cursor: "pointer",
+        }}
+      >
+        <Box sx={{ position: "relative", width: "100%" }}>
+          <CloudinaryImage
+            url={image.url}
+            cloud_name={image.cloud_name}
+            cloudinary_public_id={image.cloudinary_public_id}
+            crop={image.crop}
+            alt={image.caption || "Piece photo"}
+            context="gallery"
+            requestedWidth={Math.round(
+              width * (globalThis.window?.devicePixelRatio ?? 1),
+            )}
+            style={{
+              width: "100%",
+              height: "auto",
+              objectFit: "contain",
+              display: "block",
+            }}
+          />
+        </Box>
+      </Box>
+      {image.canDelete && (
+        <Tooltip
+          title={
+            image.isThumbnail
+              ? "Cannot delete the current piece thumbnail"
+              : "Delete photo"
+          }
+        >
+          <span>
+            <IconButton
+              aria-label={`Delete piece photo ${index + 1}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                image.onDelete();
+              }}
+              disabled={image.isThumbnail}
+              size="small"
+              sx={{
+                position: "absolute",
+                top: 8,
+                right: 8,
+                width: 28,
+                height: 28,
+                color: "common.white",
+                backgroundColor: image.isThumbnail
+                  ? "rgba(0,0,0,0.24)"
+                  : "rgba(0,0,0,0.52)",
+                backdropFilter: "blur(6px)",
+                "&:hover": {
+                  backgroundColor: image.isThumbnail
+                    ? "rgba(0,0,0,0.24)"
+                    : "rgba(0,0,0,0.68)",
+                },
+                "&.Mui-disabled": {
+                  color: "rgba(255,255,255,0.45)",
+                },
+              }}
+            >
+              <CloseIcon fontSize="small" />
+            </IconButton>
+          </span>
+        </Tooltip>
+      )}
+    </Box>
+  );
+}
 
 export default function PiecePhotoGalleryGrid({
   images,
@@ -49,112 +161,20 @@ export default function PiecePhotoGalleryGrid({
     );
   }
 
-  const MasonryTile = ({
-    data: image,
-    index,
-    width,
-  }: {
-    data: PiecePhotoGalleryGridImage;
-    index: number;
-    width: number;
-  }) => {
-    const isThumbnail = image.url === currentThumbnailUrl;
-
-    return (
-      <Box
-        sx={{
-          position: "relative",
-          border: "1px solid",
-          borderColor: "divider",
-          borderRadius: "8px",
-          overflow: "hidden",
-        }}
-      >
-        <Box
-          component="button"
-          type="button"
-          onClick={() => onOpenImage(index)}
-          aria-label={`Open piece photo ${index + 1}`}
-          sx={{
-            p: 0,
-            border: "none",
-            width: "100%",
-            background: "transparent",
-            display: "block",
-            lineHeight: 0,
-            cursor: "pointer",
-          }}
-        >
-          <Box sx={{ position: "relative", width: "100%" }}>
-            <CloudinaryImage
-              url={image.url}
-              cloud_name={image.cloud_name}
-              cloudinary_public_id={image.cloudinary_public_id}
-              crop={image.crop}
-              alt={image.caption || "Piece photo"}
-              context="gallery"
-              requestedWidth={Math.round(
-                width * (globalThis.window?.devicePixelRatio ?? 1),
-              )}
-              style={{
-                width: "100%",
-                height: "auto",
-                objectFit: "contain",
-                display: "block",
-              }}
-            />
-          </Box>
-        </Box>
-        {(image.editableCurrentStateIndex !== null ? canDeleteImages : canDeletePastImages) && (
-          <Tooltip
-            title={
-              isThumbnail
-                ? "Cannot delete the current piece thumbnail"
-                : "Delete photo"
-            }
-          >
-            <span>
-              <IconButton
-                aria-label={`Delete piece photo ${index + 1}`}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onRequestDelete(index);
-                }}
-                disabled={isThumbnail}
-                size="small"
-                sx={{
-                  position: "absolute",
-                  top: 8,
-                  right: 8,
-                  width: 28,
-                  height: 28,
-                  color: "common.white",
-                  backgroundColor: isThumbnail
-                    ? "rgba(0,0,0,0.24)"
-                    : "rgba(0,0,0,0.52)",
-                  backdropFilter: "blur(6px)",
-                  "&:hover": {
-                    backgroundColor: isThumbnail
-                      ? "rgba(0,0,0,0.24)"
-                      : "rgba(0,0,0,0.68)",
-                  },
-                  "&.Mui-disabled": {
-                    color: "rgba(255,255,255,0.45)",
-                  },
-                }}
-              >
-                <CloseIcon fontSize="small" />
-              </IconButton>
-            </span>
-          </Tooltip>
-        )}
-      </Box>
-    );
-  };
+  const tileData: MasonryTileData[] = images.map((image, idx) => ({
+    ...image,
+    canDelete:
+      image.editableCurrentStateIndex !== null
+        ? canDeleteImages
+        : canDeletePastImages,
+    isThumbnail: image.url === currentThumbnailUrl,
+    onOpen: () => onOpenImage(idx),
+    onDelete: () => onRequestDelete(idx),
+  }));
 
   return (
     <Masonry
-      items={images}
+      items={tileData}
       render={MasonryTile}
       columnCount={isMobile ? 2 : 3}
       columnGutter={6}

--- a/web/src/components/__tests__/PiecePhotoGalleryGrid.test.tsx
+++ b/web/src/components/__tests__/PiecePhotoGalleryGrid.test.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties } from "react";
 import { render, screen } from "@testing-library/react";
+import { Masonry } from "masonic";
 import { describe, expect, it, vi } from "vitest";
 import PiecePhotoGalleryGrid from "../PiecePhotoGalleryGrid";
 
@@ -16,20 +17,22 @@ vi.mock("../CloudinaryImage", () => ({
 }));
 
 vi.mock("masonic", () => ({
-  Masonry: ({
-    items,
-    render: RenderComponent,
-  }: {
-    items: any[];
-    render: React.ComponentType<{ data: any; index: number; width: number }>;
-  }) => (
-    <div data-testid="masonry-grid">
-      {items.map((item, index) => (
-        <div key={index}>
-          <RenderComponent data={item} index={index} width={320} />
-        </div>
-      ))}
-    </div>
+  Masonry: vi.fn(
+    ({
+      items,
+      render: RenderComponent,
+    }: {
+      items: any[];
+      render: React.ComponentType<{ data: any; index: number; width: number }>;
+    }) => (
+      <div data-testid="masonry-grid">
+        {items.map((item, index) => (
+          <div key={index}>
+            <RenderComponent data={item} index={index} width={320} />
+          </div>
+        ))}
+      </div>
+    ),
   ),
 }));
 
@@ -111,5 +114,50 @@ describe("PiecePhotoGalleryGrid", () => {
 
     // Second button (other) should be enabled
     expect(deleteButtons[1]).not.toBeDisabled();
+  });
+
+  it("passes a stable render function reference to Masonry across re-renders", () => {
+    const capturedRenders: React.ComponentType<unknown>[] = [];
+    vi.mocked(Masonry).mockImplementation(
+      ({ render: renderProp }: { render: React.ComponentType<unknown> }) => {
+        capturedRenders.push(renderProp);
+        return null;
+      },
+    );
+
+    const image1 = {
+      url: "https://example.com/a.jpg",
+      caption: "A",
+      stateLabel: "Throwing",
+      editableCurrentStateIndex: 0,
+    };
+    const image2 = {
+      url: "https://example.com/b.jpg",
+      caption: "B",
+      stateLabel: "Throwing",
+      editableCurrentStateIndex: 1,
+    };
+
+    const { rerender } = render(
+      <PiecePhotoGalleryGrid
+        images={[image1, image2]}
+        canDeleteImages
+        onOpenImage={vi.fn()}
+        onRequestDelete={vi.fn()}
+      />,
+    );
+    rerender(
+      <PiecePhotoGalleryGrid
+        images={[image1]}
+        canDeleteImages
+        onOpenImage={vi.fn()}
+        onRequestDelete={vi.fn()}
+      />,
+    );
+
+    expect(capturedRenders).toHaveLength(2);
+    // render prop must be the same reference across re-renders; a new reference
+    // causes masonic to remount all tiles, triggering the WeakMap crash on unmount
+    expect(capturedRenders[0]).toBe(capturedRenders[1]);
   });
 });


### PR DESCRIPTION
## Problem

Deleting an image from the gallery triggered a `TypeError: WeakMap keys must be objects or non-registered symbols` inside masonic's `use-resize-observer`, crashing the entire PieceDetailPage. Confirmed in production trace `f609a788249af8392caf6af1c278c79c`. See [#823](https://github.com/shaoster/glaze/issues/823).

## Fix

`MasonryTile` was defined **inside** `PiecePhotoGalleryGrid`, creating a new function reference on every parent render. Masonic treats a changed `render` prop as a new component type, unmounts all tile instances, and `use-resize-observer` crashes trying to observe a now-null element during cleanup.

Move `MasonryTile` to **module scope** so its reference is always the same object. The per-render context it previously captured via closure (`canDelete`, `isThumbnail`, `onOpen`, `onDelete`) is now pre-computed and threaded through the tile `data` via a private `MasonryTileData` type. The public component API (`PiecePhotoGalleryGridProps`) is unchanged.

## Regression Test

`web/src/components/__tests__/PiecePhotoGalleryGrid.test.tsx` — **"passes a stable render function reference to Masonry across re-renders"**

Captures the `render` prop reference passed to `Masonry` on the initial render and after a `rerender`, then asserts `toBe` equality. Fails with the inline definition (new reference each render), passes with the module-level definition.

## Verification

```
//web:web_piece_photo_gallery_test   PASSED in 9.1s
38 tests pass, 0 failures
```

Closes #823
