### PR TITLE
fix: disable auto-crop task enqueueing until pipeline is ready

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -638,21 +638,6 @@ class PieceCreateSerializer(serializers.ModelSerializer):
             user=user, piece=piece, state=ENTRY_STATE, notes=notes, order=1
         )
 
-        # Queue auto-detection for Cloudinary thumbnails so the matching piece
-        # history image can pick up a crop if one exists.
-        if thumbnail and thumbnail.cloud_name and thumbnail.cloudinary_public_id:
-            from .tasks import get_task_interface
-
-            task = AsyncTask.objects.create(
-                user=user,
-                task_type="detect_subject_crop",
-                input_params={
-                    "image_id": str(thumbnail.id),
-                    "piece_id": str(piece.id),
-                },
-            )
-            get_task_interface().submit(task)
-
         return piece
 
 
@@ -964,24 +949,6 @@ class PieceUpdateSerializer(serializers.Serializer):
                 thumbnail_payload, user=instance.user
             )
 
-            # Queue auto-detection for Cloudinary thumbnails so the matching
-            # piece history image can pick up a crop if one exists.
-            if (
-                instance.thumbnail
-                and instance.thumbnail.cloud_name
-                and instance.thumbnail.cloudinary_public_id
-            ):
-                from .tasks import get_task_interface
-
-                task = AsyncTask.objects.create(
-                    user=user,
-                    task_type="detect_subject_crop",
-                    input_params={
-                        "image_id": str(instance.thumbnail.id),
-                        "piece_id": str(instance.id),
-                    },
-                )
-                get_task_interface().submit(task)
         if "shared" in validated_data:
             instance.shared = validated_data["shared"]
         if "is_editable" in validated_data:

--- a/api/tests/test_pieces_create.py
+++ b/api/tests/test_pieces_create.py
@@ -51,7 +51,9 @@ class TestPiecesCreate:
         data = response.json()
         assert data["current_state"]["notes"] == ""
 
-    def test_create_with_cloudinary_thumbnail_queues_task(self, client, monkeypatch):
+    def test_create_with_cloudinary_thumbnail_does_not_queue_crop_task(
+        self, client, monkeypatch
+    ):
         submitted = []
         thumbnail = Image.objects.create(
             user=None,
@@ -83,9 +85,4 @@ class TestPiecesCreate:
         )
 
         assert response.status_code == 201
-        assert submitted == [
-            {
-                "image_id": response.json()["thumbnail"]["image_id"],
-                "piece_id": response.json()["id"],
-            }
-        ]
+        assert submitted == []


### PR DESCRIPTION
## Summary

- Removes the automatic `detect_subject_crop` task from piece create and update serializers
- The crop inference task, `CropRun` model, management commands, and all crop API endpoints are preserved for manual use
- Updates the related test to assert no task is enqueued

## Why

Auto-cropping was applying ML-inferred crops automatically on every piece upload, ahead of a proper cropping pipeline being in place. Disabling the trigger leaves the infrastructure intact while stopping spurious crops from being applied.

## Test plan

- [x] `//api:api_piece_test` passes (updated `test_create_with_cloudinary_thumbnail_does_not_queue_crop_task`)
- [x] Full backend suite `//api:api_test` passes
