### PR TITLE
fix: exclude django-helpdesk from openapi schema generation

### DIFF
--- a/api/tests/test_health.py
+++ b/api/tests/test_health.py
@@ -65,3 +65,12 @@ class TestHealthReady:
         request = rf.get("/api/health/ready/", HTTP_X_FORWARDED_HOST="159.223.154.68")
         response = health_ready(request)
         assert response.status_code == 200
+
+    def test_openapi_schema_contains_only_api_endpoints(self):
+        from drf_spectacular.generators import SchemaGenerator
+
+        generator = SchemaGenerator()
+        schema = generator.get_schema(request=None, public=True)
+        assert len(schema["paths"]) > 0
+        for path in schema["paths"].keys():
+            assert path.startswith("/api/")

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -148,6 +148,15 @@ SIMPLE_JWT = {
     "AUTH_HEADER_TYPES": ("Bearer",),
 }
 
+
+def openapi_preprocessing_filter_spec(endpoints):
+    filtered = []
+    for path, path_regex, method, callback in endpoints:
+        if path.startswith("/api/"):
+            filtered.append((path, path_regex, method, callback))
+    return filtered
+
+
 SPECTACULAR_SETTINGS = {
     "TITLE": "PotterDoc API",
     "DESCRIPTION": (
@@ -181,7 +190,9 @@ SPECTACULAR_SETTINGS = {
             },
         }
     },
+    "PREPROCESSING_HOOKS": ["backend.settings.openapi_preprocessing_filter_spec"],
 }
+
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",

--- a/backend/test_settings.py
+++ b/backend/test_settings.py
@@ -127,6 +127,15 @@ SIMPLE_JWT = {
     "AUTH_HEADER_TYPES": ("Bearer",),
 }
 
+
+def openapi_preprocessing_filter_spec(endpoints):
+    filtered = []
+    for path, path_regex, method, callback in endpoints:
+        if path.startswith("/api/"):
+            filtered.append((path, path_regex, method, callback))
+    return filtered
+
+
 SPECTACULAR_SETTINGS = {
     "TITLE": "PotterDoc API",
     "DESCRIPTION": (
@@ -160,7 +169,9 @@ SPECTACULAR_SETTINGS = {
             },
         }
     },
+    "PREPROCESSING_HOOKS": ["backend.test_settings.openapi_preprocessing_filter_spec"],
 }
+
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",


### PR DESCRIPTION
## Problem
During OpenAPI schema generation, the `django-helpdesk` endpoints generate exceptions and warnings because they are executed against an unmigrated database and lack rest-framework attributes for guessing serializers. See #868 for details.

## Fix
Defined and registered `openapi_preprocessing_filter_spec` hook in both `backend/settings.py` and `backend/test_settings.py` to filter out any endpoints not starting with `/api/`, which successfully excludes `/support/` (helpdesk) endpoints.

## Regression Test
Added `test_openapi_schema_contains_only_api_endpoints` in [test_health.py](file:///home/phil/code/glaze/api/tests/test_health.py) to assert that schema generation succeeds and all paths in the generated schema start with `/api/`.

## Verification
- Clean OpenAPI schema target builds successfully:
  ```bash
  rtk bazel build //web:openapi_schema
  ```
- Regression test and full API health tests pass:
  ```bash
  rtk bazel test //api:api_health_test
  ```
- All workspace checks and linters pass:
  ```bash
  rtk bazel build --config=lint //...
  ```

Closes #868
