### PR TITLE
feat: make PotterDoc logo clickable to navigate to landing page

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -783,6 +783,29 @@ describe("App auth flow", () => {
     expect(window.location.pathname).toBe("/pieces/piece-1");
   });
 
+  it("logo link navigates to home from a non-root route", async () => {
+    vi.mocked(fetchAppInit).mockResolvedValue({
+      googleOauthClientId: "test-client-id",
+      adminBaseUrl: null,
+      user: MOCK_USER,
+    });
+    window.history.pushState({}, "", "/analyze");
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Glaze Combinations")).toBeInTheDocument();
+    });
+
+    const logoLink = screen.getByRole("link", { name: "Go to home" });
+    expect(logoLink).toBeInTheDocument();
+    await userEvent.click(logoLink);
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe("/");
+    });
+  });
+
   it("activates the analyze tab on direct navigation to /analyze", async () => {
     vi.mocked(fetchAppInit).mockResolvedValue({
       googleOauthClientId: "test-client-id",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -445,7 +445,18 @@ function AppShell({
               flexWrap: "nowrap",
             }}
           >
-            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+            <Link
+              to="/"
+              aria-label="Go to home"
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                textDecoration: "none",
+                color: "inherit",
+                cursor: "pointer",
+              }}
+            >
               <Box
                 component="img"
                 src="/favicon.svg"
@@ -465,7 +476,7 @@ function AppShell({
               >
                 PotterDoc
               </Typography>
-            </Box>
+            </Link>
             <Chip
               id="user-chip"
               label={displayName}


### PR DESCRIPTION
## Summary

- Wraps the PotterDoc logo + wordmark in `AppShell` with a React Router `<Link to="/">` so clicking it navigates to `/` from any authenticated route
- Adds `aria-label="Go to home"` for accessibility; logo appearance is unchanged (no underline, color preserved)
- Adds a regression test covering logo-click navigation

## Test plan

- [x] `//web:web_app_test` passes (new test: "logo link navigates to home from a non-root route")
- [x] `--config=lint //web/...` passes
- [ ] Manual: start dev server, navigate to a piece, click logo — should return to `/`

Closes #833

🤖 Generated with [Claude Code](https://claude.com/claude-code)
