### PR TITLE
ci: speed up macOS smoke test (Playwright cache, pnpm cache, Bazel tuning)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -56,3 +56,12 @@ build:ci --discard_analysis_cache
 # Optimize for GitHub Actions (network-limited, CPU-limited)
 # 1. Use a local disk cache (backed by actions/cache) to bypass network latency for hits.
 build:ci --disk_cache=~/.cache/bazel-disk-cache
+
+# ── macOS CI ──────────────────────────────────────────────────────────────────
+# macOS GitHub Actions runners are slower than Linux: Gatekeeper/XPC overhead
+# on every binary exec makes high parallelism counterproductive. Cap jobs and
+# reduce memory pressure relative to the base ci config.
+build:ci-macos --config=ci
+build:ci-macos --jobs=4
+build:ci-macos --local_resources=memory=HOST_RAM*0.6
+build:ci-macos --local_resources=cpu=HOST_CPUS*0.75

--- a/.github/actions/setup-bazel-ci/action.yml
+++ b/.github/actions/setup-bazel-ci/action.yml
@@ -19,6 +19,15 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Cache pnpm store
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.local/share/pnpm/store
+          ~/Library/Caches/pnpm/store
+        key: pnpm-store-${{ runner.os }}-${{ inputs.deps-key }}
+        restore-keys: pnpm-store-${{ runner.os }}-
+
     - name: Cache Bazel Repository
       uses: actions/cache@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,12 @@ jobs:
           deps-key: ${{ needs.preflight.outputs.deps_key }}
           buildbuddy-api-key: ${{ secrets.BAZEL_REMOTE_API_KEY }}
           workdir: ${{ steps.worktree.outputs.path }}
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('web/pnpm-lock.yaml') }}
+          restore-keys: playwright-${{ runner.os }}-
       - name: Install web dependencies for browser clickthrough
         shell: bash
         working-directory: ${{ steps.worktree.outputs.path }}
@@ -321,6 +327,17 @@ jobs:
           deps-key: ${{ needs.preflight.outputs.deps_key }}
           buildbuddy-api-key: ${{ secrets.BAZEL_REMOTE_API_KEY }}
           workdir: ${{ steps.worktree.outputs.path }}
+      - name: Apply macOS Bazel resource limits
+        shell: bash
+        working-directory: ${{ steps.worktree.outputs.path }}
+        run: |
+          printf '\n# macOS runner overrides\nbuild --jobs=4\nbuild --local_resources=cpu=HOST_CPUS*0.75\nbuild --local_resources=memory=HOST_RAM*0.6\n' >> .bazelrc
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('web/pnpm-lock.yaml') }}
+          restore-keys: playwright-${{ runner.os }}-
       - name: Install web dependencies for browser clickthrough
         shell: bash
         working-directory: ${{ steps.worktree.outputs.path }}


### PR DESCRIPTION
## Summary

- **Playwright Chromium cache**: Both smoke jobs now cache the browser binary between runs (Linux: `~/.cache/ms-playwright`, macOS: `~/Library/Caches/ms-playwright`, keyed by `pnpm-lock.yaml`). This avoids a ~130 MB download on every cold run — likely the single largest time sink.
- **pnpm store cache**: Added to `setup-bazel-ci` (shared by all jobs on the same OS), so `pnpm install --frozen-lockfile` reuses cached packages instead of re-downloading.
- **macOS Bazel resource limits**: The `dev-smoke-macos` job appends `--jobs=4 / cpu*0.75 / memory*0.6` to `.bazelrc` after setup. macOS GitHub Actions runners trigger Gatekeeper/XPC checks on each Bazel-spawned binary, making high parallelism counterproductive. `.bazelrc` also gains a `build:ci-macos` named config for direct use.

## Test plan

- [ ] Observe `dev-smoke-macos` job timing on this PR vs the prior run linked in the description
- [ ] Confirm Playwright cache is populated on first run (cache miss → install) and restored on second run
- [ ] Confirm pnpm store cache hit in `setup-bazel-ci` log
- [ ] Confirm macOS smoke still passes end-to-end

Ref: https://github.com/shaoster/glaze/actions/runs/27096936545/job/79970740532

🤖 Generated with [Claude Code](https://claude.com/claude-code)