### PR TITLE
perf: use prefetch cache in _evaluate_compute for cross-state field refs

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -542,15 +542,17 @@ class PieceState(models.Model):
                 return None
 
             state_id, field_name = ref.split(".", 1)
-            # Find the state in history.
+            # Find the state in history, preferring the prefetch cache.
             if state_id == self.state:
                 val = self.resolve_custom_field(field_name)
             else:
-                ancestor = (
-                    self.piece.states.filter(state=state_id)
-                    .order_by("-created")
-                    .first()
-                )
+                ancestor = self.piece._prefetched_state(state_id)
+                if ancestor is _MISSING:
+                    ancestor = (
+                        self.piece.states.filter(state=state_id)
+                        .order_by("-created")
+                        .first()
+                    )
                 if not ancestor:
                     return None
                 val = ancestor.resolve_custom_field(field_name)

--- a/api/models.py
+++ b/api/models.py
@@ -555,6 +555,7 @@ class PieceState(models.Model):
                     )
                 if not ancestor:
                     return None
+                assert isinstance(ancestor, PieceState)
                 val = ancestor.resolve_custom_field(field_name)
 
             try:

--- a/api/tests/test_custom_fields.py
+++ b/api/tests/test_custom_fields.py
@@ -3,6 +3,8 @@ from unittest.mock import patch
 
 import pytest
 from django.contrib.auth.models import User
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 
 import api.workflow as workflow_module
 from api.models import Piece, PieceState
@@ -362,3 +364,43 @@ class TestCalculatedFields:
             ],
         }
         assert state._evaluate_compute(node) == 500.0
+
+    def test_cross_state_field_reference_uses_prefetch_cache(self, piece):
+        """_evaluate_compute must not query the DB when states are prefetched."""
+        earlier = PieceState.objects.create(
+            user=piece.user,
+            piece=piece,
+            state="glaze_fired",
+            order=2,
+            custom_fields={"length_in": 7, "width_in": 4},
+        )
+        later = PieceState.objects.create(
+            user=piece.user,
+            piece=piece,
+            state="completed",
+            order=3,
+        )
+
+        # Simulate the prefetch that piece_detail_queryset performs.
+        from django.db.models import Prefetch
+
+        piece_qs = Piece.objects.prefetch_related(
+            Prefetch("states", queryset=PieceState.objects.order_by("order"))
+        ).filter(pk=piece.pk)
+        prefetched_piece = piece_qs.get()
+        prefetched_later = next(
+            s
+            for s in prefetched_piece._prefetched_objects_cache["states"]
+            if s.pk == later.pk
+        )
+
+        # Cross-state compute: references glaze_fired.length_in from completed state.
+        node = {"field": "glaze_fired.length_in", "return_type": "number"}
+
+        with CaptureQueriesContext(connection) as ctx:
+            result = prefetched_later._evaluate_compute(node)
+
+        assert result == 7.0
+        assert len(ctx) == 0, (
+            f"Expected 0 DB queries but got {len(ctx)}: {[q['sql'][:100] for q in ctx]}"
+        )


### PR DESCRIPTION
## Summary

- `PieceState._evaluate_compute` was always issuing a DB query for cross-state field references (`state_id != self.state`), using `piece.states.filter(state=state_id).first()` without checking the prefetch cache first
- This caused a per-field DB query for every state with a computed field referencing another state, visible as 100+ ms spikes in `PieceState.resolve_custom_field` traces
- Fix: add `self.piece._prefetched_state(state_id)` lookup before the DB fallback, exactly mirroring the pattern already used in `resolve_custom_field`'s marker resolution

## Test plan

- [x] New test `test_cross_state_field_reference_uses_prefetch_cache` — creates two states, prefetches them, calls `_evaluate_compute` with a cross-state reference, and asserts 0 DB queries
- [x] Existing `TestCalculatedFields` tests all pass
- [x] Full test suite passes (`rtk bazel test //api:api_piece_test //api:api_model_test //api:api_glaze_test`)
- [x] Linters pass (`rtk bazel build --config=lint //...`)

Closes #845

🤖 Generated with [Claude Code](https://claude.com/claude-code)
