### PR TITLE
fix: eliminate per-request session writes on /api/auth/me/ and add Redis instrumentation

### DIFF
--- a/api/auth/views.py
+++ b/api/auth/views.py
@@ -134,10 +134,13 @@ def auth_me(request: Request) -> Response:
             status=status.HTTP_503_SERVICE_UNAVAILABLE,
         )
     user = request.user if request.user.is_authenticated else None
+    _DOMAIN_REISSUED = "_domain_reissued"
     if user is not None and getattr(settings, "SESSION_COOKIE_DOMAIN", None):
-        # Re-issue the authenticated session with the shared parent-domain
-        # cookie so the admin subdomain can receive the same login state.
-        request.session.modified = True
+        # Re-issue the session cookie once with the shared parent-domain so
+        # the admin subdomain can share login state. After the first call the
+        # flag is stored in the session and no further writes are needed.
+        if not request.session.get(_DOMAIN_REISSUED):
+            request.session[_DOMAIN_REISSUED] = True
     admin_host = settings.ADMIN_INGRESS_HOST
     mock_idp_url = (
         "/api/auth/mock-idp/authorize/?redirect_uri=/api/auth/mock-idp/complete/"

--- a/api/tests/test_auth.py
+++ b/api/tests/test_auth.py
@@ -523,6 +523,25 @@ class TestAuthMe:
             response.cookies[settings.SESSION_COOKIE_NAME]["domain"] == ".potterdoc.com"
         )
 
+    def test_session_not_dirtied_on_repeated_auth_me_calls(self, user, settings):
+        settings.GOOGLE_OAUTH_CLIENT_ID = "my-client-id"
+        settings.SESSION_COOKIE_DOMAIN = ".potterdoc.com"
+
+        browser = Client()
+        browser.force_login(user)
+
+        # First call: triggers the one-time domain re-issue; session is saved.
+        browser.get("/api/auth/me/")
+
+        # Second call: domain already re-issued; session must NOT be saved again.
+        # Django only emits Set-Cookie for the session when session.modified is True.
+        response = browser.get("/api/auth/me/")
+
+        assert settings.SESSION_COOKIE_NAME not in response.cookies, (
+            "session was re-saved on the second /api/auth/me/ call — "
+            "request.session.modified should not be set after the domain is already re-issued"
+        )
+
 
 @pytest.mark.django_db
 class TestAuthGoogle:

--- a/backend/BUILD.bazel
+++ b/backend/BUILD.bazel
@@ -39,6 +39,7 @@ py_library(
         "@pypi//opentelemetry_instrumentation_asgi",
         "@pypi//opentelemetry_instrumentation_django",
         "@pypi//opentelemetry_instrumentation_psycopg2",
+        "@pypi//opentelemetry_instrumentation_redis",
         "@pypi//opentelemetry_exporter_otlp_proto_grpc",
         "@pypi//celery",
         "@pypi//redis",

--- a/backend/otel.py
+++ b/backend/otel.py
@@ -123,6 +123,7 @@ def configure_otel() -> bool:
     )
     from opentelemetry.sdk.metrics import MeterProvider
     from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+    from opentelemetry.sdk.metrics.view import View
 
     metric_exporter = OTLPMetricExporter(
         endpoint=os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317"),
@@ -134,6 +135,17 @@ def configure_otel() -> bool:
             PeriodicExportingMetricReader(
                 metric_exporter, export_interval_millis=30_000
             )
+        ],
+        views=[
+            # Keep only http.status_code on the duration histogram; all other
+            # dimensions (route, method, scheme, host, port) are unused by the
+            # dashboard and inflate Grafana Cloud series quota.
+            View(
+                instrument_name="http.server.duration",
+                attribute_keys={"http.status_code"},
+            ),
+            # Active-requests gauge is only queried as a scalar sum — no per-label breakdown needed.
+            View(instrument_name="http.server.active_requests", attribute_keys=set()),
         ],
     )
     metrics.set_meter_provider(meter_provider)
@@ -158,6 +170,10 @@ def configure_otel() -> bool:
 
     DjangoInstrumentor().instrument()
     Psycopg2Instrumentor().instrument()
+
+    from opentelemetry.instrumentation.redis import RedisInstrumentor
+
+    RedisInstrumentor().instrument()
 
     # opentelemetry-instrumentation-django 0.62b1's _DjangoMiddleware has no
     # __acall__, so under ASGI/uvicorn it runs in a thread executor and loses

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ dependencies = [
     "uvicorn==0.46.0",
     "whitenoise==6.9.0",
     "djangorestframework-simplejwt>=5.5.1",
+    "opentelemetry-instrumentation-redis>=0.62b1",
 ]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -407,6 +407,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/77/4396e853c3ee3b1264a2bb23f9b1934194ab750c6ecd30aa194b53dec7b9/django_admin_sortable2-2.3.1-py3-none-any.whl", hash = "sha256:5784f441f3532013438c3c3226fbccc39b9c733f867b26a5f477d6b05f734b93", size = 107015, upload-time = "2026-01-22T14:20:27.604Z" },
 ]
 
+# DO NOT MODIFY the wheels entry below — uv rewrites the url to a relative
+# path which breaks aspect_rules_py's lockfile parser. See:
+# https://github.com/shaoster/glaze/issues/792
 [[package]]
 name = "django-bootstrap4-form"
 version = "4.0.2"
@@ -415,7 +418,7 @@ dependencies = [
     { name = "django" },
 ]
 wheels = [
-    { path = "django_bootstrap4_form-4.0.2-py3-none-any.whl" },
+    { url = "https://raw.githubusercontent.com/shaoster/glaze/7e899ff17dc550446652fa813f38ab5331e6db1f/third_party/python/django_bootstrap4_form-4.0.2-py3-none-any.whl", hash = "sha256:ed4bcfc1246e449d61b6d946c8c918e48b6d239c504fcf03cd711108c20c5555", size = 7071 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -415,7 +415,7 @@ dependencies = [
     { name = "django" },
 ]
 wheels = [
-    { url = "https://raw.githubusercontent.com/shaoster/glaze/7e899ff17dc550446652fa813f38ab5331e6db1f/third_party/python/django_bootstrap4_form-4.0.2-py3-none-any.whl", hash = "sha256:ed4bcfc1246e449d61b6d946c8c918e48b6d239c504fcf03cd711108c20c5555", size = 7071 },
+    { path = "django_bootstrap4_form-4.0.2-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -706,6 +706,7 @@ dependencies = [
     { name = "opentelemetry-instrumentation-asgi" },
     { name = "opentelemetry-instrumentation-django" },
     { name = "opentelemetry-instrumentation-psycopg2" },
+    { name = "opentelemetry-instrumentation-redis" },
     { name = "opentelemetry-sdk" },
     { name = "packaging" },
     { name = "pathspec" },
@@ -810,6 +811,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-asgi", specifier = ">=0.62b1" },
     { name = "opentelemetry-instrumentation-django", specifier = ">=0.62b1" },
     { name = "opentelemetry-instrumentation-psycopg2", specifier = ">=0.62b1" },
+    { name = "opentelemetry-instrumentation-redis", specifier = ">=0.62b1" },
     { name = "opentelemetry-sdk", specifier = ">=1.41.1" },
     { name = "packaging", specifier = "==26.2" },
     { name = "pathspec", specifier = "==1.0.4" },
@@ -1449,6 +1451,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/45/14/302c4c96bd4ec97656217e715f20e69f61dc79e3478c95e883ed50cd8100/opentelemetry_instrumentation_psycopg2-0.62b1.tar.gz", hash = "sha256:0f756c7e00babb04429c528e8cd0054b348a8458a7a986a6807c0d413222f45c", size = 12077, upload-time = "2026-04-24T13:22:57.343Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/da/e650b7077ad57048cd765d91d7c4f002bd3ec6101fc7920b14e956f73404/opentelemetry_instrumentation_psycopg2-0.62b1-py3-none-any.whl", hash = "sha256:b1de5da4b300504dbe52145d3098092b5caab2b50373809cf11506e0adddd0eb", size = 11585, upload-time = "2026-04-24T13:22:05.857Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-redis"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/ff/35414ad80409bd9e472c7959832524c5f2c8f63965af08c41c2b42d3a6a6/opentelemetry_instrumentation_redis-0.62b1.tar.gz", hash = "sha256:2d3c421d95e05ade075bee5becbe34e743b1cdf5bdee2085cb524f88c4f13dcb", size = 14796, upload-time = "2026-04-24T13:23:01.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/37/bc2271f3472e3041eeade8b8da1cfd3b06badae76fe5d0ff135b6285e70c/opentelemetry_instrumentation_redis-0.62b1-py3-none-any.whl", hash = "sha256:9aedd02c1acf631251d1d676634db47da9da04e0a626cd0c7d83fe0eb791d165", size = 15501, upload-time = "2026-04-24T13:22:11.705Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

[#861](https://github.com/shaoster/glaze/issues/861) — `GET /api/auth/me/` regularly taking >2s, confirmed via Grafana Tempo traces showing 1–2s untraced gaps and unnecessary `UPDATE django_session` on every authenticated call.

## Fix

**Session guard** (`api/auth/views.py`): replaced unconditional `request.session.modified = True` with a `_domain_reissued` flag stored in the session. The domain re-issue (needed once for admin subdomain cookie sharing) now fires exactly once per session; subsequent calls skip the write entirely.

**Redis instrumentation** (`backend/otel.py`): added `RedisInstrumentor().instrument()` so Redis/cache operations (including session reads) appear as spans in Tempo traces, making the previously untraced ~1–2s gap observable.

**OTel metric Views** (`backend/otel.py`): configured `MeterProvider` with Views that drop unused label dimensions from `http.server.duration` (keeping only `http.status_code`) and strip all extra attributes from `http.server.active_requests`. The dashboard only uses `service_name` (resource attribute) and `http.status_code` — all other dimensions (`http.method`, `http.route`, `http.scheme`, `http.flavor`, `net.host.name`, `net.host.port`) were inflating Grafana Cloud series quota.

**Dependency** (`pyproject.toml`, `uv.lock`, `backend/BUILD.bazel`): added `opentelemetry-instrumentation-redis>=0.62b1`.

## Regression Test

`api/tests/test_auth.py::TestAuthMe::test_session_not_dirtied_on_repeated_auth_me_calls` — calls `GET /api/auth/me/` twice with `SESSION_COOKIE_DOMAIN` set, asserts the session cookie is not re-sent on the second call (Django only sends `Set-Cookie` when `session.modified` is True). Failed before the fix, passes after.

The existing `test_refreshes_session_cookie_for_shared_admin_domain` continues to pass, confirming the first-call re-issue still works.

## Verification

```
//api:api_auth_test   PASSED in 25.0s
//api:api_test        11/11 pass
```

Closes #861
