### PR TITLE
fix: gate piece detail query on appInit to prevent PWA 404 race

### DIFF
--- a/web/src/pages/PieceDetailPage.tsx
+++ b/web/src/pages/PieceDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { Box, Button, CircularProgress, Typography } from "@mui/material";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { fetchPiece } from "../util/api";
+import { fetchAppInit, fetchPiece } from "../util/api";
 import PieceDetailComponent from "../components/PieceDetail";
 import { type PieceDetail } from "../util/types";
 
@@ -27,10 +27,16 @@ export default function PieceDetailPage({
   const showBackButton = fromGallery || showBackToPieces;
   const queryClient = useQueryClient();
   const pieceQueryKey = ["piece", id] as const;
+  const { isLoading: initLoading } = useQuery({
+    queryKey: ["appInit"],
+    queryFn: fetchAppInit,
+    staleTime: Infinity, // Read-only subscription; don't trigger a background refetch
+  });
   // id is always defined — this component is only rendered via the /pieces/:id route
   const { data: piece, isLoading: loading, error } = useQuery<PieceDetail>({
     queryKey: pieceQueryKey,
     queryFn: () => fetchPiece(id!),
+    enabled: !initLoading,
   });
 
   return (

--- a/web/src/pages/PieceDetailPage.tsx
+++ b/web/src/pages/PieceDetailPage.tsx
@@ -27,16 +27,18 @@ export default function PieceDetailPage({
   const showBackButton = fromGallery || showBackToPieces;
   const queryClient = useQueryClient();
   const pieceQueryKey = ["piece", id] as const;
-  const { isLoading: initLoading } = useQuery({
+  const { data: init, isFetching: initFetching } = useQuery({
     queryKey: ["appInit"],
     queryFn: fetchAppInit,
     staleTime: Infinity, // Read-only subscription; don't trigger a background refetch
   });
+  // Allow piece detail when authenticated (no wait needed), or when init has resolved
+  // and is not mid-refetch (covers the reactive-refresh re-fetch window after PWA resume).
   // id is always defined — this component is only rendered via the /pieces/:id route
   const { data: piece, isLoading: loading, error } = useQuery<PieceDetail>({
     queryKey: pieceQueryKey,
     queryFn: () => fetchPiece(id!),
-    enabled: !initLoading,
+    enabled: init !== undefined && (!!init.user || !initFetching),
   });
 
   return (

--- a/web/src/pages/__tests__/PieceDetailPage.test.tsx
+++ b/web/src/pages/__tests__/PieceDetailPage.test.tsx
@@ -13,6 +13,7 @@ import type { PieceDetail } from "../../util/types";
 
 vi.mock("../../util/api", () => ({
   fetchPiece: vi.fn(),
+  fetchAppInit: vi.fn(),
 }));
 
 vi.mock("../../components/PieceDetail", () => ({
@@ -82,6 +83,13 @@ function renderPage({
 describe("PieceDetailPage", () => {
   beforeEach(() => {
     vi.mocked(api.fetchPiece).mockResolvedValue(MOCK_PIECE);
+    // fetchAppInit is subscribed to read-only; resolve immediately so initLoading=false
+    vi.mocked(api.fetchAppInit).mockResolvedValue({
+      googleOauthClientId: "",
+      mockIdpUrl: null,
+      adminBaseUrl: null,
+      user: null,
+    });
   });
 
   it("shows Back to Pieces button by default", async () => {
@@ -131,13 +139,15 @@ describe("PieceDetailPage", () => {
     );
   });
 
-  it("shows a loading spinner while the piece is loading", () => {
+  it("shows a loading spinner while the piece is loading", async () => {
     vi.mocked(api.fetchPiece).mockImplementation(
       () => new Promise(() => undefined),
     );
 
     renderPage();
 
+    // Spinner appears after appInit resolves and piece fetch begins
+    await screen.findByRole("progressbar");
     expect(screen.getByRole("progressbar")).toBeInTheDocument();
   });
 

--- a/web/src/pages/__tests__/PieceDetailPage.test.tsx
+++ b/web/src/pages/__tests__/PieceDetailPage.test.tsx
@@ -83,7 +83,7 @@ function renderPage({
 describe("PieceDetailPage", () => {
   beforeEach(() => {
     vi.mocked(api.fetchPiece).mockResolvedValue(MOCK_PIECE);
-    // fetchAppInit is subscribed to read-only; resolve immediately so initLoading=false
+    // fetchAppInit is subscribed to read-only; resolve immediately so init is defined and not fetching
     vi.mocked(api.fetchAppInit).mockResolvedValue({
       googleOauthClientId: "",
       mockIdpUrl: null,


### PR DESCRIPTION
## Summary

- Gates `PieceDetailPage`'s piece detail query on `appInit` not loading, preventing it from racing against a still-settling auth state on PWA resume
- Adds a read-only `["appInit"]` subscription in `PieceDetailPage` (`staleTime: Infinity`) — no extra network request, zero latency impact for in-app navigation
- Updates the `PieceDetailPage` test to mock `fetchAppInit` (now subscribed) and makes the spinner test async

## Root cause

The piece detail endpoint uses `AllowAny` and returns **404** — not 401 — for private pieces when the anonymous queryset is used. The 401 interceptor never fires. On PWA resume with an expired access token and a valid refresh cookie, the piece detail query fired concurrently with `appInit` before the reactive refresh could run, producing a 404 that triggered the error boundary.

## How the fix handles the race

On PWA resume the sequence is now:

1. `appInit` fetches → `initLoading=true` → piece detail **disabled** ✓
2. `appInit` resolves → `user=null` → piece detail enabled, may get 404 for private piece
3. Reactive refresh in `AppContent` succeeds → `invalidateQueries(["appInit"])` → `appInit` re-fetches → `initLoading=true` → piece detail **disabled** again; 404 is in RQ error cache
4. `appInit` resolves → user set → piece detail **re-enabled** → React Query v5 retries errored queries on re-enable → fires with fresh token → **200** ✓

## Test plan

- [x] `bazel test //web:web_test` — all 39 tests pass
- [x] `bazel build --config=lint //web:web_lib` — no lint errors
- Manual PWA simulation: authenticate, invalidate the in-memory access token while keeping the refresh cookie, deep-link directly to a private piece URL, confirm piece loads without hitting the error boundary

Closes #822
