### PR TITLE
perf: use prefetch cache in PieceState.images to eliminate N+1 (651ms)

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -398,10 +398,10 @@ class PieceState(models.Model):
 
         if self.pk is None:
             return list(self._pending_images or [])
-        return [
-            captioned_image_to_dict(link)
-            for link in self.image_links.select_related("image").order_by("order", "pk")
-        ]
+        links = getattr(self, "_prefetched_objects_cache", {}).get("image_links")
+        if links is None:
+            links = self.image_links.select_related("image").order_by("order", "pk")
+        return [captioned_image_to_dict(link) for link in links]
 
     @images.setter
     def images(self, value: list[dict]) -> None:

--- a/api/tests/test_piece_detail.py
+++ b/api/tests/test_piece_detail.py
@@ -82,6 +82,38 @@ class TestPieceDetail:
         assert response.status_code == 200
         assert len(ctx) <= 7
 
+    def test_images_query_count_does_not_grow_with_state_count(
+        self, client, piece, user
+    ):
+        from api.models import Image, PieceStateImage
+
+        for state_name in ["handbuilt", "submitted_to_bisque_fire", "bisque_fired"]:
+            state = PieceState.objects.create(piece=piece, user=user, state=state_name)
+            for i in range(3):
+                img = Image.objects.create(
+                    user=user, url=f"https://ex.com/{state_name}-{i}.jpg"
+                )
+                PieceStateImage.objects.create(piece_state=state, image=img, order=i)
+
+        with CaptureQueriesContext(connection) as ctx:
+            response = client.get(f"/api/pieces/{piece.id}/")
+
+        assert response.status_code == 200
+        per_state_queries = [
+            q
+            for q in ctx.captured_queries
+            if "api_piecestateimage" in q["sql"]
+            and "piece_state_id" in q["sql"]
+            and '"piece_state_id" =' in q["sql"]
+        ]
+        assert len(per_state_queries) == 0, (
+            f"Expected 0 per-state image queries but got {len(per_state_queries)}: "
+            f"{[q['sql'][:120] for q in per_state_queries]}"
+        )
+        history = response.json()["history"]
+        states_with_images = [s for s in history if s["images"]]
+        assert len(states_with_images) == 3
+
     def test_get_prefetches_state_global_refs(self, client, piece, user):
         clay_body = ClayBody.objects.create(user=user, name="Stoneware")
         kiln_location = Location.objects.create(user=user, name="Kiln Shelf")

--- a/api/tests/test_piece_detail.py
+++ b/api/tests/test_piece_detail.py
@@ -102,9 +102,8 @@ class TestPieceDetail:
         per_state_queries = [
             q
             for q in ctx.captured_queries
-            if "api_piecestateimage" in q["sql"]
-            and "piece_state_id" in q["sql"]
-            and '"piece_state_id" =' in q["sql"]
+            if q["sql"].startswith('SELECT "api_piecestateimage"')
+            and '"piece_state_id" IN' not in q["sql"]
         ]
         assert len(per_state_queries) == 0, (
             f"Expected 0 per-state image queries but got {len(per_state_queries)}: "


### PR DESCRIPTION
## Summary

- `PieceState.images` property was always issuing a DB query per access via `self.image_links.select_related("image").order_by(...)`, bypassing Django's prefetch cache
- `build_keepsake_storyboard` (used by `get_showcase_video_url`) calls `state.images` for every state in the piece history, producing 1 `api_piecestateimage` SELECT per state — 10 queries totalling ~651ms in traces
- Fix: check `_prefetched_objects_cache["image_links"]` first, exactly matching the pattern already used in `PieceStateSerializer.get_images`

## Test plan

- [x] New test `test_images_query_count_does_not_grow_with_state_count` — creates a piece with 4 states (3 with 3 images each), asserts zero per-state piecestateimage queries and all images appear in the response
- [x] Existing `test_get_uses_a_small_number_of_queries` (≤7 queries) still passes
- [x] Full test suite passes (`rtk bazel test //api:api_piece_test`)
- [x] Linters pass (`rtk bazel build --config=lint //...`)

Closes #844

🤖 Generated with [Claude Code](https://claude.com/claude-code)
