### PR TITLE
feat(r2): add R2 storage and operations pie charts to Grafana dashboard

### DIFF
--- a/tools/grafana_dashboard.py
+++ b/tools/grafana_dashboard.py
@@ -288,25 +288,23 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
                 "url": "https://api.cloudflare.com/client/v4/graphql",
                 "url_options": {
                     "method": "POST",
-                    "data": '{"query":"query { viewer { accounts(filter: { accountTag: \\"e43555a6c4fcc087a74f2d775c9a0513\\" }) { r2StorageAdaptiveGroups(filter: { bucketName: \\"potterdoc\\" }, limit: 1, orderBy: [datetime_DESC]) { max { payloadSize } } } } }"}',
+                    "data": '{"query":"query { viewer { accounts(filter: { accountTag: \\"e43555a6c4fcc087a74f2d775c9a0513\\" }) { r2StorageAdaptiveGroups(filter: { bucketName: \\"potterdoc\\", datetime_geq: \\"${__from:date:YYYY-MM}-01T00:00:00Z\\", datetime_leq: \\"${__to:date:YYYY-MM-DDTHH:mm:ss}Z\\" }, limit: 1000) { max { payloadSize } } } } }"}',
                     "body_type": "raw",
                     "body_content_type": "application/json",
                 },
                 "parser": "backend",
-                "root_selector": "data.viewer.accounts.0.r2StorageAdaptiveGroups",
+                "root_selector": '($vals := data.viewer.accounts[0].r2StorageAdaptiveGroups.max.payloadSize; $avg_used := $vals ? $average($vals) : 0; [{"Used": $avg_used, "Remaining": 10000000000 - $avg_used}])',
                 "columns": [
                     {
-                        "selector": "max.payloadSize",
+                        "selector": "Used",
                         "text": "Used",
                         "type": "number",
-                    }
-                ],
-                "computed_columns": [
+                    },
                     {
-                        "selector": "10000000000 - Used",
+                        "selector": "Remaining",
                         "text": "Remaining",
                         "type": "number",
-                    }
+                    },
                 ],
                 "cache_timeout_in_seconds": 3600,
             }
@@ -331,25 +329,23 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
                 "url": "https://api.cloudflare.com/client/v4/graphql",
                 "url_options": {
                     "method": "POST",
-                    "data": '{"query":"query { viewer { accounts(filter: { accountTag: \\"e43555a6c4fcc087a74f2d775c9a0513\\" }) { r2OperationsAdaptiveGroups(filter: { bucketName: \\"potterdoc\\", datetime_geq: \\"${__from:date:YYYY-MM}-01T00:00:00Z\\", actionType_in: [\\"PutObject\\", \\"CopyObject\\", \\"ListObjects\\", \\"ListBuckets\\", \\"CompleteMultipartUpload\\", \\"InitiateMultipartUpload\\", \\"UploadPart\\"] }, limit: 1000) { sum { requests } } } } }"}',
+                    "data": '{"query":"query { viewer { accounts(filter: { accountTag: \\"e43555a6c4fcc087a74f2d775c9a0513\\" }) { r2OperationsAdaptiveGroups(filter: { bucketName: \\"potterdoc\\", datetime_geq: \\"${__from:date:YYYY-MM}-01T00:00:00Z\\", datetime_leq: \\"${__to:date:YYYY-MM-DDTHH:mm:ss}Z\\", actionType_in: [\\"PutObject\\", \\"CopyObject\\", \\"ListObjects\\", \\"ListBuckets\\", \\"CompleteMultipartUpload\\", \\"CreateMultipartUpload\\", \\"UploadPart\\"] }, limit: 1000) { sum { requests } } } } }"}',
                     "body_type": "raw",
                     "body_content_type": "application/json",
                 },
                 "parser": "backend",
-                "root_selector": "data.viewer.accounts.0.r2OperationsAdaptiveGroups",
+                "root_selector": '($reqs := data.viewer.accounts[0].r2OperationsAdaptiveGroups.sum.requests; $used := $reqs ? $sum($reqs) : 0; [{"Used": $used, "Remaining": 1000000 - $used}])',
                 "columns": [
                     {
-                        "selector": "sum.requests",
+                        "selector": "Used",
                         "text": "Used",
                         "type": "number",
-                    }
-                ],
-                "computed_columns": [
+                    },
                     {
-                        "selector": "1000000 - Used",
+                        "selector": "Remaining",
                         "text": "Remaining",
                         "type": "number",
-                    }
+                    },
                 ],
                 "cache_timeout_in_seconds": 3600,
             }
@@ -374,25 +370,23 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
                 "url": "https://api.cloudflare.com/client/v4/graphql",
                 "url_options": {
                     "method": "POST",
-                    "data": '{"query":"query { viewer { accounts(filter: { accountTag: \\"e43555a6c4fcc087a74f2d775c9a0513\\" }) { r2OperationsAdaptiveGroups(filter: { bucketName: \\"potterdoc\\", datetime_geq: \\"${__from:date:YYYY-MM}-01T00:00:00Z\\", actionType_in: [\\"GetObject\\", \\"HeadObject\\", \\"HeadBucket\\"] }, limit: 1000) { sum { requests } } } } }"}',
+                    "data": '{"query":"query { viewer { accounts(filter: { accountTag: \\"e43555a6c4fcc087a74f2d775c9a0513\\" }) { r2OperationsAdaptiveGroups(filter: { bucketName: \\"potterdoc\\", datetime_geq: \\"${__from:date:YYYY-MM}-01T00:00:00Z\\", datetime_leq: \\"${__to:date:YYYY-MM-DDTHH:mm:ss}Z\\", actionType_in: [\\"GetObject\\", \\"HeadObject\\", \\"HeadBucket\\"] }, limit: 1000) { sum { requests } } } } }"}',
                     "body_type": "raw",
                     "body_content_type": "application/json",
                 },
                 "parser": "backend",
-                "root_selector": "data.viewer.accounts.0.r2OperationsAdaptiveGroups",
+                "root_selector": '($reqs := data.viewer.accounts[0].r2OperationsAdaptiveGroups.sum.requests; $used := $reqs ? $sum($reqs) : 0; [{"Used": $used, "Remaining": 10000000 - $used}])',
                 "columns": [
                     {
-                        "selector": "sum.requests",
+                        "selector": "Used",
                         "text": "Used",
                         "type": "number",
-                    }
-                ],
-                "computed_columns": [
+                    },
                     {
-                        "selector": "10000000 - Used",
+                        "selector": "Remaining",
                         "text": "Remaining",
                         "type": "number",
-                    }
+                    },
                 ],
                 "cache_timeout_in_seconds": 3600,
             }

--- a/tools/grafana_dashboard.py
+++ b/tools/grafana_dashboard.py
@@ -288,7 +288,7 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
                 "url": "https://api.cloudflare.com/client/v4/graphql",
                 "url_options": {
                     "method": "POST",
-                    "data": '{"query":"query { viewer { accounts(filter: { accountTag: \\"e43555a6c4fcc087a74f2d775c9a0513\\" }) { r2StorageAdaptiveGroups(filter: { bucketName: \\"potterdoc\\", datetime_geq: \\"${__from:date:YYYY-MM}-01T00:00:00Z\\", datetime_leq: \\"${__to:date:YYYY-MM-DDTHH:mm:ss}Z\\" }, limit: 1000) { max { payloadSize } } } } }"}',
+                    "data": '{"query":"query { viewer { accounts(filter: { accountTag: \\"e43555a6c4fcc087a74f2d775c9a0513\\" }) { r2StorageAdaptiveGroups(filter: { bucketName: \\"potterdoc\\", datetime_geq: \\"${__from:date:YYYY-MM}-01T00:00:00Z\\", datetime_leq: \\"${__to:date:iso}\\" }, limit: 1000) { max { payloadSize } } } } }"}',
                     "body_type": "raw",
                     "body_content_type": "application/json",
                 },
@@ -329,7 +329,7 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
                 "url": "https://api.cloudflare.com/client/v4/graphql",
                 "url_options": {
                     "method": "POST",
-                    "data": '{"query":"query { viewer { accounts(filter: { accountTag: \\"e43555a6c4fcc087a74f2d775c9a0513\\" }) { r2OperationsAdaptiveGroups(filter: { bucketName: \\"potterdoc\\", datetime_geq: \\"${__from:date:YYYY-MM}-01T00:00:00Z\\", datetime_leq: \\"${__to:date:YYYY-MM-DDTHH:mm:ss}Z\\", actionType_in: [\\"PutObject\\", \\"CopyObject\\", \\"ListObjects\\", \\"ListBuckets\\", \\"CompleteMultipartUpload\\", \\"CreateMultipartUpload\\", \\"UploadPart\\"] }, limit: 1000) { sum { requests } } } } }"}',
+                    "data": '{"query":"query { viewer { accounts(filter: { accountTag: \\"e43555a6c4fcc087a74f2d775c9a0513\\" }) { r2OperationsAdaptiveGroups(filter: { bucketName: \\"potterdoc\\", datetime_geq: \\"${__from:date:YYYY-MM}-01T00:00:00Z\\", datetime_leq: \\"${__to:date:iso}\\", actionType_in: [\\"PutObject\\", \\"CopyObject\\", \\"ListObjects\\", \\"ListBuckets\\", \\"CompleteMultipartUpload\\", \\"CreateMultipartUpload\\", \\"UploadPart\\"] }, limit: 1000) { sum { requests } } } } }"}',
                     "body_type": "raw",
                     "body_content_type": "application/json",
                 },
@@ -370,7 +370,7 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
                 "url": "https://api.cloudflare.com/client/v4/graphql",
                 "url_options": {
                     "method": "POST",
-                    "data": '{"query":"query { viewer { accounts(filter: { accountTag: \\"e43555a6c4fcc087a74f2d775c9a0513\\" }) { r2OperationsAdaptiveGroups(filter: { bucketName: \\"potterdoc\\", datetime_geq: \\"${__from:date:YYYY-MM}-01T00:00:00Z\\", datetime_leq: \\"${__to:date:YYYY-MM-DDTHH:mm:ss}Z\\", actionType_in: [\\"GetObject\\", \\"HeadObject\\", \\"HeadBucket\\"] }, limit: 1000) { sum { requests } } } } }"}',
+                    "data": '{"query":"query { viewer { accounts(filter: { accountTag: \\"e43555a6c4fcc087a74f2d775c9a0513\\" }) { r2OperationsAdaptiveGroups(filter: { bucketName: \\"potterdoc\\", datetime_geq: \\"${__from:date:YYYY-MM}-01T00:00:00Z\\", datetime_leq: \\"${__to:date:iso}\\", actionType_in: [\\"GetObject\\", \\"HeadObject\\", \\"HeadBucket\\"] }, limit: 1000) { sum { requests } } } } }"}',
                     "body_type": "raw",
                     "body_content_type": "application/json",
                 },

--- a/tools/grafana_dashboard.py
+++ b/tools/grafana_dashboard.py
@@ -269,6 +269,135 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
             },
         ],
     },
+    18: {
+        "title": "R2 Storage",
+        "type": "piechart",
+        "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "cloudflare-r2-infinity",
+        },
+        "targets": [
+            {
+                "refId": "A",
+                "datasource": {
+                    "type": "yesoreyeram-infinity-datasource",
+                    "uid": "cloudflare-r2-infinity",
+                },
+                "type": "json",
+                "source": "url",
+                "url": "https://api.cloudflare.com/client/v4/graphql",
+                "url_options": {
+                    "method": "POST",
+                    "data": '{"query":"query { viewer { accounts(filter: { accountTag: \\"e43555a6c4fcc087a74f2d775c9a0513\\" }) { r2StorageAdaptiveGroups(filter: { bucketName: \\"potterdoc\\" }, limit: 1, orderBy: [datetime_DESC]) { max { payloadSize } } } } }"}',
+                    "body_type": "raw",
+                    "body_content_type": "application/json",
+                },
+                "parser": "backend",
+                "root_selector": "data.viewer.accounts.0.r2StorageAdaptiveGroups",
+                "columns": [
+                    {
+                        "selector": "max.payloadSize",
+                        "text": "Used",
+                        "type": "number",
+                    }
+                ],
+                "computed_columns": [
+                    {
+                        "selector": "10000000000 - Used",
+                        "text": "Remaining",
+                        "type": "number",
+                    }
+                ],
+                "cache_timeout_in_seconds": 3600,
+            }
+        ],
+    },
+    19: {
+        "title": "R2 Class A Operations",
+        "type": "piechart",
+        "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "cloudflare-r2-infinity",
+        },
+        "targets": [
+            {
+                "refId": "A",
+                "datasource": {
+                    "type": "yesoreyeram-infinity-datasource",
+                    "uid": "cloudflare-r2-infinity",
+                },
+                "type": "json",
+                "source": "url",
+                "url": "https://api.cloudflare.com/client/v4/graphql",
+                "url_options": {
+                    "method": "POST",
+                    "data": '{"query":"query { viewer { accounts(filter: { accountTag: \\"e43555a6c4fcc087a74f2d775c9a0513\\" }) { r2OperationsAdaptiveGroups(filter: { bucketName: \\"potterdoc\\", datetime_geq: \\"${__from:date:YYYY-MM}-01T00:00:00Z\\", actionType_in: [\\"PutObject\\", \\"CopyObject\\", \\"ListObjects\\", \\"ListBuckets\\", \\"CompleteMultipartUpload\\", \\"InitiateMultipartUpload\\", \\"UploadPart\\"] }, limit: 1000) { sum { requests } } } } }"}',
+                    "body_type": "raw",
+                    "body_content_type": "application/json",
+                },
+                "parser": "backend",
+                "root_selector": "data.viewer.accounts.0.r2OperationsAdaptiveGroups",
+                "columns": [
+                    {
+                        "selector": "sum.requests",
+                        "text": "Used",
+                        "type": "number",
+                    }
+                ],
+                "computed_columns": [
+                    {
+                        "selector": "1000000 - Used",
+                        "text": "Remaining",
+                        "type": "number",
+                    }
+                ],
+                "cache_timeout_in_seconds": 3600,
+            }
+        ],
+    },
+    20: {
+        "title": "R2 Class B Operations",
+        "type": "piechart",
+        "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "cloudflare-r2-infinity",
+        },
+        "targets": [
+            {
+                "refId": "A",
+                "datasource": {
+                    "type": "yesoreyeram-infinity-datasource",
+                    "uid": "cloudflare-r2-infinity",
+                },
+                "type": "json",
+                "source": "url",
+                "url": "https://api.cloudflare.com/client/v4/graphql",
+                "url_options": {
+                    "method": "POST",
+                    "data": '{"query":"query { viewer { accounts(filter: { accountTag: \\"e43555a6c4fcc087a74f2d775c9a0513\\" }) { r2OperationsAdaptiveGroups(filter: { bucketName: \\"potterdoc\\", datetime_geq: \\"${__from:date:YYYY-MM}-01T00:00:00Z\\", actionType_in: [\\"GetObject\\", \\"HeadObject\\", \\"HeadBucket\\"] }, limit: 1000) { sum { requests } } } } }"}',
+                    "body_type": "raw",
+                    "body_content_type": "application/json",
+                },
+                "parser": "backend",
+                "root_selector": "data.viewer.accounts.0.r2OperationsAdaptiveGroups",
+                "columns": [
+                    {
+                        "selector": "sum.requests",
+                        "text": "Used",
+                        "type": "number",
+                    }
+                ],
+                "computed_columns": [
+                    {
+                        "selector": "10000000 - Used",
+                        "text": "Remaining",
+                        "type": "number",
+                    }
+                ],
+                "cache_timeout_in_seconds": 3600,
+            }
+        ],
+    },
 }
 
 EXPECTED_PANEL_IDS = set(EXPECTED_PANELS)

--- a/tools/tests/test_grafana_dashboard.py
+++ b/tools/tests/test_grafana_dashboard.py
@@ -53,6 +53,21 @@ def test_dashboard_json_contains_expected_sdk_fields() -> None:
     assert 13 not in panels
     assert panels[14]["targets"][0]["queryType"] == "traceql"
 
+    # R2 panels
+    assert panels[18]["title"] == "R2 Storage"
+    assert panels[18]["type"] == "piechart"
+    assert panels[18]["targets"][0]["type"] == "json"
+    assert panels[18]["targets"][0]["source"] == "url"
+    assert "payloadSize" in panels[18]["targets"][0]["url_options"]["data"]
+
+    assert panels[19]["title"] == "R2 Class A Operations"
+    assert panels[19]["type"] == "piechart"
+    assert "PutObject" in panels[19]["targets"][0]["url_options"]["data"]
+
+    assert panels[20]["title"] == "R2 Class B Operations"
+    assert panels[20]["type"] == "piechart"
+    assert "GetObject" in panels[20]["targets"][0]["url_options"]["data"]
+
 
 def test_publish_dashboard_uses_generated_dashboard_and_live_metadata(
     monkeypatch: pytest.MonkeyPatch,
@@ -106,6 +121,9 @@ def test_publish_dashboard_uses_generated_dashboard_and_live_metadata(
     assert published["uid"] == "glaze-app-summary"
     published_panels = _panel_map(published)
     assert published_panels[14]["targets"][0]["queryType"] == "traceql"
+    assert published_panels[18]["title"] == "R2 Storage"
+    assert published_panels[19]["title"] == "R2 Class A Operations"
+    assert published_panels[20]["title"] == "R2 Class B Operations"
 
 
 def test_main_validate_prints_ok(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
This PR replaces the retired Cloudinary quota panel in the Grafana application summary dashboard with three R2-focused pie charts: **R2 Storage**, **R2 Class A Operations**, and **R2 Class B Operations**.

### Changes

1. **R2 Storage Panel (ID 18)**:
   - Configures a pie chart utilizing the `yesoreyeram-infinity-datasource` pointed at `https://api.cloudflare.com/client/v4/graphql`.
   - Queries `r2StorageAdaptiveGroups` for the `potterdoc` bucket, fetching metrics over the calendar month (using dynamic start `${__from:date:YYYY-MM}-01T00:00:00Z` and end `${__to:date:iso}` bounds).
   - Computes monthly storage usage as average daily peak (GB-months) using JSONata `$average()` to properly align with the 10 GB free tier.

2. **R2 Class A Operations Panel (ID 19)**:
   - Queries `r2OperationsAdaptiveGroups` for write/list operations (`PutObject`, `CopyObject`, `ListObjects`, `ListBuckets`, `CompleteMultipartUpload`, `CreateMultipartUpload`, `UploadPart`) performed on the `potterdoc` bucket since the start of the current month up to the selected time range end.
   - Aggregates returned group requests count using JSONata `$sum()` and calculates Used vs. Remaining based on the 1 million requests free tier limit.

3. **R2 Class B Operations Panel (ID 20)**:
   - Queries `r2OperationsAdaptiveGroups` for read operations (`GetObject`, `HeadObject`, `HeadBucket`) performed on the `potterdoc` bucket since the start of the current month up to the selected time range end.
   - Aggregates returned group requests count using JSONata `$sum()` and calculates Used vs. Remaining based on the 10 million requests free tier limit.

4. **Data Source Integration**:
   - Switched queries to target the new `cloudflare-r2-infinity` data source configured via the Grafana API.

5. **Test Updates**:
   - Added validation assertions to `tools/tests/test_grafana_dashboard.py` to cover the new R2 panels and ensure correct publication schema.

### Validation

- Run full test suite and all linters locally: `rtk bazel test //...` and `rtk bazel build --config=lint //...` passed successfully.
