### PR TITLE
fix: pre-seed masonry positioner for pieces without crops

### DIFF
--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -539,12 +539,10 @@ const PieceList = (props: PieceListProps) => {
     );
 
     filteredPieces.forEach((piece, index) => {
-      if (piece.thumbnail?.crop) {
-        nextPositioner.set(
-          index,
-          getPieceCardLayout(piece, nextPositioner.columnWidth).estimatedHeight,
-        );
-      }
+      nextPositioner.set(
+        index,
+        getPieceCardLayout(piece, nextPositioner.columnWidth).estimatedHeight,
+      );
     });
 
     return nextPositioner;

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -291,11 +291,14 @@ describe("PieceList", () => {
       expect(mockPositioner.set).toHaveBeenCalled();
     });
 
-    it("does not pre-seed the positioner for pieces without a crop", () => {
+    it("pre-seeds the positioner for pieces without a crop using fallback height", () => {
       const piece = makePiece({ thumbnail: null });
       renderPieceList([piece]);
       expect(mockPositioner.update).not.toHaveBeenCalled();
-      expect(mockPositioner.set).not.toHaveBeenCalled();
+      expect(mockPositioner.set).toHaveBeenCalledWith(
+        0,
+        estimateCardHeight(piece, mockPositioner.columnWidth),
+      );
     });
 
     it("applies the tall crop height before the first masonry pass", async () => {
@@ -612,12 +615,12 @@ describe("PieceList", () => {
           CARD_CHROME_HEIGHT;
         expect(mockPositioner.set).toHaveBeenCalledWith(1, naiveHeight);
 
-        // pieces[2]: no crop → not seeded; exactly 2 set() calls total
-        expect(mockPositioner.set).not.toHaveBeenCalledWith(
-          2,
-          expect.anything(),
-        );
-        expect(mockPositioner.set).toHaveBeenCalledTimes(2);
+        // pieces[2]: no crop -> seeded with 4:3 fallback; exactly 3 set() calls total
+        const fallbackHeight =
+          Math.round((mockPositioner.columnWidth * 3) / 4) +
+          CARD_CHROME_HEIGHT;
+        expect(mockPositioner.set).toHaveBeenCalledWith(2, fallbackHeight);
+        expect(mockPositioner.set).toHaveBeenCalledTimes(3);
       });
 
       // The true-pixel height for pieces[0] must differ from the naive height


### PR DESCRIPTION
## Problem
Newly created pieces without image thumbnails (i.e., only the default `.svg` thumbnail) do not show up in the `PieceList` page's masonry layout, even though they appear in the Django admin and the backend API response.

## Fix
In `PieceList.tsx`, calling `positioner.set` on only some indices while leaving others unset causes sequential layout positioning to break because Masonic has no access to the `itemHeightEstimate` inside the positioner itself. Consequently, unset items are computed with height `0`, causing overlaps and rendering them invisible.
We resolved this by removing the guard `if (piece.thumbnail?.crop)` so that `positioner.set` is called for every single item sequentially. For pieces without a crop, it falls back to the default 4:3 aspect ratio height calculation.

## Regression Test
Added/updated tests in `web/src/components/__tests__/PieceList.test.tsx`:
- `pre-seeds the positioner for pieces without a crop using fallback height`
- `seeded heights match estimated heights for all card types`

These tests verify that the positioner is indeed seeded with the correct estimated or fallback height for all pieces (with or without crops).

## Verification
Ran all frontend and backend tests and linters successfully:
- `rtk bazel test //web:web_piece_list_test` (PASSED)
- `rtk bazel test //...` (PASSED)
- `rtk bazel build --config=lint //...` (PASSED)
- `gz_format` (PASSED)
