### PR TITLE
fix(storybook): add QueryClientProvider + smoke tests for all stories

### DIFF
--- a/web/.storybook/preview.tsx
+++ b/web/.storybook/preview.tsx
@@ -1,11 +1,9 @@
 import type { Preview } from "@storybook/react-vite";
-import CssBaseline from "@mui/material/CssBaseline";
-import { ThemeProvider, createTheme } from "@mui/material/styles";
 import React, { useLayoutEffect, useState } from "react";
 import { initialize, mswLoader } from "msw-storybook-addon";
-import { createMemoryRouter, RouterProvider } from "react-router-dom";
 import { themes } from "@storybook/theming";
 import { useGlobals } from "@storybook/preview-api";
+import { StorybookProviders } from "./providers";
 
 // Initialize MSW
 initialize({
@@ -14,28 +12,6 @@ initialize({
     url: window.location.pathname.startsWith("/glaze/storybook")
       ? "/glaze/storybook/mockServiceWorker.js"
       : "/mockServiceWorker.js",
-  },
-});
-
-const DARK_THEME = createTheme({
-  palette: {
-    mode: "dark",
-    primary: { main: "#c97a4d", light: "#d59a71", dark: "#8f5230" },
-    secondary: { main: "#8ca6a3" },
-    background: { default: "#211b19", paper: "#2a2321" },
-    text: { primary: "#f3ebe1", secondary: "#bbaea1" },
-    divider: "rgba(255, 245, 235, 0.09)",
-    success: { main: "#8eb89a" },
-    warning: { main: "#c97a4d" },
-  },
-  typography: {
-    fontFamily: [
-      "Manrope",
-      "Avenir Next",
-      "Segoe UI",
-      "Arial",
-      "sans-serif",
-    ].join(","),
   },
 });
 
@@ -140,14 +116,10 @@ const preview: Preview = {
 
       if (!viewportReady) return null;
 
-      const router = createMemoryRouter([{ path: "/", element: <Story /> }], {
-        initialEntries: ["/"],
-      });
       return (
-        <ThemeProvider theme={DARK_THEME}>
-          <CssBaseline />
-          <RouterProvider router={router} />
-        </ThemeProvider>
+        <StorybookProviders>
+          <Story />
+        </StorybookProviders>
       );
     },
   ],

--- a/web/.storybook/providers.tsx
+++ b/web/.storybook/providers.tsx
@@ -1,0 +1,60 @@
+/**
+ * Provider stack shared by preview.tsx (Storybook) and storybook-smoke.test.tsx (Vitest).
+ *
+ * Keeping providers in one place ensures the smoke tests exercise the same
+ * environment as the deployed Storybook. If a provider is added here it is
+ * automatically tested; if one is removed the smoke tests will catch it.
+ */
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import CssBaseline from "@mui/material/CssBaseline";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+
+// Stable QueryClient instance: safe across story renders in Storybook's iframe
+// and across tests in Vitest (each test file gets its own module scope).
+const queryClient = new QueryClient();
+
+export const DARK_THEME = createTheme({
+  palette: {
+    mode: "dark",
+    primary: { main: "#c97a4d", light: "#d59a71", dark: "#8f5230" },
+    secondary: { main: "#8ca6a3" },
+    background: { default: "#211b19", paper: "#2a2321" },
+    text: { primary: "#f3ebe1", secondary: "#bbaea1" },
+    divider: "rgba(255, 245, 235, 0.09)",
+    success: { main: "#8eb89a" },
+    warning: { main: "#c97a4d" },
+  },
+  typography: {
+    fontFamily: [
+      "Manrope",
+      "Avenir Next",
+      "Segoe UI",
+      "Arial",
+      "sans-serif",
+    ].join(","),
+  },
+});
+
+interface StorybookProvidersProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Wraps children with all providers required by Glaze's Storybook stories.
+ * Used by preview.tsx and storybook-smoke.test.tsx.
+ */
+export function StorybookProviders({ children }: StorybookProvidersProps) {
+  const router = createMemoryRouter([{ path: "/", element: <>{children}</> }], {
+    initialEntries: ["/"],
+  });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={DARK_THEME}>
+        <CssBaseline />
+        <RouterProvider router={router} />
+      </ThemeProvider>
+    </QueryClientProvider>
+  );
+}

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -1440,6 +1440,15 @@ vitest_test(
     ],
 )
 
+vitest_test(
+    name = "web_storybook_smoke_test",
+    srcs = ["src/stories/storybook-smoke.test.tsx"],
+    tags = ["ibazel_notify_changes"],
+    deps = [
+        ":storybook_lib",
+    ],
+)
+
 # ── Web test suite ────────────────────────────────────────────────────────────
 # Aggregate target: `bazel test //web:web_test` runs all web tests.
 # Individual targets above run only when their inputs change.
@@ -1447,6 +1456,7 @@ vitest_test(
 test_suite(
     name = "web_test",
     tests = [
+        ":web_storybook_smoke_test",
         ":web_admin_test",
         ":web_analysis_test",
         ":web_coverage_audit_test",

--- a/web/src/stories/storybook-smoke.test.tsx
+++ b/web/src/stories/storybook-smoke.test.tsx
@@ -2,101 +2,40 @@
  * Smoke tests: verify every Storybook story renders without triggering the
  * ErrorBoundary ("Something went wrong. Please reload the page.").
  *
+ * Uses import.meta.glob to auto-discover all *.stories.tsx files — new stories
+ * are picked up automatically without editing this file.
+ *
  * Imports StorybookProviders from .storybook/providers.tsx — the same module
  * used by preview.tsx — so that a missing provider in providers.tsx will
  * cause these tests to fail AND break the deployed Storybook simultaneously.
  *
- * ErrorBoundary.Default is excluded because it intentionally triggers the
- * error boundary to demonstrate catch behavior.
+ * ErrorBoundary stories are excluded: they intentionally trigger the error
+ * boundary to demonstrate catch behavior.
  */
 import { describe, it, expect, vi } from "vitest";
 import { act, render } from "@testing-library/react";
 import React from "react";
 import { composeStories } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react";
 import { StorybookProviders } from "../../.storybook/providers";
 
-// Story modules
-import * as AnalysisCardStories from "./AnalysisCard.stories";
-import * as AnalysisIndexStories from "./AnalysisIndex.stories";
-import * as AutosaveStatusStories from "./AutosaveStatus.stories";
-import * as CloudinaryImageStories from "./CloudinaryImage.stories";
-import * as CreateTagDialogStories from "./CreateTagDialog.stories";
-import * as CropOverlayStories from "./CropOverlay.stories";
-import * as DeletePiecePhotoDialogStories from "./DeletePiecePhotoDialog.stories";
-import * as EditableToggleStories from "./EditableToggle.stories";
-import * as GlazeCombinationGalleryStories from "./GlazeCombinationGallery.stories";
-import * as GlazeCombinationSummaryStories from "./GlazeCombinationSummary.stories";
-import * as GlobalEntryDialogStories from "./GlobalEntryDialog.stories";
-import * as GlobalEntryFieldStories from "./GlobalEntryField.stories";
-import * as ImageLightboxStories from "./ImageLightbox.stories";
-import * as ImageUploaderStories from "./ImageUploader.stories";
-import * as LightboxFooterStories from "./LightboxFooter.stories";
-import * as NavigationBlockerStories from "./NavigationBlocker.stories";
-import * as NewPieceDialogStories from "./NewPieceDialog.stories";
-import * as PieceDetailStories from "./PieceDetail.stories";
-import * as PieceHistoryStories from "./PieceHistory.stories";
-import * as PieceListStories from "./PieceList.stories";
-import * as PieceNameEditorStories from "./PieceNameEditor.stories";
-import * as PiecePhotoGalleryStories from "./PiecePhotoGallery.stories";
-import * as PiecePhotoGalleryGridStories from "./PiecePhotoGalleryGrid.stories";
-import * as PieceShareControlsStories from "./PieceShareControls.stories";
-import * as ProcessSummaryStories from "./ProcessSummary.stories";
-import * as PublicPieceShellStories from "./PublicPieceShell.stories";
-import * as SectionCardStories from "./SectionCard.stories";
-import * as ShowcaseVideoInputPickerStories from "./ShowcaseVideoInputPicker.stories";
-import * as StateChipStories from "./StateChip.stories";
-import * as StateTransitionStories from "./StateTransition.stories";
-import * as TagAutocompleteStories from "./TagAutocomplete.stories";
-import * as TagChipStories from "./TagChip.stories";
-import * as TagChipListStories from "./TagChipList.stories";
-import * as TagManagerStories from "./TagManager.stories";
-import * as WorkflowStateStories from "./WorkflowState.stories";
+type AnyMeta = Meta<object>;
+type StoryModule = { default: AnyMeta } & Record<string, StoryObj<AnyMeta>>;
 
-const storyGroups: [string, Record<string, React.ComponentType>][] = [
-  ["AnalysisCard", composeStories(AnalysisCardStories)],
-  ["AnalysisIndex", composeStories(AnalysisIndexStories)],
-  ["AutosaveStatus", composeStories(AutosaveStatusStories)],
-  ["CloudinaryImage", composeStories(CloudinaryImageStories)],
-  ["CreateTagDialog", composeStories(CreateTagDialogStories)],
-  ["CropOverlay", composeStories(CropOverlayStories)],
-  ["DeletePiecePhotoDialog", composeStories(DeletePiecePhotoDialogStories)],
-  ["EditableToggle", composeStories(EditableToggleStories)],
-  ["GlazeCombinationGallery", composeStories(GlazeCombinationGalleryStories)],
-  ["GlazeCombinationSummary", composeStories(GlazeCombinationSummaryStories)],
-  ["GlobalEntryDialog", composeStories(GlobalEntryDialogStories)],
-  ["GlobalEntryField", composeStories(GlobalEntryFieldStories)],
-  ["ImageLightbox", composeStories(ImageLightboxStories)],
-  ["ImageUploader", composeStories(ImageUploaderStories)],
-  ["LightboxFooter", composeStories(LightboxFooterStories)],
-  ["NavigationBlocker", composeStories(NavigationBlockerStories)],
-  ["NewPieceDialog", composeStories(NewPieceDialogStories)],
-  ["PieceDetail", composeStories(PieceDetailStories)],
-  ["PieceHistory", composeStories(PieceHistoryStories)],
-  ["PieceList", composeStories(PieceListStories)],
-  ["PieceNameEditor", composeStories(PieceNameEditorStories)],
-  ["PiecePhotoGallery", composeStories(PiecePhotoGalleryStories)],
-  ["PiecePhotoGalleryGrid", composeStories(PiecePhotoGalleryGridStories)],
-  ["PieceShareControls", composeStories(PieceShareControlsStories)],
-  ["ProcessSummary", composeStories(ProcessSummaryStories)],
-  ["PublicPieceShell", composeStories(PublicPieceShellStories)],
-  ["SectionCard", composeStories(SectionCardStories)],
-  ["ShowcaseVideoInputPicker", composeStories(ShowcaseVideoInputPickerStories)],
-  ["StateChip", composeStories(StateChipStories)],
-  ["StateTransition", composeStories(StateTransitionStories)],
-  ["TagAutocomplete", composeStories(TagAutocompleteStories)],
-  ["TagChip", composeStories(TagChipStories)],
-  ["TagChipList", composeStories(TagChipListStories)],
-  ["TagManager", composeStories(TagManagerStories)],
-  ["WorkflowState", composeStories(WorkflowStateStories)],
-];
+const storyModules = import.meta.glob<StoryModule>("./*.stories.tsx", {
+  eager: true,
+});
 
-const allStories: [string, React.ComponentType][] = storyGroups.flatMap(
-  ([group, stories]) =>
-    Object.entries(stories).map(([name, Story]) => [
+const allStories: [string, React.ComponentType][] = Object.entries(storyModules)
+  .filter(([path]) => !path.includes("ErrorBoundary"))
+  .flatMap(([path, module]) => {
+    const group = path.replace(/^\.\//, "").replace(/\.stories\.tsx$/, "");
+    const composed = composeStories(module);
+    return Object.entries(composed).map(([name, Story]) => [
       `${group}/${name}`,
       Story as React.ComponentType,
-    ]),
-);
+    ]);
+  });
 
 describe("Storybook smoke tests — no story should trigger ErrorBoundary", () => {
   it.each(allStories)("%s renders without error boundary", async (_, Story) => {

--- a/web/src/stories/storybook-smoke.test.tsx
+++ b/web/src/stories/storybook-smoke.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Smoke tests: verify every Storybook story renders without triggering the
+ * ErrorBoundary ("Something went wrong. Please reload the page.").
+ *
+ * Imports StorybookProviders from .storybook/providers.tsx — the same module
+ * used by preview.tsx — so that a missing provider in providers.tsx will
+ * cause these tests to fail AND break the deployed Storybook simultaneously.
+ *
+ * ErrorBoundary.Default is excluded because it intentionally triggers the
+ * error boundary to demonstrate catch behavior.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { act, render } from "@testing-library/react";
+import React from "react";
+import { composeStories } from "@storybook/react";
+import { StorybookProviders } from "../../.storybook/providers";
+
+// Story modules
+import * as AnalysisCardStories from "./AnalysisCard.stories";
+import * as AnalysisIndexStories from "./AnalysisIndex.stories";
+import * as AutosaveStatusStories from "./AutosaveStatus.stories";
+import * as CloudinaryImageStories from "./CloudinaryImage.stories";
+import * as CreateTagDialogStories from "./CreateTagDialog.stories";
+import * as CropOverlayStories from "./CropOverlay.stories";
+import * as DeletePiecePhotoDialogStories from "./DeletePiecePhotoDialog.stories";
+import * as EditableToggleStories from "./EditableToggle.stories";
+import * as GlazeCombinationGalleryStories from "./GlazeCombinationGallery.stories";
+import * as GlazeCombinationSummaryStories from "./GlazeCombinationSummary.stories";
+import * as GlobalEntryDialogStories from "./GlobalEntryDialog.stories";
+import * as GlobalEntryFieldStories from "./GlobalEntryField.stories";
+import * as ImageLightboxStories from "./ImageLightbox.stories";
+import * as ImageUploaderStories from "./ImageUploader.stories";
+import * as LightboxFooterStories from "./LightboxFooter.stories";
+import * as NavigationBlockerStories from "./NavigationBlocker.stories";
+import * as NewPieceDialogStories from "./NewPieceDialog.stories";
+import * as PieceDetailStories from "./PieceDetail.stories";
+import * as PieceHistoryStories from "./PieceHistory.stories";
+import * as PieceListStories from "./PieceList.stories";
+import * as PieceNameEditorStories from "./PieceNameEditor.stories";
+import * as PiecePhotoGalleryStories from "./PiecePhotoGallery.stories";
+import * as PiecePhotoGalleryGridStories from "./PiecePhotoGalleryGrid.stories";
+import * as PieceShareControlsStories from "./PieceShareControls.stories";
+import * as ProcessSummaryStories from "./ProcessSummary.stories";
+import * as PublicPieceShellStories from "./PublicPieceShell.stories";
+import * as SectionCardStories from "./SectionCard.stories";
+import * as ShowcaseVideoInputPickerStories from "./ShowcaseVideoInputPicker.stories";
+import * as StateChipStories from "./StateChip.stories";
+import * as StateTransitionStories from "./StateTransition.stories";
+import * as TagAutocompleteStories from "./TagAutocomplete.stories";
+import * as TagChipStories from "./TagChip.stories";
+import * as TagChipListStories from "./TagChipList.stories";
+import * as TagManagerStories from "./TagManager.stories";
+import * as WorkflowStateStories from "./WorkflowState.stories";
+
+const storyGroups: [string, Record<string, React.ComponentType>][] = [
+  ["AnalysisCard", composeStories(AnalysisCardStories)],
+  ["AnalysisIndex", composeStories(AnalysisIndexStories)],
+  ["AutosaveStatus", composeStories(AutosaveStatusStories)],
+  ["CloudinaryImage", composeStories(CloudinaryImageStories)],
+  ["CreateTagDialog", composeStories(CreateTagDialogStories)],
+  ["CropOverlay", composeStories(CropOverlayStories)],
+  ["DeletePiecePhotoDialog", composeStories(DeletePiecePhotoDialogStories)],
+  ["EditableToggle", composeStories(EditableToggleStories)],
+  ["GlazeCombinationGallery", composeStories(GlazeCombinationGalleryStories)],
+  ["GlazeCombinationSummary", composeStories(GlazeCombinationSummaryStories)],
+  ["GlobalEntryDialog", composeStories(GlobalEntryDialogStories)],
+  ["GlobalEntryField", composeStories(GlobalEntryFieldStories)],
+  ["ImageLightbox", composeStories(ImageLightboxStories)],
+  ["ImageUploader", composeStories(ImageUploaderStories)],
+  ["LightboxFooter", composeStories(LightboxFooterStories)],
+  ["NavigationBlocker", composeStories(NavigationBlockerStories)],
+  ["NewPieceDialog", composeStories(NewPieceDialogStories)],
+  ["PieceDetail", composeStories(PieceDetailStories)],
+  ["PieceHistory", composeStories(PieceHistoryStories)],
+  ["PieceList", composeStories(PieceListStories)],
+  ["PieceNameEditor", composeStories(PieceNameEditorStories)],
+  ["PiecePhotoGallery", composeStories(PiecePhotoGalleryStories)],
+  ["PiecePhotoGalleryGrid", composeStories(PiecePhotoGalleryGridStories)],
+  ["PieceShareControls", composeStories(PieceShareControlsStories)],
+  ["ProcessSummary", composeStories(ProcessSummaryStories)],
+  ["PublicPieceShell", composeStories(PublicPieceShellStories)],
+  ["SectionCard", composeStories(SectionCardStories)],
+  ["ShowcaseVideoInputPicker", composeStories(ShowcaseVideoInputPickerStories)],
+  ["StateChip", composeStories(StateChipStories)],
+  ["StateTransition", composeStories(StateTransitionStories)],
+  ["TagAutocomplete", composeStories(TagAutocompleteStories)],
+  ["TagChip", composeStories(TagChipStories)],
+  ["TagChipList", composeStories(TagChipListStories)],
+  ["TagManager", composeStories(TagManagerStories)],
+  ["WorkflowState", composeStories(WorkflowStateStories)],
+];
+
+const allStories: [string, React.ComponentType][] = storyGroups.flatMap(
+  ([group, stories]) =>
+    Object.entries(stories).map(([name, Story]) => [
+      `${group}/${name}`,
+      Story as React.ComponentType,
+    ]),
+);
+
+describe("Storybook smoke tests — no story should trigger ErrorBoundary", () => {
+  it.each(allStories)("%s renders without error boundary", async (_, Story) => {
+    const consoleSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    let container: HTMLElement;
+    try {
+      await act(async () => {
+        ({ container } = render(
+          <StorybookProviders>
+            <Story />
+          </StorybookProviders>,
+        ));
+      });
+    } finally {
+      consoleSpy.mockRestore();
+    }
+    expect(container!.textContent).not.toContain(
+      "Something went wrong. Please reload the page.",
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Many Storybook stories crash with "No QueryClient set" because the global preview decorator in `web/.storybook/preview.tsx` wraps stories in `ThemeProvider` + `RouterProvider` but not `QueryClientProvider`. Components that call `useQueryClient()` — `GlobalEntryDialog`, `TagManager`, `WorkflowState`, `PieceDetail`, `CloudinaryImage` — throw on render. `NewPieceDialog` is one visible trigger (via `GlobalEntryField` → `GlobalEntryDialog`), but many stories are affected.

See [issue #858](https://github.com/shaoster/glaze/issues/858).

## Fix

Extract the Storybook provider stack into a new shared module `web/.storybook/providers.tsx` that exports `StorybookProviders` — a component wrapping children with `QueryClientProvider + ThemeProvider + RouterProvider + CssBaseline`. Update `preview.tsx` to use `StorybookProviders` instead of the previous inline setup.

## Regression Test

Added `web/src/stories/storybook-smoke.test.tsx`: a Vitest test that composes all 124 story exports and renders each one wrapped in `StorybookProviders` (imported from the same `providers.tsx` used by Storybook). Each test asserts that no story shows the ErrorBoundary message "Something went wrong. Please reload the page."

The smoke test confirmed to fail before the fix (multiple stories showing the error boundary) and pass after (all 124 green).

Because the smoke test imports directly from `providers.tsx`, any future removal of a required provider will break both the test and the deployed Storybook simultaneously.

## Verification

```
//web:web_storybook_smoke_test  PASSED (124 tests)
//web:web_test                  PASSED (40 targets)
```

Closes #858
