### PR TITLE
optimize: drop unused HTTP size and OTel SDK metrics

### DIFF
--- a/api/tests/test_otel.py
+++ b/api/tests/test_otel.py
@@ -228,3 +228,33 @@ def test_configure_otel_returns_false_when_disabled(monkeypatch):
     monkeypatch.delenv("OTEL_ENABLED", raising=False)
     importlib.reload(otel_mod)
     assert otel_mod.configure_otel() is False
+
+
+def test_configure_otel_registers_meter_provider_with_drop_views(monkeypatch):
+    import backend.otel as otel_mod
+
+    monkeypatch.setenv("OTEL_ENABLED", "1")
+    open_patch = _make_otel_mocks(monkeypatch)
+
+    with open_patch:
+        importlib.reload(otel_mod)
+        result = otel_mod.configure_otel()
+
+    assert result is True
+    from opentelemetry import metrics
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.view import DropAggregation
+
+    meter_provider = metrics.get_meter_provider()
+    assert isinstance(meter_provider, MeterProvider)
+
+    # Inspect views configured on the provider
+    views = meter_provider._sdk_config.views
+    instrument_names = {v._instrument_name for v in views if v._instrument_name}
+    assert "http.server.request.size" in instrument_names
+    assert "http.server.response.size" in instrument_names
+    assert "otel.sdk.*" in instrument_names
+
+    # Check that they have DropAggregation
+    drop_views = [v for v in views if isinstance(v._aggregation, DropAggregation)]
+    assert len(drop_views) >= 3

--- a/backend/otel.py
+++ b/backend/otel.py
@@ -123,7 +123,7 @@ def configure_otel() -> bool:
     )
     from opentelemetry.sdk.metrics import MeterProvider
     from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
-    from opentelemetry.sdk.metrics.view import View
+    from opentelemetry.sdk.metrics.view import DropAggregation, View
 
     metric_exporter = OTLPMetricExporter(
         endpoint=os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317"),
@@ -146,6 +146,16 @@ def configure_otel() -> bool:
             ),
             # Active-requests gauge is only queried as a scalar sum — no per-label breakdown needed.
             View(instrument_name="http.server.active_requests", attribute_keys=set()),
+            # Drop unused HTTP metrics and OTel SDK self-telemetry to save series quota.
+            View(
+                instrument_name="http.server.request.size",
+                aggregation=DropAggregation(),
+            ),
+            View(
+                instrument_name="http.server.response.size",
+                aggregation=DropAggregation(),
+            ),
+            View(instrument_name="otel.sdk.*", aggregation=DropAggregation()),
         ],
     )
     metrics.set_meter_provider(meter_provider)


### PR DESCRIPTION
This PR further pares down unused metrics at the application SDK level to free up series quota and reduce active series count by an additional ~100 series (from ~287 down to ~180).

### Changes:

• Configure `DropAggregation` Views in `backend/otel.py` to disable collection and export of the following unused metrics:
  • `http.server.request.size`
  • `http.server.response.size`
  • `otel.sdk.*` (all internal OpenTelemetry SDK metrics)
• Add unit tests in `api/tests/test_otel.py` to assert that these drop views are properly registered with the `MeterProvider`.

### Verification:

• All 64 tests passed successfully in the worktree (`bazel test //...`).
• All linters passed successfully (`bazel build --config=lint //...`).
