### PR TITLE
[codex] fix backend anomalous traces query

### DIFF
--- a/tools/grafana_dashboard.py
+++ b/tools/grafana_dashboard.py
@@ -137,7 +137,7 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
                 "metricsQueryType": "range",
                 "serviceMapUseNativeHistograms": False,
                 "limit": 30,
-                "query": '{resource.service.name="glaze" && (duration > 500ms || status=error)}',
+                "query": '{trace:rootService="glaze" && (duration > 500ms || status=error)}',
             }
         ],
     },

--- a/tools/tests/test_grafana_dashboard.py
+++ b/tools/tests/test_grafana_dashboard.py
@@ -44,7 +44,7 @@ def test_dashboard_json_contains_expected_sdk_fields() -> None:
     assert panels[7]["targets"][0]["queryType"] == "range"
     assert panels[8]["targets"][0]["queryType"] == "traceql"
     assert panels[8]["targets"][0]["limit"] == 30
-    assert panels[8]["targets"][0]["query"] == '{resource.service.name="glaze" && (duration > 500ms || status=error)}'
+    assert panels[8]["targets"][0]["query"] == '{trace:rootService="glaze" && (duration > 500ms || status=error)}'
 
     assert panels[13]["transformations"][0]["id"] == "filterFieldsByName"
     assert panels[13]["transformations"][1]["options"]["renameByName"]["remaining"] == "Headroom"


### PR DESCRIPTION
This updates the Backend Anomalous Traces dashboard panel so it only returns backend-rooted traces.

What changed:
- Switched the Tempo query from `resource.service.name="glaze"` to `trace:rootService="glaze"` for the backend anomalous traces panel.
- Updated the dashboard test to lock in the new query.

Why:
- The old filter still allowed frontend-sourced traces (`glaze-web`) into the backend table whenever those traces contained backend spans.
- Filtering by the trace root service keeps the panel focused on traces that originate from the backend service.

Validation:
- `rtk bazel test //tools:test_grafana_dashboard --test_output=errors`
- `rtk bazel run //tools:grafana_dashboard -- validate`
