### PR TITLE
fix: register OpenApiAuthenticationExtension for JWTCookieAuthentication and deduplicate AuthToken schema component

### DIFF
--- a/api/auth/jwt_auth.py
+++ b/api/auth/jwt_auth.py
@@ -5,13 +5,26 @@ session auth in the DRF auth stack so existing browser flows continue to work
 while the rollout is in progress.
 """
 
+from drf_spectacular.extensions import OpenApiAuthenticationExtension
 from rest_framework.authentication import get_authorization_header
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.request import Request
 from rest_framework_simplejwt.authentication import JWTAuthentication
 from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
 
-__all__ = ["JWTCookieAuthentication"]
+__all__ = ["JWTCookieAuthentication", "JWTCookieAuthenticationExtension"]
+
+
+class JWTCookieAuthenticationExtension(OpenApiAuthenticationExtension):
+    target_class = "api.auth.jwt_auth.JWTCookieAuthentication"
+    name = "bearerAuth"
+
+    def get_security_definition(self, auto_schema):
+        return {
+            "type": "http",
+            "scheme": "bearer",
+            "bearerFormat": "JWT",
+        }
 
 
 class JWTCookieAuthentication(JWTAuthentication):

--- a/api/auth/token_views.py
+++ b/api/auth/token_views.py
@@ -20,6 +20,7 @@ from typing import cast
 from backend.otel import traced
 
 _AUTH_TOKEN_NAME = "AuthToken"
+_AUTH_TOKEN_REFRESH_NAME = "AuthTokenRefresh"
 _REFRESH_COOKIE_NAME = "potterdoc_refresh"
 _REFRESH_COOKIE_MAX_AGE = int(timedelta(days=30).total_seconds())
 
@@ -136,7 +137,7 @@ def auth_token(request: Request) -> Response:
     request=None,
     responses={
         200: inline_serializer(
-            _AUTH_TOKEN_NAME,
+            _AUTH_TOKEN_REFRESH_NAME,
             fields={
                 "accessToken": drf_serializers.CharField(),
             },

--- a/api/tests/test_auth.py
+++ b/api/tests/test_auth.py
@@ -1145,3 +1145,17 @@ class TestMockIdp:
         response = client.get("/api/auth/me/")
         assert response.status_code == 200
         assert response.json()["mockIdpUrl"] is None
+
+
+class TestOpenApiSchemaWarnings:
+    def test_jwt_cookie_authentication_extension_registered(self):
+        # Before fix: JWTCookieAuthenticationExtension does not exist → ImportError
+        from api.auth.jwt_auth import JWTCookieAuthenticationExtension  # noqa: F401
+
+        assert JWTCookieAuthenticationExtension.name == "bearerAuth"
+
+    def test_auth_token_refresh_uses_distinct_serializer_name(self):
+        # Before fix: _AUTH_TOKEN_REFRESH_NAME does not exist → ImportError
+        from api.auth.token_views import _AUTH_TOKEN_NAME, _AUTH_TOKEN_REFRESH_NAME
+
+        assert _AUTH_TOKEN_NAME != _AUTH_TOKEN_REFRESH_NAME


### PR DESCRIPTION
## Problem

Closes #829. Schema generation emitted ~35 warnings because `JWTCookieAuthentication` had no `OpenApiAuthenticationExtension` registered with drf-spectacular, and `inline_serializer("AuthToken", …)` was called with the same name in both `auth_token` and `auth_token_refresh`, producing a duplicate-component conflict.

## Fix

**`api/auth/jwt_auth.py`** — Added `JWTCookieAuthenticationExtension(OpenApiAuthenticationExtension)` with `name = "bearerAuth"`, matching the scheme already declared in `SPECTACULAR_SETTINGS["COMPONENTS"]["securitySchemes"]`. Subclassing auto-registers the extension with drf-spectacular's discovery mechanism.

**`api/auth/token_views.py`** — Added `_AUTH_TOKEN_REFRESH_NAME = "AuthTokenRefresh"` and used it in the `auth_token_refresh` endpoint's `extend_schema` decorator. The fields are identical; only the component name was changed to be distinct from `"AuthToken"`.

## Regression Test

Added `TestOpenApiSchemaWarnings` in `api/tests/test_auth.py` with two tests:

- `test_jwt_cookie_authentication_extension_registered` — imports `JWTCookieAuthenticationExtension` directly (fails with `ImportError` before the fix) and asserts `name == "bearerAuth"`.
- `test_auth_token_refresh_uses_distinct_serializer_name` — imports `_AUTH_TOKEN_REFRESH_NAME` (fails with `ImportError` before the fix) and asserts it differs from `_AUTH_TOKEN_NAME`.

Both tests failed before the fix and pass after.

## Verification

```
bazel test //api:api_test   → 11/11 pass
bazel run //tools:generate_schema   → 0 warnings
```
