### PR TITLE
chore: further pare down metrics sent to Grafana

### DIFF
--- a/chart/glaze/templates/configmap.yaml
+++ b/chart/glaze/templates/configmap.yaml
@@ -14,19 +14,6 @@ data:
           http:
             endpoint: 0.0.0.0:4318
 
-      postgresql:
-        endpoint: {{ include "glaze.fullname" . }}-postgres:5432
-        username: {{ .Values.postgres.user }}
-        password: ${env:POSTGRES_PASSWORD}
-        databases: [{{ .Values.postgres.database }}]
-        collection_interval: 30s
-        tls:
-          insecure: true
-
-      redis:
-        endpoint: {{ include "glaze.fullname" . }}-redis:6379
-        collection_interval: 30s
-
     extensions:
       basicauth/grafana_cloud:
         client_auth:
@@ -49,7 +36,7 @@ data:
           receivers: [otlp]
           exporters: [otlphttp/grafana_cloud]
         metrics:
-          receivers: [otlp, postgresql, redis]
+          receivers: [otlp]
           exporters: [otlphttp/grafana_cloud]
 ---
 apiVersion: v1

--- a/infra/k3s/alloy-configmap.yaml
+++ b/infra/k3s/alloy-configmap.yaml
@@ -26,39 +26,13 @@ data:
     prometheus.relabel "cadvisor" {
       rule {
         source_labels = ["__name__"]
-        regex         = "container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_memory_swap|machine_memory_bytes|machine_swap_bytes"
+        regex         = "container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_memory_swap|machine_memory_bytes|machine_swap_bytes|machine_cpu_cores"
         action        = "keep"
       }
       // Drop per-machine UUID labels that Grafana Cloud rejects as high-cardinality identifiers.
       rule {
         regex  = "boot_id|machine_id|system_uuid"
         action = "labeldrop"
-      }
-      forward_to = [prometheus.remote_write.grafana_cloud.receiver]
-    }
-
-    // Node metrics via kubelet summary API (CPU, memory, disk, network)
-    prometheus.scrape "kubelet" {
-      targets = [{
-        __address__ = sys.env("NODE_IP") + ":10250",
-        __scheme__  = "https",
-      }]
-      bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-      tls_config {
-        insecure_skip_verify = true
-      }
-      metrics_path    = "/metrics"
-      scrape_interval = "60s"
-      forward_to      = [prometheus.relabel.kubelet.receiver]
-    }
-
-    // Drop k3s API server metrics — these are control-plane internals that push
-    // the Grafana Cloud free-tier series limit (15k) when mixed with cadvisor.
-    prometheus.relabel "kubelet" {
-      rule {
-        source_labels = ["__name__"]
-        regex         = "apiserver_.*"
-        action        = "drop"
       }
       forward_to = [prometheus.remote_write.grafana_cloud.receiver]
     }

--- a/otel-collector-config.yml
+++ b/otel-collector-config.yml
@@ -6,23 +6,6 @@ receivers:
       http:
         endpoint: 0.0.0.0:4318
 
-  postgresql:
-    endpoint: db:5432
-    username: glaze
-    password: ${env:POSTGRES_PASSWORD}
-    databases: [glaze]
-    collection_interval: 30s
-    tls:
-      insecure: true
-
-  redis:
-    endpoint: redis:6379
-    collection_interval: 30s
-
-  nginx:
-    endpoint: http://nginx/nginx_status
-    collection_interval: 30s
-
 extensions:
   basicauth/grafana_cloud:
     client_auth:
@@ -45,5 +28,5 @@ service:
       receivers: [otlp]
       exporters: [otlphttp/grafana_cloud]
     metrics:
-      receivers: [otlp, postgresql, redis, nginx]
+      receivers: [otlp]
       exporters: [otlphttp/grafana_cloud]


### PR DESCRIPTION
This PR pares down the metrics sent to Grafana Cloud to help fit within the 15k series limit, while fixing the CPU Utilization panel.

### Changes:

• Remove PostgreSQL, Redis, and NGINX metrics:
  • Removed these receivers and excluded them from the metrics pipeline in `otel-collector-config.yml`.
  • Removed postgresql and redis receivers and metrics from `chart/glaze/templates/configmap.yaml`.
  • None of these metrics are queried by the dashboard, making them completely redundant.
• Remove Kubelet Summary scrape:
  • Removed the unused `kubelet` `/metrics` scrape target and its relabel rules in `infra/k3s/alloy-configmap.yaml`. None of the dashboard panels query these metrics, saving thousands of series.
• Fix CPU Utilization panel:
  • Added `machine_cpu_cores` to the kept cadvisor metrics whitelist in `infra/k3s/alloy-configmap.yaml`. The CPU Utilization panel divides by this metric, and it was previously being dropped by the relabel rule.

### Verification:

• Ran full test suite successfully in the worktree (`rtk bazel test //...`).
• Ran all linters successfully (`rtk bazel build --config=lint //...`).
