### PR TITLE
ci: add macOS dev bootstrap smoke test to record-fingerprint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -589,8 +589,8 @@ jobs:
 
   record-fingerprint:
     name: Record successful fingerprint
-    needs: [preflight, lint, coverage, dev-smoke, image, compose-smoke]
-    if: ${{ github.event_name == 'pull_request' && needs.lint.result == 'success' && needs.coverage.result == 'success' && needs.dev-smoke.result == 'success' && needs.image.result == 'success' && needs.compose-smoke.result == 'success' }}
+    needs: [preflight, lint, coverage, dev-smoke, dev-smoke-macos, image, compose-smoke]
+    if: ${{ github.event_name == 'pull_request' && needs.lint.result == 'success' && needs.coverage.result == 'success' && needs.dev-smoke.result == 'success' && needs.dev-smoke-macos.result == 'success' && needs.image.result == 'success' && needs.compose-smoke.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Write fingerprint marker

--- a/api/tests/test_public_library_commands.py
+++ b/api/tests/test_public_library_commands.py
@@ -319,36 +319,6 @@ class TestLoadPublicLibrary:
         )
         assert "skipping" in out.getvalue().lower()
 
-    def test_skips_version_cache_when_table_missing(self, tmp_path, monkeypatch):
-        fixture = self._write_fixture(
-            tmp_path,
-            [
-                {
-                    "model": "api.claybody",
-                    "fields": {"name": "Stoneware", "short_description": "A body"},
-                }
-            ],
-        )
-
-        monkeypatch.setattr(
-            connection.introspection,
-            "table_names",
-            lambda: [],
-        )
-        monkeypatch.setattr(
-            load_public_library_command.PublicLibraryVersion.objects,
-            "get_or_create",
-            lambda *args, **kwargs: pytest.fail("get_or_create should not run"),
-        )
-        monkeypatch.setattr(
-            load_public_library_command.PublicLibraryVersion.objects,
-            "filter",
-            lambda *args, **kwargs: pytest.fail("filter should not run"),
-        )
-
-        call_command("load_public_library", fixture=str(fixture))
-        assert ClayBody.objects.filter(user=None, name="Stoneware").exists()
-
     def test_raises_for_invalid_json(self, tmp_path):
         bad = tmp_path / "bad.json"
         bad.write_text("not valid json {{{")


### PR DESCRIPTION
Adds `dev-smoke-macos` to the dependency block of the `record-fingerprint` job in `.github/workflows/ci.yml`. This ensures that the fingerprint artifact isn't stamped until the macOS dev bootstrap test succeeds.

Also includes a pre-existing linter fix:
- Removed a duplicate `test_skips_version_cache_when_table_missing` method from `api/tests/test_public_library_commands.py` to resolve the `F811` redefinition error.
