### PR TITLE
feat: make all non-transient UI states routeable

### DIFF
--- a/.agents/skills/glaze-frontend/SKILL.md
+++ b/.agents/skills/glaze-frontend/SKILL.md
@@ -212,6 +212,42 @@ Glaze uses YAML-driven UI generation to maintain consistency with the backend.
 - Authenticated non-owners: can open shared pieces read-only; API returns `can_edit: false`
 - Do not introduce a separate public piece detail page — canonical URL is `/pieces/:id`
 
+## Routing Contract
+
+Any non-transient UI state — one the user would bookmark, share, or restore on reload — must live in the URL. Prefer hierarchical routes that mirror the data model. Use query params only when the state is orthogonal to the route hierarchy (e.g. lightbox index in a flat gallery).
+
+**Routed piece detail hierarchy:**
+```
+/pieces/:id                              — piece detail
+/pieces/:id/history/:stateId             — historical state view
+/pieces/:id/video                        — showcase video panel
+/pieces/:id/photos                       — photo gallery
+/pieces/:id/photos/:index                — photo lightbox (existing)
+/pieces/:id/tags/new                     — tag creation dialog
+/pieces/:id/state/fields/:fieldName      — global entry browse dialog
+/pieces/:id/state/fields/:fieldName/new  — global entry create dialog
+```
+`/analyze/glaze-combinations?combo=<id>&image=<idx>` — combination gallery lightbox (query params because the gallery is a flat list).
+
+**Routing hook pattern** — all URL parsing lives in `web/src/routing/pieceRouting.ts` and `web/src/routing/galleryRouting.ts`. Route-aware parents call the hook and inject the result as props; components themselves have no URL dependencies:
+
+```ts
+// In PieceDetailContent (the route-aware parent):
+const historyRouting = usePieceHistoryRouting(piece.id);
+<PieceHistory rewindedStateId={historyRouting.rewindedStateId}
+              onRewind={historyRouting.onRewind} />
+
+// In WorkflowState (uses RoutedGlobalEntryField wrapper):
+<RoutedGlobalEntryField pieceId={pieceId} fieldName={field.name}
+                        globalName={field.globalName} ... />
+```
+
+Components receive routing props and can be tested without any Router wrapper. `RoutedGlobalEntryField` is the HOC that injects routing into `GlobalEntryField`; use bare `GlobalEntryField` in unrouted contexts (e.g. `NewPieceDialog`).
+
+**Acceptable transient-only state** (do not route): state transition confirmation dialogs, photo deletion confirmations, menu anchors, drag gestures, save-in-progress flags.
+
+`GlobalEntryDialog` internal filter state is intentionally transient — it resets on close and need not survive a reload.
+
 ## Cloudinary Image Upload Flow
 
 - `WorkflowState` calls `GET /api/uploads/cloudinary/widget-config/` → opens Cloudinary Upload Widget → widget calls `POST /api/uploads/cloudinary/widget-signature/` for signing → on success stores `secure_url` + `public_id` → `PATCH /api/pieces/<id>/state/` persists the array

--- a/docs/agents/typescript-react-vite.md
+++ b/docs/agents/typescript-react-vite.md
@@ -15,6 +15,26 @@ React, TypeScript (strict), Vite, Material UI (MUI), Axios
 
 This is a Single Page Application (SPA). Routing is handled client-side via React Router (`RouterProvider` with a data router) mounted in the top-level `App` component. There is no server-side rendering.
 
+## Routing Convention
+
+Non-transient UI state — anything the user would bookmark, share, or restore on reload — must live in the URL. Prefer hierarchical routes that mirror the data model. Use query params only when state is orthogonal to the URL hierarchy.
+
+**Routing hook pattern**: URL parsing lives in dedicated hooks (`web/src/routing/`). Route-aware parents call the hook and inject the parsed result as props into child components. Children have no URL dependencies and require no Router wrapper in tests.
+
+```ts
+// ✅ Route-aware parent injects props
+const historyRouting = usePieceHistoryRouting(piece.id);
+<ChildComponent rewindedStateId={historyRouting.rewindedStateId}
+                onRewind={historyRouting.onRewind} />
+
+// ✅ Child is pure props-in/render-out — no routing hooks inside
+function ChildComponent({ rewindedStateId, onRewind }) { ... }
+```
+
+**Routed dialog pattern**: where a dialog is the target URL itself (e.g. `/new`, `/preferences/:sectionId`), use `useMatch` in the parent and pass `open` as a prop. Where a dialog is a sub-route of a resource, use a routing hook.
+
+**Acceptable transient-only state**: confirmation dialogs, menu anchors, drag gestures, save-in-progress flags, inline draft text fields.
+
 ## TypeScript
 
 - Strict mode is on. Beyond `strict: true`, also enforce `noUnusedLocals`, `noUnusedParameters`, and `noFallthroughCasesInSwitch` — remove unused variables and parameters rather than suppressing errors.

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -107,6 +107,7 @@ ts_project(
             "src/components/**/*.tsx",
             "src/pages/**/*.ts",
             "src/pages/**/*.tsx",
+            "src/routing/**/*.ts",
             "src/util/*.ts",
         ],
         exclude = [
@@ -350,6 +351,7 @@ js_library(
             "src/assets/**/*",
             "src/components/**/*",
             "src/pages/**/*",
+            "src/routing/**/*",
             "*.json",
             "*.config.*",
             "public/**/*",

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -265,6 +265,21 @@ js_library(
     ],
 )
 
+# ── Routing hooks ────────────────────────────────────────────────────────────
+
+js_library(
+    name = "routing_src",
+    srcs = [
+        "src/routing/galleryRouting.ts",
+        "src/routing/pieceRouting.ts",
+    ],
+    deps = [
+        ":generated_types",
+        ":node_modules",
+        ":util_lib",
+    ],
+)
+
 # ── Web source library ────────────────────────────────────────────────────────
 
 WEB_APP_SRCS = glob(
@@ -478,6 +493,7 @@ js_library(
     srcs = [
         "src/components/GlobalEntryDialog.tsx",
         "src/components/GlobalEntryField.tsx",
+        "src/components/RoutedGlobalEntryField.tsx",
     ],
     deps = [
         ":autosave_src",
@@ -485,6 +501,7 @@ js_library(
         ":generated_types",
         ":node_modules",
         ":primitive_src",
+        ":routing_src",
         ":util_lib",
     ],
 )
@@ -516,6 +533,7 @@ js_library(
         ":image_lightbox_src",
         ":node_modules",
         ":primitive_src",
+        ":routing_src",
         ":util_lib",
     ],
 )
@@ -697,12 +715,14 @@ js_library(
         ":autosave_src",
         ":cloudinary_image_src",
         ":generated_types",
+        ":global_picker_src",
         ":node_modules",
         ":piece_history_src",
         ":piece_photo_gallery_src",
         ":piece_share_controls_src",
         ":primitive_src",
         ":process_summary_src",
+        ":routing_src",
         ":state_transition_src",
         ":tag_manager_src",
         ":util_lib",

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -289,6 +289,7 @@ WEB_APP_SRCS = glob(
         "src/assets/**/*",
         "src/components/**/*",
         "src/pages/**/*",
+        "src/routing/**/*",
         "*.json",
         "public/**/*",
     ],

--- a/web/src/components/GlazeCombinationGallery.tsx
+++ b/web/src/components/GlazeCombinationGallery.tsx
@@ -253,7 +253,7 @@ export default function GlazeCombinationGallery() {
             combo={combo}
             pieces={pieces}
             onTileClick={handleTileClick}
-            onPieceImageClick={(images, idx) =>
+            onPieceImageClick={(_images, idx) =>
               onPieceImageClick(combo.id, idx)
             }
           />

--- a/web/src/components/GlazeCombinationGallery.tsx
+++ b/web/src/components/GlazeCombinationGallery.tsx
@@ -15,6 +15,7 @@
  */
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useCombinationGalleryRouting, type GalleryImage } from "../routing/galleryRouting";
 import {
   Box,
   Button,
@@ -43,12 +44,7 @@ const EMPTY_STATE_MESSAGE =
 
 type PieceEntry = GlazeCombinationImageEntry["pieces"][number];
 
-// A CaptionedImage tagged with the piece it came from.
-interface GalleryImage extends CaptionedImage {
-  pieceId: string;
-  pieceName: string;
-  pieceState: string;
-}
+// GalleryImage is defined in galleryRouting — imported above.
 
 type LightboxState =
   | { kind: "tile"; images: CaptionedImage[]; initialIndex: 0 }
@@ -214,8 +210,12 @@ export default function GlazeCombinationGallery() {
     queryKey: GLAZE_COMBINATION_IMAGES_QUERY_KEY,
     queryFn: fetchGlazeCombinationImages,
   });
-  const [lightbox, setLightbox] = useState<LightboxState | null>(null);
+  // Tile lightboxes are local (ephemeral, not shareable).
+  const [tileBox, setTileBox] = useState<LightboxState | null>(null);
   const navigate = useNavigate();
+  const { pieceLightbox, onPieceImageClick, onClosePieceLightbox } =
+    useCombinationGalleryRouting(entries);
+  const lightbox = pieceLightbox ?? tileBox;
 
   if (entries.length === 0) {
     return (
@@ -229,7 +229,7 @@ export default function GlazeCombinationGallery() {
     image: NonNullable<GlazeCombinationEntry["test_tile_image"]>,
     name: string,
   ) {
-    setLightbox({
+    setTileBox({
       kind: "tile",
       initialIndex: 0,
       images: [
@@ -244,10 +244,6 @@ export default function GlazeCombinationGallery() {
     });
   }
 
-  function handlePieceImageClick(images: GalleryImage[], idx: number) {
-    setLightbox({ kind: "piece", images, initialIndex: idx });
-  }
-
   return (
     <>
       <Stack spacing={2}>
@@ -257,7 +253,9 @@ export default function GlazeCombinationGallery() {
             combo={combo}
             pieces={pieces}
             onTileClick={handleTileClick}
-            onPieceImageClick={handlePieceImageClick}
+            onPieceImageClick={(images, idx) =>
+              onPieceImageClick(combo.id, idx)
+            }
           />
         ))}
       </Stack>
@@ -265,15 +263,23 @@ export default function GlazeCombinationGallery() {
         <ImageLightbox
           images={lightbox.images}
           initialIndex={lightbox.initialIndex}
-          onClose={() => setLightbox(null)}
+          onClose={() => {
+            if (pieceLightbox) {
+              onClosePieceLightbox();
+            } else {
+              setTileBox(null);
+            }
+          }}
           footerActions={
             lightbox.kind === "piece"
-              ? ({ index }) => (
+              ? ({ index }) => {
+                  const img = lightbox.images[index] as GalleryImage;
+                  return (
                   <Button
                     size="small"
                     variant="outlined"
                     onClick={() =>
-                      navigate(`/pieces/${lightbox.images[index].pieceId}`, {
+                      navigate(`/pieces/${img.pieceId}`, {
                         state: { fromGallery: true },
                       })
                     }
@@ -284,7 +290,8 @@ export default function GlazeCombinationGallery() {
                   >
                     Go to the Piece
                   </Button>
-                )
+                  );
+                }
               : undefined
           }
         />

--- a/web/src/components/GlazeCombinationGallery.tsx
+++ b/web/src/components/GlazeCombinationGallery.tsx
@@ -213,8 +213,12 @@ export default function GlazeCombinationGallery() {
   // Tile lightboxes are local (ephemeral, not shareable).
   const [tileBox, setTileBox] = useState<LightboxState | null>(null);
   const navigate = useNavigate();
-  const { pieceLightbox, onPieceImageClick, onClosePieceLightbox } =
-    useCombinationGalleryRouting(entries);
+  const {
+    pieceLightbox,
+    onPieceImageClick,
+    onPieceLightboxIndexChange,
+    onClosePieceLightbox,
+  } = useCombinationGalleryRouting(entries);
   const lightbox = pieceLightbox ?? tileBox;
 
   if (entries.length === 0) {
@@ -263,6 +267,7 @@ export default function GlazeCombinationGallery() {
         <ImageLightbox
           images={lightbox.images}
           initialIndex={lightbox.initialIndex}
+          onIndexChange={pieceLightbox ? onPieceLightboxIndexChange : undefined}
           onClose={() => {
             if (pieceLightbox) {
               onClosePieceLightbox();

--- a/web/src/components/GlobalEntryDialog.tsx
+++ b/web/src/components/GlobalEntryDialog.tsx
@@ -47,6 +47,9 @@ export interface GlobalEntryDialogProps {
   onClose: () => void;
   onSelect: (entry: { id: string; name: string }) => void;
   canCreate?: boolean;
+  // When provided, makes the tab fully controlled (routing-driven).
+  tab?: "browse" | "create";
+  onTabChange?: (tab: "browse" | "create") => void;
 }
 
 interface NamedRef {
@@ -140,6 +143,8 @@ export default function GlobalEntryDialog({
   onClose,
   onSelect,
   canCreate = false,
+  tab: tabProp,
+  onTabChange,
 }: GlobalEntryDialogProps) {
   const boolFilterableFields = useMemo(
     () => getFilterableFields(globalName),
@@ -166,7 +171,17 @@ export default function GlobalEntryDialog({
   const composeFieldName = composeEntry?.[0] ?? null;
   const composeFieldConfig = composeEntry?.[1] ?? null;
   const createWithLayers = composeFieldConfig !== null;
-  const [tab, setTab] = useState<"browse" | "create">("browse");
+  const [internalTab, setInternalTab] = useState<"browse" | "create">("browse");
+  // Controlled when the parent passes tab+onTabChange (routing-driven);
+  // uncontrolled otherwise (local state).
+  const tab = tabProp ?? internalTab;
+  const setTab = (newTab: "browse" | "create") => {
+    if (onTabChange) {
+      onTabChange(newTab);
+    } else {
+      setInternalTab(newTab);
+    }
+  };
   const [filters, setFilters] = useState<FilterState>(() =>
     makeEmptyFilters(boolFieldNames, relatedFilterDefs),
   );
@@ -259,7 +274,7 @@ export default function GlobalEntryDialog({
 
   function handleClose() {
     setFilters(makeEmptyFilters(boolFieldNames, relatedFilterDefs));
-    setTab("browse");
+    setInternalTab("browse"); // reset local state; controlled tab is owned by parent
     resetCreateState();
     onClose();
   }

--- a/web/src/components/GlobalEntryDialog.tsx
+++ b/web/src/components/GlobalEntryDialog.tsx
@@ -272,10 +272,18 @@ export default function GlobalEntryDialog({
     setNextLayerKey(1);
   }
 
+  // Reset ephemeral dialog state whenever it closes, whether via the close
+  // button/cancel (handleClose) or browser Back changing the URL (open flips
+  // false without handleClose running). Idempotent — double-reset is safe.
+  useEffect(() => {
+    if (!open) {
+      setFilters(makeEmptyFilters(boolFieldNames, relatedFilterDefs));
+      setInternalTab("browse");
+      resetCreateState();
+    }
+  }, [open, boolFieldNames, relatedFilterDefs]);
+
   function handleClose() {
-    setFilters(makeEmptyFilters(boolFieldNames, relatedFilterDefs));
-    setInternalTab("browse"); // reset local state; controlled tab is owned by parent
-    resetCreateState();
     onClose();
   }
 

--- a/web/src/components/GlobalEntryField.tsx
+++ b/web/src/components/GlobalEntryField.tsx
@@ -35,7 +35,8 @@ export default function GlobalEntryField({
   routing,
 }: GlobalEntryFieldProps) {
   const [localOpen, setLocalOpen] = useState(false);
-  const open = routing?.open ?? localOpen;
+  // Disabled fields never open the picker, even when the URL targets this field.
+  const open = !disabled && (routing?.open ?? localOpen);
   const onOpen = routing?.onOpen ?? (() => setLocalOpen(true));
   const onClose = routing?.onClose ?? (() => setLocalOpen(false));
   const showAction = !disabled || !hideActionWhenDisabled;

--- a/web/src/components/GlobalEntryField.tsx
+++ b/web/src/components/GlobalEntryField.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Button, Chip, InputAdornment, TextField } from "@mui/material";
 import type { SxProps, Theme } from "@mui/material";
 import GlobalEntryDialog from "./GlobalEntryDialog";
+import type { GlobalFieldRouting } from "../routing/pieceRouting";
 
 export interface GlobalEntryFieldProps {
   globalName: string;
@@ -15,6 +16,9 @@ export interface GlobalEntryFieldProps {
   disabled?: boolean;
   hideActionWhenDisabled?: boolean;
   sx?: SxProps<Theme>;
+  // Injected by RoutedGlobalEntryField when inside a /pieces/:id context.
+  // Absent when used in unrouted contexts (e.g. NewPieceDialog).
+  routing?: GlobalFieldRouting;
 }
 
 export default function GlobalEntryField({
@@ -28,8 +32,12 @@ export default function GlobalEntryField({
   disabled = false,
   hideActionWhenDisabled = false,
   sx,
+  routing,
 }: GlobalEntryFieldProps) {
-  const [open, setOpen] = useState(false);
+  const [localOpen, setLocalOpen] = useState(false);
+  const open = routing?.open ?? localOpen;
+  const onOpen = routing?.onOpen ?? (() => setLocalOpen(true));
+  const onClose = routing?.onClose ?? (() => setLocalOpen(false));
   const showAction = !disabled || !hideActionWhenDisabled;
 
   return (
@@ -59,7 +67,7 @@ export default function GlobalEntryField({
                   size="small"
                   onClick={(e) => {
                     e.stopPropagation();
-                    setOpen(true);
+                    onOpen();
                   }}
                   disabled={disabled}
                   aria-label={value ? `Change ${label}` : `Browse ${label}`}
@@ -82,12 +90,14 @@ export default function GlobalEntryField({
           },
           ...(Array.isArray(sx) ? sx : [sx]),
         ]}
-        onClick={disabled ? undefined : () => setOpen(true)}
+        onClick={disabled ? undefined : onOpen}
       />
       <GlobalEntryDialog
         globalName={globalName}
         open={open}
-        onClose={() => setOpen(false)}
+        tab={routing?.tab}
+        onTabChange={routing?.onTabChange}
+        onClose={onClose}
         onSelect={onSelect}
         canCreate={canCreate}
       />

--- a/web/src/components/ImageLightbox.tsx
+++ b/web/src/components/ImageLightbox.tsx
@@ -44,13 +44,16 @@ export default function ImageLightbox({
 }: ImageLightboxProps) {
   const [index, setIndex] = useState(initialIndex);
 
-  // Notify caller when index changes due to navigation (swipe, arrow, thumbnail).
-  // Use a ref so the effect dep list stays stable and doesn't fire on mount.
+  // Notify caller when index changes due to user navigation (swipe, arrow,
+  // thumbnail). Suppressed when the change is driven by a URL sync so we
+  // don't write a duplicate history entry for an already-current URL.
   const onIndexChangeRef = useRef(onIndexChange);
   onIndexChangeRef.current = onIndexChange;
   const mountedRef = useRef(false);
+  const syncingFromUrlRef = useRef(false);
   useEffect(() => {
     if (!mountedRef.current) { mountedRef.current = true; return; }
+    if (syncingFromUrlRef.current) { syncingFromUrlRef.current = false; return; }
     onIndexChangeRef.current?.(index);
   }, [index]);
   const [dragDeltaX, setDragDeltaX] = useState(0);
@@ -69,8 +72,10 @@ export default function ImageLightbox({
   }
 
   // Sync to URL-driven index changes (e.g. browser Back while lightbox is open).
+  // Set the flag before setIndex so the onIndexChange effect skips this update.
   if (initialIndex !== prevInitialIndex) {
     setPrevInitialIndex(initialIndex);
+    syncingFromUrlRef.current = true;
     setIndex(initialIndex);
   }
   function prev() {

--- a/web/src/components/ImageLightbox.tsx
+++ b/web/src/components/ImageLightbox.tsx
@@ -61,10 +61,17 @@ export default function ImageLightbox({
   const image = images[index];
 
   const [prevIndex, setPrevIndex] = useState(index);
+  const [prevInitialIndex, setPrevInitialIndex] = useState(initialIndex);
 
   if (index !== prevIndex) {
     setPrevIndex(index);
     setOptimisticCrop(null);
+  }
+
+  // Sync to URL-driven index changes (e.g. browser Back while lightbox is open).
+  if (initialIndex !== prevInitialIndex) {
+    setPrevInitialIndex(initialIndex);
+    setIndex(initialIndex);
   }
   function prev() {
     setIndex((i) => {

--- a/web/src/components/ImageLightbox.tsx
+++ b/web/src/components/ImageLightbox.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   Box,
   IconButton,
@@ -17,6 +17,7 @@ type ImageLightboxProps = {
   images: CaptionedImage[];
   initialIndex: number;
   onClose: () => void;
+  onIndexChange?: (index: number) => void;
   currentThumbnailUrl?: string;
   onSetAsThumbnail?: (image: CaptionedImage) => Promise<void>;
   onCropSave?: (image: CaptionedImage, crop: ImageCrop) => Promise<void>;
@@ -34,6 +35,7 @@ export default function ImageLightbox({
   images,
   initialIndex,
   onClose,
+  onIndexChange,
   currentThumbnailUrl,
   onSetAsThumbnail,
   onCropSave,
@@ -41,6 +43,16 @@ export default function ImageLightbox({
   footerActions,
 }: ImageLightboxProps) {
   const [index, setIndex] = useState(initialIndex);
+
+  // Notify caller when index changes due to navigation (swipe, arrow, thumbnail).
+  // Use a ref so the effect dep list stays stable and doesn't fire on mount.
+  const onIndexChangeRef = useRef(onIndexChange);
+  onIndexChangeRef.current = onIndexChange;
+  const mountedRef = useRef(false);
+  useEffect(() => {
+    if (!mountedRef.current) { mountedRef.current = true; return; }
+    onIndexChangeRef.current?.(index);
+  }, [index]);
   const [dragDeltaX, setDragDeltaX] = useState(0);
   const [dragDeltaY, setDragDeltaY] = useState(0);
   const [cropMode, setCropMode] = useState(false);

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -438,7 +438,7 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
             piece={piece}
             onPieceUpdated={onPieceUpdated}
             rewindedStateId={rewindedStateId}
-            onRewind={historyRouting.onRewind}
+            onRewind={(id) => id && historyRouting.onRewind(id)}
           />
         </SectionCard>
       </Box>

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -123,13 +123,23 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
     },
   );
 
-  // Only block navigation that leaves this piece's subtree entirely.
-  // Sub-route changes within /pieces/:id (history, video, tags, fields) are
-  // in-page state and must not trigger the unsaved-changes prompt.
+  // Block navigation away from the dirty form, but allow routing-hook sub-routes
+  // that are pure in-page UI and do not mutate piece state.
+  // /photos is intentionally excluded: the gallery can write back to the current
+  // state using the last-saved prop values, which would silently drop dirty edits.
   const blocker = useBlocker(
     useCallback(
-      ({ nextLocation }: { nextLocation: { pathname: string } }) =>
-        canEdit && isDirty && !nextLocation.pathname.startsWith(`/pieces/${piece.id}`),
+      ({ nextLocation }: { nextLocation: { pathname: string } }) => {
+        if (!canEdit || !isDirty) return false;
+        const next = nextLocation.pathname;
+        const base = `/pieces/${piece.id}`;
+        if (next === base) return false;
+        if (next.startsWith(`${base}/history/`)) return false;
+        if (next === `${base}/video`) return false;
+        if (next === `${base}/tags/new`) return false;
+        if (next.startsWith(`${base}/state/fields/`)) return false;
+        return true;
+      },
       [canEdit, isDirty, piece.id],
     ),
   );

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -1,5 +1,6 @@
 import {
   type ComponentProps,
+  useCallback,
   useState,
 } from "react";
 import {
@@ -122,7 +123,16 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
     },
   );
 
-  const blocker = useBlocker(canEdit && isDirty);
+  // Only block navigation that leaves this piece's subtree entirely.
+  // Sub-route changes within /pieces/:id (history, video, tags, fields) are
+  // in-page state and must not trigger the unsaved-changes prompt.
+  const blocker = useBlocker(
+    useCallback(
+      ({ nextLocation }: { nextLocation: { pathname: string } }) =>
+        canEdit && isDirty && !nextLocation.pathname.startsWith(`/pieces/${piece.id}`),
+      [canEdit, isDirty, piece.id],
+    ),
+  );
 
 
 
@@ -438,7 +448,9 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
             piece={piece}
             onPieceUpdated={onPieceUpdated}
             rewindedStateId={rewindedStateId}
-            onRewind={(id) => id && historyRouting.onRewind(id)}
+            onRewind={(id) =>
+              id ? historyRouting.onRewind(id) : historyRouting.onClearRewind()
+            }
           />
         </SectionCard>
       </Box>

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -3,6 +3,12 @@ import {
   useState,
 } from "react";
 import {
+  usePieceHistoryRouting,
+  usePieceTagsRouting,
+  usePieceVideoRouting,
+} from "../routing/pieceRouting";
+import RoutedGlobalEntryField from "./RoutedGlobalEntryField";
+import {
   Alert,
   alpha,
   Box,
@@ -41,7 +47,6 @@ import TagManager from "./TagManager";
 import StateTransition from "./StateTransition";
 import PieceHistory from "./PieceHistory";
 import ProcessSummary from "./ProcessSummary";
-import GlobalEntryField from "./GlobalEntryField";
 import PiecePhotoGallery, {
   PiecePhotoGalleryButton,
   type PiecePhotoGalleryImage,
@@ -83,10 +88,11 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
     canEdit || getCustomFieldDefinitions(currentState.state).length > 0;
   const pastHistory = piece.history.slice(0, -1);
 
-  const [rewindedStateId, setRewindedStateId] = useState<string | null>(null);
+  const historyRouting = usePieceHistoryRouting(piece.id);
+  const videoRouting = usePieceVideoRouting(piece.id);
+  const tagsRouting = usePieceTagsRouting(piece.id);
 
-  // Keep rewindedStateId when toggling is_editable to allow viewing history in read-only mode.
-
+  const { rewindedStateId } = historyRouting;
   const rewindedState = rewindedStateId
     ? pastHistory.find((ps) => ps.id === rewindedStateId) ?? null
     : null;
@@ -217,6 +223,9 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
                 pieceId={piece.id}
                 initialTags={piece.tags ?? []}
                 onSaved={onPieceUpdated}
+                tagDialogOpen={tagsRouting.tagDialogOpen}
+                onOpenTagDialog={tagsRouting.onOpenTagDialog}
+                onCloseTagDialog={tagsRouting.onCloseTagDialog}
               />
             ) : null}
             {canEdit && (
@@ -247,7 +256,9 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
             )}
             <Box sx={{ mb: 1.5 }}>
               <SectionCard>
-                <GlobalEntryField
+                <RoutedGlobalEntryField
+                  pieceId={piece.id}
+                  fieldName="current_location"
                   globalName="location"
                   label="Current location"
                   value={piece.current_location ?? ""}
@@ -352,7 +363,7 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
                 color="primary"
                 variant="outlined"
                 size="small"
-                onDelete={() => setRewindedStateId(null)}
+                onDelete={historyRouting.onClearRewind}
               />
               <Typography variant="caption" color="text.secondary">
                 {piece.is_editable
@@ -401,7 +412,11 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
 
         {canEdit && isTerminal && (
           <Box sx={{ mb: 2.5 }}>
-            <ShowcaseVideoPanel piece={piece} />
+            <ShowcaseVideoPanel
+            piece={piece}
+            atVideo={videoRouting.atVideo}
+            onVideoNavigate={videoRouting.onVideoNavigate}
+          />
           </Box>
         )}
 
@@ -423,7 +438,7 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
             piece={piece}
             onPieceUpdated={onPieceUpdated}
             rewindedStateId={rewindedStateId}
-            onRewind={setRewindedStateId}
+            onRewind={historyRouting.onRewind}
           />
         </SectionCard>
       </Box>
@@ -460,7 +475,15 @@ function ArtifactActions({ artifact }: ArtifactActionsProps) {
   );
 }
 
-function ShowcaseVideoPanel({ piece }: { piece: PieceDetailType }) {
+function ShowcaseVideoPanel({
+  piece,
+  atVideo,
+  onVideoNavigate,
+}: {
+  piece: PieceDetailType;
+  atVideo: boolean;
+  onVideoNavigate: (open: boolean) => void;
+}) {
   const queryClient = useQueryClient();
   const [userExpanded, setUserExpanded] = useState<boolean | null>(null);
   const [selection, setSelection] = useState<ShowcaseVideoInputSelection>({
@@ -492,6 +515,7 @@ function ShowcaseVideoPanel({ piece }: { piece: PieceDetailType }) {
     onSuccess: (updated) => {
       queryClient.setQueryData(["showcase-video", piece.id], updated);
       setUserExpanded(true);
+      onVideoNavigate(true);
     },
   });
 
@@ -519,9 +543,8 @@ function ShowcaseVideoPanel({ piece }: { piece: PieceDetailType }) {
     currentStatus === "running" ? (showcaseVideo?.progress ?? 0) : null;
 
   const artifact = showcaseVideo?.artifact ?? null;
-  // Pinned open after the user generates a video in this session; otherwise
-  // defaults to open when no artifact exists yet, closed when one already does.
-  const expanded = userExpanded ?? (artifact === null);
+  // atVideo (URL) takes strict priority; local pin used for session state.
+  const expanded = atVideo ? true : (userExpanded ?? (artifact === null));
   const errorMessage = rawGenerateError
     ? extractErrorMessage(
         rawGenerateError,
@@ -541,7 +564,11 @@ function ShowcaseVideoPanel({ piece }: { piece: PieceDetailType }) {
       titleAdornment={
         <IconButton
           size="small"
-          onClick={() => setUserExpanded(!expanded)}
+          onClick={() => {
+            const next = !expanded;
+            setUserExpanded(next);
+            onVideoNavigate(next);
+          }}
           aria-label={expanded ? "Collapse showcase video" : "Expand showcase video"}
           sx={{ transform: expanded ? "rotate(180deg)" : "rotate(0deg)", transition: "transform 0.2s" }}
         >

--- a/web/src/components/RoutedGlobalEntryField.tsx
+++ b/web/src/components/RoutedGlobalEntryField.tsx
@@ -1,0 +1,21 @@
+import { useGlobalFieldRouting } from "../routing/pieceRouting";
+import GlobalEntryField, { type GlobalEntryFieldProps } from "./GlobalEntryField";
+
+interface RoutedGlobalEntryFieldProps extends Omit<GlobalEntryFieldProps, "routing"> {
+  pieceId: string;
+  // fieldName uniquely identifies this field in the URL. Defaults to globalName
+  // but must be set explicitly when multiple fields on the same state reference
+  // the same globalName (e.g. "current_location" and "kiln_location" both
+  // reference globalName "location").
+  fieldName?: string;
+}
+
+export default function RoutedGlobalEntryField({
+  pieceId,
+  fieldName,
+  globalName,
+  ...props
+}: RoutedGlobalEntryFieldProps) {
+  const routing = useGlobalFieldRouting(pieceId, fieldName ?? globalName);
+  return <GlobalEntryField {...props} globalName={globalName} routing={routing} />;
+}

--- a/web/src/components/RoutedGlobalEntryField.tsx
+++ b/web/src/components/RoutedGlobalEntryField.tsx
@@ -1,3 +1,4 @@
+import { useInRouterContext } from "react-router-dom";
 import { useGlobalFieldRouting } from "../routing/pieceRouting";
 import GlobalEntryField, { type GlobalEntryFieldProps } from "./GlobalEntryField";
 
@@ -10,7 +11,8 @@ interface RoutedGlobalEntryFieldProps extends Omit<GlobalEntryFieldProps, "routi
   fieldName?: string;
 }
 
-export default function RoutedGlobalEntryField({
+// Inner component so useGlobalFieldRouting is always called unconditionally.
+function RoutedGlobalEntryFieldInner({
   pieceId,
   fieldName,
   globalName,
@@ -18,4 +20,18 @@ export default function RoutedGlobalEntryField({
 }: RoutedGlobalEntryFieldProps) {
   const routing = useGlobalFieldRouting(pieceId, fieldName ?? globalName);
   return <GlobalEntryField {...props} globalName={globalName} routing={routing} />;
+}
+
+// When rendered outside a Router context (e.g. Django admin), fall back to
+// the unrouted GlobalEntryField so admin forms still work.
+export default function RoutedGlobalEntryField({
+  pieceId,
+  fieldName,
+  ...rest
+}: RoutedGlobalEntryFieldProps) {
+  const inRouter = useInRouterContext();
+  if (!inRouter) {
+    return <GlobalEntryField {...rest} />;
+  }
+  return <RoutedGlobalEntryFieldInner pieceId={pieceId} fieldName={fieldName} {...rest} />;
 }

--- a/web/src/components/TagManager.tsx
+++ b/web/src/components/TagManager.tsx
@@ -18,6 +18,10 @@ type TagManagerProps = {
   pieceId: string;
   initialTags: TagEntry[];
   onSaved: (updated: PieceDetail) => void;
+  // Routing props injected by the parent (PieceDetailContent via usePieceTagsRouting).
+  tagDialogOpen: boolean;
+  onOpenTagDialog: () => void;
+  onCloseTagDialog: () => void;
 };
 
 function toTagEntry(entry: {
@@ -38,6 +42,9 @@ export default function TagManager({
   pieceId,
   initialTags,
   onSaved,
+  tagDialogOpen,
+  onOpenTagDialog,
+  onCloseTagDialog,
 }: TagManagerProps) {
   const pieceDetailSaveStatus = usePieceDetailSaveStatus();
   const queryClient = useQueryClient();
@@ -52,7 +59,6 @@ export default function TagManager({
   const [selectedTags, setSelectedTags] = useState<TagEntry[]>(initialTags);
   const [editingTags, setEditingTags] = useState(false);
   const [draftTags, setDraftTags] = useState<TagEntry[]>(initialTags);
-  const [tagDialogOpen, setTagDialogOpen] = useState(false);
   const [newTagName, setNewTagName] = useState("");
   const [newTagColor, setNewTagColor] = useState(
     pickDefaultTagColor(initialTags.length),
@@ -67,6 +73,13 @@ export default function TagManager({
     setDraftTags(initialTags);
     setEditingTags(false);
   }, [initialTags]);
+
+  // When the dialog opens via a direct URL (/tags/new), ensure editing mode
+  // is active so the newly created tag lands in the pending save.
+  useEffect(() => {
+    if (tagDialogOpen && !editingTags) startEditingTags();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tagDialogOpen]);
 
   function startEditingTags() {
     if (!shouldLoadTags) {
@@ -131,7 +144,7 @@ export default function TagManager({
         is_public: false, // New tags are private by default.
       };
       setDraftTags((prev) => [...prev, createdTag]);
-      setTagDialogOpen(false);
+      onCloseTagDialog();
       setNewTagName("");
       setNewTagColor(pickDefaultTagColor(trimmed.length));
     } catch (error) {
@@ -161,7 +174,7 @@ export default function TagManager({
             options={availableTags}
             value={draftTags}
             onChange={setDraftTags}
-            onCreateNew={() => setTagDialogOpen(true)}
+            onCreateNew={onOpenTagDialog}
             disabled={tagSaving}
             sx={{ minWidth: 0 }}
           />
@@ -220,7 +233,7 @@ export default function TagManager({
         color={newTagColor}
         error={tagError}
         saving={tagSaving}
-        onClose={() => setTagDialogOpen(false)}
+        onClose={onCloseTagDialog}
         onNameChange={setNewTagName}
         onColorChange={setNewTagColor}
         onCreate={() => void createTag()}

--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -23,7 +23,7 @@ import {
   getDefinitionsFromSchema,
 } from "../util/workflow";
 import { entryNameOrEmpty } from "../util/optionalValues";
-import GlobalEntryField from "./GlobalEntryField";
+import RoutedGlobalEntryField from "./RoutedGlobalEntryField";
 import AutosaveStatus from "./AutosaveStatus";
 import { useAutosave } from "./useAutosave";
 import { usePieceDetailSaveStatus } from "./usePieceDetailSaveStatus";
@@ -258,7 +258,9 @@ export default function WorkflowState({
             if (field.isGlobalRef && field.globalName) {
               return (
                 <Box key={field.name} data-testid={`global-entry-field-${field.globalName}`}>
-                  <GlobalEntryField
+                  <RoutedGlobalEntryField
+                    pieceId={pieceId}
+                    fieldName={field.name}
                     globalName={field.globalName}
                     label={label}
                     value={value}

--- a/web/src/components/__tests__/TagManager.test.tsx
+++ b/web/src/components/__tests__/TagManager.test.tsx
@@ -7,6 +7,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
+import { useState } from "react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import TagManager from "../TagManager";
@@ -67,17 +68,34 @@ function makePiece(overrides = {}): PieceDetail {
   };
 }
 
+// Stateful wrapper so tagDialogOpen mirrors what the parent would do in prod.
+function ControlledTagManager({
+  initialTags = [] as TagEntry[],
+  onSaved = vi.fn(),
+}: {
+  initialTags?: TagEntry[];
+  onSaved?: (updated: PieceDetail) => void;
+}) {
+  const [tagDialogOpen, setTagDialogOpen] = useState(false);
+  return (
+    <TagManager
+      pieceId="piece-id-1"
+      initialTags={initialTags}
+      onSaved={onSaved}
+      tagDialogOpen={tagDialogOpen}
+      onOpenTagDialog={() => setTagDialogOpen(true)}
+      onCloseTagDialog={() => setTagDialogOpen(false)}
+    />
+  );
+}
+
 function renderTagManager(initialTags: TagEntry[] = [], onSaved = vi.fn()) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
   return render(
     <QueryClientProvider client={queryClient}>
-      <TagManager
-        pieceId="piece-id-1"
-        initialTags={initialTags}
-        onSaved={onSaved}
-      />
+      <ControlledTagManager initialTags={initialTags} onSaved={onSaved} />
     </QueryClientProvider>,
   );
 }

--- a/web/src/components/__tests__/WorkflowState.test.tsx
+++ b/web/src/components/__tests__/WorkflowState.test.tsx
@@ -7,6 +7,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import type { ReactElement } from "react";
+import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 function render(ui: ReactElement) {
@@ -14,7 +15,9 @@ function render(ui: ReactElement) {
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
   const wrap = (node: ReactElement) => (
-    <QueryClientProvider client={queryClient}>{node}</QueryClientProvider>
+    <MemoryRouter initialEntries={["/pieces/piece-1"]}>
+      <QueryClientProvider client={queryClient}>{node}</QueryClientProvider>
+    </MemoryRouter>
   );
   const result = baseRender(wrap(ui));
   return {

--- a/web/src/routing/galleryRouting.ts
+++ b/web/src/routing/galleryRouting.ts
@@ -1,0 +1,60 @@
+/**
+ * Routing hook for /analyze/glaze-combinations?combo=<id>&image=<idx>.
+ *
+ * Piece lightboxes are derived from URL so browser back/forward and direct
+ * links stay in sync. Tile lightboxes (local, ephemeral) are not routed.
+ */
+import { useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+import type { CaptionedImage, GlazeCombinationImageEntry } from "../util/types";
+
+export interface GalleryImage extends CaptionedImage {
+  pieceId: string;
+  pieceName: string;
+  pieceState: string;
+}
+
+export interface PieceLightboxState {
+  kind: "piece";
+  images: GalleryImage[];
+  initialIndex: number;
+}
+
+export interface CombinationGalleryRouting {
+  pieceLightbox: PieceLightboxState | null;
+  onPieceImageClick: (comboId: string, idx: number) => void;
+  onClosePieceLightbox: () => void;
+}
+
+export function useCombinationGalleryRouting(
+  entries: GlazeCombinationImageEntry[],
+): CombinationGalleryRouting {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const pieceLightbox = useMemo<PieceLightboxState | null>(() => {
+    const comboParam = searchParams.get("combo");
+    const imageParam = searchParams.get("image");
+    if (!comboParam || imageParam === null) return null;
+    const idx = parseInt(imageParam, 10);
+    if (isNaN(idx) || idx < 0) return null;
+    const entry = entries.find((e) => e.glaze_combination.id === comboParam);
+    if (!entry) return null;
+    const images: GalleryImage[] = entry.pieces.flatMap((piece) =>
+      piece.images.map((img) => ({
+        ...img,
+        pieceId: piece.id,
+        pieceName: piece.name,
+        pieceState: piece.state,
+      })),
+    );
+    if (idx >= images.length) return null;
+    return { kind: "piece", images, initialIndex: idx };
+  }, [searchParams, entries]);
+
+  return {
+    pieceLightbox,
+    onPieceImageClick: (comboId, idx) =>
+      setSearchParams({ combo: comboId, image: String(idx) }),
+    onClosePieceLightbox: () => setSearchParams({}),
+  };
+}

--- a/web/src/routing/galleryRouting.ts
+++ b/web/src/routing/galleryRouting.ts
@@ -23,6 +23,7 @@ export interface PieceLightboxState {
 export interface CombinationGalleryRouting {
   pieceLightbox: PieceLightboxState | null;
   onPieceImageClick: (comboId: string, idx: number) => void;
+  onPieceLightboxIndexChange: (idx: number) => void;
   onClosePieceLightbox: () => void;
 }
 
@@ -51,10 +52,15 @@ export function useCombinationGalleryRouting(
     return { kind: "piece", images, initialIndex: idx };
   }, [searchParams, entries]);
 
+  const comboParam = searchParams.get("combo");
+
   return {
     pieceLightbox,
     onPieceImageClick: (comboId, idx) =>
       setSearchParams({ combo: comboId, image: String(idx) }),
+    onPieceLightboxIndexChange: (idx) => {
+      if (comboParam) setSearchParams({ combo: comboParam, image: String(idx) });
+    },
     onClosePieceLightbox: () => setSearchParams({}),
   };
 }

--- a/web/src/routing/pieceRouting.ts
+++ b/web/src/routing/pieceRouting.ts
@@ -1,0 +1,103 @@
+/**
+ * Routing hooks for /pieces/:id sub-routes.
+ *
+ * Each hook returns a typed props object. Route-aware parents call the hook
+ * and spread/inject the result into the child component so the child itself
+ * has no URL dependencies and tests stay clean.
+ */
+import { useLocation, useNavigate } from "react-router-dom";
+
+// ── History (/pieces/:id/history/:stateId) ────────────────────────────────────
+
+export interface PieceHistoryRouting {
+  rewindedStateId: string | null;
+  onRewind: (stateId: string) => void;
+  onClearRewind: () => void;
+}
+
+export function usePieceHistoryRouting(pieceId: string): PieceHistoryRouting {
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const match = pathname.match(/\/history\/([^/]+)$/);
+  return {
+    rewindedStateId: match?.[1] ?? null,
+    onRewind: (stateId) => navigate(`/pieces/${pieceId}/history/${stateId}`),
+    onClearRewind: () => navigate(`/pieces/${pieceId}`),
+  };
+}
+
+// ── Video (/pieces/:id/video) ─────────────────────────────────────────────────
+
+export interface PieceVideoRouting {
+  atVideo: boolean;
+  onVideoNavigate: (open: boolean) => void;
+}
+
+export function usePieceVideoRouting(pieceId: string): PieceVideoRouting {
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+  return {
+    atVideo: pathname.endsWith("/video"),
+    onVideoNavigate: (open) =>
+      navigate(open ? `/pieces/${pieceId}/video` : `/pieces/${pieceId}`),
+  };
+}
+
+// ── Tags (/pieces/:id/tags/new) ───────────────────────────────────────────────
+
+export interface PieceTagsRouting {
+  tagDialogOpen: boolean;
+  onOpenTagDialog: () => void;
+  onCloseTagDialog: () => void;
+}
+
+export function usePieceTagsRouting(pieceId: string): PieceTagsRouting {
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+  return {
+    tagDialogOpen: pathname.endsWith("/tags/new"),
+    onOpenTagDialog: () => navigate(`/pieces/${pieceId}/tags/new`),
+    onCloseTagDialog: () => navigate(`/pieces/${pieceId}`),
+  };
+}
+
+// ── Global fields (/pieces/:id/state/fields/:fieldName[/new]) ─────────────────
+//
+// fieldName is the workflow field key (e.g. "current_location"), which may
+// differ from globalName (the underlying global type, e.g. "location") when
+// multiple fields on the same state reference the same global type.
+
+export interface GlobalFieldRouting {
+  open: boolean;
+  tab: "browse" | "create";
+  onOpen: () => void;
+  onClose: () => void;
+  onTabChange: (tab: "browse" | "create") => void;
+}
+
+export function useGlobalFieldRouting(
+  pieceId: string,
+  fieldName: string,
+): GlobalFieldRouting {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const match = location.pathname.match(/\/state\/fields\/([^/]+)(\/new)?$/);
+  const tab: "browse" | "create" = match?.[2] === "/new" ? "create" : "browse";
+  return {
+    open: match?.[1] === fieldName,
+    tab,
+    onOpen: () =>
+      navigate(`/pieces/${pieceId}/state/fields/${fieldName}`, {
+        state: location.state,
+      }),
+    onClose: () =>
+      navigate(`/pieces/${pieceId}`, { state: location.state }),
+    onTabChange: (newTab) =>
+      navigate(
+        newTab === "create"
+          ? `/pieces/${pieceId}/state/fields/${fieldName}/new`
+          : `/pieces/${pieceId}/state/fields/${fieldName}`,
+        { state: location.state },
+      ),
+  };
+}

--- a/web/src/stories/TagManager.stories.tsx
+++ b/web/src/stories/TagManager.stories.tsx
@@ -39,6 +39,9 @@ export const Default: Story = {
     pieceId: "p1",
     initialTags: [mockTags[0]],
     onSaved: fn(),
+    tagDialogOpen: false,
+    onOpenTagDialog: fn(),
+    onCloseTagDialog: fn(),
   },
   parameters: {
     msw: {


### PR DESCRIPTION
## Summary

- All URL parsing lives in two routing hook files (`web/src/routing/`); no parsing scattered across components
- Route-aware parents call hooks and inject typed props into children; children have no URL dependencies
- `GlobalEntryDialog` tab is now fully controlled (no `useEffect` for sync)
- `GlobalEntryField` has no routing hooks internally; `RoutedGlobalEntryField` is the HOC for piece-context use
- `TagManager` and `ShowcaseVideoPanel` receive routing props from parent — no internal `useNavigate`

## Routes added

| URL | What it drives |
|---|---|
| `/pieces/:id/history/:stateId` | Historical state view (`rewindedStateId`) |
| `/pieces/:id/video` | Showcase video panel |
| `/pieces/:id/tags/new` | Tag creation dialog |
| `/pieces/:id/state/fields/:fieldName` | Global entry browse dialog |
| `/pieces/:id/state/fields/:fieldName/new` | Global entry create tab |
| `/analyze/glaze-combinations?combo=<id>&image=<idx>` | Combination gallery lightbox |

## Architecture

```
web/src/routing/
  pieceRouting.ts    — usePieceHistoryRouting, usePieceVideoRouting,
                       usePieceTagsRouting, useGlobalFieldRouting
  galleryRouting.ts  — useCombinationGalleryRouting
```

Route-aware parents (e.g. `PieceDetailContent`) call hooks and spread results as props:
```ts
const historyRouting = usePieceHistoryRouting(piece.id);
<PieceHistory rewindedStateId={historyRouting.rewindedStateId}
              onRewind={historyRouting.onRewind} />
```

`RoutedGlobalEntryField` is the HOC that injects `useGlobalFieldRouting` into `GlobalEntryField`. Bare `GlobalEntryField` is used in unrouted contexts (e.g. `NewPieceDialog`) — it falls back to local `useState`.

Gallery lightbox uses `useMemo` derived directly from `useSearchParams` — no `useEffect`/`setState`, so browser back/forward works without cascading renders.

## Test surface

- `GlobalEntryField.test` — no Router wrapper needed (component has no routing hooks)
- `TagManager.test` — uses `ControlledTagManager` stateful wrapper; no Router wrapper
- `WorkflowState.test` — keeps `MemoryRouter` since `RoutedGlobalEntryField` needs it

Closes #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)
