### PR TITLE
fix(infra): resolve Traefik GOMEMLIMIT strategic patch collision

### DIFF
--- a/infra/k3s/traefik.yaml
+++ b/infra/k3s/traefik.yaml
@@ -20,12 +20,11 @@ spec:
     env:
       - name: GOGC
         value: "25"
-      - name: GOMEMLIMIT
-        value: "60MiB"
     deployment:
       podAnnotations:
         prometheus.io/port: "8082"
         prometheus.io/scrape: "true"
+      goMemLimitPercentage: 0.75
     providers:
       kubernetesIngress:
         publishedService:


### PR DESCRIPTION
Resolves the issue where Tailscale ingress routing to admin.potterdoc.com was dropped. The manual GOMEMLIMIT override conflicted with the Helm chart's auto-generated GOMEMLIMIT, causing the Traefik deployment upgrade to fail. Replaced with goMemLimitPercentage: 0.75 to achieve GOMEMLIMIT=60MiB safely.