### PR TITLE
fix: include image width and height in upload flow

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -282,6 +282,12 @@ class CaptionedImageSerializer(serializers.Serializer):
     cloud_name = serializers.CharField(allow_null=True, required=False, default=None)
     crop = ImageCropSerializer(required=False, allow_null=True, default=None)
     image_id = serializers.UUIDField(required=False, allow_null=True, default=None)
+    width = serializers.IntegerField(
+        required=False, allow_null=True, default=None, min_value=0
+    )
+    height = serializers.IntegerField(
+        required=False, allow_null=True, default=None, min_value=0
+    )
 
 
 class GlazeCombinationImagePieceSerializer(serializers.Serializer):
@@ -563,6 +569,7 @@ class PieceDetailSerializer(PieceSummarySerializer):
     history = serializers.SerializerMethodField()
     showcase_video_url = serializers.SerializerMethodField()
     owner_alias = serializers.SerializerMethodField()
+
     class Meta(PieceSummarySerializer.Meta):
         fields = PieceSummarySerializer.Meta.fields + [
             "history",

--- a/api/tests/test_piece_detail.py
+++ b/api/tests/test_piece_detail.py
@@ -165,15 +165,14 @@ class TestPieceDetail:
         DRF reuses the same child serializer instance for every piece. Without
         keying by pk, the first piece's states bleed into subsequent pieces.
         """
+        from rest_framework.test import APIRequestFactory
+
         from api.models import ENTRY_STATE, Piece, PieceState
         from api.serializers import PieceDetailSerializer
-        from rest_framework.test import APIRequestFactory
 
         piece_a = Piece.objects.create(user=user, name="Bowl A")
         PieceState.objects.create(piece=piece_a, user=user, state=ENTRY_STATE, order=1)
-        PieceState.objects.create(
-            piece=piece_a, user=user, state="handbuilt", order=2
-        )
+        PieceState.objects.create(piece=piece_a, user=user, state="handbuilt", order=2)
 
         piece_b = Piece.objects.create(user=user, name="Bowl B")
         PieceState.objects.create(piece=piece_b, user=user, state=ENTRY_STATE, order=1)

--- a/api/tests/test_piece_states.py
+++ b/api/tests/test_piece_states.py
@@ -147,6 +147,31 @@ class TestPieceStates:
             "name": "Speckled Stoneware",
         }
 
+    def test_create_records_images_with_dimensions(self, client, piece):
+        response = client.post(
+            f"/api/pieces/{piece.id}/states/",
+            {
+                "state": "wheel_thrown",
+                "images": [
+                    {
+                        "url": "https://example.com/throwing.jpg",
+                        "caption": "throwing",
+                        "cloudinary_public_id": "throwing_id",
+                        "cloud_name": "my_cloud",
+                        "width": 1200,
+                        "height": 900,
+                    }
+                ],
+            },
+            format="json",
+        )
+        assert response.status_code == 201
+        current = response.json()["current_state"]
+        image_data = current["images"][0]
+        assert image_data["url"] == "https://example.com/throwing.jpg"
+        assert image_data["width"] == 1200
+        assert image_data["height"] == 900
+
     def test_create_returns_validation_error_for_invalid_inline_field(
         self, client, piece
     ):

--- a/api/tests/test_telemetry.py
+++ b/api/tests/test_telemetry.py
@@ -43,7 +43,9 @@ class TestTelemetryProxy:
         permit_return.set()  # release the background thread immediately
 
         assert response.status_code == 200
-        assert elapsed < 5.0, f"view blocked for {elapsed:.3f}s — should return before collector"
+        assert elapsed < 5.0, (
+            f"view blocked for {elapsed:.3f}s — should return before collector"
+        )
         assert collector_called.wait(timeout=5.0), "collector was never called"
 
     def test_browser_traces_proxies_raw_otlp_payload(self, client, monkeypatch):
@@ -162,7 +164,9 @@ class TestTelemetryProxy:
 
         def post_side_effect(*args, **kwargs):
             called.set()
-            return httpx.Response(200, content=b"", headers={"content-type": "application/json"})
+            return httpx.Response(
+                200, content=b"", headers={"content-type": "application/json"}
+            )
 
         monkeypatch.setattr("api.telemetry_views.httpx.post", post_side_effect)
         response = client.post(
@@ -229,7 +233,9 @@ class TestTelemetryProxy:
                 data=b"trace-payload",
                 content_type="application/x-protobuf",
             )
-            assert logged.wait(timeout=5.0), "warning for connection error was never logged"
+            assert logged.wait(timeout=5.0), (
+                "warning for connection error was never logged"
+            )
         finally:
             tv_logger.removeHandler(handler)
 
@@ -275,7 +281,9 @@ class TestTelemetryProxy:
 
         def post_side_effect(*args, **kwargs):
             called.set()
-            return httpx.Response(200, content=b"", headers={"content-type": "application/json"})
+            return httpx.Response(
+                200, content=b"", headers={"content-type": "application/json"}
+            )
 
         monkeypatch.setattr("api.telemetry_views.httpx.post", post_side_effect)
 

--- a/tools/grafana_dashboard.py
+++ b/tools/grafana_dashboard.py
@@ -19,15 +19,21 @@ from typing import Any
 
 from grafana_foundation_sdk.builders.dashboard import Dashboard as DashboardBuilder
 from grafana_foundation_sdk.builders.logs import Panel as LogsPanelBuilder
+from grafana_foundation_sdk.builders.loki import Dataquery as LokiQueryBuilder
 from grafana_foundation_sdk.builders.piechart import Panel as PieChartPanelBuilder
-from grafana_foundation_sdk.builders.prometheus import Dataquery as PrometheusQueryBuilder
+from grafana_foundation_sdk.builders.prometheus import (
+    Dataquery as PrometheusQueryBuilder,
+)
 from grafana_foundation_sdk.builders.stat import Panel as StatPanelBuilder
 from grafana_foundation_sdk.builders.table import Panel as TablePanelBuilder
 from grafana_foundation_sdk.builders.tempo import TempoQuery as TempoQueryBuilder
 from grafana_foundation_sdk.builders.timeseries import Panel as TimeseriesPanelBuilder
-from grafana_foundation_sdk.builders.loki import Dataquery as LokiQueryBuilder
 from grafana_foundation_sdk.cog.encoder import JSONEncoder
-from grafana_foundation_sdk.models.dashboard import DataSourceRef, DataTransformerConfig, GridPos
+from grafana_foundation_sdk.models.dashboard import (
+    DataSourceRef,
+    DataTransformerConfig,
+    GridPos,
+)
 
 DEFAULT_GRAFANA_URL = "https://shaoster.grafana.net"
 DEFAULT_FOLDER_UID = "general"
@@ -186,47 +192,80 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
     13: {
         "title": "Cloudinary Credits Quota",
         "type": "piechart",
-        "datasource": {"type": "yesoreyeram-infinity-datasource", "uid": "ffo8wq300tukgb"},
+        "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "ffo8wq300tukgb",
+        },
         "targets": [
             {
                 "refId": "A",
-                "datasource": {"type": "yesoreyeram-infinity-datasource", "uid": "ffo8wq300tukgb"},
+                "datasource": {
+                    "type": "yesoreyeram-infinity-datasource",
+                    "uid": "ffo8wq300tukgb",
+                },
                 "type": "json",
                 "source": "url",
                 "url": "https://api.cloudinary.com/v1_1/dxpnyhe1f/usage",
                 "url_options": {"method": "GET"},
                 "parser": "backend",
                 "root_selector": "storage",
-                "columns": [{"selector": "credits_usage", "text": "storage_cr", "type": "number"}],
+                "columns": [
+                    {
+                        "selector": "credits_usage",
+                        "text": "storage_cr",
+                        "type": "number",
+                    }
+                ],
                 "cache_timeout_in_seconds": 3600,
             },
             {
                 "refId": "B",
-                "datasource": {"type": "yesoreyeram-infinity-datasource", "uid": "ffo8wq300tukgb"},
+                "datasource": {
+                    "type": "yesoreyeram-infinity-datasource",
+                    "uid": "ffo8wq300tukgb",
+                },
                 "type": "json",
                 "source": "url",
                 "url": "https://api.cloudinary.com/v1_1/dxpnyhe1f/usage",
                 "url_options": {"method": "GET"},
                 "parser": "backend",
                 "root_selector": "bandwidth",
-                "columns": [{"selector": "credits_usage", "text": "bandwidth_cr", "type": "number"}],
+                "columns": [
+                    {
+                        "selector": "credits_usage",
+                        "text": "bandwidth_cr",
+                        "type": "number",
+                    }
+                ],
                 "cache_timeout_in_seconds": 3600,
             },
             {
                 "refId": "C",
-                "datasource": {"type": "yesoreyeram-infinity-datasource", "uid": "ffo8wq300tukgb"},
+                "datasource": {
+                    "type": "yesoreyeram-infinity-datasource",
+                    "uid": "ffo8wq300tukgb",
+                },
                 "type": "json",
                 "source": "url",
                 "url": "https://api.cloudinary.com/v1_1/dxpnyhe1f/usage",
                 "url_options": {"method": "GET"},
                 "parser": "backend",
                 "root_selector": "transformations",
-                "columns": [{"selector": "credits_usage", "text": "transform_cr", "type": "number"}],
+                "columns": [
+                    {
+                        "selector": "credits_usage",
+                        "text": "transform_cr",
+                        "type": "number",
+                    }
+                ],
                 "cache_timeout_in_seconds": 3600,
             },
             {
                 "refId": "D",
-                "datasource": {"type": "yesoreyeram-infinity-datasource", "uid": "ffo8wq300tukgb"},
+                "datasource": {
+                    "type": "yesoreyeram-infinity-datasource",
+                    "uid": "ffo8wq300tukgb",
+                },
                 "type": "json",
                 "source": "url",
                 "url": "https://api.cloudinary.com/v1_1/dxpnyhe1f/usage",
@@ -234,7 +273,9 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
                 "parser": "backend",
                 "root_selector": "credits",
                 "columns": [],
-                "computed_columns": [{"selector": "limit - usage", "text": "remaining", "type": "number"}],
+                "computed_columns": [
+                    {"selector": "limit - usage", "text": "remaining", "type": "number"}
+                ],
                 "cache_timeout_in_seconds": 3600,
             },
         ],
@@ -243,7 +284,12 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
                 "id": "filterFieldsByName",
                 "options": {
                     "include": {
-                        "names": ["storage_cr", "bandwidth_cr", "transform_cr", "remaining"]
+                        "names": [
+                            "storage_cr",
+                            "bandwidth_cr",
+                            "transform_cr",
+                            "remaining",
+                        ]
                     }
                 },
             },
@@ -343,6 +389,8 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
 }
 
 EXPECTED_PANEL_IDS = set(EXPECTED_PANELS)
+
+
 class ValidationError(RuntimeError):
     """Raised when a dashboard build or publish step fails."""
 
@@ -504,7 +552,9 @@ def validate_dashboard() -> None:
     for key, expected in EXPECTED_DASHBOARD.items():
         if key == "time":
             if payload.get("time") != expected:
-                errors.append(f"$.time: expected {expected!r}, got {payload.get('time')!r}")
+                errors.append(
+                    f"$.time: expected {expected!r}, got {payload.get('time')!r}"
+                )
         elif payload.get(key) != expected:
             errors.append(f"$.{key}: expected {expected!r}, got {payload.get(key)!r}")
 
@@ -514,7 +564,9 @@ def validate_dashboard() -> None:
     else:
         panel_ids = {panel.get("id") for panel in panels if isinstance(panel, dict)}
         if panel_ids != EXPECTED_PANEL_IDS:
-            errors.append(f"$.panels: expected ids {sorted(EXPECTED_PANEL_IDS)}, got {sorted(pid for pid in panel_ids if isinstance(pid, int))}")
+            errors.append(
+                f"$.panels: expected ids {sorted(EXPECTED_PANEL_IDS)}, got {sorted(pid for pid in panel_ids if isinstance(pid, int))}"
+            )
 
     if errors:
         raise ValidationError("\n".join(errors))
@@ -529,7 +581,9 @@ def fetch_dashboard(url: str, api_token: str, uid: str) -> dict[str, Any]:
         with urllib.request.urlopen(request) as response:
             payload = json.load(response)
     except urllib.error.HTTPError as exc:
-        raise RuntimeError(f"failed to fetch dashboard {uid}: {exc.read().decode('utf-8', 'replace')}") from exc
+        raise RuntimeError(
+            f"failed to fetch dashboard {uid}: {exc.read().decode('utf-8', 'replace')}"
+        ) from exc
     if not isinstance(payload, dict) or "dashboard" not in payload:
         raise RuntimeError(f"unexpected dashboard response for {uid}")
     dashboard = payload["dashboard"]
@@ -573,7 +627,9 @@ def publish_dashboard(grafana_url: str, api_token: str) -> None:
         with urllib.request.urlopen(request) as response:
             result = json.load(response)
     except urllib.error.HTTPError as exc:
-        raise RuntimeError(f"failed to publish dashboard {uid}: {exc.read().decode('utf-8', 'replace')}") from exc
+        raise RuntimeError(
+            f"failed to publish dashboard {uid}: {exc.read().decode('utf-8', 'replace')}"
+        ) from exc
 
     print(json.dumps(result, indent=2, sort_keys=True))
 
@@ -582,13 +638,20 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    subparsers.add_parser("validate", help="Validate the dashboard code and generated JSON")
+    subparsers.add_parser(
+        "validate", help="Validate the dashboard code and generated JSON"
+    )
 
-    publish_parser = subparsers.add_parser("publish", help="Publish the generated dashboard to Grafana")
-    publish_parser.add_argument("--grafana-url", default=os.environ.get("GRAFANA_URL", DEFAULT_GRAFANA_URL))
+    publish_parser = subparsers.add_parser(
+        "publish", help="Publish the generated dashboard to Grafana"
+    )
+    publish_parser.add_argument(
+        "--grafana-url", default=os.environ.get("GRAFANA_URL", DEFAULT_GRAFANA_URL)
+    )
     publish_parser.add_argument(
         "--api-token",
-        default=os.environ.get("GRAFANA_SERVICE_ACCOUNT_TOKEN") or os.environ.get("GRAFANA_API_TOKEN"),
+        default=os.environ.get("GRAFANA_SERVICE_ACCOUNT_TOKEN")
+        or os.environ.get("GRAFANA_API_TOKEN"),
     )
 
     return parser

--- a/tools/tests/test_grafana_dashboard.py
+++ b/tools/tests/test_grafana_dashboard.py
@@ -44,10 +44,16 @@ def test_dashboard_json_contains_expected_sdk_fields() -> None:
     assert panels[7]["targets"][0]["queryType"] == "range"
     assert panels[8]["targets"][0]["queryType"] == "traceql"
     assert panels[8]["targets"][0]["limit"] == 30
-    assert panels[8]["targets"][0]["query"] == '{trace:rootService="glaze" && (duration > 500ms || status=error)}'
+    assert (
+        panels[8]["targets"][0]["query"]
+        == '{trace:rootService="glaze" && (duration > 500ms || status=error)}'
+    )
 
     assert panels[13]["transformations"][0]["id"] == "filterFieldsByName"
-    assert panels[13]["transformations"][1]["options"]["renameByName"]["remaining"] == "Headroom"
+    assert (
+        panels[13]["transformations"][1]["options"]["renameByName"]["remaining"]
+        == "Headroom"
+    )
 
 
 def test_publish_dashboard_uses_generated_dashboard_and_live_metadata(
@@ -101,7 +107,12 @@ def test_publish_dashboard_uses_generated_dashboard_and_live_metadata(
     assert published["title"] == "Glaze Application Observability"
     assert published["uid"] == "glaze-app-summary"
     published_panels = _panel_map(published)
-    assert published_panels[13]["transformations"][1]["options"]["renameByName"]["remaining"] == "Headroom"
+    assert (
+        published_panels[13]["transformations"][1]["options"]["renameByName"][
+            "remaining"
+        ]
+        == "Headroom"
+    )
 
 
 def test_main_validate_prints_ok(capsys: pytest.CaptureFixture[str]) -> None:

--- a/web/src/components/ImageUploader.tsx
+++ b/web/src/components/ImageUploader.tsx
@@ -169,6 +169,8 @@ export default function ImageUploader({
             cloudinary_public_id: result.info.public_id,
             cloud_name: config.cloud_name,
             crop: null,
+            width: result.info.width ?? null,
+            height: result.info.height ?? null,
           });
         },
       },

--- a/web/src/components/__tests__/WorkflowState.test.tsx
+++ b/web/src/components/__tests__/WorkflowState.test.tsx
@@ -275,19 +275,21 @@ function setScreenWidth(width: number) {
 // Helper to simulate a successful Cloudinary Upload Widget upload.
 // The widget fires display-changed (shown) then success when open() is called.
 function setupUploadWidget(
-  overrides: { secure_url?: string; public_id?: string } = {},
+  overrides: { secure_url?: string; public_id?: string; width?: number; height?: number } = {},
 ) {
   const secure_url =
     overrides.secure_url ??
     "https://res.cloudinary.com/demo/image/upload/sample.jpg";
   const public_id = overrides.public_id ?? "sample";
+  const width = overrides.width ?? 1200;
+  const height = overrides.height ?? 900;
   window.cloudinary = {
     createUploadWidget: vi.fn((_options, callback) => ({
       open: vi.fn(() => {
         callback(null, { event: "display-changed", info: { state: "shown" } });
         callback(null, {
           event: "success",
-          info: { secure_url, public_id, resource_type: "image" },
+          info: { secure_url, public_id, resource_type: "image", width, height },
         });
       }),
       close: noop,
@@ -886,6 +888,8 @@ describe("WorkflowState", () => {
     setupUploadWidget({
       secure_url: "https://res.cloudinary.com/demo/image/upload/sample.jpg",
       public_id: "sample",
+      width: 1200,
+      height: 900,
     });
     render(<WorkflowState {...defaultProps} />);
     fireEvent.click(screen.getByRole("button", { name: "Upload Image" }));
@@ -898,6 +902,8 @@ describe("WorkflowState", () => {
               url: "https://res.cloudinary.com/demo/image/upload/sample.jpg",
               cloudinary_public_id: "sample",
               crop: null,
+              width: 1200,
+              height: 900,
             }),
           ]),
         }),

--- a/web/src/components/workflowStateDraft.ts
+++ b/web/src/components/workflowStateDraft.ts
@@ -10,6 +10,8 @@ export type ImageEntry = {
   cloudinary_public_id?: string | null;
   cloud_name?: string | null;
   crop?: ImageCrop | null;
+  width?: number | null;
+  height?: number | null;
 };
 
 type CustomFieldInputMap = Record<string, string>;
@@ -142,6 +144,8 @@ function stateImages(pieceState: PieceState): ImageEntry[] {
     cloudinary_public_id: img.cloudinary_public_id ?? null,
     cloud_name: img.cloud_name ?? null,
     crop: img.crop ?? null,
+    width: img.width ?? null,
+    height: img.height ?? null,
   }));
 }
 


### PR DESCRIPTION
## Problem
Images created via the web application's upload flow lack `width` and `height` dimensions in the database (they are stored as `null`). This causes downstream layout and rendering issues that expect image metadata to be fully populated.
Closes https://github.com/shaoster/glaze/issues/865

## Fix
- **Backend:** Declared `width` and `height` fields in `CaptionedImageSerializer` so DRF does not strip them from requests and serializes them in responses.
- **Frontend:**
  - Updated `ImageEntry` type and `stateImages` mapping to include `width` and `height`.
  - Updated `ImageUploader` to forward `width` and `height` from the Cloudinary upload widget callback `result.info`.

## Regression Test
- Added `test_create_records_images_with_dimensions` in `api/tests/test_piece_states.py` to assert that image `width` and `height` dimensions sent to the backend are preserved in the DB and returned in the API payload.
- Updated `successful widget upload` test in `web/src/components/__tests__/WorkflowState.test.tsx` to assert that `width` and `height` are passed to `api.updateCurrentState`.

## Verification
- Ran backend regression tests: `rtk bazel test //api:api_test` (passed)
- Ran frontend test suite: `rtk bazel test //web:web_test` (passed)
- Checked typecheck and web lint: `rtk bazel build --config=lint //web/...` (passed)

Closes #865
