### PR TITLE
fix: don't show fullscreen error on transient appInit refetch failure

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -180,6 +180,11 @@ describe("App auth flow", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    // Restore document.visibilityState to jsdom's default in case a test modified it.
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    });
   });
 
   it("shows error when /api/auth/me/ returns a server error", async () => {
@@ -190,6 +195,50 @@ describe("App auth flow", () => {
         screen.getByText(/All identity providers are misconfigured/),
       ).toBeInTheDocument();
     });
+  });
+
+  it("does not show error screen on transient refetch failure when stale session data exists", async () => {
+    // First load succeeds with a logged-in user
+    vi.mocked(fetchAppInit)
+      .mockResolvedValueOnce({
+        googleOauthClientId: "test-client-id",
+        adminBaseUrl: null,
+        user: MOCK_USER,
+      })
+      // Transient failure on the window-focus refetch
+      .mockRejectedValueOnce(new Error("503 transient"));
+
+    render(<App />);
+
+    // App renders authenticated view
+    await waitFor(() => {
+      expect(screen.getByText("Piece List Content")).toBeInTheDocument();
+    });
+
+    // Simulate tab hide → show, which triggers TanStack Query's refetchOnWindowFocus.
+    // TQ v5's FocusManager listens on window for both 'focus' and 'visibilitychange'.
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "hidden",
+    });
+    window.dispatchEvent(new Event("visibilitychange"));
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    });
+    window.dispatchEvent(new Event("visibilitychange"));
+
+    // Confirm the refetch actually fired
+    await waitFor(() => {
+      expect(fetchAppInit).toHaveBeenCalledTimes(2);
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/All identity providers are misconfigured/),
+      ).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("Piece List Content")).toBeInTheDocument();
   });
 
   it("shows landing form when not authenticated", async () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1087,7 +1087,7 @@ function AppContent() {
           <FullscreenCenter>
             <CircularProgress />
           </FullscreenCenter>
-        ) : error ? (
+        ) : error && !init ? (
           <FullscreenCenter>
             <Alert severity="error">
               All identity providers are misconfigured. The developer has been


### PR DESCRIPTION
## Problem

Closes #832. After a period of browser inactivity, TanStack Query fires a `refetchOnWindowFocus` re-fetch of `/api/auth/me/`. If that re-fetch fails transiently (network blip, brief 503), the app shows the fullscreen "All identity providers are misconfigured" error even though the user was already authenticated and valid stale session data was available.

## Fix

One-line change in `App.tsx`: guard the fullscreen error branch with `error && !init` instead of just `error`.

In TanStack Query v5, when a background refetch fails while the query has previous successful data, both `error` (the new error) and `data` (the stale data) are set simultaneously. The old `error ?` check fired before `init?.user ?`, so stale data was ignored. The new guard ensures the error screen only renders when there is genuinely no prior session data (i.e. a cold-load failure).

## Regression Test

Added to `web/src/App.test.tsx`: **"does not show error screen on transient refetch failure when stale session data exists"**

The test simulates the full path:
1. `fetchAppInit` resolves successfully → app shows authenticated view
2. `visibilitychange` event (hidden → visible) triggers TanStack Query's `refetchOnWindowFocus`
3. Second call to `fetchAppInit` rejects
4. Assert the error screen is absent and the authenticated view is still visible

This test failed on the unfixed code and passes with the fix.

## Verification

```
//web:web_app_test  PASSED  (29 tests, 0 failures)
//web:web_test      PASSED  (39 test targets, 0 failures)
```
