### PR TITLE
fix: restore Grafana dashboard layout

### DIFF
--- a/tools/grafana_dashboard.py
+++ b/tools/grafana_dashboard.py
@@ -51,6 +51,7 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
     1: {
         "title": "Total Requests (1h)",
         "type": "stat",
+        "gridPos": {"h": 4, "w": 3, "x": 0, "y": 0},
         "datasource": {"type": "prometheus", "uid": "grafanacloud-prom"},
         "targets": [
             {
@@ -65,6 +66,7 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
     2: {
         "title": "HTTP Error Rate (5xx)",
         "type": "stat",
+        "gridPos": {"h": 4, "w": 3, "x": 3, "y": 0},
         "datasource": {"type": "prometheus", "uid": "grafanacloud-prom"},
         "targets": [
             {
@@ -79,6 +81,7 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
     3: {
         "title": "p95 Latency",
         "type": "stat",
+        "gridPos": {"h": 4, "w": 3, "x": 0, "y": 4},
         "datasource": {"type": "prometheus", "uid": "grafanacloud-prom"},
         "targets": [
             {
@@ -93,6 +96,7 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
     4: {
         "title": "Active Requests",
         "type": "stat",
+        "gridPos": {"h": 4, "w": 3, "x": 3, "y": 4},
         "datasource": {"type": "prometheus", "uid": "grafanacloud-prom"},
         "targets": [
             {
@@ -107,6 +111,7 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
     5: {
         "title": "Request Rate by Status Code",
         "type": "timeseries",
+        "gridPos": {"h": 8, "w": 6, "x": 6, "y": 0},
         "datasource": {"type": "prometheus", "uid": "grafanacloud-prom"},
         "targets": [
             {
@@ -120,6 +125,7 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
     7: {
         "title": "Error & Warning Logs",
         "type": "logs",
+        "gridPos": {"h": 7, "w": 12, "x": 0, "y": 8},
         "datasource": {"type": "loki", "uid": "grafanacloud-logs"},
         "targets": [
             {
@@ -133,6 +139,7 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
     8: {
         "title": "Backend Anomalous Traces (Slow >500ms or Errored)",
         "type": "table",
+        "gridPos": {"h": 8, "w": 12, "x": 0, "y": 15},
         "datasource": {"type": "tempo", "uid": "grafanacloud-traces"},
         "targets": [
             {
@@ -150,6 +157,7 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
     9: {
         "title": "Metrics Series Quota",
         "type": "piechart",
+        "gridPos": {"h": 5, "w": 5, "x": 12, "y": 0},
         "datasource": {"type": "prometheus", "uid": "grafanacloud-usage"},
         "targets": [
             {
@@ -171,6 +179,7 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
     10: {
         "title": "Logs Quota (Monthly)",
         "type": "piechart",
+        "gridPos": {"h": 5, "w": 5, "x": 17, "y": 0},
         "datasource": {"type": "prometheus", "uid": "grafanacloud-usage"},
         "targets": [
             {
@@ -192,6 +201,7 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
     14: {
         "title": "Frontend Anomalous Traces (glaze-web, Slow >2s or Errored)",
         "type": "table",
+        "gridPos": {"h": 8, "w": 12, "x": 0, "y": 23},
         "datasource": {"type": "tempo", "uid": "grafanacloud-traces"},
         "targets": [
             {
@@ -209,6 +219,7 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
     15: {
         "title": "CPU Utilization",
         "type": "piechart",
+        "gridPos": {"h": 5, "w": 5, "x": 12, "y": 10},
         "datasource": {"type": "prometheus", "uid": "grafanacloud-prom"},
         "targets": [
             {
@@ -230,6 +241,7 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
     16: {
         "title": "RAM Utilization",
         "type": "piechart",
+        "gridPos": {"h": 5, "w": 5, "x": 17, "y": 5},
         "datasource": {"type": "prometheus", "uid": "grafanacloud-prom"},
         "targets": [
             {
@@ -251,6 +263,7 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
     17: {
         "title": "Swap Utilization",
         "type": "piechart",
+        "gridPos": {"h": 5, "w": 5, "x": 17, "y": 10},
         "datasource": {"type": "prometheus", "uid": "grafanacloud-prom"},
         "targets": [
             {
@@ -272,6 +285,7 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
     18: {
         "title": "R2 Storage",
         "type": "piechart",
+        "gridPos": {"h": 5, "w": 5, "x": 12, "y": 15},
         "datasource": {
             "type": "yesoreyeram-infinity-datasource",
             "uid": "cloudflare-r2-infinity",
@@ -313,6 +327,7 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
     19: {
         "title": "R2 Class A Operations",
         "type": "piechart",
+        "gridPos": {"h": 5, "w": 5, "x": 17, "y": 15},
         "datasource": {
             "type": "yesoreyeram-infinity-datasource",
             "uid": "cloudflare-r2-infinity",
@@ -354,6 +369,7 @@ EXPECTED_PANELS: dict[int, dict[str, Any]] = {
     20: {
         "title": "R2 Class B Operations",
         "type": "piechart",
+        "gridPos": {"h": 5, "w": 5, "x": 12, "y": 20},
         "datasource": {
             "type": "yesoreyeram-infinity-datasource",
             "uid": "cloudflare-r2-infinity",

--- a/tools/tests/test_grafana_dashboard.py
+++ b/tools/tests/test_grafana_dashboard.py
@@ -17,6 +17,10 @@ def _panel_map(payload: dict[str, Any]) -> dict[int, dict[str, Any]]:
     return {panel["id"]: panel for panel in panels}
 
 
+def _assert_grid_pos(panel: dict[str, Any], expected: dict[str, int]) -> None:
+    assert panel["gridPos"] == expected
+
+
 def test_validate_dashboard_builds_expected_dashboard() -> None:
     dashboard.validate_dashboard()
 
@@ -31,6 +35,23 @@ def test_dashboard_json_contains_expected_sdk_fields() -> None:
     assert payload["refresh"] == "10s"
     assert payload["timezone"] == "browser"
     assert payload["time"] == {"from": "now-1h", "to": "now"}
+
+    _assert_grid_pos(panels[1], {"h": 4, "w": 3, "x": 0, "y": 0})
+    _assert_grid_pos(panels[2], {"h": 4, "w": 3, "x": 3, "y": 0})
+    _assert_grid_pos(panels[5], {"h": 8, "w": 6, "x": 6, "y": 0})
+    _assert_grid_pos(panels[9], {"h": 5, "w": 5, "x": 12, "y": 0})
+    _assert_grid_pos(panels[10], {"h": 5, "w": 5, "x": 17, "y": 0})
+    _assert_grid_pos(panels[3], {"h": 4, "w": 3, "x": 0, "y": 4})
+    _assert_grid_pos(panels[4], {"h": 4, "w": 3, "x": 3, "y": 4})
+    _assert_grid_pos(panels[16], {"h": 5, "w": 5, "x": 17, "y": 5})
+    _assert_grid_pos(panels[7], {"h": 7, "w": 12, "x": 0, "y": 8})
+    _assert_grid_pos(panels[15], {"h": 5, "w": 5, "x": 12, "y": 10})
+    _assert_grid_pos(panels[17], {"h": 5, "w": 5, "x": 17, "y": 10})
+    _assert_grid_pos(panels[8], {"h": 8, "w": 12, "x": 0, "y": 15})
+    _assert_grid_pos(panels[18], {"h": 5, "w": 5, "x": 12, "y": 15})
+    _assert_grid_pos(panels[19], {"h": 5, "w": 5, "x": 17, "y": 15})
+    _assert_grid_pos(panels[20], {"h": 5, "w": 5, "x": 12, "y": 20})
+    _assert_grid_pos(panels[14], {"h": 8, "w": 12, "x": 0, "y": 23})
 
     assert panels[1]["title"] == "Total Requests (1h)"
     assert panels[1]["targets"][0]["expr"] == (


### PR DESCRIPTION
## Problem
Fixes [#904](https://github.com/shaoster/glaze/issues/904): the Grafana dashboard regressed to Grafana's default two-column layout because the generated panels no longer carried explicit `gridPos` values.

## Fix
Restored explicit `gridPos` entries in `tools/grafana_dashboard.py` so the generated dashboard keeps the prior four-column layout, including the newer R2 panels.

## Regression Test
`tools/tests/test_grafana_dashboard.py::test_dashboard_json_contains_expected_sdk_fields` now asserts the generated `gridPos` for the dashboard panels, so the layout regression fails before the fix and passes after it.

## Verification
- `rtk bazel test //tools:test_grafana_dashboard --test_output=errors`
- `rtk bazel test //tools/... --test_output=errors`
- `git diff --check`

Closes #904
