### PR TITLE
fix: set DEFAULT_FOLDER_UID to empty string for General folder

### DIFF
--- a/tools/grafana_dashboard.py
+++ b/tools/grafana_dashboard.py
@@ -36,7 +36,7 @@ from grafana_foundation_sdk.models.dashboard import (
 )
 
 DEFAULT_GRAFANA_URL = "https://shaoster.grafana.net"
-DEFAULT_FOLDER_UID = "general"
+DEFAULT_FOLDER_UID = ""
 
 EXPECTED_DASHBOARD = {
     "uid": "glaze-app-summary",


### PR DESCRIPTION
Change `DEFAULT_FOLDER_UID` from `"general"` to `""` in [grafana_dashboard.py](file:///home/phil/code/glaze/tools/grafana_dashboard.py).

This resolves the `"folder not found"` error when publishing the dashboard to Grafana Cloud. In modern versions of Grafana, saving a dashboard in the `General` folder requires sending `""` (empty string) as the `folderUid`, rather than the string `"general"`.

Co-Authored-By: Antigravity (Gemini 3.5 Flash) <noreply@google.com>
