### PR TITLE
fix: fallback to 1:1 aspect ratio for default/local SVG thumbnails

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -292,7 +292,7 @@
         "bzlTransitiveDigest": "3GB+HVbmUfi1gaE0kWIzYPstolh7vaSq+4B96AikLiA=",
         "usagesDigest": "ZXxKBmt+bDvqYeAjgAl/x/xI/QLW5EbehLOG2a9mYMM=",
         "recordedFileInputs": {
-          "@@//web/package.json": "845ec1905352bdfe23cdd68924fd24e7d2f143b165d14b202b5d12fc47de0d20"
+          "@@//web/package.json": "93ddacf4abc004e1153246bb32bd2bdbcb0ae3328935388b22d54ff60bce9396"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -144,6 +144,7 @@ eslint_pkg.eslint(
     name = "eslint_run",
     srcs = [
         "eslint.config.js",
+        ":storybook_lib",
         ":web_lib",
         ":web_test_configs",
         ":web_test_files",
@@ -961,6 +962,7 @@ vitest_test(
     name = "web_piece_list_test",
     srcs = [
         "src/components/__tests__/PieceList.test.tsx",
+        "src/components/__tests__/pieceCardHeight.test.ts",
     ],
     tags = ["ibazel_notify_changes"],
     deps = [
@@ -968,6 +970,7 @@ vitest_test(
     ],
     expected_coverage = [
         "web/src/components/PieceList*",
+        "web/src/components/pieceCardHeight*",
     ],
 )
 

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -1,7 +1,7 @@
 import type React from "react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createMemoryRouter, RouterProvider } from "react-router-dom";
 import PieceList from "../PieceList";
@@ -23,6 +23,7 @@ vi.mock("../CloudinaryImage", () => ({
     style,
     url,
     alt,
+    onLoad,
   }: {
     crop?: unknown;
     requestedHeight?: number;
@@ -30,6 +31,7 @@ vi.mock("../CloudinaryImage", () => ({
     style?: React.CSSProperties;
     url: string;
     alt?: string;
+    onLoad?: React.ReactEventHandler<HTMLImageElement>;
   }) => (
     <img
       src={url}
@@ -38,6 +40,7 @@ vi.mock("../CloudinaryImage", () => ({
       data-requested-height={requestedHeight}
       data-requested-width={requestedWidth}
       style={style}
+      onLoad={onLoad}
     />
   ),
 }));
@@ -84,6 +87,37 @@ vi.mock("masonic", () => ({
     const [, forceRender] = useState(0);
     rerenderMasonryScroller = () => forceRender((value) => value + 1);
 
+    const [measuredHeights, setMeasuredHeights] = useState<Map<number, number>>(new Map());
+
+    useEffect(() => {
+      const handleScroll = () => {
+        const nextMeasured = new Map<number, number>();
+        items.forEach((item, index) => {
+          const key = itemKey ? itemKey(item, index) : index;
+          const element = document.querySelector(`[data-key="${key}"]`);
+          if (element) {
+            const thumbnailShell = element.querySelector('[data-testid="piece-thumbnail-shell"]');
+            if (thumbnailShell) {
+              const style = window.getComputedStyle(thumbnailShell);
+              const aspectRatioStr = style.aspectRatio;
+              if (aspectRatioStr) {
+                const parts = aspectRatioStr.split("/").map(Number);
+                if (parts.length === 2 && parts[0] > 0 && parts[1] > 0) {
+                  const ratio = parts[0] / parts[1];
+                  const actualHeight = Math.round(positioner.columnWidth / ratio) + CARD_CHROME_HEIGHT;
+                  nextMeasured.set(index, actualHeight);
+                  positioner.set(index, actualHeight);
+                }
+              }
+            }
+          }
+        });
+        setMeasuredHeights(nextMeasured);
+      };
+      window.addEventListener("scroll", handleScroll);
+      return () => window.removeEventListener("scroll", handleScroll);
+    }, [items, positioner, itemKey]);
+
     return (
       <div data-testid="piece-grid" style={{ position: "relative" }}>
         {(() => {
@@ -106,7 +140,7 @@ vi.mock("masonic", () => ({
           ]);
 
           return items.map((item, index) => {
-            const height = seededHeights.get(index) ?? itemHeightEstimate;
+            const height = measuredHeights.get(index) ?? seededHeights.get(index) ?? itemHeightEstimate;
             const column = columnHeights.indexOf(Math.min(...columnHeights));
             const top = columnHeights[column];
             const left = column * (columnWidth + gutter);
@@ -374,12 +408,21 @@ describe("PieceList", () => {
       });
     });
 
-    it("falls back to 4/3 aspect ratio on the thumbnail shell for pieces without a crop", () => {
+    it("falls back to 4/3 aspect ratio on the thumbnail shell for Cloudinary pieces without a crop", () => {
       // Without this fallback the shell collapses to zero height while
       // CloudinaryImage loads (opacity:0, no intrinsic size), causing masonic
       // to measure the card as chrome-only height and place the next card too
       // close, resulting in visible overlap once the image loads.
-      renderPieceList([makePiece({ thumbnail: null })]);
+      renderPieceList([
+        makePiece({
+          thumbnail: {
+            url: "https://res.cloudinary.com/demo/image/upload/sample.jpg",
+            cloudinary_public_id: "sample",
+            cloud_name: "demo",
+            crop: null,
+          },
+        }),
+      ]);
       expect(screen.getByTestId("piece-thumbnail-shell")).toHaveStyle({
         aspectRatio: `${DEFAULT_THUMBNAIL_ASPECT_WIDTH} / ${DEFAULT_THUMBNAIL_ASPECT_HEIGHT}`,
       });
@@ -388,20 +431,18 @@ describe("PieceList", () => {
     it("passes requestedHeight matching the 4/3 fallback to CloudinaryImage for pieces without a crop", () => {
       // The Cloudinary fill request must match the shell aspect ratio so the
       // delivered image fills the container without driving reflow after load.
-      const { container } = renderPieceList([
-        makePiece({
-          thumbnail: {
-            url: "https://example.com/img.jpg",
-            cloudinary_public_id: "pieces/nocrop",
-            cloud_name: "demo",
-            crop: null,
-          },
-        }),
-      ]);
+      const piece = makePiece({
+        thumbnail: {
+          url: "https://example.com/img.jpg",
+          cloudinary_public_id: "pieces/nocrop",
+          cloud_name: "demo",
+          crop: null,
+        },
+      });
+      const { container } = renderPieceList([piece]);
       const image = container.querySelector("img")!;
       const rw = Number(image.getAttribute("data-requested-width"));
       const rh = Number(image.getAttribute("data-requested-height"));
-      const piece = { thumbnail: { crop: null } } as PieceSummary;
       expect(rh).toBe(getThumbnailRequestedHeight(piece, rw));
     });
 
@@ -473,20 +514,20 @@ describe("PieceList", () => {
       );
     }
 
-    it("falls back to 4:3 aspect ratio height when thumbnail is null", () => {
+    it("falls back to 1:1 aspect ratio height when thumbnail is null", () => {
       expect(estimateCardHeight({ thumbnail: null } as PieceSummary, 160)).toBe(
-        fallbackAt(160),
+        160 + CARD_CHROME_HEIGHT,
       );
     });
 
     it("falls back to 4:3 aspect ratio height when crop is null", () => {
       expect(
-        estimateCardHeight({ thumbnail: { crop: null } } as PieceSummary, 160),
+        estimateCardHeight({ thumbnail: { url: "https://example.com/img.jpg", crop: null } } as PieceSummary, 160),
       ).toBe(fallbackAt(160));
     });
 
     it("falls back to 4:3 aspect ratio height when crop is absent", () => {
-      expect(estimateCardHeight({ thumbnail: {} } as PieceSummary, 160)).toBe(
+      expect(estimateCardHeight({ thumbnail: { url: "https://example.com/img.jpg" } } as PieceSummary, 160)).toBe(
         fallbackAt(160),
       );
     });
@@ -513,7 +554,7 @@ describe("PieceList", () => {
 
     it("falls back to 4:3 aspect ratio height when crop.width is 0 (guard against division by zero)", () => {
       const piece = {
-        thumbnail: { crop: { x: 0, y: 0, width: 0, height: 200 } },
+        thumbnail: { url: "https://example.com/img.jpg", crop: { x: 0, y: 0, width: 0, height: 200 } },
       } as PieceSummary;
       expect(estimateCardHeight(piece, 160)).toBe(fallbackAt(160));
     });
@@ -615,10 +656,8 @@ describe("PieceList", () => {
           CARD_CHROME_HEIGHT;
         expect(mockPositioner.set).toHaveBeenCalledWith(1, naiveHeight);
 
-        // pieces[2]: no crop -> seeded with 4:3 fallback; exactly 3 set() calls total
-        const fallbackHeight =
-          Math.round((mockPositioner.columnWidth * 3) / 4) +
-          CARD_CHROME_HEIGHT;
+        // pieces[2]: no crop -> seeded with 1:1 fallback for local thumbnail; exactly 3 set() calls total
+        const fallbackHeight = mockPositioner.columnWidth + CARD_CHROME_HEIGHT;
         expect(mockPositioner.set).toHaveBeenCalledWith(2, fallbackHeight);
         expect(mockPositioner.set).toHaveBeenCalledTimes(3);
       });
@@ -1261,6 +1300,37 @@ describe("PieceList", () => {
       render(<RouterProvider router={router} />);
       await new Promise<void>((resolve) => setTimeout(resolve, 50));
       expect(onLoadMore).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("layout stability with default thumbnails", () => {
+    it("keeps layout stable for default SVG thumbnails upon loading and scrolling", () => {
+      const pieces = Array.from({ length: 9 }, (_, i) =>
+        makePiece({
+          id: `aaaaaaaa-0000-0000-0000-00000000000${i + 1}`,
+          thumbnail: null,
+        }),
+      );
+
+      const { container } = renderPieceList(pieces);
+
+      const grid = screen.getByTestId("piece-grid");
+      const cardsBefore = Array.from(grid.children) as HTMLDivElement[];
+      const topsBefore = cardsBefore.map((c) => c.getAttribute("data-top"));
+
+      const images = container.querySelectorAll("img");
+      images.forEach((img) => {
+        Object.defineProperty(img, "naturalWidth", { value: 100, configurable: true });
+        Object.defineProperty(img, "naturalHeight", { value: 100, configurable: true });
+        fireEvent.load(img);
+      });
+
+      fireEvent.scroll(window);
+
+      const cardsAfter = Array.from(grid.children) as HTMLDivElement[];
+      const topsAfter = cardsAfter.map((c) => c.getAttribute("data-top"));
+
+      expect(topsAfter).toEqual(topsBefore);
     });
   });
 });

--- a/web/src/components/__tests__/pieceCardHeight.test.ts
+++ b/web/src/components/__tests__/pieceCardHeight.test.ts
@@ -89,8 +89,20 @@ describe("getPieceCardLayout", () => {
     });
   });
 
-  it("falls back to the 4:3 shell and Cloudinary request when there is no crop", () => {
+  it("falls back to the 1:1 shell for local thumbnails (including null/default)", () => {
     const piece = makePiece({ thumbnail: null });
+
+    const layout = getPieceCardLayout(piece, 240);
+
+    expect(layout).toEqual({
+      thumbnailAspectRatio: "1 / 1",
+      estimatedHeight: 240 + CARD_CHROME_HEIGHT,
+      requestedHeight: undefined,
+    });
+  });
+
+  it("falls back to 4:3 for non-cloudinary image without dimensions and without crop", () => {
+    const piece = makePiece(); // non-cloudinary, url only, no dimensions
 
     const layout = getPieceCardLayout(piece, 240);
 
@@ -105,6 +117,26 @@ describe("getPieceCardLayout", () => {
         (240 * DEFAULT_THUMBNAIL_ASPECT_HEIGHT) /
           DEFAULT_THUMBNAIL_ASPECT_WIDTH,
       ),
+    });
+  });
+
+  it("uses original dimensions for non-cloudinary thumbnail without crop", () => {
+    const piece = makePiece({
+      thumbnail: {
+        url: "https://example.com/img.jpg",
+        cloudinary_public_id: null,
+        cloud_name: null,
+        width: 600,
+        height: 800,
+      },
+    });
+
+    const layout = getPieceCardLayout(piece, 220);
+
+    expect(layout).toEqual({
+      thumbnailAspectRatio: "600 / 800",
+      estimatedHeight: Math.round((220 * 800) / 600) + CARD_CHROME_HEIGHT,
+      requestedHeight: undefined,
     });
   });
 });

--- a/web/src/components/pieceCardHeight.ts
+++ b/web/src/components/pieceCardHeight.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_THUMBNAIL } from "./thumbnailConstants";
 import type { PieceSummary } from "../util/types";
 
 // Border, body padding, title, activity caption, and the tag row all live
@@ -22,11 +23,15 @@ export interface PieceCardLayout {
 }
 
 function getThumbnailMetrics(piece: PieceSummary) {
-  const crop = piece.thumbnail?.crop;
-  const origW = piece.thumbnail?.width;
-  const origH = piece.thumbnail?.height;
+  const thumbnail = piece.thumbnail;
+  const url = thumbnail?.url ?? DEFAULT_THUMBNAIL;
+  const crop = thumbnail?.crop;
+  const origW = thumbnail?.width;
+  const origH = thumbnail?.height;
   const hasCrop = !!(crop && crop.width > 0 && crop.height > 0);
   const hasOriginalDimensions = !!(origW && origH);
+  const isLocal = url.startsWith("/thumbnails/");
+  const isCloudinary = !!(thumbnail?.cloudinary_public_id && thumbnail?.cloud_name);
 
   if (hasCrop && crop) {
     return {
@@ -35,6 +40,20 @@ function getThumbnailMetrics(piece: PieceSummary) {
       aspectRatio: hasOriginalDimensions
         ? `${crop.width * origW} / ${crop.height * origH}`
         : `${crop.width} / ${crop.height}`,
+    } as const;
+  }
+
+  if (isLocal) {
+    return {
+      hasCrop: false,
+      aspectRatio: "1 / 1",
+    } as const;
+  }
+
+  if (!isCloudinary && hasOriginalDimensions) {
+    return {
+      hasCrop: false,
+      aspectRatio: `${origW} / ${origH}`,
     } as const;
   }
 
@@ -68,6 +87,29 @@ export function getPieceCardLayout(
             ) + CARD_CHROME_HEIGHT
           : Math.round((columnWidth * crop.height) / crop.width) +
             CARD_CHROME_HEIGHT,
+    };
+  }
+
+  const url = piece.thumbnail?.url ?? DEFAULT_THUMBNAIL;
+  const isLocal = url.startsWith("/thumbnails/");
+  if (isLocal) {
+    return {
+      thumbnailAspectRatio: thumbnail.aspectRatio,
+      estimatedHeight: columnWidth + CARD_CHROME_HEIGHT,
+    };
+  }
+
+  const isCloudinary = !!(
+    piece.thumbnail?.cloudinary_public_id && piece.thumbnail?.cloud_name
+  );
+  const origW = piece.thumbnail?.width;
+  const origH = piece.thumbnail?.height;
+
+  if (!isCloudinary && origW && origH) {
+    return {
+      thumbnailAspectRatio: thumbnail.aspectRatio,
+      estimatedHeight:
+        Math.round((columnWidth * origH) / origW) + CARD_CHROME_HEIGHT,
     };
   }
 


### PR DESCRIPTION
This PR resolves the masonry layout overlapping and reflow issues for newly created pieces that use default local SVG thumbnails (which do not have a saved/native resolution).

### Problem
When pieces are created, they start with a `null` thumbnail which displays a default local SVG thumbnail. These local SVGs have a `1:1` aspect ratio (`viewBox="0 0 100 100"`), but our layout estimator was falling back to a `4:3` default aspect ratio (which is only suitable for Cloudinary-filled images). Consequently, the Masonry positioner pre-estimated the card heights assuming a 4:3 image, but when the browser rendered them as 1:1 square images, the actual card height exceeded the estimate, leading to overlaps and reflows during scroll events.

### Solution
1. Modified [pieceCardHeight.ts](file:///home/phil/code/glaze/web/src/components/pieceCardHeight.ts) to evaluate local/default thumbnails (starting with `/thumbnails/` or when thumbnail is null) with a `1:1` aspect ratio.
2. Estimated heights for other non-Cloudinary external images without crops using their original dimensions (`origW / origH`), if available.
3. Updated the tests in [pieceCardHeight.test.ts](file:///home/phil/code/glaze/web/src/components/__tests__/pieceCardHeight.test.ts) to verify this new estimation logic.
4. Updated [PieceList.test.tsx](file:///home/phil/code/glaze/web/src/components/__tests__/PieceList.test.tsx) to add a regression test ensuring layout stability for default SVG thumbnails when loaded and scrolled.
5. Fixed the ESLint sandboxing build issue in [web/BUILD.bazel](file:///home/phil/code/glaze/web/BUILD.bazel) by adding `:storybook_lib` to the `srcs` of `eslint_run`, resolving errors about missing story files.

Closes [issue #871](https://github.com/shaoster/glaze/issues/871)
