### PR TITLE
feat: showcase view with video, preview URL, and login CTA

### DIFF
--- a/api/piece/helpers.py
+++ b/api/piece/helpers.py
@@ -57,7 +57,7 @@ def piece_queryset(request: Request):
     user_id = request.user.id
     assert user_id is not None
     return (
-        Piece.objects.select_related("current_location", "thumbnail")
+        Piece.objects.select_related("current_location", "thumbnail", "user__profile")
         .annotate(thumbnail_crop=_thumbnail_crop_subquery())
         .prefetch_related("states", "tag_links__tag")
         .filter(user_id=user_id)
@@ -68,7 +68,7 @@ def piece_queryset(request: Request):
 def piece_read_queryset(request: Request):
     """Return the queryset for pieces visible to the current request."""
     qs = (
-        Piece.objects.select_related("current_location", "thumbnail")
+        Piece.objects.select_related("current_location", "thumbnail", "user__profile")
         .annotate(thumbnail_crop=_thumbnail_crop_subquery())
         .prefetch_related("states", "tag_links__tag")
     )

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -538,10 +538,16 @@ class PieceSummarySerializer(serializers.ModelSerializer):
         if not (obj.shared and not obj.is_editable):
             return None
         from .piece.showcase_views import _latest_showcase_task
+        from .showcase import build_keepsake_storyboard, compute_storyboard_hash
 
         task = _latest_showcase_task(obj)
         if task is None or task.status != AsyncTask.Status.SUCCESS:
             return None
+        stored_hash = (task.input_params or {}).get("input_hash")
+        if stored_hash:
+            current_hash = compute_storyboard_hash(build_keepsake_storyboard(obj))
+            if stored_hash != current_hash:
+                return None
         result = task.result if isinstance(task.result, dict) else {}
         return result.get("artifact_url")
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -457,8 +457,6 @@ class PieceSummarySerializer(serializers.ModelSerializer):
         read_only=True,
     )
     last_modified = serializers.DateTimeField(read_only=True)
-    showcase_video_url = serializers.SerializerMethodField()
-    owner_alias = serializers.SerializerMethodField()
 
     class Meta:
         model = Piece
@@ -473,8 +471,6 @@ class PieceSummarySerializer(serializers.ModelSerializer):
             "is_editable",
             "showcase_story",
             "showcase_fields",
-            "showcase_video_url",
-            "owner_alias",
             "can_edit",
             "current_state",
             "current_location",
@@ -533,39 +529,19 @@ class PieceSummarySerializer(serializers.ModelSerializer):
             total += len(links)
         return total
 
-    @extend_schema_field(serializers.CharField(allow_null=True, required=False))
-    def get_showcase_video_url(self, obj: Piece) -> str | None:
-        if not (obj.shared and not obj.is_editable):
-            return None
-        from .piece.showcase_views import _latest_showcase_task
-        from .showcase import build_keepsake_storyboard, compute_storyboard_hash
-
-        task = _latest_showcase_task(obj)
-        if task is None or task.status != AsyncTask.Status.SUCCESS:
-            return None
-        stored_hash = (task.input_params or {}).get("input_hash")
-        if stored_hash:
-            current_hash = compute_storyboard_hash(build_keepsake_storyboard(obj))
-            if stored_hash != current_hash:
-                return None
-        result = task.result if isinstance(task.result, dict) else {}
-        return result.get("artifact_url")
-
-    @extend_schema_field(serializers.CharField(allow_null=True, required=False))
-    def get_owner_alias(self, obj: Piece) -> str | None:
-        try:
-            return obj.user.profile.alias or None
-        except Exception:
-            return None
-
-
 @traced_class
 class PieceDetailSerializer(PieceSummarySerializer):
     current_state = serializers.SerializerMethodField()
     history = serializers.SerializerMethodField()
+    showcase_video_url = serializers.SerializerMethodField()
+    owner_alias = serializers.SerializerMethodField()
 
     class Meta(PieceSummarySerializer.Meta):
-        fields = PieceSummarySerializer.Meta.fields + ["history"]
+        fields = PieceSummarySerializer.Meta.fields + [
+            "history",
+            "showcase_video_url",
+            "owner_alias",
+        ]
 
     @extend_schema_field(_relation_schema("PieceState", shape="detail"))
     def get_current_state(self, obj: Piece) -> dict:
@@ -578,6 +554,50 @@ class PieceDetailSerializer(PieceSummarySerializer):
         return list(
             PieceStateSerializer(obj.states.all(), many=True, context=self.context).data
         )
+
+    @extend_schema_field(serializers.CharField(allow_null=True, required=False))
+    def get_showcase_video_url(self, obj: Piece) -> str | None:
+        if not (obj.shared and not obj.is_editable):
+            return None
+        from .piece.showcase_views import SHOWCASE_VIDEO_TASK_TYPE
+        from .showcase import build_keepsake_storyboard, compute_storyboard_hash
+
+        # Use the latest succeeded task so an in-progress retry does not hide
+        # an existing artifact while it runs (or if it fails).
+        task = (
+            AsyncTask.objects.filter(
+                user=obj.user,
+                task_type=SHOWCASE_VIDEO_TASK_TYPE,
+                input_params__piece_id=str(obj.id),
+                status=AsyncTask.Status.SUCCESS,
+            )
+            .order_by("-created")
+            .first()
+        )
+        if task is None:
+            return None
+        input_params = task.input_params if isinstance(task.input_params, dict) else {}
+        stored_hash = input_params.get("input_hash")
+        if stored_hash:
+            # Rebuild the storyboard with the same exclusions used when
+            # rendering so custom renders are not incorrectly flagged stale.
+            storyboard = build_keepsake_storyboard(
+                obj,
+                excluded_image_keys=input_params.get("excluded_image_keys") or [],
+                excluded_note_keys=input_params.get("excluded_note_keys") or [],
+                music_track_id=input_params.get("music_track_id"),
+            )
+            if stored_hash != compute_storyboard_hash(storyboard.to_dict()):
+                return None
+        result = task.result if isinstance(task.result, dict) else {}
+        return result.get("artifact_url")
+
+    @extend_schema_field(serializers.CharField(allow_null=True, required=False))
+    def get_owner_alias(self, obj: Piece) -> str | None:
+        try:
+            return obj.user.profile.alias or None
+        except Exception:
+            return None
 
 
 @traced_class

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -457,6 +457,8 @@ class PieceSummarySerializer(serializers.ModelSerializer):
         read_only=True,
     )
     last_modified = serializers.DateTimeField(read_only=True)
+    showcase_video_url = serializers.SerializerMethodField()
+    owner_alias = serializers.SerializerMethodField()
 
     class Meta:
         model = Piece
@@ -471,6 +473,8 @@ class PieceSummarySerializer(serializers.ModelSerializer):
             "is_editable",
             "showcase_story",
             "showcase_fields",
+            "showcase_video_url",
+            "owner_alias",
             "can_edit",
             "current_state",
             "current_location",
@@ -479,7 +483,7 @@ class PieceSummarySerializer(serializers.ModelSerializer):
     @classmethod
     def prepare_global_entry_queryset(cls, qs, display_field):
         return (
-            qs.select_related("current_location", "thumbnail")
+            qs.select_related("current_location", "thumbnail", "user__profile")
             .prefetch_related("states__image_links__image", "tag_links__tag")
             .order_by(display_field)
         )
@@ -528,6 +532,25 @@ class PieceSummarySerializer(serializers.ModelSerializer):
                 links = state.image_links.all()
             total += len(links)
         return total
+
+    @extend_schema_field(serializers.CharField(allow_null=True, required=False))
+    def get_showcase_video_url(self, obj: Piece) -> str | None:
+        if not (obj.shared and not obj.is_editable):
+            return None
+        from .piece.showcase_views import _latest_showcase_task
+
+        task = _latest_showcase_task(obj)
+        if task is None or task.status != AsyncTask.Status.SUCCESS:
+            return None
+        result = task.result if isinstance(task.result, dict) else {}
+        return result.get("artifact_url")
+
+    @extend_schema_field(serializers.CharField(allow_null=True, required=False))
+    def get_owner_alias(self, obj: Piece) -> str | None:
+        try:
+            return obj.user.profile.alias or None
+        except Exception:
+            return None
 
 
 @traced_class

--- a/api/tests/test_global_entries.py
+++ b/api/tests/test_global_entries.py
@@ -212,8 +212,7 @@ class TestGlobalEntries:
                 "is_editable": False,
                 "showcase_story": "",
                 "showcase_fields": [],
-                "showcase_video_url": None,
-                "owner_alias": None,
+
                 "photo_count": 0,
                 "can_edit": True,
                 "current_state": {"state": "designed"},

--- a/api/tests/test_global_entries.py
+++ b/api/tests/test_global_entries.py
@@ -212,6 +212,8 @@ class TestGlobalEntries:
                 "is_editable": False,
                 "showcase_story": "",
                 "showcase_fields": [],
+                "showcase_video_url": None,
+                "owner_alias": None,
                 "photo_count": 0,
                 "can_edit": True,
                 "current_state": {"state": "designed"},

--- a/api/tests/test_piece_detail.py
+++ b/api/tests/test_piece_detail.py
@@ -739,3 +739,85 @@ class TestPieceCurrentStateDetail:
         PieceState.objects.create(piece=foreign_piece, state=ENTRY_STATE)
         response = client.get(f"/api/pieces/{foreign_piece.id}/current_state/")
         assert response.status_code == 404
+
+
+@pytest.mark.django_db
+class TestPieceSummaryShowcaseVideoUrl:
+    """Test showcase_video_url and owner_alias on PieceSummarySerializer."""
+
+    def _make_public_terminal_piece(self, user):
+        from api.models import Piece, PieceState
+        from api.workflow import TERMINAL_STATES
+
+        piece = Piece.objects.create(user=user, name="Public Bowl")
+        terminal_state = sorted(TERMINAL_STATES)[0]
+        PieceState.objects.create(piece=piece, user=user, state=terminal_state)
+        piece.shared = True
+        piece.is_editable = False
+        piece.save()
+        return piece
+
+    def _make_succeeded_task(self, user, piece, artifact_url):
+        from api.models import AsyncTask
+        from api.showcase.render import SHOWCASE_VIDEO_TASK_TYPE
+
+        return AsyncTask.objects.create(
+            user=user,
+            task_type=SHOWCASE_VIDEO_TASK_TYPE,
+            status=AsyncTask.Status.SUCCESS,
+            input_params={"piece_id": str(piece.id)},
+            result={"artifact_url": artifact_url},
+        )
+
+    def test_public_piece_with_succeeded_task_returns_artifact_url(self, client, user):
+        piece = self._make_public_terminal_piece(user)
+        artifact_url = "https://res.cloudinary.com/demo/video/upload/showcase.mp4"
+        self._make_succeeded_task(user, piece, artifact_url)
+
+        response = client.get(f"/api/pieces/{piece.id}/")
+        assert response.status_code == 200
+        assert response.json()["showcase_video_url"] == artifact_url
+
+    def test_public_piece_with_no_task_returns_null(self, client, user):
+        piece = self._make_public_terminal_piece(user)
+
+        response = client.get(f"/api/pieces/{piece.id}/")
+        assert response.status_code == 200
+        assert response.json()["showcase_video_url"] is None
+
+    def test_private_piece_with_succeeded_task_returns_null(self, client, user):
+        from api.models import Piece, PieceState
+        from api.workflow import TERMINAL_STATES
+
+        piece = Piece.objects.create(user=user, name="Private Bowl")
+        terminal_state = sorted(TERMINAL_STATES)[0]
+        PieceState.objects.create(piece=piece, user=user, state=terminal_state)
+        # piece.shared defaults to False
+        artifact_url = "https://res.cloudinary.com/demo/video/upload/showcase.mp4"
+        self._make_succeeded_task(user, piece, artifact_url)
+
+        response = client.get(f"/api/pieces/{piece.id}/")
+        assert response.status_code == 200
+        assert response.json()["showcase_video_url"] is None
+
+    def test_owner_alias_returned_when_profile_has_alias(self, client, user):
+        from api.models import UserProfile
+
+        piece = self._make_public_terminal_piece(user)
+        profile, _ = UserProfile.objects.get_or_create(user=user)
+        profile.alias = "PotterJane"
+        profile.save()
+
+        response = client.get(f"/api/pieces/{piece.id}/")
+        assert response.status_code == 200
+        assert response.json()["owner_alias"] == "PotterJane"
+
+    def test_owner_alias_null_when_profile_has_no_alias(self, client, user):
+        from api.models import UserProfile
+
+        piece = self._make_public_terminal_piece(user)
+        UserProfile.objects.filter(user=user).delete()
+
+        response = client.get(f"/api/pieces/{piece.id}/")
+        assert response.status_code == 200
+        assert response.json()["owner_alias"] is None

--- a/api/tests/test_pieces_list.py
+++ b/api/tests/test_pieces_list.py
@@ -148,6 +148,8 @@ class TestPiecesList:
             "tags",
             "showcase_story",
             "showcase_fields",
+            "showcase_video_url",
+            "owner_alias",
         }
 
     def test_does_not_include_other_users_pieces(self, client, other_user):

--- a/api/tests/test_pieces_list.py
+++ b/api/tests/test_pieces_list.py
@@ -148,8 +148,6 @@ class TestPiecesList:
             "tags",
             "showcase_story",
             "showcase_fields",
-            "showcase_video_url",
-            "owner_alias",
         }
 
     def test_does_not_include_other_users_pieces(self, client, other_user):

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -115,6 +115,7 @@ urlpatterns = [
         name="swagger",
     ),
     path("pieces/<uuid:piece_id>", _piece_spa),
+    path("pieces/<uuid:piece_id>/showcase", _piece_spa),
     # Catch-all: serve the React SPA for client routes only. File-like URLs
     # (for example Vite chunk files) must fall through so static handling can
     # return the real asset or a 404 instead of HTML.

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -1337,6 +1337,20 @@ vitest_test(
 )
 
 vitest_test(
+    name = "web_post_login_redirect_test",
+    srcs = [
+        "src/util/__tests__/postLoginRedirect.test.ts",
+    ],
+    tags = ["ibazel_notify_changes"],
+    deps = [
+        ":util_lib",
+    ],
+    expected_coverage = [
+        "web/src/util/postLoginRedirect*",
+    ],
+)
+
+vitest_test(
     name = "web_analyze_page_test",
     srcs = [
         "src/pages/__tests__/AnalyzePage.test.tsx",
@@ -1440,6 +1454,7 @@ test_suite(
         ":web_user_preferences_dialog_test",
         ":web_tag_test",
         ":web_generate_types_test",
+        ":web_post_login_redirect_test",
         ":web_telemetry_test",
         ":web_workflow_state_test",
         ":web_tutorial_manager_test",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -69,7 +69,7 @@ import { getPostLoginRedirectTarget } from "./util/postLoginRedirect";
 import { AuthTokenProvider, useAuthToken } from "./components/AuthTokenContext";
 import ErrorBoundary from "./components/ErrorBoundary";
 import AppFooterLinks from "./components/AppFooterLinks";
-import PublicPieceShell from "./components/PublicPieceShell";
+import PublicPieceShell, { ShowcasePage } from "./components/PublicPieceShell";
 import UserPreferencesDialog from "./components/UserPreferencesDialog";
 import TutorialManager from "./components/TutorialManager";
 import {
@@ -788,6 +788,16 @@ function UnauthenticatedApp({
               }
             />
             <Route
+              path="/pieces/:id/showcase"
+              element={
+                <ErrorBoundary>
+                  <Suspense fallback={<Box sx={{ display: "flex", justifyContent: "center", py: 4 }}><CircularProgress /></Box>}>
+                    <ShowcasePage />
+                  </Suspense>
+                </ErrorBoundary>
+              }
+            />
+            <Route
               path="/pieces/:id/*"
               element={
                 <ErrorBoundary>
@@ -859,6 +869,16 @@ function AuthenticatedApp({
               <Route path="new" element={<PieceListPage />} />
               <Route path="analyze/*" element={<AnalyzePage />} />
             </Route>
+            <Route
+              path="/pieces/:id/showcase"
+              element={
+                <ErrorBoundary>
+                  <Suspense fallback={<Box sx={{ display: "flex", justifyContent: "center", py: 4 }}><CircularProgress /></Box>}>
+                    <ShowcasePage isAuthenticated />
+                  </Suspense>
+                </ErrorBoundary>
+              }
+            />
             <Route path="/pieces/:id/*" element={<PieceDetailPage />} />
             <Route
               path="/tools/glaze-import"

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -18,7 +18,7 @@ import {
 } from "@mui/material";
 import HistoryIcon from "@mui/icons-material/History";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import { useBlocker, useLocation, useNavigate } from "react-router-dom";
+import { useBlocker, useLocation, useNavigate, Link as RouterLink } from "react-router-dom";
 import type { PieceDetail as PieceDetailType } from "../util/types";
 import { DEFAULT_TRACK_ID } from "../util/music";
 import { formatState, isTerminalState, getCustomFieldDefinitions } from "../util/workflow";
@@ -238,6 +238,18 @@ function PieceDetailContent({ piece, onPieceUpdated }: PieceDetailProps) {
             {canEdit && isTerminal && (
               <Box sx={{ mb: 1.5 }}>
                 <ShareControls piece={piece} onPieceUpdated={onPieceUpdated} />
+              </Box>
+            )}
+            {piece.can_edit && (
+              <Box sx={{ mb: 1.5 }}>
+                <Button
+                  component={RouterLink}
+                  to={`/pieces/${piece.id}/showcase`}
+                  variant="outlined"
+                  size="small"
+                >
+                  Preview showcase
+                </Button>
               </Box>
             )}
             {canEdit && (

--- a/web/src/components/PieceShareControls.tsx
+++ b/web/src/components/PieceShareControls.tsx
@@ -36,7 +36,7 @@ function buildThumbnailShareUrl(thumbnail: Thumbnail): string {
 }
 
 function publicPieceUrl(pieceId: string): string {
-  return `${window.location.origin}/pieces/${pieceId}`;
+  return `${window.location.origin}/pieces/${pieceId}/showcase`;
 }
 
 function buildShareText(piece: PieceDetail): string {

--- a/web/src/components/PublicPieceShell.tsx
+++ b/web/src/components/PublicPieceShell.tsx
@@ -94,8 +94,8 @@ function ShowcaseHeader({ piece, isAuthenticated }: { piece: PieceDetail; isAuth
         <Typography variant="h6" component="p">PotterDoc</Typography>
       </Box>
       <Button
-        component={RouterLink}
-        to={`/?next=/pieces/${id}/showcase`}
+        component="a"
+        href={`/?next=${encodeURIComponent(`/pieces/${id}/showcase`)}`}
         variant="outlined"
         size="small"
       >

--- a/web/src/components/PublicPieceShell.tsx
+++ b/web/src/components/PublicPieceShell.tsx
@@ -1,20 +1,19 @@
-import { useParams } from "react-router-dom";
+import { useParams, Link as RouterLink } from "react-router-dom";
 import {
   Box,
+  Button,
   Container,
   Typography,
   alpha,
   Divider,
 } from "@mui/material";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { formatValue } from "../util/format";
 import { fetchPiece } from "../util/api";
 import { type PieceDetail } from "../util/types";
-import { formatWorkflowFieldLabel } from "../util/workflow";
 import CloudinaryImage from "./CloudinaryImage";
 import ProcessSummary from "./ProcessSummary";
 
-export default function PublicPieceShell() {
+export function ShowcasePage({ isAuthenticated = false }: { isAuthenticated?: boolean }) {
   const { id } = useParams<{ id: string }>();
   const { data: piece } = useSuspenseQuery<PieceDetail>({
     queryKey: ["piece", id],
@@ -41,42 +40,84 @@ export default function PublicPieceShell() {
         },
       }}
     >
-      <Box sx={{ display: "flex", alignItems: "center", gap: 1, mb: 1.5 }}>
-        <Box
-          component="img"
-          src="/favicon.svg"
-          alt="PotterDoc app icon"
-          sx={{ width: 22, height: 22, flexShrink: 0, display: "block" }}
-        />
-        <Typography variant="h6" component="p" color="text.primary">
-          PotterDoc
-        </Typography>
-      </Box>
-
-      <ShowcaseView piece={piece} />
+      <ShowcaseHeader piece={piece} isAuthenticated={isAuthenticated} />
+      <ShowcaseView piece={piece} isAuthenticated={isAuthenticated} />
     </Container>
   );
 }
 
-function ShowcaseView({ piece }: { piece: PieceDetail }) {
-  const showcaseFields = piece.showcase_fields ?? [];
-  const resolvedFields = showcaseFields
-    .map((ref) => {
-      const [stateId, fieldName] = ref.split(".", 2);
-      const state = [...piece.history]
-        .reverse()
-        .find((s) => s.state === stateId);
-      const rawValue = state?.custom_fields?.[fieldName];
-      const value = formatValue(rawValue);
-      return {
-        label: formatWorkflowFieldLabel(fieldName),
-        value,
-      };
-    })
-    .filter((f) => !!f.value);
+export default ShowcasePage;
 
+function ShowcaseHeader({ piece, isAuthenticated }: { piece: PieceDetail; isAuthenticated: boolean }) {
+  const { id } = useParams<{ id: string }>();
+
+  if (isAuthenticated && piece.can_edit) {
+    // Owner
+    return (
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 1.5 }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <Box component="img" src="/favicon.svg" alt="PotterDoc" sx={{ width: 22, height: 22 }} />
+          <Typography variant="h6" component="p">PotterDoc</Typography>
+        </Box>
+        <Button component={RouterLink} to={`/pieces/${id}`} variant="outlined" size="small">
+          Edit
+        </Button>
+      </Box>
+    );
+  }
+
+  if (isAuthenticated && !piece.can_edit) {
+    // Authenticated non-owner
+    return (
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 1.5 }}>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <Box component="img" src="/favicon.svg" alt="PotterDoc" sx={{ width: 22, height: 22 }} />
+          <Typography variant="h6" component="p">PotterDoc</Typography>
+        </Box>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+          <Typography variant="body2" color="text.secondary">
+            {piece.owner_alias ? `Viewing ${piece.owner_alias}'s piece` : "Viewing a shared piece"}
+          </Typography>
+          <Button component={RouterLink} to="/" variant="text" size="small">
+            My pieces
+          </Button>
+        </Box>
+      </Box>
+    );
+  }
+
+  // Unauthenticated visitor
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 1.5 }}>
+      <Box component={RouterLink} to="/" sx={{ display: "flex", alignItems: "center", gap: 1, textDecoration: "none", color: "inherit" }}>
+        <Box component="img" src="/favicon.svg" alt="PotterDoc" sx={{ width: 22, height: 22 }} />
+        <Typography variant="h6" component="p">PotterDoc</Typography>
+      </Box>
+      <Button
+        component={RouterLink}
+        to={`/?next=/pieces/${id}/showcase`}
+        variant="outlined"
+        size="small"
+      >
+        Log in
+      </Button>
+    </Box>
+  );
+}
+
+function ShowcaseView({ piece }: { piece: PieceDetail; isAuthenticated: boolean }) {
   return (
     <Box sx={{ mx: "auto", maxWidth: 800, mt: 4 }}>
+      {piece.showcase_video_url && (
+        <Box
+          component="video"
+          src={piece.showcase_video_url}
+          controls
+          playsInline
+          sx={{ width: "100%", borderRadius: 1, display: "block", backgroundColor: "black", mb: 3 }}
+        />
+      )}
+
       <Box
         sx={(theme) => ({
           position: "relative",
@@ -128,47 +169,6 @@ function ShowcaseView({ piece }: { piece: PieceDetail }) {
           >
             {piece.showcase_story}
           </Typography>
-        </Box>
-      )}
-
-      {resolvedFields.length > 0 && (
-        <Box sx={{ mb: 6 }}>
-          <Typography
-            variant="subtitle2"
-            sx={{
-              mb: 2,
-              color: "text.secondary",
-              fontWeight: 700,
-              letterSpacing: "0.1em",
-              textTransform: "uppercase",
-            }}
-          >
-            Details
-          </Typography>
-          <Box
-            sx={{
-              display: "grid",
-              gap: 3,
-              gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
-            }}
-          >
-            {resolvedFields.map((field) => (
-              <Box
-                key={field.label}
-                sx={{ borderTop: "1px solid", borderColor: "divider", pt: 1.5 }}
-              >
-                <Typography
-                  variant="caption"
-                  sx={{ color: "text.secondary", display: "block", mb: 0.5 }}
-                >
-                  {field.label}
-                </Typography>
-                <Typography variant="body1" sx={{ fontWeight: 500 }}>
-                  {field.value}
-                </Typography>
-              </Box>
-            ))}
-          </Box>
         </Box>
       )}
 

--- a/web/src/components/__tests__/PieceDetail.test.tsx
+++ b/web/src/components/__tests__/PieceDetail.test.tsx
@@ -541,7 +541,7 @@ describe("PieceDetail", () => {
 
     await waitFor(() =>
       expect(writeText).toHaveBeenCalledWith(
-        "http://localhost:3000/pieces/piece-id-1",
+        "http://localhost:3000/pieces/piece-id-1/showcase",
       ),
     );
   });
@@ -566,7 +566,7 @@ describe("PieceDetail", () => {
       expect(share).toHaveBeenCalledWith({
         text: "Powered by PotterDoc",
         title: "Test Bowl — Completed",
-        url: "http://localhost:3000/pieces/piece-id-1",
+        url: "http://localhost:3000/pieces/piece-id-1/showcase",
       }),
     );
   });

--- a/web/src/components/__tests__/PieceShareControls.test.tsx
+++ b/web/src/components/__tests__/PieceShareControls.test.tsx
@@ -111,7 +111,7 @@ describe("PieceShareControls", () => {
 
     await waitFor(() =>
       expect(writeText).toHaveBeenCalledWith(
-        "http://localhost:3000/pieces/piece-id-1",
+        "http://localhost:3000/pieces/piece-id-1/showcase",
       ),
     );
     expect(screen.getByText("Public link copied.")).toBeInTheDocument();
@@ -175,7 +175,7 @@ describe("PieceShareControls", () => {
       expect(share).toHaveBeenCalledWith({
         text: "Powered by PotterDoc",
         title: "Test Bowl — Completed",
-        url: "http://localhost:3000/pieces/piece-id-1",
+        url: "http://localhost:3000/pieces/piece-id-1/showcase",
       }),
     );
   });

--- a/web/src/components/__tests__/PublicPieceShell.test.tsx
+++ b/web/src/components/__tests__/PublicPieceShell.test.tsx
@@ -3,13 +3,10 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import CircularProgress from "@mui/material/CircularProgress";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import PublicPieceShell from "../PublicPieceShell";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { ShowcasePage } from "../PublicPieceShell";
 import ErrorBoundary from "../ErrorBoundary";
 import * as api from "../../util/api";
-
-vi.mock("react-router-dom", () => ({
-  useParams: () => ({ id: "piece-1" }),
-}));
 
 vi.mock("../../util/api", () => ({
   fetchPiece: vi.fn(),
@@ -31,19 +28,45 @@ vi.mock("../../../workflow.yml", () => ({
   },
 }));
 
-function renderShell(queryClient: QueryClient) {
+const BASE_PIECE = {
+  id: "piece-1",
+  name: "Beautiful Bowl",
+  showcase_story: "This is a hand-crafted bowl.",
+  showcase_fields: [],
+  showcase_video_url: null,
+  owner_alias: null,
+  thumbnail: null,
+  can_edit: false,
+  history: [
+    {
+      state: "state1",
+      custom_fields: {},
+    },
+  ],
+} as any;
+
+function renderShell(queryClient: QueryClient, isAuthenticated = false, pieceId = "piece-1") {
   return render(
     <QueryClientProvider client={queryClient}>
-      <ErrorBoundary>
-        <Suspense fallback={<CircularProgress />}>
-          <PublicPieceShell />
-        </Suspense>
-      </ErrorBoundary>
+      <MemoryRouter initialEntries={[`/pieces/${pieceId}/showcase`]}>
+        <Routes>
+          <Route
+            path="/pieces/:id/showcase"
+            element={
+              <ErrorBoundary>
+                <Suspense fallback={<CircularProgress />}>
+                  <ShowcasePage isAuthenticated={isAuthenticated} />
+                </Suspense>
+              </ErrorBoundary>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
     </QueryClientProvider>,
   );
 }
 
-describe("PublicPieceShell", () => {
+describe("ShowcasePage", () => {
   it("renders a loading indicator while fetching", () => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
@@ -55,43 +78,96 @@ describe("PublicPieceShell", () => {
     expect(screen.getByRole("progressbar")).toBeInTheDocument();
   });
 
-  it("renders piece content with showcase story and custom fields when loaded", async () => {
+  it("renders piece name and story when loaded", async () => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
-    vi.mocked(api.fetchPiece).mockResolvedValue({
-      id: "piece-1",
-      name: "Beautiful Bowl",
-      showcase_story: "This is a hand-crafted bowl.",
-      showcase_fields: [
-        "state1.material",
-        "state1.emptyField",
-        "state1.validBool",
-      ],
-      thumbnail: null,
-      history: [
-        {
-          state: "state1",
-          custom_fields: {
-            material: "Clay",
-            emptyField: "",
-            validBool: true,
-          },
-        },
-      ],
-    } as any);
+    vi.mocked(api.fetchPiece).mockResolvedValue(BASE_PIECE);
 
     renderShell(queryClient);
 
     expect(await screen.findByText("Beautiful Bowl")).toBeInTheDocument();
-    expect(
-      screen.getByText("This is a hand-crafted bowl."),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Details")).toBeInTheDocument();
+    expect(screen.getByText("This is a hand-crafted bowl.")).toBeInTheDocument();
+  });
 
-    expect(screen.getByText("Clay")).toBeInTheDocument();
-    expect(screen.getByText("Yes")).toBeInTheDocument();
+  it("renders video element when showcase_video_url is present", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const videoUrl = "https://res.cloudinary.com/demo/video/upload/showcase.mp4";
+    vi.mocked(api.fetchPiece).mockResolvedValue({
+      ...BASE_PIECE,
+      showcase_video_url: videoUrl,
+    });
 
-    expect(screen.queryByText("EmptyField")).not.toBeInTheDocument();
+    renderShell(queryClient);
+
+    await screen.findByText("Beautiful Bowl");
+    const video = document.querySelector("video");
+    expect(video).not.toBeNull();
+    expect(video?.src).toBe(videoUrl);
+  });
+
+  it("does not render video element when showcase_video_url is null", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    vi.mocked(api.fetchPiece).mockResolvedValue({
+      ...BASE_PIECE,
+      showcase_video_url: null,
+    });
+
+    renderShell(queryClient);
+
+    await screen.findByText("Beautiful Bowl");
+    expect(document.querySelector("video")).toBeNull();
+  });
+
+  it("shows Log in button for unauthenticated visitor", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    vi.mocked(api.fetchPiece).mockResolvedValue(BASE_PIECE);
+
+    renderShell(queryClient, false);
+
+    await screen.findByText("Beautiful Bowl");
+    const loginBtn = screen.getByRole("link", { name: "Log in" });
+    expect(loginBtn).toBeInTheDocument();
+    expect(loginBtn).toHaveAttribute("href", "/?next=/pieces/piece-1/showcase");
+  });
+
+  it("shows Edit button for authenticated owner", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    vi.mocked(api.fetchPiece).mockResolvedValue({
+      ...BASE_PIECE,
+      can_edit: true,
+    });
+
+    renderShell(queryClient, true);
+
+    await screen.findByText("Beautiful Bowl");
+    const editBtn = screen.getByRole("link", { name: "Edit" });
+    expect(editBtn).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Log in" })).toBeNull();
+  });
+
+  it("shows owner alias context for authenticated non-owner", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    vi.mocked(api.fetchPiece).mockResolvedValue({
+      ...BASE_PIECE,
+      can_edit: false,
+      owner_alias: "Alice",
+    });
+
+    renderShell(queryClient, true);
+
+    await screen.findByText("Beautiful Bowl");
+    expect(screen.getByText("Viewing Alice's piece")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Log in" })).toBeNull();
   });
 });

--- a/web/src/components/__tests__/PublicPieceShell.test.tsx
+++ b/web/src/components/__tests__/PublicPieceShell.test.tsx
@@ -134,7 +134,7 @@ describe("ShowcasePage", () => {
     await screen.findByText("Beautiful Bowl");
     const loginBtn = screen.getByRole("link", { name: "Log in" });
     expect(loginBtn).toBeInTheDocument();
-    expect(loginBtn).toHaveAttribute("href", "/?next=/pieces/piece-1/showcase");
+    expect(loginBtn).toHaveAttribute("href", "/?next=%2Fpieces%2Fpiece-1%2Fshowcase");
   });
 
   it("shows Edit button for authenticated owner", async () => {

--- a/web/src/stories/EditableToggle.stories.tsx
+++ b/web/src/stories/EditableToggle.stories.tsx
@@ -39,6 +39,8 @@ const basePiece: PieceDetail = {
   current_location: "",
   showcase_story: "",
   showcase_fields: [],
+  showcase_video_url: null,
+  owner_alias: null,
   current_state: {
     id: "s1",
     state: "trimmed",

--- a/web/src/stories/PieceDetail.stories.tsx
+++ b/web/src/stories/PieceDetail.stories.tsx
@@ -49,6 +49,8 @@ const mockPiece: PieceDetailType = {
   current_location: "Studio Shelf A",
   showcase_story: "",
   showcase_fields: [],
+  showcase_video_url: null,
+  owner_alias: null,
   current_state: {
     id: "s2",
     state: "trimmed",

--- a/web/src/stories/PieceHistory.stories.tsx
+++ b/web/src/stories/PieceHistory.stories.tsx
@@ -83,6 +83,8 @@ const mockPiece: PieceDetail = {
   current_location: "Studio",
   showcase_story: "",
   showcase_fields: [],
+  showcase_video_url: null,
+  owner_alias: null,
   current_state: mockPastHistory[2],
   history: mockPastHistory,
 };

--- a/web/src/stories/PieceList.stories.tsx
+++ b/web/src/stories/PieceList.stories.tsx
@@ -90,8 +90,6 @@ function makePiece(overrides: Partial<PieceSummary>): PieceSummary {
     is_editable: false,
     can_edit: true,
     showcase_fields: [],
-    showcase_video_url: null,
-    owner_alias: null,
     ...overrides,
   };
 }

--- a/web/src/stories/PieceList.stories.tsx
+++ b/web/src/stories/PieceList.stories.tsx
@@ -90,6 +90,8 @@ function makePiece(overrides: Partial<PieceSummary>): PieceSummary {
     is_editable: false,
     can_edit: true,
     showcase_fields: [],
+    showcase_video_url: null,
+    owner_alias: null,
     ...overrides,
   };
 }

--- a/web/src/stories/PieceNameEditor.stories.tsx
+++ b/web/src/stories/PieceNameEditor.stories.tsx
@@ -46,6 +46,8 @@ const basePiece: PieceDetail = {
   current_location: "",
   showcase_story: "",
   showcase_fields: [],
+  showcase_video_url: null,
+  owner_alias: null,
   current_state: {
     id: "s1",
     state: "trimmed",

--- a/web/src/stories/PieceShareControls.stories.tsx
+++ b/web/src/stories/PieceShareControls.stories.tsx
@@ -12,6 +12,8 @@ const basePiece: PieceDetail = {
   tags: [],
   showcase_fields: [],
   showcase_story: "",
+  showcase_video_url: null,
+  owner_alias: null,
   photo_count: 0,
   thumbnail: null,
   current_location: null,

--- a/web/src/stories/ProcessSummary.stories.tsx
+++ b/web/src/stories/ProcessSummary.stories.tsx
@@ -58,6 +58,8 @@ const piece = {
   tags: [],
   showcase_story: "",
   showcase_fields: [],
+  showcase_video_url: null,
+  owner_alias: null,
   history,
 } satisfies PieceDetail;
 

--- a/web/src/stories/ShowcaseVideoInputPicker.stories.tsx
+++ b/web/src/stories/ShowcaseVideoInputPicker.stories.tsx
@@ -37,6 +37,8 @@ const basePiece: PieceDetail = {
   current_location: "",
   showcase_story: "",
   showcase_fields: [],
+  showcase_video_url: null,
+  owner_alias: null,
   current_state: {
     id: "s3",
     state: "completed",

--- a/web/src/util/__tests__/postLoginRedirect.test.ts
+++ b/web/src/util/__tests__/postLoginRedirect.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { getPostLoginRedirectTarget } from "../postLoginRedirect";
+
+const HOST = "potterdoc.com";
+const PROTO = "https:";
+
+describe("getPostLoginRedirectTarget", () => {
+  it("returns null when next is null", () => {
+    expect(getPostLoginRedirectTarget(HOST, PROTO, null)).toBeNull();
+  });
+
+  it("returns null for an external domain", () => {
+    expect(
+      getPostLoginRedirectTarget(HOST, PROTO, "https://evil.com/steal"),
+    ).toBeNull();
+  });
+
+  it("returns null for a path that does not start with /pieces/", () => {
+    expect(
+      getPostLoginRedirectTarget(HOST, PROTO, "/admin-fake/path"),
+    ).toBeNull();
+  });
+
+  it("returns the full URL for a /pieces/* same-origin redirect", () => {
+    expect(
+      getPostLoginRedirectTarget(HOST, PROTO, "/pieces/abc/showcase"),
+    ).toBe("https://potterdoc.com/pieces/abc/showcase");
+  });
+
+  it("returns null for localhost hostname", () => {
+    expect(
+      getPostLoginRedirectTarget("localhost", PROTO, "/pieces/abc/showcase"),
+    ).toBeNull();
+  });
+});

--- a/web/src/util/api.ts
+++ b/web/src/util/api.ts
@@ -310,6 +310,8 @@ function mapPieceSummary(raw: Wire<PieceSummary>): PieceSummary {
     tags: (raw.tags ?? []).map(mapTagEntry),
     showcase_story: raw.showcase_story ?? "",
     showcase_fields: (raw.showcase_fields as string[]) ?? [],
+    showcase_video_url: raw.showcase_video_url ?? null,
+    owner_alias: raw.owner_alias ?? null,
   };
 }
 

--- a/web/src/util/api.ts
+++ b/web/src/util/api.ts
@@ -310,8 +310,6 @@ function mapPieceSummary(raw: Wire<PieceSummary>): PieceSummary {
     tags: (raw.tags ?? []).map(mapTagEntry),
     showcase_story: raw.showcase_story ?? "",
     showcase_fields: (raw.showcase_fields as string[]) ?? [],
-    showcase_video_url: raw.showcase_video_url ?? null,
-    owner_alias: raw.owner_alias ?? null,
   };
 }
 
@@ -320,6 +318,8 @@ function mapPieceDetail(raw: Wire<PieceDetail>): PieceDetail {
     ...mapPieceSummary(raw),
     current_state: mapPieceState(raw.current_state),
     history: raw.history.map(mapPieceState),
+    showcase_video_url: raw.showcase_video_url ?? null,
+    owner_alias: raw.owner_alias ?? null,
   };
 }
 

--- a/web/src/util/postLoginRedirect.ts
+++ b/web/src/util/postLoginRedirect.ts
@@ -25,5 +25,19 @@ export function getPostLoginRedirectTarget(
     return null;
   }
 
+  // Allow same-origin /pieces/* redirects (e.g. showcase preview after login)
+  try {
+    const target = new URL(next, `${currentProtocol}//${currentHostname}`);
+    if (
+      target.protocol === currentProtocol &&
+      target.hostname === currentHostname &&
+      target.pathname.startsWith("/pieces/")
+    ) {
+      return target.toString();
+    }
+  } catch {
+    return null;
+  }
+
   return null;
 }


### PR DESCRIPTION
## Summary

- Adds `/pieces/:id/showcase` route accessible to all viewers (authenticated and unauthenticated), rendering a clean read-only showcase view
- Surfaces the generated Keepsake video on the showcase when one is ready (`showcase_video_url` field added to piece detail API)
- Showcase header adapts by viewer type: owners get an "Edit" back-link, authenticated non-owners get a context bar with the owner's alias, visitors get a "Log in" CTA that redirects back to the showcase after sign-in
- Owners on `/pieces/:id` get a "Preview showcase" button near ShareControls
- Share link in `PieceShareControls` updated to point to `/pieces/:id/showcase`
- `showcase_fields` detail grid removed from showcase view (deferred until inline editing is available)

## Backend changes

- `PieceSummarySerializer` gains `showcase_video_url` (non-null only for public pieces with a succeeded video artifact) and `owner_alias` (piece owner's profile alias)
- `user__profile` added to `select_related` in piece querysets to avoid N+1 queries
- **[SECURITY]** `showcase_video_url` gated on `shared=True AND is_editable=False` — the same condition that already governs public piece visibility; no new data exposure

## Frontend changes

- `PublicPieceShell.tsx` refactored to `ShowcasePage` with `isAuthenticated` prop; registered in both routers before the `/pieces/:id/*` wildcard
- `postLoginRedirect.ts` extended to allow same-origin `/pieces/*` redirects (allowlisted by path prefix to prevent open-redirect)

## Test plan

- [ ] Backend: `rtk bazel test //api:api_tests` — 5 new tests for `showcase_video_url` and `owner_alias`
- [ ] Frontend: `rtk bazel test //web:vitest` — 5 new `PublicPieceShell` cases (video, login CTA, Edit link, context bar), 4 new `postLoginRedirect` cases
- [ ] Manual: navigate to `/pieces/:id/showcase` while logged out → showcase with video (if generated), "Log in" button
- [ ] Manual: click "Log in" → sign in → redirected back to showcase
- [ ] Manual: as owner, navigate to `/pieces/:id/showcase` → "Edit" button in header, no login CTA
- [ ] Manual: as authenticated non-owner → context bar with owner alias, "My pieces" link
- [ ] Manual: `PieceDetail` → "Preview showcase" button opens `/pieces/:id/showcase`
- [ ] Manual: copy share link → confirms URL ends in `/showcase`

Closes #819
