### PR TITLE
feat(#903): offload heavy compute tasks to Modal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,12 @@ DATABASE_URL=sqlite:///db.sqlite3
 # Mobile API base URL (Expo)
 # EXPO_PUBLIC_API_BASE_URL=http://localhost:8080/api/
 
+# Modal Labs (offloads CPU/memory-intensive tasks: image crop, JPEG conversion, video render)
+# Required for generate_cropped_image, convert_image_to_jpeg, and generate_showcase_video
+# tasks to run. Without these, Celery tasks will fail when attempting to call Modal.
+# MODAL_TOKEN_ID=
+# MODAL_TOKEN_SECRET=
+
 # Production cluster SSH target (used by tools/ensure_cluster.sh and helm_deploy.sh)
 # SSH is restricted to the tailnet — you must be connected to Tailscale and
 # tagged as an admin-client. Tailscale SSH handles auth; no extra keys needed.

--- a/api/BUILD.bazel
+++ b/api/BUILD.bazel
@@ -111,6 +111,8 @@ py_library(
         ":api_schema_lib",
         ":api_workflow_lib",
         "@pypi//celery",
+        "@pypi//gevent",
+        "@pypi//modal",
         "@pypi//redis",
     ],
 )
@@ -313,6 +315,7 @@ pytest_test(
         "tests/test_host_settings.py",
         "tests/test_image_field_migration.py",
         "tests/test_model_factory.py",
+        "tests/test_task_progress_webhook.py",
         "tests/test_utils.py",
     ],
     args = [
@@ -327,6 +330,7 @@ pytest_test(
         "api/tests/test_host_settings.py",
         "api/tests/test_global_entries.py",
         "api/tests/test_image_field_migration.py",
+        "api/tests/test_task_progress_webhook.py",
     ],
     data = _TEST_DATA,
     env = _TEST_ENV,

--- a/api/task_views.py
+++ b/api/task_views.py
@@ -1,8 +1,15 @@
+import hashlib
+import hmac
+import time
+import uuid as _uuid
+
+from django.conf import settings
 from django.shortcuts import get_object_or_404
+from django.utils.crypto import constant_time_compare
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
-from rest_framework.permissions import IsAdminUser
+from rest_framework.permissions import AllowAny, IsAdminUser
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -15,6 +22,34 @@ from .serializers import (
     AsyncTaskSerializer,
     TaskSubmissionSerializer,
 )
+
+_PROGRESS_TOKEN_TTL = 3600  # seconds — must cover the longest render job
+
+
+def _make_progress_token(task_id: _uuid.UUID | str) -> str:
+    """Generate an HMAC-signed token authorizing progress callbacks for task_id."""
+    expiry = int(time.time()) + _PROGRESS_TOKEN_TTL
+    payload = f"{task_id}:{expiry}"
+    sig = hmac.new(
+        settings.SECRET_KEY.encode(), payload.encode(), hashlib.sha256
+    ).hexdigest()
+    return f"{payload}:{sig}"
+
+
+def _verify_progress_token(token: str, task_id: _uuid.UUID | str) -> bool:
+    try:
+        tid, expiry_str, sig = token.rsplit(":", 2)
+        if tid != str(task_id):
+            return False
+        if int(expiry_str) < int(time.time()):
+            return False
+        payload = f"{tid}:{expiry_str}"
+        expected = hmac.new(
+            settings.SECRET_KEY.encode(), payload.encode(), hashlib.sha256
+        ).hexdigest()
+        return constant_time_compare(sig, expected)
+    except Exception:
+        return False
 
 
 @extend_schema(
@@ -56,6 +91,28 @@ def task_detail(request: Request, task_id: str) -> Response:
     # Scope to current user to prevent leaking task state between accounts.
     task = get_object_or_404(AsyncTask, id=task_id, user=request.user)
     return Response(AsyncTaskSerializer(task).data)
+
+
+@extend_schema(exclude=True)
+@api_view(["POST"])
+@permission_classes([AllowAny])
+def report_task_progress(request: Request, task_id: _uuid.UUID) -> Response:
+    """Receive a progress callback from a Modal compute function.
+
+    Authentication is via an HMAC token in the X-Task-Token header signed with
+    Django's SECRET_KEY. The token encodes the task_id and an expiry timestamp,
+    so it is single-purpose and short-lived — Modal holds no session credentials.
+    """
+    token = request.headers.get("X-Task-Token", "")
+    if not _verify_progress_token(token, task_id):
+        return Response(status=status.HTTP_403_FORBIDDEN)
+    task = get_object_or_404(AsyncTask, id=task_id)
+    progress = request.data.get("progress")
+    if not isinstance(progress, int) or not (0 <= progress <= 100):
+        return Response(status=status.HTTP_400_BAD_REQUEST)
+    task.progress = progress
+    task.save(update_fields=["progress", "last_modified"])
+    return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 # ── Readiness ────────────────────────────────────────────────────────────────

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -224,7 +224,7 @@ def _modal_function(app_name: str, fn_name: str) -> Any:
     """Thin wrapper around modal.Function.lookup — mock this in tests."""
     import modal  # noqa: PLC0415
 
-    return modal.Function.lookup(app_name, fn_name)
+    return modal.Function.lookup(app_name, fn_name)  # type: ignore[attr-defined]
 
 
 def get_task_interface() -> TaskInterface:

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -402,7 +402,7 @@ def generate_cropped_image(task: AsyncTask) -> dict:
 
     presigned_put = r2.generate_presigned_put(key, "image/jpeg")
     crop_image_fn = _modal_function("glaze-compute", "crop_image")
-    asyncio.run(crop_image_fn.remote.aio(image.url, crop, presigned_put))
+    asyncio.run(crop_image_fn.remote.aio(r2.public_url_for_key(image.r2_key), crop, presigned_put))
     updated = set_cropped_fields(image, crop, r2_key=key, url=url)
     return {
         "status": "success",

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Callable, Dict, Optional, Protocol
@@ -219,6 +220,13 @@ def handle_task_failure(
 
 
 # Global interface instance.
+def _modal_function(app_name: str, fn_name: str) -> Any:
+    """Thin wrapper around modal.Function.lookup — mock this in tests."""
+    import modal  # noqa: PLC0415
+
+    return modal.Function.lookup(app_name, fn_name)
+
+
 def get_task_interface() -> TaskInterface:
     global _task_interface
     if _task_interface is not None:
@@ -345,16 +353,20 @@ def detect_subject_crop(task: AsyncTask) -> dict | None:
     }
 
 
-@TaskRegistry.register("generate_cropped_image", time_limit=60)
+@TaskRegistry.register("generate_cropped_image", time_limit=120)
 def generate_cropped_image(task: AsyncTask) -> dict:
     """Materialize a PieceStateImage crop as an eager JPEG derivative in R2.
 
     Input is the value pair ``(image_id, crop coords)`` — never a PSI pk —
     so completion can update every current row matching the pair even if the
     triggering row was deleted and recreated while the task ran.
+
+    Heavy compute (PIL crop) is offloaded to Modal. Celery owns all DB reads
+    and writes; Modal receives public URLs and presigned PUT URLs only — no
+    bytes transit the Celery↔Modal boundary.
     """
     from . import r2
-    from .crops import crop_key_for, generate_cropped_image_bytes, set_cropped_fields
+    from .crops import crop_key_for, set_cropped_fields
     from .models import Image
     from .utils import crop_to_dict
 
@@ -388,9 +400,9 @@ def generate_cropped_image(task: AsyncTask) -> dict:
             "reused_existing_object": True,
         }
 
-    original = r2.get_object_bytes(image.r2_key)
-    derived_bytes = generate_cropped_image_bytes(original, crop)
-    r2.upload_bytes(key, derived_bytes, "image/jpeg")
+    presigned_put = r2.generate_presigned_put(key, "image/jpeg")
+    crop_image_fn = _modal_function("glaze-compute", "crop_image")
+    asyncio.run(crop_image_fn.remote.aio(image.url, crop, presigned_put))
     updated = set_cropped_fields(image, crop, r2_key=key, url=url)
     return {
         "status": "success",
@@ -400,26 +412,24 @@ def generate_cropped_image(task: AsyncTask) -> dict:
     }
 
 
-@TaskRegistry.register("convert_image_to_jpeg")
+@TaskRegistry.register("convert_image_to_jpeg", time_limit=120)
 def convert_image_to_jpeg(task: AsyncTask) -> dict:
     """Convert an R2-hosted image to a JPEG derivative at a new key.
 
     Triggered immediately after a presigned-PUT upload for any non-JPEG image
     (PNG, WebP, HEIC/HEIF, AVIF, GIF). After conversion the original object is
-    deleted and the Image model row is updated to point at the JPEG URL.
+    kept in R2 for provenance and the Image model row is updated to the JPEG URL.
 
     Input params:
         key        R2 key of the uploaded source image.
         image_id   UUID of the Image row to rewrite after conversion.
 
     Returns ``url``, ``key``, ``width``, and ``height`` of the new JPEG.
-    """
-    import io  # noqa: PLC0415
-    import uuid  # noqa: PLC0415
 
-    from PIL import Image as PILImage  # noqa: PLC0415
-    from PIL import ImageOps  # noqa: PLC0415
-    from pillow_heif import register_heif_opener  # noqa: PLC0415
+    Heavy compute (PIL decode/encode) is offloaded to Modal. Celery owns all
+    DB reads and writes; Modal receives public URLs and a presigned PUT URL.
+    """
+    import uuid  # noqa: PLC0415
 
     from . import r2
     from .models import Image
@@ -433,44 +443,25 @@ def convert_image_to_jpeg(task: AsyncTask) -> dict:
     if not r2.is_r2_configured():
         return {"status": "skipped", "reason": "R2 is not configured"}
 
-    register_heif_opener()
-    original = r2.get_object_bytes(source_key)
-
-    with PILImage.open(io.BytesIO(original)) as src:
-        img = ImageOps.exif_transpose(src)
-        assert img is not None
-        if img.mode not in ("RGB", "RGBA"):
-            img = img.convert("RGB")
-        elif img.mode == "RGBA":
-            # Flatten transparency onto white before JPEG encoding.
-            background = PILImage.new("RGB", img.size, (255, 255, 255))
-            background.paste(img, mask=img.split()[3])
-            img = background
-        long_edge = max(img.size)
-        _MAX = 2560
-        if long_edge > _MAX:
-            scale = _MAX / long_edge
-            img = img.resize(
-                (max(1, round(img.size[0] * scale)), max(1, round(img.size[1] * scale)))
-            )
-        width, height = img.size
-        out = io.BytesIO()
-        img.save(out, format="JPEG", quality=85, optimize=True)
-
     # Derive a stable JPEG key: same prefix/owner path, new UUID, .jpg extension.
     # e.g. images/42/abc.heic  →  images/42/<new-uuid>.jpg
     parts = source_key.rsplit("/", 1)
     owner_prefix = parts[0] if len(parts) == 2 else "images"
     new_key = f"{owner_prefix}/{uuid.uuid4()}.jpg"
 
-    jpeg_bytes = out.getvalue()
-    new_url = r2.upload_bytes(new_key, jpeg_bytes, "image/jpeg")
+    presigned_put = r2.generate_presigned_put(new_key, "image/jpeg")
+    source_public_url = r2.public_url_for_key(source_key)
+
+    convert_fn = _modal_function("glaze-compute", "convert_to_jpeg")
+    result = asyncio.run(convert_fn.remote.aio(source_public_url, presigned_put))
+    width: int = result["width"]
+    height: int = result["height"]
+    new_url = r2.public_url_for_key(new_key)
 
     # Source object is kept in R2 for provenance (GC handles cleanup later).
 
     # Ensure a source Image row exists so the lineage FK is meaningful, then
     # create a new JPEG Image row derived from it.
-    source_public_url = r2.public_url_for_key(source_key)
     if image_id:
         source_image = Image.objects.filter(id=image_id).first()
     else:
@@ -506,17 +497,25 @@ def convert_image_to_jpeg(task: AsyncTask) -> dict:
     }
 
 
-@TaskRegistry.register("generate_showcase_video")
+@TaskRegistry.register("generate_showcase_video", time_limit=900)
 def generate_showcase_video(task: AsyncTask) -> dict:
-    """Render a deterministic Keepsake showcase video from a storyboard snapshot."""
+    """Render a deterministic Keepsake showcase video from a storyboard snapshot.
+
+    Heavy compute (PyAV ffmpeg render) is offloaded to Modal via presigned R2
+    PUT URL. Progress callbacks POST to /api/tasks/{id}/progress/ using an
+    HMAC token so Modal never holds Django session credentials.
+    """
+    from django.conf import settings
+
     from .showcase import (
         SHOWCASE_VIDEO_RENDER_VERSION,
         compute_storyboard_hash,
         is_showcase_video_storage_enabled,
-        render_storyboard_to_mp4,
-        upload_showcase_video_to_r2,
         validate_storyboard,
     )
+    from .showcase.render import showcase_video_key
+    from . import r2
+    from .task_views import _make_progress_token
 
     params = task.input_params or {}
     if not isinstance(params, dict):
@@ -528,44 +527,38 @@ def generate_showcase_video(task: AsyncTask) -> dict:
 
     validate_storyboard(storyboard)
 
-    # input_hash is now a piece-level deduplication hash (compute_piece_input_hash).
-    # Use it for the R2 object key so uploads are idempotent.  Fall back to
-    # the storyboard hash for tasks created before this change.
     stored_hash = params.get("input_hash")
     input_hash = stored_hash or compute_storyboard_hash(storyboard)
 
     if not is_showcase_video_storage_enabled():
         raise ValueError("Showcase video object storage is not configured.")
 
+    key = showcase_video_key(input_hash)
+    artifact_url = r2.public_url_for_key(key)
+
+    if r2.object_exists(key):
+        return {
+            "status": "success",
+            "render_version": SHOWCASE_VIDEO_RENDER_VERSION,
+            "input_hash": input_hash,
+            "artifact_filename": f"{input_hash}.mp4",
+            "artifact_url": artifact_url,
+            "download_url": artifact_url,
+            "content_type": "video/mp4",
+            "storyboard": storyboard,
+        }
+
     task.progress = 0
     task.save(update_fields=["progress", "last_modified"])
 
-    def _report_progress(pct: int) -> None:
-        task.progress = pct
-        task.save(update_fields=["progress", "last_modified"])
+    # Presigned PUT valid for 60 minutes — long enough for the largest renders.
+    presigned_put = r2.generate_presigned_put(key, "video/mp4", expires=3600)
+    progress_token = _make_progress_token(task.id)
+    app_origin = getattr(settings, "_APP_ORIGIN", "")
+    progress_webhook_url = f"{app_origin}/api/tasks/{task.id}/progress/"
 
-    output_path = render_storyboard_to_mp4(storyboard, on_progress=_report_progress)
-    try:
-        artifact_url = upload_showcase_video_to_r2(
-            output_path,
-            input_hash=input_hash,
-        )
-        if not artifact_url:
-            raise ValueError("Showcase video upload to R2 failed.")
-    except Exception:
-        logger.exception(
-            f"R2 upload failed for showcase video task {task.id}; "
-            "marking the task as failed."
-        )
-        raise
-    finally:
-        try:
-            output_path.unlink(missing_ok=True)
-        except OSError:
-            logger.warning(
-                "Could not remove temporary showcase video file for task %s",
-                task.id,
-            )
+    render_fn = _modal_function("glaze-compute", "render_showcase_video")
+    asyncio.run(render_fn.remote.aio(storyboard, presigned_put, progress_webhook_url, progress_token))
 
     return {
         "status": "success",

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -221,10 +221,10 @@ def handle_task_failure(
 
 # Global interface instance.
 def _modal_function(app_name: str, fn_name: str) -> Any:
-    """Thin wrapper around modal.Function.lookup — mock this in tests."""
+    """Thin wrapper around modal.Function.from_name — mock this in tests."""
     import modal  # noqa: PLC0415
 
-    return modal.Function.lookup(app_name, fn_name)  # type: ignore[attr-defined]
+    return modal.Function.from_name(app_name, fn_name)
 
 
 def get_task_interface() -> TaskInterface:

--- a/api/tests/test_convert_image_to_jpeg.py
+++ b/api/tests/test_convert_image_to_jpeg.py
@@ -4,6 +4,7 @@ import io
 import re
 import uuid
 from unittest import mock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from PIL import Image as PILImage
@@ -55,44 +56,54 @@ class TestConvertImageToJpegTask:
             input_params={"key": key},
         )
 
-    def test_converts_png_to_jpeg_and_keeps_original(self, user, r2_env, monkeypatch):
-        from api.models import Image
-        from api.tasks import convert_image_to_jpeg
+    def _mock_modal(self, monkeypatch, *, width=4, height=4):
+        """Mock _modal_function and r2.generate_presigned_put for convert task."""
+        modal_calls = []
 
-        png_bytes = _make_tiny_png()
-        key = f"images/{user.id}/{uuid.uuid4()}.png"
-        uploaded: dict = {}
+        def _mock_fn(app_name, fn_name):
+            fn_mock = MagicMock()
+            fn_mock.remote = MagicMock()
+            fn_mock.remote.aio = AsyncMock(
+                return_value={"width": width, "height": height},
+                side_effect=lambda *a, **kw: modal_calls.append(a) or {"width": width, "height": height},
+            )
+            return fn_mock
 
-        def fake_get_object_bytes(k):
-            assert k == key
-            return png_bytes
-
-        def fake_upload_bytes(k, data, content_type):
-            uploaded["key"] = k
-            uploaded["data"] = data
-            uploaded["content_type"] = content_type
-            return f"https://media.example.com/{k}"
-
-        monkeypatch.setattr("api.r2.get_object_bytes", fake_get_object_bytes)
-        monkeypatch.setattr("api.r2.upload_bytes", fake_upload_bytes)
+        monkeypatch.setattr("api.tasks._modal_function", _mock_fn)
+        monkeypatch.setattr(
+            "api.r2.generate_presigned_put",
+            lambda key, content_type, **kwargs: f"https://presigned.example.com/{key}",
+        )
         monkeypatch.setattr(
             "api.r2.public_url_for_key",
             lambda k: f"https://media.example.com/{k}",
         )
+        return modal_calls
+
+    def test_converts_png_to_jpeg_and_keeps_original(self, user, r2_env, monkeypatch):
+        from api.models import Image
+        from api.tasks import convert_image_to_jpeg
+
+        key = f"images/{user.id}/{uuid.uuid4()}.png"
+        modal_calls = self._mock_modal(monkeypatch)
 
         task = self._make_task(user, key)
         result = convert_image_to_jpeg(task)
 
         assert result["status"] == "success"
-        assert uploaded["content_type"] == "image/jpeg"
-        assert uploaded["key"].endswith(".jpg")
-        assert re.fullmatch(rf"images/{user.id}/[0-9a-f-]{{36}}\.jpg", uploaded["key"])
-        # Return value includes dimensions.
+        assert result["key"].endswith(".jpg")
+        assert re.fullmatch(rf"images/{user.id}/[0-9a-f-]{{36}}\.jpg", result["key"])
+        # Return value includes dimensions from Modal.
         assert result["width"] == 4
         assert result["height"] == 4
+        # Modal was called with the source public URL and a presigned PUT URL.
+        assert len(modal_calls) == 1
+        source_public_url, presigned_put = modal_calls[0]
+        assert source_public_url == f"https://media.example.com/{key}"
+        assert result["key"] in presigned_put
 
         # A new JPEG Image row is created with lineage; the source is kept.
-        jpeg_img = Image.objects.get(r2_key=uploaded["key"])
+        jpeg_img = Image.objects.get(r2_key=result["key"])
         assert jpeg_img.derived_type == "jpeg_conversion"
         assert jpeg_img.derived_from is not None
         # Source Image row must also exist (created by the task).
@@ -134,29 +145,14 @@ class TestConvertImageToJpegTask:
             r2_key=f"images/{user.id}/orig.png",
         )
         key = source_image.r2_key
-        new_url = None
-
-        def fake_get_object_bytes(k):
-            return _make_tiny_png()
-
-        def fake_upload_bytes(k, data, ct):
-            nonlocal new_url
-            new_url = f"https://media.example.com/{k}"
-            return new_url
-
-        monkeypatch.setattr("api.r2.get_object_bytes", fake_get_object_bytes)
-        monkeypatch.setattr("api.r2.upload_bytes", fake_upload_bytes)
-        monkeypatch.setattr(
-            "api.r2.public_url_for_key",
-            lambda k: f"https://media.example.com/{k}",
-        )
+        self._mock_modal(monkeypatch)
 
         task = AsyncTask.objects.create(
             user=user,
             task_type="convert_image_to_jpeg",
             input_params={"key": key, "image_id": str(source_image.id)},
         )
-        convert_image_to_jpeg(task)
+        result = convert_image_to_jpeg(task)
 
         # Source Image row must be unchanged.
         source_image.refresh_from_db()
@@ -164,8 +160,7 @@ class TestConvertImageToJpegTask:
         assert source_image.r2_key == key
 
         # A new JPEG Image row must have been created with lineage.
-        assert new_url is not None
-        jpeg_image = Image.objects.get(url=new_url)
+        jpeg_image = Image.objects.get(url=result["url"])
         assert jpeg_image.r2_key.endswith(".jpg")
         assert jpeg_image.derived_from_id == source_image.id
         assert jpeg_image.derived_type == "jpeg_conversion"

--- a/api/tests/test_generate_cropped_image.py
+++ b/api/tests/test_generate_cropped_image.py
@@ -1,6 +1,7 @@
 """Tests for the eager crop pipeline (generate_cropped_image task + helpers)."""
 
 import io
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from django.contrib.auth.models import User
@@ -120,21 +121,31 @@ class TestGenerateCroppedImageTask:
         )
 
     def _mock_r2(self, monkeypatch, *, exists=False):
-        uploads = []
+        """Mock R2 and Modal for crop task execution.
+
+        Returns a list of Modal call args tuples (source_url, crop, presigned_put).
+        """
+        modal_calls = []
         monkeypatch.setattr("api.r2.object_exists", lambda key: exists)
-        monkeypatch.setattr("api.r2.get_object_bytes", lambda key: _png_bytes())
         monkeypatch.setattr(
-            "api.r2.upload_bytes",
-            lambda key, data, content_type: uploads.append(
-                {"key": key, "data": data, "content_type": content_type}
-            )
-            or f"https://media.example.com/{key}",
+            "api.r2.generate_presigned_put",
+            lambda key, content_type, **kwargs: f"https://presigned.example.com/{key}",
         )
-        return uploads
+
+        def _mock_fn_lookup(app_name, fn_name):
+            fn_mock = MagicMock()
+            fn_mock.remote = MagicMock()
+            fn_mock.remote.aio = AsyncMock(
+                side_effect=lambda *args, **kwargs: modal_calls.append(args)
+            )
+            return fn_mock
+
+        monkeypatch.setattr("api.tasks._modal_function", _mock_fn_lookup)
+        return modal_calls
 
     def test_materializes_crop_and_updates_all_matching_links(self, user, monkeypatch):
         _set_r2_env(monkeypatch)
-        uploads = self._mock_r2(monkeypatch)
+        modal_calls = self._mock_r2(monkeypatch)
         piece, state, image, link = _make_piece_with_image(user, crop=CROP)
         # A second link to the same image with the same crop (e.g. after a
         # move), plus one with a different crop that must stay untouched.
@@ -159,10 +170,11 @@ class TestGenerateCroppedImageTask:
         task.refresh_from_db()
         assert task.status == AsyncTask.Status.SUCCESS
         expected_key = crop_key_for(image.r2_key, CROP)
-        assert [u["key"] for u in uploads] == [expected_key]
-        assert uploads[0]["content_type"] == "image/jpeg"
-        with PILImage.open(io.BytesIO(uploads[0]["data"])) as derived:
-            assert derived.format == "JPEG"
+        # Modal was called once with (source_url, crop, presigned_put).
+        assert len(modal_calls) == 1
+        assert modal_calls[0][0] == image.url
+        assert modal_calls[0][1] == CROP
+        assert expected_key in modal_calls[0][2]
 
         link.refresh_from_db()
         same_pair.refresh_from_db()
@@ -179,11 +191,7 @@ class TestGenerateCroppedImageTask:
 
     def test_idempotent_skip_when_object_already_exists(self, user, monkeypatch):
         _set_r2_env(monkeypatch)
-        uploads = self._mock_r2(monkeypatch, exists=True)
-        monkeypatch.setattr(
-            "api.r2.get_object_bytes",
-            lambda key: pytest.fail("must not re-download when object exists"),
-        )
+        modal_calls = self._mock_r2(monkeypatch, exists=True)
         piece, state, image, link = _make_piece_with_image(user, crop=CROP)
 
         task = self._make_task(user, image)
@@ -192,7 +200,7 @@ class TestGenerateCroppedImageTask:
         task.refresh_from_db()
         assert task.status == AsyncTask.Status.SUCCESS
         assert task.result["reused_existing_object"] is True
-        assert uploads == []
+        assert modal_calls == []
         link.refresh_from_db()
         assert link.cropped_image is not None
         assert link.cropped_image.url == (
@@ -268,11 +276,14 @@ class TestPatchCropTriggersPipeline:
 
         # Task completion populates cropped_image on the link.
         monkeypatch.setattr("api.r2.object_exists", lambda key: False)
-        monkeypatch.setattr("api.r2.get_object_bytes", lambda key: _png_bytes())
         monkeypatch.setattr(
-            "api.r2.upload_bytes",
-            lambda key, data, content_type: f"https://media.example.com/{key}",
+            "api.r2.generate_presigned_put",
+            lambda key, content_type, **kwargs: f"https://presigned.example.com/{key}",
         )
+        fn_mock = MagicMock()
+        fn_mock.remote = MagicMock()
+        fn_mock.remote.aio = AsyncMock(return_value=None)
+        monkeypatch.setattr("api.tasks._modal_function", lambda *a, **kw: fn_mock)
         _execute_task(task.id)
         link.refresh_from_db()
         assert link.cropped_image is not None

--- a/api/tests/test_showcase_video.py
+++ b/api/tests/test_showcase_video.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import av
 import numpy as np
@@ -66,6 +66,31 @@ def local_music_asset(monkeypatch, tmp_path_factory):
 
     monkeypatch.setattr("api.showcase.render.get_track", _local_track)
     return flac_path
+
+
+def _mock_modal_render(monkeypatch):
+    """Mock the Modal render_showcase_video function and required R2 helpers.
+
+    Returns a list of (storyboard, presigned_put, webhook_url, token) tuples
+    for each Modal call made by the task.
+    """
+    modal_calls = []
+    monkeypatch.setattr("api.r2.object_exists", lambda key: False)
+    monkeypatch.setattr(
+        "api.r2.generate_presigned_put",
+        lambda key, content_type, **kwargs: f"https://presigned.example.com/{key}",
+    )
+
+    def _mock_lookup(app_name, fn_name):
+        fn_mock = MagicMock()
+        fn_mock.remote = MagicMock()
+        fn_mock.remote.aio = AsyncMock(
+            side_effect=lambda *args, **kwargs: modal_calls.append(args)
+        )
+        return fn_mock
+
+    monkeypatch.setattr("api.tasks._modal_function", _mock_lookup)
+    return modal_calls
 
 
 def _set_r2_env(monkeypatch):
@@ -298,19 +323,11 @@ class TestShowcaseVideoApi:
         client.force_authenticate(user=user)
         url = reverse("piece-showcase-video", kwargs={"piece_id": piece.id})
 
-        with (
-            patch(
-                "api.tasks.InMemoryTaskInterface.submit",
-                autospec=True,
-                side_effect=lambda self_obj, task_obj: _execute_task(task_obj.id),
-            ),
-            patch(
-                "api.showcase.upload_showcase_video_to_r2",
-                autospec=True,
-                return_value=(
-                    "https://media.example.com/videos/showcase/video-hash.mp4"
-                ),
-            ),
+        _mock_modal_render(monkeypatch)
+        with patch(
+            "api.tasks.InMemoryTaskInterface.submit",
+            autospec=True,
+            side_effect=lambda self_obj, task_obj: _execute_task(task_obj.id),
         ):
             response = client.post(url, {}, format="json")
 
@@ -327,12 +344,11 @@ class TestShowcaseVideoApi:
         assert status_response.status_code == 200
         status_body = status_response.json()
         assert status_body["status"] == "succeeded"
-        assert status_body["artifact"]["url"] == (
-            "https://media.example.com/videos/showcase/video-hash.mp4"
+        assert status_body["artifact"]["url"].startswith(
+            "https://media.example.com/videos/showcase/"
         )
-        assert status_body["artifact"]["download_url"] == (
-            "https://media.example.com/videos/showcase/video-hash.mp4"
-        )
+        assert status_body["artifact"]["url"].endswith(".mp4")
+        assert status_body["artifact"]["download_url"] == status_body["artifact"]["url"]
 
     def test_task_uses_storyboard_snapshot_even_if_piece_changes_before_execution(
         self, client, user, tmp_path, monkeypatch
@@ -356,19 +372,11 @@ class TestShowcaseVideoApi:
         def _capture_submit(self_obj, task_obj):
             submitted.append(task_obj)
 
-        with (
-            patch(
-                "api.tasks.InMemoryTaskInterface.submit",
-                autospec=True,
-                side_effect=_capture_submit,
-            ),
-            patch(
-                "api.showcase.upload_showcase_video_to_r2",
-                autospec=True,
-                return_value=(
-                    "https://media.example.com/videos/showcase/video-hash.mp4"
-                ),
-            ),
+        _mock_modal_render(monkeypatch)
+        with patch(
+            "api.tasks.InMemoryTaskInterface.submit",
+            autospec=True,
+            side_effect=_capture_submit,
         ):
             response = client.post(url, {}, format="json")
 
@@ -379,12 +387,7 @@ class TestShowcaseVideoApi:
         piece.name = "Mutated Name"
         piece.save(update_fields=["name"])
 
-        with patch(
-            "api.showcase.upload_showcase_video_to_r2",
-            autospec=True,
-            return_value=("https://media.example.com/videos/showcase/video-hash.mp4"),
-        ):
-            _execute_task(task.id)
+        _execute_task(task.id)
 
         task.refresh_from_db()
         assert task.status == AsyncTask.Status.SUCCESS
@@ -407,19 +410,11 @@ class TestShowcaseVideoApi:
         client.force_authenticate(user=user)
         url = reverse("piece-showcase-video", kwargs={"piece_id": piece.id})
 
-        with (
-            patch(
-                "api.tasks.InMemoryTaskInterface.submit",
-                autospec=True,
-                side_effect=lambda self_obj, task_obj: _execute_task(task_obj.id),
-            ),
-            patch(
-                "api.showcase.upload_showcase_video_to_r2",
-                autospec=True,
-                return_value=(
-                    "https://media.example.com/videos/showcase/video-hash.mp4"
-                ),
-            ),
+        _mock_modal_render(monkeypatch)
+        with patch(
+            "api.tasks.InMemoryTaskInterface.submit",
+            autospec=True,
+            side_effect=lambda self_obj, task_obj: _execute_task(task_obj.id),
         ):
             response = client.post(url, {}, format="json")
 
@@ -461,45 +456,31 @@ class TestShowcaseVideoApi:
         piece.save()
 
         _set_r2_env(monkeypatch)
+        modal_calls = _mock_modal_render(monkeypatch)
 
         client.force_authenticate(user=user)
         url = reverse("piece-showcase-video", kwargs={"piece_id": piece.id})
 
-        with (
-            patch(
-                "api.tasks.InMemoryTaskInterface.submit",
-                autospec=True,
-                side_effect=lambda self_obj, task_obj: _execute_task(task_obj.id),
-            ),
-            patch(
-                "api.showcase.upload_showcase_video_to_r2",
-                autospec=True,
-                return_value=(
-                    "https://media.example.com/videos/showcase/video-hash.mp4"
-                ),
-            ) as upload_mock,
+        with patch(
+            "api.tasks.InMemoryTaskInterface.submit",
+            autospec=True,
+            side_effect=lambda self_obj, task_obj: _execute_task(task_obj.id),
         ):
             response = client.post(url, {}, format="json")
 
         assert response.status_code == 202
         task_id = response.json()["task_id"]
-        upload_mock.assert_called_once()
-        assert (
-            upload_mock.call_args.kwargs["input_hash"]
-            == AsyncTask.objects.get(id=task_id).input_params["input_hash"]
-        )
+        assert len(modal_calls) == 1
+        task_obj = AsyncTask.objects.get(id=task_id)
+        assert task_obj.result["input_hash"] == task_obj.input_params["input_hash"]
 
         status_response = client.get(url)
         assert status_response.status_code == 200
         artifact_url = status_response.json()["artifact"]["url"]
-        assert artifact_url == (
-            "https://media.example.com/videos/showcase/video-hash.mp4"
-        )
+        assert artifact_url.startswith("https://media.example.com/videos/showcase/")
+        assert artifact_url.endswith(".mp4")
 
-        task = AsyncTask.objects.get(id=task_id)
-        assert task.result["download_url"] == (
-            "https://media.example.com/videos/showcase/video-hash.mp4"
-        )
+        assert task_obj.result["download_url"] == artifact_url
 
     def test_submit_rejected_when_video_storage_is_not_configured(
         self, client, user, tmp_path, monkeypatch
@@ -614,6 +595,7 @@ class TestShowcaseVideoApi:
         self, client, user, tmp_path, monkeypatch
     ):
         _set_r2_env(monkeypatch)
+        _mock_modal_render(monkeypatch)
 
         piece = _make_piece_with_terminal_state(user)
         cover_path = tmp_path / "cover.png"
@@ -627,19 +609,10 @@ class TestShowcaseVideoApi:
         client.force_authenticate(user=user)
         url = reverse("piece-showcase-video", kwargs={"piece_id": piece.id})
 
-        with (
-            patch(
-                "api.tasks.InMemoryTaskInterface.submit",
-                autospec=True,
-                side_effect=lambda self_obj, task_obj: _execute_task(task_obj.id),
-            ),
-            patch(
-                "api.showcase.upload_showcase_video_to_r2",
-                autospec=True,
-                return_value=(
-                    "https://media.example.com/videos/showcase/video-hash.mp4"
-                ),
-            ),
+        with patch(
+            "api.tasks.InMemoryTaskInterface.submit",
+            autospec=True,
+            side_effect=lambda self_obj, task_obj: _execute_task(task_obj.id),
         ):
             first = client.post(url, {}, format="json")
             second = client.post(url, {}, format="json")

--- a/api/tests/test_task_progress_webhook.py
+++ b/api/tests/test_task_progress_webhook.py
@@ -1,0 +1,110 @@
+"""Tests for the Modal→Django progress webhook endpoint."""
+
+import time
+import uuid
+
+import pytest
+from django.contrib.auth.models import User
+from rest_framework.test import APIClient
+
+from api.models import AsyncTask
+from api.task_views import _make_progress_token, _verify_progress_token
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_superuser(
+        username="progress@example.com", email="progress@example.com", password="x"
+    )
+
+
+@pytest.fixture
+def task(user):
+    return AsyncTask.objects.create(user=user, task_type="ping")
+
+
+@pytest.fixture
+def client():
+    return APIClient()
+
+
+class TestProgressToken:
+    def test_make_and_verify_round_trip(self, task):
+        token = _make_progress_token(task.id)
+        assert _verify_progress_token(token, task.id)
+
+    def test_wrong_task_id_fails(self, task):
+        token = _make_progress_token(task.id)
+        other_id = uuid.uuid4()
+        assert not _verify_progress_token(token, other_id)
+
+    def test_tampered_sig_fails(self, task):
+        token = _make_progress_token(task.id)
+        parts = token.rsplit(":", 1)
+        bad_token = parts[0] + ":deadbeef" * 8
+        assert not _verify_progress_token(bad_token, task.id)
+
+    def test_malformed_token_fails(self, task):
+        assert not _verify_progress_token("not-a-token", task.id)
+        assert not _verify_progress_token("", task.id)
+
+    def test_expired_token_fails(self, task, monkeypatch):
+        monkeypatch.setattr("api.task_views._PROGRESS_TOKEN_TTL", -1)
+        token = _make_progress_token(task.id)
+        assert not _verify_progress_token(token, task.id)
+
+
+@pytest.mark.django_db
+class TestReportTaskProgressEndpoint:
+    def _url(self, task_id):
+        return f"/api/tasks/{task_id}/progress/"
+
+    def test_valid_token_updates_progress(self, client, task):
+        token = _make_progress_token(task.id)
+        resp = client.post(
+            self._url(task.id),
+            {"progress": 42},
+            format="json",
+            HTTP_X_TASK_TOKEN=token,
+        )
+        assert resp.status_code == 204
+        task.refresh_from_db()
+        assert task.progress == 42
+
+    def test_missing_token_returns_403(self, client, task):
+        resp = client.post(
+            self._url(task.id), {"progress": 10}, format="json"
+        )
+        assert resp.status_code == 403
+
+    def test_wrong_task_id_in_token_returns_403(self, client, task):
+        other_token = _make_progress_token(uuid.uuid4())
+        resp = client.post(
+            self._url(task.id),
+            {"progress": 10},
+            format="json",
+            HTTP_X_TASK_TOKEN=other_token,
+        )
+        assert resp.status_code == 403
+
+    def test_progress_out_of_range_returns_400(self, client, task):
+        token = _make_progress_token(task.id)
+        for bad_value in (101, -1, "not-an-int"):
+            resp = client.post(
+                self._url(task.id),
+                {"progress": bad_value},
+                format="json",
+                HTTP_X_TASK_TOKEN=token,
+            )
+            assert resp.status_code == 400, f"expected 400 for progress={bad_value}"
+
+    def test_unknown_task_id_returns_404(self, client):
+        random_id = uuid.uuid4()
+        token = _make_progress_token(random_id)
+        resp = client.post(
+            self._url(random_id),
+            {"progress": 50},
+            format="json",
+            HTTP_X_TASK_TOKEN=token,
+        )
+        assert resp.status_code == 404

--- a/api/urls.py
+++ b/api/urls.py
@@ -59,6 +59,7 @@ urlpatterns = [
     path("health/ready/", views.health_ready, name="health-ready"),
     path("tasks/", views.submit_task, name="tasks-submit"),
     path("tasks/<uuid:task_id>/", views.task_detail, name="tasks-detail"),
+    path("tasks/<uuid:task_id>/progress/", views.report_task_progress, name="tasks-progress"),
     path("telemetry/traces/", views.browser_traces, name="telemetry-traces"),
     path("pieces/", views.pieces, name="pieces"),
     path("pieces/<uuid:piece_id>/", views.piece_detail, name="piece-detail"),

--- a/api/views.py
+++ b/api/views.py
@@ -48,7 +48,7 @@ from .piece.views import (
     piece_states,
     pieces,
 )
-from .task_views import submit_task, task_detail
+from .task_views import report_task_progress, submit_task, task_detail
 from .telemetry_views import browser_traces
 from .uploads.views import (
     r2_convert_image,
@@ -96,6 +96,7 @@ __all__ = [
     "send_invite",
     "staff_invite_batch",
     "staff_invite_code",
+    "report_task_progress",
     "submit_task",
     "task_detail",
     "browser_traces",

--- a/chart/glaze/templates/deployment-worker.yaml
+++ b/chart/glaze/templates/deployment-worker.yaml
@@ -22,7 +22,7 @@ spec:
         - name: worker
           image: "{{ .Values.worker.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["python", "-m", "celery", "-A", "backend", "worker", "-l", "INFO", "--pool=solo"]
+          command: ["python", "-m", "celery", "-A", "backend", "worker", "-l", "INFO", "--pool=gevent"]
           securityContext:
             runAsUser: 1001
             runAsGroup: 1001
@@ -53,6 +53,16 @@ spec:
                 secretKeyRef:
                   name: glaze-secrets
                   key: R2_SECRET_ACCESS_KEY
+            - name: MODAL_TOKEN_ID
+              valueFrom:
+                secretKeyRef:
+                  name: glaze-secrets
+                  key: MODAL_TOKEN_ID
+            - name: MODAL_TOKEN_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: glaze-secrets
+                  key: MODAL_TOKEN_SECRET
             # Intentionally overrides the ConfigMap value (service.name=glaze) for the worker.
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: "service.name=glaze-worker"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,8 @@ dependencies = [
     "opentelemetry-instrumentation-redis>=0.62b1",
     "strawberry-graphql-django>=0.86.1",
     "boto3>=1.43.27",
+    "modal>=1.5.0",
+    "gevent>=26.5.0",
 ]
 
 [tool.uv]

--- a/services/BUILD.bazel
+++ b/services/BUILD.bazel
@@ -10,6 +10,7 @@ py_binary(
     srcs = ["glaze_compute_service.py"],
     deps = [
         "@pypi//modal",
+        "@pypi//pyyaml",
         "@pypi//requests",
         "@pypi//pillow",
         "@pypi//pillow_heif",

--- a/services/BUILD.bazel
+++ b/services/BUILD.bazel
@@ -6,6 +6,18 @@ load("@aspect_rules_py//py:defs.bzl", "py_binary")
 # The service will listen on port 8080 for segment requests.
 
 py_binary(
+    name = "glaze_compute_service",
+    srcs = ["glaze_compute_service.py"],
+    deps = [
+        "@pypi//modal",
+        "@pypi//requests",
+        "@pypi//pillow",
+        "@pypi//pillow_heif",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+py_binary(
     name = "piece_image_segment_service",
     srcs = ["piece_image_segment_service.py"],
     deps = [

--- a/services/glaze_compute_service.py
+++ b/services/glaze_compute_service.py
@@ -1,0 +1,571 @@
+"""Glaze compute service — remote offloading of CPU/memory-intensive tasks.
+
+All three functions use a metadata-in / metadata-out interface:
+- Celery passes public R2 source URLs and presigned PUT destination URLs.
+- Modal fetches source bytes, processes them, and PUTs results directly to R2.
+- No bytes transit through the Celery↔Modal boundary.
+
+Deployment (Modal):
+    modal deploy services/glaze_compute_service.py
+
+Local usage:
+    modal run services/glaze_compute_service.py::crop_image ...
+"""
+
+import io
+import logging
+import math
+import tempfile
+from fractions import Fraction
+from pathlib import Path
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+# ── Modal configuration ───────────────────────────────────────────────────────
+
+try:
+    import modal
+
+    _pil_image = (
+        modal.Image.debian_slim()
+        .pip_install(
+            # Versions must stay in sync with pyproject.toml — enforced by
+            # tools/check_modal_deps.py in CI.
+            "pillow==12.2.0",
+            "pillow-heif==1.3.0",
+            "requests==2.33.1",
+        )
+    )
+
+    _video_image = (
+        modal.Image.debian_slim()
+        .apt_install("ffmpeg")
+        .pip_install(
+            "av>=17.0.1",
+            "numpy",
+            "pillow==12.2.0",
+            "pillow-heif==1.3.0",
+            "requests==2.33.1",
+        )
+    )
+
+    app = modal.App("glaze-compute")
+
+except ImportError:
+    app = None  # type: ignore[assignment]
+    modal = None  # type: ignore[assignment]
+
+
+# ── Crop constants (mirror api/crops.py) ─────────────────────────────────────
+
+_CROPPED_IMAGE_MAX_EDGE = 1600
+_CROPPED_IMAGE_JPEG_QUALITY = 82
+
+# ── Showcase video constants (mirror api/showcase/render.py) ─────────────────
+
+_SHOWCASE_VIDEO_FPS = 24
+_SHOWCASE_VIDEO_CANVAS_SIZE = (1280, 720)
+_SHOWCASE_VIDEO_FADE_SECONDS = 0.75
+_SHOWCASE_VIDEO_CLOSING_SECONDS = 3.0
+_SLIDE_RENDER_SCALE = 2
+_BACKGROUND = (0, 0, 0)
+
+
+# ── PIL helpers ───────────────────────────────────────────────────────────────
+
+
+def _fetch_bytes(url: str) -> bytes:
+    import requests
+
+    resp = requests.get(url, timeout=60)
+    resp.raise_for_status()
+    return resp.content
+
+
+def _put_bytes(presigned_url: str, data: bytes, content_type: str) -> None:
+    import requests
+
+    resp = requests.put(
+        presigned_url,
+        data=data,
+        headers={"Content-Type": content_type},
+        timeout=120,
+    )
+    resp.raise_for_status()
+
+
+def _crop_image_bytes(original_bytes: bytes, crop: dict) -> bytes:
+    """Crop and resize image bytes to a JPEG derivative.
+
+    Mirrors generate_cropped_image_bytes() in api/crops.py exactly.
+    """
+    from PIL import Image as PILImage
+    from PIL import ImageOps
+    from pillow_heif import register_heif_opener
+
+    register_heif_opener()
+
+    with PILImage.open(io.BytesIO(original_bytes)) as source:
+        image = ImageOps.exif_transpose(source)
+        assert image is not None
+        width, height = image.size
+        left = max(0, min(width, round(float(crop["x"]) * width)))
+        top = max(0, min(height, round(float(crop["y"]) * height)))
+        right = max(
+            left + 1,
+            min(width, round((float(crop["x"]) + float(crop["width"])) * width)),
+        )
+        bottom = max(
+            top + 1,
+            min(height, round((float(crop["y"]) + float(crop["height"])) * height)),
+        )
+        cropped = image.crop((left, top, right, bottom))
+        long_edge = max(cropped.size)
+        if long_edge > _CROPPED_IMAGE_MAX_EDGE:
+            scale = _CROPPED_IMAGE_MAX_EDGE / long_edge
+            cropped = cropped.resize(
+                (
+                    max(1, round(cropped.size[0] * scale)),
+                    max(1, round(cropped.size[1] * scale)),
+                )
+            )
+        if cropped.mode == "RGBA":
+            bg = PILImage.new("RGB", cropped.size, (255, 255, 255))
+            bg.paste(cropped, mask=cropped.split()[3])
+            cropped = bg
+        elif cropped.mode != "RGB":
+            cropped = cropped.convert("RGB")
+        out = io.BytesIO()
+        cropped.save(out, format="JPEG", quality=_CROPPED_IMAGE_JPEG_QUALITY)
+        return out.getvalue()
+
+
+def _convert_to_jpeg_bytes(original_bytes: bytes) -> tuple[bytes, int, int]:
+    """Convert image bytes to JPEG, returning (jpeg_bytes, width, height).
+
+    Mirrors the PIL pipeline in the convert_image_to_jpeg task in api/tasks.py.
+    """
+    from PIL import Image as PILImage
+    from PIL import ImageOps
+    from pillow_heif import register_heif_opener
+
+    register_heif_opener()
+
+    with PILImage.open(io.BytesIO(original_bytes)) as src:
+        img = ImageOps.exif_transpose(src)
+        assert img is not None
+        if img.mode not in ("RGB", "RGBA"):
+            img = img.convert("RGB")
+        elif img.mode == "RGBA":
+            background = PILImage.new("RGB", img.size, (255, 255, 255))
+            background.paste(img, mask=img.split()[3])
+            img = background
+        long_edge = max(img.size)
+        _MAX = 2560
+        if long_edge > _MAX:
+            scale = _MAX / long_edge
+            img = img.resize(
+                (max(1, round(img.size[0] * scale)), max(1, round(img.size[1] * scale)))
+            )
+        width, height = img.size
+        out = io.BytesIO()
+        img.save(out, format="JPEG", quality=85, optimize=True)
+        return out.getvalue(), width, height
+
+
+# ── Showcase video helpers (mirrors api/showcase/render.py) ──────────────────
+
+
+def _slide_start_times(durations: list[float], transition_seconds: float) -> list[float]:
+    starts = []
+    t = 0.0
+    for i, d in enumerate(durations):
+        starts.append(t)
+        t += d
+        if i < len(durations) - 1:
+            t -= transition_seconds
+    return starts
+
+
+def _fade_alpha(t: float, fade_start: float, fade_seconds: float) -> float:
+    if fade_seconds <= 0 or t <= fade_start:
+        return 1.0
+    return min(1.0, max(0.0, 1.0 - (t - fade_start) / fade_seconds))
+
+
+def _render_slide_canvas(slide: dict) -> Any:
+    """Render a single slide dict to a PIL image at canvas size."""
+    from PIL import Image as PILImage
+    from PIL import ImageDraw, ImageFont, ImageOps
+    from pillow_heif import register_heif_opener
+    import requests
+
+    register_heif_opener()
+
+    scale = _SLIDE_RENDER_SCALE
+    canvas_w, canvas_h = _SHOWCASE_VIDEO_CANVAS_SIZE
+    render_w, render_h = canvas_w * scale, canvas_h * scale
+
+    canvas = PILImage.new("RGB", (render_w, render_h), _BACKGROUND)
+
+    image_url = (slide.get("cropped_image") or {}).get("url") or (
+        slide.get("image") or {}
+    ).get("url")
+    if image_url:
+        try:
+            img_bytes = requests.get(image_url, timeout=30).content
+            with PILImage.open(io.BytesIO(img_bytes)) as raw:
+                img = ImageOps.exif_transpose(raw)
+                assert img is not None
+                img = img.convert("RGB")
+                img_w, img_h = img.size
+                scale_factor = min(render_w / img_w, render_h / img_h)
+                new_w = max(1, round(img_w * scale_factor))
+                new_h = max(1, round(img_h * scale_factor))
+                img = img.resize((new_w, new_h), PILImage.Resampling.LANCZOS)
+                x = (render_w - new_w) // 2
+                y = (render_h - new_h) // 2
+                canvas.paste(img, (x, y))
+        except Exception:
+            logger.warning("Failed to fetch slide image: %s", image_url)
+
+    canvas = canvas.resize(
+        _SHOWCASE_VIDEO_CANVAS_SIZE, PILImage.Resampling.LANCZOS
+    )
+    return canvas
+
+
+def _make_progress_callback(
+    progress_webhook_url: str, progress_token: str
+) -> Callable[[int], None]:
+    import requests as req
+
+    def callback(pct: int) -> None:
+        try:
+            req.post(
+                progress_webhook_url,
+                json={"progress": pct},
+                headers={"X-Task-Token": progress_token},
+                timeout=5,
+            )
+        except Exception:
+            pass
+
+    return callback
+
+
+def _render_to_file(
+    storyboard: dict,
+    output_path: Path,
+    on_progress: Callable[[int], None] | None = None,
+) -> None:
+    """Render a storyboard to an fMP4+sidx file at output_path.
+
+    Uses frag_keyframe+empty_moov+default_base_moof+dash movflags for
+    efficient HTTP range-request seeking without a player library.
+    Fixed GOP (gop_size = FPS) gives deterministic fragment count.
+    """
+    import av
+    import numpy as np
+    from av.audio.resampler import AudioResampler
+
+    slides = list(storyboard.get("slides", []))
+    durations = [float(s.get("duration_seconds", 3.0)) for s in slides]
+    durations.append(_SHOWCASE_VIDEO_CLOSING_SECONDS)
+
+    transition_seconds = min(
+        _SHOWCASE_VIDEO_FADE_SECONDS,
+        *(d / 2 for d in durations),
+    )
+    fade_seconds = min(_SHOWCASE_VIDEO_FADE_SECONDS, durations[-1] / 2)
+
+    slide_canvases = [_render_slide_canvas(s) for s in slides]
+    closing_canvas = PILImage.new("RGB", _SHOWCASE_VIDEO_CANVAS_SIZE, _BACKGROUND)
+    slide_canvases.append(closing_canvas)
+
+    with av.open(
+        str(output_path),
+        mode="w",
+        format="mp4",
+        options={"movflags": "frag_keyframe+empty_moov+default_base_moof+dash"},
+    ) as container:
+        video_stream = container.add_stream("libx264", rate=_SHOWCASE_VIDEO_FPS)
+        video_stream.width = _SHOWCASE_VIDEO_CANVAS_SIZE[0]
+        video_stream.height = _SHOWCASE_VIDEO_CANVAS_SIZE[1]
+        video_stream.pix_fmt = "yuv420p"
+        video_stream.time_base = Fraction(1, _SHOWCASE_VIDEO_FPS)
+        video_stream.thread_count = 1
+        video_stream.codec_context.gop_size = _SHOWCASE_VIDEO_FPS
+
+        if len(slide_canvases) == 1:
+            total_frames = max(1, math.ceil(durations[0] * _SHOWCASE_VIDEO_FPS))
+        else:
+            starts = _slide_start_times(durations, transition_seconds)
+            effective_duration = starts[-1] + durations[-1]
+            total_frames = max(1, math.ceil(effective_duration * _SHOWCASE_VIDEO_FPS))
+
+        import time as _time
+        last_reported = _time.monotonic()
+        frame_count = 0
+        video_packets: list[Any] = []
+
+        for frame_img in _iter_video_frames(
+            slide_canvases, durations, transition_seconds, fade_seconds
+        ):
+            video_frame = av.VideoFrame.from_image(frame_img)
+            video_frame.pts = frame_count
+            video_frame.time_base = Fraction(1, _SHOWCASE_VIDEO_FPS)
+            for packet in video_stream.encode(video_frame):
+                video_packets.append(packet)
+            frame_count += 1
+            if on_progress is not None:
+                now = _time.monotonic()
+                if now - last_reported >= 1.0:
+                    on_progress(min(100, round(frame_count / total_frames * 100)))
+                    last_reported = now
+
+        for packet in video_stream.encode():
+            video_packets.append(packet)
+
+        video_duration_seconds = frame_count / _SHOWCASE_VIDEO_FPS
+
+        audio_stream = container.add_stream("aac", rate=44100)
+        audio_stream.layout = "stereo"
+        audio_resampler = AudioResampler(format="fltp", layout="stereo", rate=44100)
+
+        music_url = (storyboard.get("music") or {}).get("url")
+        audio_packets: list[Any] = []
+        sample_rate = 44100
+        target_samples = round(video_duration_seconds * sample_rate)
+        layout = "stereo"
+        packet_time_base = Fraction(1, sample_rate)
+
+        if music_url:
+            import requests as req
+
+            try:
+                music_bytes = req.get(music_url, timeout=30).content
+                with av.open(io.BytesIO(music_bytes)) as music_container:
+                    in_stream = music_container.streams.audio[0]
+                    samples_written = 0
+                    for frame in music_container.decode(in_stream):
+                        resampled = audio_resampler.resample(frame)
+                        if resampled is None:
+                            continue
+                        for rf in resampled if isinstance(resampled, list) else [resampled]:
+                            samples = np.array(rf.to_ndarray(), dtype=np.float32)
+                            if samples_written + samples.shape[-1] > target_samples:
+                                samples = samples[..., : target_samples - samples_written]
+                            audio_frame = av.AudioFrame.from_ndarray(
+                                samples, format="fltp", layout=layout
+                            )
+                            audio_frame.sample_rate = sample_rate
+                            audio_frame.pts = samples_written
+                            audio_frame.time_base = packet_time_base
+                            for packet in audio_stream.encode(audio_frame):
+                                packet.time_base = packet_time_base
+                                audio_packets.append(packet)
+                            samples_written += samples.shape[-1]
+                            if samples_written >= target_samples:
+                                break
+                    if samples_written < target_samples:
+                        remaining = target_samples - samples_written
+                        silence = av.AudioFrame(
+                            format="fltp", layout=layout, samples=remaining
+                        )
+                        silence.sample_rate = sample_rate
+                        silence.pts = samples_written
+                        silence.time_base = packet_time_base
+                        for plane in silence.planes:
+                            plane.update(b"\x00" * plane.buffer_size)
+                        for packet in audio_stream.encode(silence):
+                            packet.time_base = packet_time_base
+                            audio_packets.append(packet)
+            except Exception:
+                logger.warning("Failed to load music track, rendering silent video")
+
+        if not audio_packets:
+            silence = av.AudioFrame(
+                format="fltp", layout=layout, samples=target_samples
+            )
+            silence.sample_rate = sample_rate
+            silence.pts = 0
+            silence.time_base = packet_time_base
+            for plane in silence.planes:
+                plane.update(b"\x00" * plane.buffer_size)
+            for packet in audio_stream.encode(silence):
+                packet.time_base = packet_time_base
+                audio_packets.append(packet)
+
+        for packet in audio_stream.encode():
+            audio_packets.append(packet)
+
+        audio_offset = 0
+        for packet in audio_packets:
+            timestamp = packet.dts if packet.dts is not None else packet.pts
+            if timestamp is None:
+                continue
+            audio_offset = max(audio_offset, -int(timestamp))
+        if audio_offset:
+            for packet in audio_packets:
+                if packet.pts is not None:
+                    packet.pts += audio_offset
+                if packet.dts is not None:
+                    packet.dts += audio_offset
+
+        def _packet_timestamp(packet: Any) -> float:
+            timestamp = packet.dts if packet.dts is not None else packet.pts
+            if timestamp is None or packet.time_base is None:
+                return 0.0
+            return float(timestamp * packet.time_base)
+
+        for packet in sorted(
+            [*video_packets, *audio_packets],
+            key=lambda p: (
+                _packet_timestamp(p),
+                0 if p.stream and p.stream.type == "video" else 1,
+            ),
+        ):
+            container.mux(packet)
+
+
+def _iter_video_frames(
+    slide_canvases: list[Any],
+    durations: list[float],
+    transition_seconds: float,
+    fade_seconds: float,
+) -> Any:
+    """Yield PIL images for each video frame, with fade transitions."""
+    from PIL import Image as PILImage
+
+    fps = _SHOWCASE_VIDEO_FPS
+    n = len(slide_canvases)
+
+    if n == 1:
+        total_duration = durations[0]
+        fade_start = total_duration - fade_seconds
+        num_frames = max(1, math.ceil(total_duration * fps))
+        for i in range(num_frames):
+            t = i / fps
+            alpha = _fade_alpha(t, fade_start, fade_seconds)
+            if alpha < 1.0:
+                frame = PILImage.blend(
+                    slide_canvases[0],
+                    PILImage.new("RGB", _SHOWCASE_VIDEO_CANVAS_SIZE, _BACKGROUND),
+                    1.0 - alpha,
+                )
+            else:
+                frame = slide_canvases[0].copy()
+            yield frame
+        return
+
+    starts = _slide_start_times(durations, transition_seconds)
+    effective_duration = starts[-1] + durations[-1]
+    num_frames = max(1, math.ceil(effective_duration * fps))
+
+    for i in range(num_frames):
+        t = i / fps
+        # Find which slide(s) are active at time t
+        active_idx = 0
+        for idx in range(n):
+            if t >= starts[idx]:
+                active_idx = idx
+
+        slide_t = t - starts[active_idx]
+        current = slide_canvases[active_idx]
+
+        # Transition blend with next slide
+        if (
+            active_idx < n - 1
+            and slide_t >= durations[active_idx] - transition_seconds
+        ):
+            blend_t = (slide_t - (durations[active_idx] - transition_seconds)) / max(
+                transition_seconds, 1e-9
+            )
+            blend_t = max(0.0, min(1.0, blend_t))
+            frame = PILImage.blend(current, slide_canvases[active_idx + 1], blend_t)
+        else:
+            frame = current.copy()
+
+        # Fade out at end
+        global_fade_start = effective_duration - durations[-1] + (
+            durations[-1] - fade_seconds
+        )
+        alpha = _fade_alpha(t, global_fade_start, fade_seconds)
+        if alpha < 1.0:
+            frame = PILImage.blend(
+                frame,
+                PILImage.new("RGB", _SHOWCASE_VIDEO_CANVAS_SIZE, _BACKGROUND),
+                1.0 - alpha,
+            )
+
+        yield frame
+
+
+# Import at module level for _render_to_file reference
+try:
+    from PIL import Image as PILImage
+except ImportError:
+    PILImage = None  # type: ignore[assignment]
+
+
+# ── Modal functions ───────────────────────────────────────────────────────────
+
+if app is not None:
+
+    @app.function(image=_pil_image)
+    def crop_image(source_url: str, crop: dict, presigned_put_url: str) -> None:
+        """Fetch source image, apply crop, PUT JPEG derivative to R2.
+
+        Args:
+            source_url: Public R2 URL of the original image.
+            crop: Normalized {x, y, width, height} crop coordinates.
+            presigned_put_url: Presigned PUT URL for the crop derivative key.
+        """
+        original_bytes = _fetch_bytes(source_url)
+        jpeg_bytes = _crop_image_bytes(original_bytes, crop)
+        _put_bytes(presigned_put_url, jpeg_bytes, "image/jpeg")
+
+    @app.function(image=_pil_image)
+    def convert_to_jpeg(source_url: str, presigned_put_url: str) -> dict:
+        """Fetch source image, convert to JPEG, PUT to R2.
+
+        Args:
+            source_url: Public R2 URL of the source image.
+            presigned_put_url: Presigned PUT URL for the JPEG derivative key.
+
+        Returns:
+            {"width": int, "height": int} for DB writeback by Celery.
+        """
+        original_bytes = _fetch_bytes(source_url)
+        jpeg_bytes, width, height = _convert_to_jpeg_bytes(original_bytes)
+        _put_bytes(presigned_put_url, jpeg_bytes, "image/jpeg")
+        return {"width": width, "height": height}
+
+    @app.function(image=_video_image, ephemeral_disk=2048)
+    def render_showcase_video(
+        storyboard: dict,
+        presigned_put_url: str,
+        progress_webhook_url: str,
+        progress_token: str,
+    ) -> None:
+        """Render storyboard to fMP4+sidx, PUT MP4 to R2 via presigned URL.
+
+        Args:
+            storyboard: Render-ready storyboard snapshot dict.
+            presigned_put_url: Presigned PUT URL for the showcase video R2 key.
+            progress_webhook_url: URL to POST progress updates to.
+            progress_token: HMAC token for authenticating progress callbacks.
+        """
+        on_progress = _make_progress_callback(progress_webhook_url, progress_token)
+
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tf:
+            output_path = Path(tf.name)
+
+        try:
+            _render_to_file(storyboard, output_path, on_progress=on_progress)
+            mp4_bytes = output_path.read_bytes()
+            _put_bytes(presigned_put_url, mp4_bytes, "video/mp4")
+        finally:
+            output_path.unlink(missing_ok=True)

--- a/services/glaze_compute_service.py
+++ b/services/glaze_compute_service.py
@@ -40,14 +40,16 @@ try:
 
     _video_image = (
         modal.Image.debian_slim()
-        .apt_install("ffmpeg")
+        .apt_install("ffmpeg", "fonts-dejavu-core")
         .pip_install(
             "av>=17.0.1",
             "numpy",
             "pillow==12.2.0",
             "pillow-heif==1.3.0",
+            "pyyaml",
             "requests==2.33.1",
         )
+        .copy_local_file("music_catalog.yml", "/root/music_catalog.yml")
     )
 
     app = modal.App("glaze-compute")
@@ -194,25 +196,83 @@ def _fade_alpha(t: float, fade_start: float, fade_seconds: float) -> float:
     return min(1.0, max(0.0, 1.0 - (t - fade_start) / fade_seconds))
 
 
+_FONT_BOLD = "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf"
+_FONT_REGULAR = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+_TEXT_COLOR_PRIMARY = (255, 255, 255)
+_TEXT_COLOR_SECONDARY = (180, 180, 180)
+_TEXT_SHADOW = (0, 0, 0)
+
+
+def _load_font(path: str, size: int) -> Any:
+    from PIL import ImageFont
+
+    try:
+        return ImageFont.truetype(path, size)
+    except Exception:
+        return ImageFont.load_default()
+
+
+def _draw_text_centered(draw: Any, text: str, font: Any, canvas_w: int, y: int, color: tuple) -> None:
+    from PIL import ImageDraw
+
+    bbox = draw.textbbox((0, 0), text, font=font)
+    text_w = bbox[2] - bbox[0]
+    x = max(0, (canvas_w - text_w) // 2)
+    # Drop shadow for legibility over any background
+    draw.text((x + 2, y + 2), text, font=font, fill=_TEXT_SHADOW)
+    draw.text((x, y), text, font=font, fill=color)
+
+
+def _draw_text_wrapped(
+    draw: Any, text: str, font: Any, max_width: int, x: int, y: int, color: tuple
+) -> int:
+    """Draw wrapped text, return the y position after the last line."""
+    words = text.split()
+    lines: list[str] = []
+    current = ""
+    for word in words:
+        candidate = f"{current} {word}".strip() if current else word
+        bbox = draw.textbbox((0, 0), candidate, font=font)
+        if bbox[2] - bbox[0] <= max_width:
+            current = candidate
+        else:
+            if current:
+                lines.append(current)
+            current = word
+    if current:
+        lines.append(current)
+
+    line_height = draw.textbbox((0, 0), "A", font=font)[3] + 8
+    for line in lines:
+        draw.text((x + 2, y + 2), line, font=font, fill=_TEXT_SHADOW)
+        draw.text((x, y), line, font=font, fill=color)
+        y += line_height
+    return y
+
+
 def _render_slide_canvas(slide: dict) -> Any:
-    """Render a single slide dict to a PIL image at canvas size."""
+    """Render a single slide dict (cover/image/note) to a PIL image at canvas size."""
     from PIL import Image as PILImage
-    from PIL import ImageDraw, ImageFont, ImageOps
+    from PIL import ImageDraw, ImageOps
     from pillow_heif import register_heif_opener
     import requests
 
     register_heif_opener()
 
-    scale = _SLIDE_RENDER_SCALE
     canvas_w, canvas_h = _SHOWCASE_VIDEO_CANVAS_SIZE
-    render_w, render_h = canvas_w * scale, canvas_h * scale
+    canvas = PILImage.new("RGB", (canvas_w, canvas_h), _BACKGROUND)
+    draw = ImageDraw.Draw(canvas)
 
-    canvas = PILImage.new("RGB", (render_w, render_h), _BACKGROUND)
+    kind = slide.get("kind", "image")
+    image_data = slide.get("image")
+    heading = slide.get("heading") or ""
+    caption = slide.get("caption") or ""
+    text = slide.get("text") or ""
+    state_label = slide.get("state_label") or ""
 
-    image_url = (slide.get("cropped_image") or {}).get("url") or (
-        slide.get("image") or {}
-    ).get("url")
-    if image_url:
+    # Render photo if present (cover and image slides may have one)
+    if image_data and image_data.get("url"):
+        image_url = image_data["url"]
         try:
             img_bytes = requests.get(image_url, timeout=30).content
             with PILImage.open(io.BytesIO(img_bytes)) as raw:
@@ -220,19 +280,56 @@ def _render_slide_canvas(slide: dict) -> Any:
                 assert img is not None
                 img = img.convert("RGB")
                 img_w, img_h = img.size
-                scale_factor = min(render_w / img_w, render_h / img_h)
+                scale_factor = min(canvas_w / img_w, canvas_h / img_h)
                 new_w = max(1, round(img_w * scale_factor))
                 new_h = max(1, round(img_h * scale_factor))
                 img = img.resize((new_w, new_h), PILImage.Resampling.LANCZOS)
-                x = (render_w - new_w) // 2
-                y = (render_h - new_h) // 2
+                x = (canvas_w - new_w) // 2
+                y = (canvas_h - new_h) // 2
                 canvas.paste(img, (x, y))
         except Exception:
             logger.warning("Failed to fetch slide image: %s", image_url)
 
-    canvas = canvas.resize(
-        _SHOWCASE_VIDEO_CANVAS_SIZE, PILImage.Resampling.LANCZOS
-    )
+    if kind == "cover":
+        font_title = _load_font(_FONT_BOLD, 56)
+        font_sub = _load_font(_FONT_REGULAR, 28)
+        if heading:
+            _draw_text_centered(draw, heading, font_title, canvas_w, canvas_h // 2 - 40, _TEXT_COLOR_PRIMARY)
+        if state_label:
+            _draw_text_centered(draw, state_label, font_sub, canvas_w, canvas_h // 2 + 30, _TEXT_COLOR_SECONDARY)
+
+    elif kind == "note":
+        font_label = _load_font(_FONT_REGULAR, 22)
+        font_body = _load_font(_FONT_REGULAR, 30)
+        margin = 80
+        if state_label:
+            _draw_text_centered(draw, state_label.upper(), font_label, canvas_w, 40, _TEXT_COLOR_SECONDARY)
+        if text:
+            _draw_text_wrapped(draw, text, font_body, canvas_w - margin * 2, margin, 100, _TEXT_COLOR_PRIMARY)
+
+    else:  # "image"
+        font_caption = _load_font(_FONT_REGULAR, 24)
+        font_label = _load_font(_FONT_REGULAR, 20)
+        if caption:
+            _draw_text_centered(draw, caption, font_caption, canvas_w, canvas_h - 52, _TEXT_COLOR_SECONDARY)
+        if state_label:
+            draw.text((22, canvas_h - 52), state_label, font=font_label, fill=_TEXT_COLOR_SECONDARY)
+
+    return canvas
+
+
+def _render_closing_canvas() -> Any:
+    """Render a branded closing frame (black background, 'PotterDoc' wordmark)."""
+    from PIL import Image as PILImage
+    from PIL import ImageDraw
+
+    canvas_w, canvas_h = _SHOWCASE_VIDEO_CANVAS_SIZE
+    canvas = PILImage.new("RGB", (canvas_w, canvas_h), _BACKGROUND)
+    draw = ImageDraw.Draw(canvas)
+    font = _load_font(_FONT_BOLD, 64)
+    font_sub = _load_font(_FONT_REGULAR, 28)
+    _draw_text_centered(draw, "PotterDoc", font, canvas_w, canvas_h // 2 - 48, _TEXT_COLOR_PRIMARY)
+    _draw_text_centered(draw, "potterdoc.com", font_sub, canvas_w, canvas_h // 2 + 28, _TEXT_COLOR_SECONDARY)
     return canvas
 
 
@@ -255,6 +352,22 @@ def _make_progress_callback(
     return callback
 
 
+def _resolve_music_url(track_id: str | None) -> str | None:
+    """Resolve a music_track_id to its audio URL via the bundled catalog."""
+    if not track_id:
+        return None
+    try:
+        import yaml
+
+        with open("/root/music_catalog.yml") as f:
+            catalog = yaml.safe_load(f)
+        track = catalog.get("tracks", {}).get(track_id, {})
+        return (track.get("audio") or {}).get("url")
+    except Exception:
+        logger.warning("Failed to resolve music track %s from catalog", track_id)
+    return None
+
+
 def _render_to_file(
     storyboard: dict,
     output_path: Path,
@@ -271,7 +384,7 @@ def _render_to_file(
     from av.audio.resampler import AudioResampler
 
     slides = list(storyboard.get("slides", []))
-    durations = [float(s.get("duration_seconds", 3.0)) for s in slides]
+    durations = [float(s.get("duration_ms", 3000)) / 1000.0 for s in slides]
     durations.append(_SHOWCASE_VIDEO_CLOSING_SECONDS)
 
     transition_seconds = min(
@@ -281,8 +394,7 @@ def _render_to_file(
     fade_seconds = min(_SHOWCASE_VIDEO_FADE_SECONDS, durations[-1] / 2)
 
     slide_canvases = [_render_slide_canvas(s) for s in slides]
-    closing_canvas = PILImage.new("RGB", _SHOWCASE_VIDEO_CANVAS_SIZE, _BACKGROUND)
-    slide_canvases.append(closing_canvas)
+    slide_canvases.append(_render_closing_canvas())
 
     with av.open(
         str(output_path),
@@ -334,7 +446,7 @@ def _render_to_file(
         audio_stream.layout = "stereo"
         audio_resampler = AudioResampler(format="fltp", layout="stereo", rate=44100)
 
-        music_url = (storyboard.get("music") or {}).get("url")
+        music_url = _resolve_music_url(storyboard.get("music_track_id"))
         audio_packets: list[Any] = []
         sample_rate = 44100
         target_samples = round(video_duration_seconds * sample_rate)
@@ -503,13 +615,6 @@ def _iter_video_frames(
         yield frame
 
 
-# Import at module level for _render_to_file reference
-try:
-    from PIL import Image as PILImage
-except ImportError:
-    PILImage = None  # type: ignore[assignment]
-
-
 # ── Modal functions ───────────────────────────────────────────────────────────
 
 if app is not None:
@@ -543,7 +648,7 @@ if app is not None:
         _put_bytes(presigned_put_url, jpeg_bytes, "image/jpeg")
         return {"width": width, "height": height}
 
-    @app.function(image=_video_image, ephemeral_disk=2048)
+    @app.function(image=_video_image, ephemeral_disk=2048, timeout=900)
     def render_showcase_video(
         storyboard: dict,
         presigned_put_url: str,

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,64 @@ wheels = [
 ]
 
 [[package]]
+name = "aiohappyeyeballs"
+version = "2.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/c6/61a2d7b7572279226bb2e7f61d7a19ca7c90da0329c93fa0d560cbf288d8/aiohappyeyeballs-2.6.2.tar.gz", hash = "sha256:e202810ee718bd01fc6ef49e8ea53d023d5cb6b581076d7925aa499fa55dbe64", size = 22591, upload-time = "2026-05-20T15:12:24.631Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/fc/a7bf5b6e4e617b45f90f2d9d2a68519c249c81dd4fc2658c7a2a61c4f4b7/aiohappyeyeballs-2.6.2-py3-none-any.whl", hash = "sha256:4708045e2d7a6c6bdf8aafa8ed39649eaf926a4543b54560659129e3365953c4", size = 15062, upload-time = "2026-05-20T15:12:23.328Z" },
+]
+
+[[package]]
+name = "aiohttp"
+version = "3.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohappyeyeballs" },
+    { name = "aiosignal" },
+    { name = "attrs" },
+    { name = "frozenlist" },
+    { name = "multidict" },
+    { name = "propcache" },
+    { name = "typing-extensions" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/78/8ea7308cac6934de8c74a14f3d5f65d1c89287426688be79538d0e5c013d/aiohttp-3.14.1.tar.gz", hash = "sha256:307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035", size = 7955794, upload-time = "2026-06-07T21:09:35.529Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/21/151624b51cd92553d95424daf4bf19f19ce9be9002d19253e7e7ce67197b/aiohttp-3.14.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d35143e27778b4bb0fb189562d7f275bff79c62ab8e98459717c0ea617ff2480", size = 757402, upload-time = "2026-06-07T21:06:40.311Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/82/280619e0bd7bf2454987e19282616e84762255dd9c8468f62382e8c191f1/aiohttp-3.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:bcfb80a2cc36fba2534e5e5b5264dc7ae6fcd9bf15256da3e53d2f499e6fa29d", size = 512310, upload-time = "2026-06-07T21:06:42.207Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b2/2aac325583aaa1353045f96dffa586d8a34e8322e14a7ba49cffeb103ab4/aiohttp-3.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:27fd7c91e51729b4f7e1577865fa6d34c9adccbc39aabe9000285b48af9f0ec2", size = 512448, upload-time = "2026-06-07T21:06:43.813Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/72/a60607cb849faa8af8a356c9329ea2eb6f395d49e82cc82ccba1fd8deb8f/aiohttp-3.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:64c567bf9eaf664280116a8688f63016e6b32db2505908e2bdaca1b6438142f2", size = 1766854, upload-time = "2026-06-07T21:06:45.391Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d3/d9fe1c9ec7557ab4d0d82bebaa728c6418f0b93295ec2f4ab015f7710cc7/aiohttp-3.14.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:f5e6ff2bdbb8f4cd3fbe41f99e25bbcd58e3bf9f13d3dd31a11e7917251cc77a", size = 1740884, upload-time = "2026-06-07T21:06:47.413Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/dc/f2cecfaf9337ba3e63f181500814ff502aa3d00d9c7ec93a9d23d10a27b2/aiohttp-3.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2f73e01dc37122325caf079982621262f96d74823c179038a82fddfc50359264", size = 1810034, upload-time = "2026-06-07T21:06:50.165Z" },
+    { url = "https://files.pythonhosted.org/packages/66/d7/2ff65c5e65c0d7476daf7e15c032e0805e36811185b9623e3238ad6c763e/aiohttp-3.14.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bb2c0c80d431c0d03f2c7dbf125150fedd4f0de17366a7ca33f7ccb822391842", size = 1904054, upload-time = "2026-06-07T21:06:52.035Z" },
+    { url = "https://files.pythonhosted.org/packages/20/9c/d445818389df371f56d141d881153ba23183c4735a03f7356ffb43f7757d/aiohttp-3.14.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3e6fc1a85fa7194a1a7d19f44e8609180f4a8eb5fa4c7ed8b4355f080fad235c", size = 1790278, upload-time = "2026-06-07T21:06:54.049Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/aa/bf04cb4d865fc6101c2229a294ad744973b72e513fdc5a6b791e6983d72a/aiohttp-3.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:686b6c0d3911ec387b444ddf5dc62fb7f7c0a7d5186a7861626496a5ab4aff95", size = 1591795, upload-time = "2026-06-07T21:06:55.911Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b4/4dac0038960427ba832f6609dfb4ea5437d7fd80c72001b9e48f834f428b/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c6fa4dc7ad6f8109c70bb1499e589f76b0b792baf39f9b017eb92c8a81d0a199", size = 1728397, upload-time = "2026-06-07T21:06:57.777Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/7cd4e8ad7aa3b75f17d56bb5498dd604a93d4e6eece822ba0568c413fff0/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:87a5eea1b2a5e21e1ebdbb33ad4165359189327e63fc4e4894693e7f821ac817", size = 1766504, upload-time = "2026-06-07T21:07:00.009Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/df/fc01d9fcad0f73fed3f3d361f1f94f975947b50dff82919f6dc2bf4316cc/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1c1421eb01d4fd608d88cc8290211d177a58532b55ad94076fb349c5bf467f0a", size = 1777806, upload-time = "2026-06-07T21:07:02.064Z" },
+    { url = "https://files.pythonhosted.org/packages/41/09/47e2d090bddcc8fb4ccb4c314aadc32d7c5d9bb55f50f6ad1c92fc15d501/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:34b257ec41345c1e8f2df68fa908a7952f5de932723871eb633ecbbff396c9a4", size = 1580707, upload-time = "2026-06-07T21:07:03.942Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/36/f1a4ce904ae0b6930cfe9afc96d0896f7ec1a620c400405d63783bb95a9c/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:de538791a80e5d862addbc183f70f0158ac9b9bb872bb147f1fd2a683691e087", size = 1798121, upload-time = "2026-06-07T21:07:05.987Z" },
+    { url = "https://files.pythonhosted.org/packages/70/0a/e0075ce9ca0279ee1d4f0c0b85f54fea02ebc83c3007651a72bece658fec/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6f71173be42d3241d428f760122febb748de0623f44308a6f120d0dd9ec572e3", size = 1767580, upload-time = "2026-06-07T21:07:07.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/a0c0a8f327a9c52095cdd8e312391b00d3ed64ab6c72bb5c33d8ec251cf7/aiohttp-3.14.1-cp312-cp312-win32.whl", hash = "sha256:ec8dc383ee57ea3e883477dcca3f11b65d58199f1080acaf4cd6ad9a99698be4", size = 452771, upload-time = "2026-06-07T21:07:09.669Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d9/ea367c75f16ac9c6cdc8febb25e8318fa21a2b1bc8d6514d4b2d890bface/aiohttp-3.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:2aa92c87868cd13674989f9ee83e5f9f7ea4237589b728048e1f0c8f6caa3271", size = 479873, upload-time = "2026-06-07T21:07:11.538Z" },
+    { url = "https://files.pythonhosted.org/packages/03/64/8d96784a7851156db8a4c6c3f6f91042fdf39fb15a4cc38c8b3c14833c45/aiohttp-3.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:2c840c90759922cb5e6dda94596e079a30fb5a5ba548e7e0dc00574703940847", size = 448073, upload-time = "2026-06-07T21:07:13.637Z" },
+]
+
+[[package]]
+name = "aiosignal"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "frozenlist" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
+
+[[package]]
 name = "akismet"
 version = "25.10.1"
 source = { registry = "https://pypi.org/simple" }
@@ -173,6 +231,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/3b/39e13ce78a8e9a621c5df3aeb5fd181fcc8caba8c48a194cd629771f6828/brotli-1.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:af43b8711a8264bb4e7d6d9a6d004c3a2019c04c01127a868709ec29962b6036", size = 1487913, upload-time = "2025-11-05T18:38:31.618Z" },
     { url = "https://files.pythonhosted.org/packages/62/28/4d00cb9bd76a6357a66fcd54b4b6d70288385584063f4b07884c1e7286ac/brotli-1.2.0-cp312-cp312-win32.whl", hash = "sha256:e99befa0b48f3cd293dafeacdd0d191804d105d279e0b387a32054c1180f3161", size = 334362, upload-time = "2025-11-05T18:38:32.939Z" },
     { url = "https://files.pythonhosted.org/packages/1c/4e/bc1dcac9498859d5e353c9b153627a3752868a9d5f05ce8dedd81a2354ab/brotli-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:b35c13ce241abdd44cb8ca70683f20c0c079728a36a996297adb5334adfc1c44", size = 369115, upload-time = "2025-11-05T18:38:33.765Z" },
+]
+
+[[package]]
+name = "cbor2"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/af/473c241e41c142ea06ebef8d1f660fa6ff928fb97210e7bec8ee5974f8cd/cbor2-6.1.2.tar.gz", hash = "sha256:6b43037a66947dee5af0abb1a4c3a13b3abac5a4a3f32f9771efbbcd030fd909", size = 86760, upload-time = "2026-06-02T19:01:29.333Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/0c/a857b6ca032282b564cf25de18ad92fe0614e8b3fa3422eb10e32a873939/cbor2-6.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:92b158d3ff9d9dce70eeb09786a6e518e3cb0ecb927fd23e9a0f7fc4b175c01a", size = 409592, upload-time = "2026-06-02T19:00:44.556Z" },
+    { url = "https://files.pythonhosted.org/packages/29/db/e0518153b3228159d9373f3b5785d7ea2d68898e27ee1bce7d03f0b5f7aa/cbor2-6.1.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:d29a11044b07048e19f39a87fe8fea7ea865eb0ace50dc4c29513d52d40e2ddf", size = 454598, upload-time = "2026-06-02T19:00:45.784Z" },
+    { url = "https://files.pythonhosted.org/packages/29/67/62127b22edc6011ba55b76a28ab7c2219a45d01871a8199532e0978b26d1/cbor2-6.1.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a106f174eda34d8937a621c7f3e6044586cb209170cdc8da0ffbea89d1d6e385", size = 467380, upload-time = "2026-06-02T19:00:47.196Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/95/7992d8ec904c116ad547abb4960cc3fde695d5853c66596b1465d14d2f7b/cbor2-6.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ea16a25cc457a92879ff7a36cc50b587bddba09d8176bf1a94803eec5aa27eb", size = 521672, upload-time = "2026-06-02T19:00:48.656Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/cf/80cc4be132a523f0c92fb4c71813577bb393abea9e27990ca74605e0e930/cbor2-6.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2652a94224980d47f2a3866dd35b1afe532ecdfaf91f8cfcec39a026c457a844", size = 534402, upload-time = "2026-06-02T19:00:50.064Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ea/99e466d8bef61a0775a1d8538ae6c9d95f4533fadc01f8f7814cb7ab80ad/cbor2-6.1.2-cp312-cp312-win32.whl", hash = "sha256:618666292900487db4a5abcade3150105c9c9fdd22576e6ff297c9a72eef0c6a", size = 283225, upload-time = "2026-06-02T19:00:51.406Z" },
+    { url = "https://files.pythonhosted.org/packages/14/13/e6a677bdc499e43049006cb54fe605b0f7aef621402d31354cc42ef293c9/cbor2-6.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:c61c0b2e2cee64497e6c62d1976bc212f62ac0cd2b5b903613610d79b8b06b60", size = 300844, upload-time = "2026-06-02T19:00:52.628Z" },
+    { url = "https://files.pythonhosted.org/packages/77/4a/08bd8461f8e2e1ce1de5ae2768f2b7ca39a090e3156c1ee0d9b5fd86e70d/cbor2-6.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c871e7266ddc545b258e6f8e5300396985dc485d7ccf8bb4777385782f302153", size = 289040, upload-time = "2026-06-02T19:00:53.971Z" },
 ]
 
 [[package]]
@@ -433,9 +507,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/77/4396e853c3ee3b1264a2bb23f9b1934194ab750c6ecd30aa194b53dec7b9/django_admin_sortable2-2.3.1-py3-none-any.whl", hash = "sha256:5784f441f3532013438c3c3226fbccc39b9c733f867b26a5f477d6b05f734b93", size = 107015, upload-time = "2026-01-22T14:20:27.604Z" },
 ]
 
-# DO NOT MODIFY the wheels entry below — uv rewrites the url to a relative
-# path which breaks aspect_rules_py's lockfile parser. See:
-# https://github.com/shaoster/glaze/issues/792
 [[package]]
 name = "django-bootstrap4-form"
 version = "4.0.2"
@@ -443,6 +514,9 @@ source = { registry = "third_party/python" }
 dependencies = [
     { name = "django" },
 ]
+# DO NOT MODIFY the wheels entry below — uv rewrites the url to a relative
+# path which breaks aspect_rules_py's lockfile parser. See:
+# https://github.com/shaoster/glaze/issues/792
 wheels = [
     { url = "https://raw.githubusercontent.com/shaoster/glaze/7e899ff17dc550446652fa813f38ab5331e6db1f/third_party/python/django_bootstrap4_form-4.0.2-py3-none-any.whl", hash = "sha256:ed4bcfc1246e449d61b6d946c8c918e48b6d239c504fcf03cd711108c20c5555", size = 7071 },
 ]
@@ -674,6 +748,54 @@ wheels = [
 ]
 
 [[package]]
+name = "frozenlist"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/29/948b9aa87e75820a38650af445d2ef2b6b8a6fab1a23b6bb9e4ef0be2d59/frozenlist-1.8.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:78f7b9e5d6f2fdb88cdde9440dc147259b62b9d3b019924def9f6478be254ac1", size = 87782, upload-time = "2025-10-06T05:36:06.649Z" },
+    { url = "https://files.pythonhosted.org/packages/64/80/4f6e318ee2a7c0750ed724fa33a4bdf1eacdc5a39a7a24e818a773cd91af/frozenlist-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:229bf37d2e4acdaf808fd3f06e854a4a7a3661e871b10dc1f8f1896a3b05f18b", size = 50594, upload-time = "2025-10-06T05:36:07.69Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/94/5c8a2b50a496b11dd519f4a24cb5496cf125681dd99e94c604ccdea9419a/frozenlist-1.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f833670942247a14eafbb675458b4e61c82e002a148f49e68257b79296e865c4", size = 50448, upload-time = "2025-10-06T05:36:08.78Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:494a5952b1c597ba44e0e78113a7266e656b9794eec897b19ead706bd7074383", size = 242411, upload-time = "2025-10-06T05:36:09.801Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/83/f61505a05109ef3293dfb1ff594d13d64a2324ac3482be2cedc2be818256/frozenlist-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f423a119f4777a4a056b66ce11527366a8bb92f54e541ade21f2374433f6d4", size = 243014, upload-time = "2025-10-06T05:36:11.394Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/cb/cb6c7b0f7d4023ddda30cf56b8b17494eb3a79e3fda666bf735f63118b35/frozenlist-1.8.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3462dd9475af2025c31cc61be6652dfa25cbfb56cbbf52f4ccfe029f38decaf8", size = 234909, upload-time = "2025-10-06T05:36:12.598Z" },
+    { url = "https://files.pythonhosted.org/packages/31/c5/cd7a1f3b8b34af009fb17d4123c5a778b44ae2804e3ad6b86204255f9ec5/frozenlist-1.8.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4c800524c9cd9bac5166cd6f55285957fcfc907db323e193f2afcd4d9abd69b", size = 250049, upload-time = "2025-10-06T05:36:14.065Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/01/2f95d3b416c584a1e7f0e1d6d31998c4a795f7544069ee2e0962a4b60740/frozenlist-1.8.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d6a5df73acd3399d893dafc71663ad22534b5aa4f94e8a2fabfe856c3c1b6a52", size = 256485, upload-time = "2025-10-06T05:36:15.39Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/03/024bf7720b3abaebcff6d0793d73c154237b85bdf67b7ed55e5e9596dc9a/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:405e8fe955c2280ce66428b3ca55e12b3c4e9c336fb2103a4937e891c69a4a29", size = 237619, upload-time = "2025-10-06T05:36:16.558Z" },
+    { url = "https://files.pythonhosted.org/packages/69/fa/f8abdfe7d76b731f5d8bd217827cf6764d4f1d9763407e42717b4bed50a0/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:908bd3f6439f2fef9e85031b59fd4f1297af54415fb60e4254a95f75b3cab3f3", size = 250320, upload-time = "2025-10-06T05:36:17.821Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/3c/b051329f718b463b22613e269ad72138cc256c540f78a6de89452803a47d/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:294e487f9ec720bd8ffcebc99d575f7eff3568a08a253d1ee1a0378754b74143", size = 246820, upload-time = "2025-10-06T05:36:19.046Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ae/58282e8f98e444b3f4dd42448ff36fa38bef29e40d40f330b22e7108f565/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:74c51543498289c0c43656701be6b077f4b265868fa7f8a8859c197006efb608", size = 250518, upload-time = "2025-10-06T05:36:20.763Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/96/007e5944694d66123183845a106547a15944fbbb7154788cbf7272789536/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:776f352e8329135506a1d6bf16ac3f87bc25b28e765949282dcc627af36123aa", size = 239096, upload-time = "2025-10-06T05:36:22.129Z" },
+    { url = "https://files.pythonhosted.org/packages/66/bb/852b9d6db2fa40be96f29c0d1205c306288f0684df8fd26ca1951d461a56/frozenlist-1.8.0-cp312-cp312-win32.whl", hash = "sha256:433403ae80709741ce34038da08511d4a77062aa924baf411ef73d1146e74faf", size = 39985, upload-time = "2025-10-06T05:36:23.661Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/af/38e51a553dd66eb064cdf193841f16f077585d4d28394c2fa6235cb41765/frozenlist-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:34187385b08f866104f0c0617404c8eb08165ab1272e884abc89c112e9c00746", size = 44591, upload-time = "2025-10-06T05:36:24.958Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/06/1dc65480ab147339fecc70797e9c2f69d9cea9cf38934ce08df070fdb9cb/frozenlist-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:fe3c58d2f5db5fbd18c2987cba06d51b0529f52bc3a6cdc33d3f4eab725104bd", size = 40102, upload-time = "2025-10-06T05:36:26.333Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "gevent"
+version = "26.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation == 'CPython' and sys_platform == 'win32'" },
+    { name = "greenlet", marker = "platform_python_implementation == 'CPython'" },
+    { name = "zope-event" },
+    { name = "zope-interface" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/cb/98aa3a299e2fc4a2372b5d124863e02965b64579ffc29fe54d0641e65b2f/gevent-26.5.0.tar.gz", hash = "sha256:1655eb04c1e20d71b2aa4a3c7528162dd58ff6cc46a037af1f01f534c80fefba", size = 6712354, upload-time = "2026-05-20T21:22:45.132Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/0b/1a530b2db55c97cc0cf44116201f538f3033c04c1d2aca143979b412f4be/gevent-26.5.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:e80ad2a8a1e8bdaa5605e3bf4929e0cebf9ea7b8237c83362f7257698bb14280", size = 2929714, upload-time = "2026-05-20T20:13:24.656Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/df/32fe851ed5f68493f354e09b19bdebae0de1185be4db0b2988e71e737fd3/gevent-26.5.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:fe42c037253580a3386fce275f8a2a845e540f5a729916934a732f13d42e72cc", size = 1784838, upload-time = "2026-05-20T21:17:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/9a/21332674f9a10e8cdf13b41b52e9d663647a1c6e1dc3c62b07c0aeefd360/gevent-26.5.0-cp312-cp312-manylinux_2_28_ppc64le.whl", hash = "sha256:9f463c7d6f69d13b6fe8e3b832a6175a6e95328a940f38495d25496d1ae8ad88", size = 1880440, upload-time = "2026-05-20T21:16:00.881Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/b1/5f8a4196113cf7f3fdd987b483f7e6b10c28ea3930c4727e31ba8cce51b6/gevent-26.5.0-cp312-cp312-manylinux_2_28_s390x.whl", hash = "sha256:96d5e96b1b14a4c1023dcfcc114533217f13febc3b6169254f23fc18d19fee29", size = 1831592, upload-time = "2026-05-20T21:30:53.832Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/69/1559b1f6b5107a9118fccd300240879bd581b6d87b03d568d0d155ea702c/gevent-26.5.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:bccff69c462e3650a0fd1d4e9cfc8b6effe15f3e9b1cad20a7bb5ce14b057efd", size = 2114915, upload-time = "2026-05-20T20:35:25.041Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/32/602c499d54472f64e5cdf6013aeab5ce6aa6fed005387e8b4f2d22f5dc8d/gevent-26.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f519139354d5ca7625df9ddb1b2ffada885c14abc5b4dbae3682e967ddf79669", size = 1796906, upload-time = "2026-05-20T21:16:39.65Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/3c/2fe77ee6e3d381b3c50c0b7d6c4c08c08b8ff5e8c0d9dd51a3b426d61eec/gevent-26.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0bf57df54f1c66273bf3601c2a1e41b12138fe848933718369663bc54f177ca2", size = 2140806, upload-time = "2026-05-20T20:43:28.895Z" },
+    { url = "https://files.pythonhosted.org/packages/22/d5/4620797bbd9c88f4541188efc138b0d615f9834db540da36a2249ee929c5/gevent-26.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:e49ce0de007dfd7412edbc2b5d41cce33b049bb1b7086f50be5a09e601bde603", size = 1699995, upload-time = "2026-05-20T20:15:39.311Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/83/ac3477dfc0f9fd80c88110102c73cefc35dcded2b248544f45a8fa5412df/gevent-26.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:5c5ff29495a2eed2a244de8150f21893d6c1b15d8b4b5719ab4bbfa06db1e28f", size = 1547433, upload-time = "2026-05-20T20:15:51.656Z" },
+]
+
+[[package]]
 name = "glaze"
 version = "0.1.0"
 source = { virtual = "." }
@@ -712,6 +834,7 @@ dependencies = [
     { name = "drf-spectacular" },
     { name = "fastapi" },
     { name = "flatbuffers" },
+    { name = "gevent" },
     { name = "google-auth" },
     { name = "gunicorn" },
     { name = "h11" },
@@ -728,6 +851,7 @@ dependencies = [
     { name = "lazy-loader" },
     { name = "librt" },
     { name = "llvmlite" },
+    { name = "modal" },
     { name = "msgpack" },
     { name = "mypy" },
     { name = "mypy-extensions" },
@@ -818,6 +942,7 @@ requires-dist = [
     { name = "drf-spectacular", specifier = "==0.29.0" },
     { name = "fastapi", specifier = "==0.136.1" },
     { name = "flatbuffers", specifier = "==25.12.19" },
+    { name = "gevent", specifier = ">=26.5.0" },
     { name = "google-auth", specifier = "==2.49.1" },
     { name = "gunicorn", specifier = "==23.0.0" },
     { name = "h11", specifier = "==0.16.0" },
@@ -834,6 +959,7 @@ requires-dist = [
     { name = "lazy-loader", specifier = "==0.5" },
     { name = "librt", specifier = "==0.8.1" },
     { name = "llvmlite", specifier = "==0.47.0" },
+    { name = "modal", specifier = ">=1.5.0" },
     { name = "msgpack", specifier = "==1.1.2" },
     { name = "mypy", specifier = "==1.20.0" },
     { name = "mypy-extensions", specifier = "==1.1.0" },
@@ -973,6 +1099,24 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/6e/802acd792aebb2256fbbee8cacf2727faaeb6f240ac11008f09eae4414bc/greenlet-3.5.1.tar.gz", hash = "sha256:5a56aeb7d5d9cc4b3a735efb5095bd4b4f6f0e4f93e5ca876d0e2315137b7829", size = 197356, upload-time = "2026-05-20T15:05:03.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/37/4549f149c9797c21b32c2683c33522af22522099de128b2406672526d005/greenlet-3.5.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:fa4f98af3a528f0c3fd592a26df7f376f93329c8f4d987f6bb979057af8bf5e2", size = 286220, upload-time = "2026-05-20T13:07:28.463Z" },
+    { url = "https://files.pythonhosted.org/packages/38/ff/a4f436709716965eaab9f36ea7b906c8a927fbe32fb1372a2071d964f6b1/greenlet-3.5.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffea73584b216150eab159b6d12348fb253e68757974de1e2c40d8a318ac89ed", size = 601585, upload-time = "2026-05-20T14:00:06.141Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ad/54bc3fcee3ad368a61b19b67d88117f7a8c29727bf71fffdeda81fbd946e/greenlet-3.5.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1072b4f9edcc1e192d9283a66a3e68d6b84c561de33a83d7858beb9ba1effe10", size = 614215, upload-time = "2026-05-20T14:05:42.675Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/6c/de5b1b388cd2d9fbdfeab324863daba37d54e6e233ddbefd70b385a8c591/greenlet-3.5.1-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:89101bfd5011e069be974903cb3a4e4523845e4ece2d62dcd8d358933c0ef249", size = 620094, upload-time = "2026-05-20T14:09:09.18Z" },
+    { url = "https://files.pythonhosted.org/packages/40/69/b91cda0647df839483201545913514c2827ebea5e5ccdf931842763bc127/greenlet-3.5.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:add5217d68b31130f0beca584d7fef4878327d2e31642b66618a14eef312b63b", size = 611358, upload-time = "2026-05-20T13:14:26.37Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/43/1204baffab8a6476464795a7ccf394a3248d4f22c9f87173a15b36b6d971/greenlet-3.5.1-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:e6cd99ea59dd5d89f0c956606571d79bfe6f68c9eb7f4a4083a41a7f1587edee", size = 422782, upload-time = "2026-05-20T14:01:39.597Z" },
+    { url = "https://files.pythonhosted.org/packages/59/90/3cf77e080350cd02fa307bb2abf05df48f4482c240275bbd2c203ba8bb1c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a5ea42a752d47a145eae922b605cd1634665ac3d5ec1e72402d5048e8d60d207", size = 1570475, upload-time = "2026-05-20T14:02:25.29Z" },
+    { url = "https://files.pythonhosted.org/packages/65/2c/18cece62045e74598c3c393f70dce4a63f56222015ba29a5d4eeb04f764c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c5551170cf4f5ff5623e9af81323751979fee2c731e2287b61f73cd27257b823", size = 1635625, upload-time = "2026-05-20T13:14:34.027Z" },
+    { url = "https://files.pythonhosted.org/packages/30/f5/310d104ddf41eb5a70f4c268d22508dfb0c3c8e86fec152be34d0d2ed819/greenlet-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3c8bb982ad117d29478ef8f5533e97df21f1e2befd17a299257b0c96d1371c0b", size = 238791, upload-time = "2026-05-20T13:10:39.018Z" },
+    { url = "https://files.pythonhosted.org/packages/62/90/ceca11f504cd23a8047a3dea31919adc48df9b626dd0c13f0d858734fdfd/greenlet-3.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:80eb4b04dadc4e67df3fae179a32c4706a3f495bc7f22fc8a81115d5f5512188", size = 235580, upload-time = "2026-05-20T13:08:45.056Z" },
+]
+
+[[package]]
 name = "grpcio"
 version = "1.80.0"
 source = { registry = "https://pypi.org/simple" }
@@ -994,6 +1138,19 @@ wheels = [
 ]
 
 [[package]]
+name = "grpclib"
+version = "0.4.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h2" },
+    { name = "multidict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/28/5a2c299ec82a876a252c5919aa895a6f1d1d35c96417c5ce4a4660dc3a80/grpclib-0.4.9.tar.gz", hash = "sha256:cc589c330fa81004c6400a52a566407574498cb5b055fa927013361e21466c46", size = 84798, upload-time = "2025-12-14T22:23:14.349Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/90/b0cbbd9efcc82816c58f31a34963071aa19fb792a212a5d9caf8e0fc3097/grpclib-0.4.9-py3-none-any.whl", hash = "sha256:7762ec1c8ed94dfad597475152dd35cbd11aecaaca2f243e29702435ca24cf0e", size = 77063, upload-time = "2025-12-14T22:23:13.224Z" },
+]
+
+[[package]]
 name = "gunicorn"
 version = "23.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1012,6 +1169,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
 ]
 
 [[package]]
@@ -1040,6 +1219,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -1247,6 +1435,51 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "modal"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "cbor2" },
+    { name = "certifi" },
+    { name = "click" },
+    { name = "grpclib" },
+    { name = "protobuf" },
+    { name = "rich" },
+    { name = "synchronicity" },
+    { name = "toml" },
+    { name = "types-certifi" },
+    { name = "types-toml" },
+    { name = "typing-extensions" },
+    { name = "watchfiles" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/f9/87425e60db2a8597b248417772b409c49ca3a05ff6b1282a21cd7d856f09/modal-1.5.0.tar.gz", hash = "sha256:15033cf84f5f4f9f8a3dcf47a768cfcca36d1ad38ab7b3459fd3cbc29aa84a77", size = 771722, upload-time = "2026-06-09T22:37:27.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/71/85e476e7d32c0a648d5aa97c4335ac02357d059c2bb734cf175b08446597/modal-1.5.0-py3-none-any.whl", hash = "sha256:9c5687eff775d1372bd70b87e43499e40777a1de160f23786c00807bf342fcb6", size = 882122, upload-time = "2026-06-09T22:37:24.608Z" },
+]
+
+[[package]]
 name = "msgpack"
 version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1261,6 +1494,33 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/41/0d/2ddfaa8b7e1cee6c490d46cb0a39742b19e2481600a7a0e96537e9c22f43/msgpack-1.1.2-cp312-cp312-win32.whl", hash = "sha256:1fff3d825d7859ac888b0fbda39a42d59193543920eda9d9bea44d958a878029", size = 65096, upload-time = "2025-10-08T09:15:11.11Z" },
     { url = "https://files.pythonhosted.org/packages/8c/ec/d431eb7941fb55a31dd6ca3404d41fbb52d99172df2e7707754488390910/msgpack-1.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1de460f0403172cff81169a30b9a92b260cb809c4cb7e2fc79ae8d0510c78b6b", size = 72708, upload-time = "2025-10-08T09:15:12.554Z" },
     { url = "https://files.pythonhosted.org/packages/c5/31/5b1a1f70eb0e87d1678e9624908f86317787b536060641d6798e3cf70ace/msgpack-1.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:be5980f3ee0e6bd44f3a9e9dea01054f175b50c3e6cdb692bc9424c0bbb8bf69", size = 64119, upload-time = "2025-10-08T09:15:13.589Z" },
+]
+
+[[package]]
+name = "multidict"
+version = "6.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9c/f20e0e2cf80e4b2e4b1c365bf5fe104ee633c751a724246262db8f1a0b13/multidict-6.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a90f75c956e32891a4eda3639ce6dd86e87105271f43d43442a3aedf3cddf172", size = 76893, upload-time = "2026-01-26T02:43:52.754Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/cf/18ef143a81610136d3da8193da9d80bfe1cb548a1e2d1c775f26b23d024a/multidict-6.7.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3fccb473e87eaa1382689053e4a4618e7ba7b9b9b8d6adf2027ee474597128cd", size = 45456, upload-time = "2026-01-26T02:43:53.893Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/65/1caac9d4cd32e8433908683446eebc953e82d22b03d10d41a5f0fefe991b/multidict-6.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b0fa96985700739c4c7853a43c0b3e169360d6855780021bfc6d0f1ce7c123e7", size = 43872, upload-time = "2026-01-26T02:43:55.041Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/3b/d6bd75dc4f3ff7c73766e04e705b00ed6dbbaccf670d9e05a12b006f5a21/multidict-6.7.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cb2a55f408c3043e42b40cc8eecd575afa27b7e0b956dfb190de0f8499a57a53", size = 251018, upload-time = "2026-01-26T02:43:56.198Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/80/c959c5933adedb9ac15152e4067c702a808ea183a8b64cf8f31af8ad3155/multidict-6.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb0ce7b2a32d09892b3dd6cc44877a0d02a33241fafca5f25c8b6b62374f8b75", size = 258883, upload-time = "2026-01-26T02:43:57.499Z" },
+    { url = "https://files.pythonhosted.org/packages/86/85/7ed40adafea3d4f1c8b916e3b5cc3a8e07dfcdcb9cd72800f4ed3ca1b387/multidict-6.7.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c3a32d23520ee37bf327d1e1a656fec76a2edd5c038bf43eddfa0572ec49c60b", size = 242413, upload-time = "2026-01-26T02:43:58.755Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/57/b8565ff533e48595503c785f8361ff9a4fde4d67de25c207cd0ba3befd03/multidict-6.7.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9c90fed18bffc0189ba814749fdcc102b536e83a9f738a9003e569acd540a733", size = 268404, upload-time = "2026-01-26T02:44:00.216Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/50/9810c5c29350f7258180dfdcb2e52783a0632862eb334c4896ac717cebcb/multidict-6.7.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:da62917e6076f512daccfbbde27f46fed1c98fee202f0559adec8ee0de67f71a", size = 269456, upload-time = "2026-01-26T02:44:02.202Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfde23ef6ed9db7eaee6c37dcec08524cb43903c60b285b172b6c094711b3961", size = 256322, upload-time = "2026-01-26T02:44:03.56Z" },
+    { url = "https://files.pythonhosted.org/packages/31/6e/d8a26d81ac166a5592782d208dd90dfdc0a7a218adaa52b45a672b46c122/multidict-6.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3758692429e4e32f1ba0df23219cd0b4fc0a52f476726fff9337d1a57676a582", size = 253955, upload-time = "2026-01-26T02:44:04.845Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4c/7c672c8aad41534ba619bcd4ade7a0dc87ed6b8b5c06149b85d3dd03f0cd/multidict-6.7.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:398c1478926eca669f2fd6a5856b6de9c0acf23a2cb59a14c0ba5844fa38077e", size = 251254, upload-time = "2026-01-26T02:44:06.133Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/bd/84c24de512cbafbdbc39439f74e967f19570ce7924e3007174a29c348916/multidict-6.7.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:c102791b1c4f3ab36ce4101154549105a53dc828f016356b3e3bcae2e3a039d3", size = 252059, upload-time = "2026-01-26T02:44:07.518Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ba/f5449385510825b73d01c2d4087bf6d2fccc20a2d42ac34df93191d3dd03/multidict-6.7.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:a088b62bd733e2ad12c50dad01b7d0166c30287c166e137433d3b410add807a6", size = 263588, upload-time = "2026-01-26T02:44:09.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/11/afc7c677f68f75c84a69fe37184f0f82fce13ce4b92f49f3db280b7e92b3/multidict-6.7.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:3d51ff4785d58d3f6c91bdbffcb5e1f7ddfda557727043aa20d20ec4f65e324a", size = 259642, upload-time = "2026-01-26T02:44:10.73Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/17/ebb9644da78c4ab36403739e0e6e0e30ebb135b9caf3440825001a0bddcb/multidict-6.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc5907494fccf3e7d3f94f95c91d6336b092b5fc83811720fae5e2765890dfba", size = 251377, upload-time = "2026-01-26T02:44:12.042Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/a4/840f5b97339e27846c46307f2530a2805d9d537d8b8bd416af031cad7fa0/multidict-6.7.1-cp312-cp312-win32.whl", hash = "sha256:28ca5ce2fd9716631133d0e9a9b9a745ad7f60bac2bccafb56aa380fc0b6c511", size = 41887, upload-time = "2026-01-26T02:44:14.245Z" },
+    { url = "https://files.pythonhosted.org/packages/80/31/0b2517913687895f5904325c2069d6a3b78f66cc641a86a2baf75a05dcbb/multidict-6.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcee94dfbd638784645b066074b338bc9cc155d4b4bffa4adce1615c5a426c19", size = 46053, upload-time = "2026-01-26T02:44:15.371Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/5b/aba28e4ee4006ae4c7df8d327d31025d760ffa992ea23812a601d226e682/multidict-6.7.1-cp312-cp312-win_arm64.whl", hash = "sha256:ba0a9fb644d0c1a2194cf7ffb043bd852cea63a57f66fbd33959f7dae18517bf", size = 43307, upload-time = "2026-01-26T02:44:16.852Z" },
+    { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
 ]
 
 [[package]]
@@ -1680,6 +1940,32 @@ wheels = [
 ]
 
 [[package]]
+name = "propcache"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/44/c87281c333769159c50594f22610f77398a47ccbfbbf23074e744e86f87c/propcache-0.5.2.tar.gz", hash = "sha256:01c4fc7480cd0598bb4b57022df55b9ca296da7fc5a8760bd8451a7e63a7d427", size = 50208, upload-time = "2026-05-08T21:02:12.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/cb/e27bc2b2737a0bb49962b275efa051e8f1c35a936df7d5139b6b658b7dc9/propcache-0.5.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:806719138ecd720339a12410fb9614ac9b2b2d3a5fdf8235d56981c36f4039ba", size = 95887, upload-time = "2026-05-08T21:00:11.277Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/13/b8ae04c59392f8d11c6cd9fb4011d1dc7c86b81225c770280300e259ffe1/propcache-0.5.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:db2b80ea58eab4f86b2beec3cc8b39e8ff9276ac20e96b7cce43c8ae84cd6b5a", size = 54654, upload-time = "2026-05-08T21:00:12.604Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/7d/49777a3e20b55863d4794384a38acd460c04157b0a00f8602b0d508b8431/propcache-0.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e5cbfac9f61484f7e9f3597775500cd3ebe8274e9b050c38f9525c77c97520bf", size = 55190, upload-time = "2026-05-08T21:00:13.935Z" },
+    { url = "https://files.pythonhosted.org/packages/44/c7/085d0cd63062e84044e3f05797749c3f8e3938ff3aeb0eb2f69d43fafc91/propcache-0.5.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbc581d2814337da56222fab8dc5f161cd798a434e49bac27930aaef798e144", size = 59995, upload-time = "2026-05-08T21:00:15.526Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/42/32cf8e3009e92b2645cf1e944f701e8ea4e924dffde1ee26db860bcbf7e4/propcache-0.5.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:857187f381f88c8e2fa2fe56ab94879d011b883d5a2ee5a1b60a8cd2a06846d9", size = 63422, upload-time = "2026-05-08T21:00:16.824Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1b/f112433f99fc979431b87a39ef169e3f8df070d99a72792c56d6937ac48b/propcache-0.5.2-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:178b4a2cdaac1818e2bf1c5a99b94383fa73ea5382e032a48dec07dc5668dc42", size = 64342, upload-time = "2026-05-08T21:00:18.362Z" },
+    { url = "https://files.pythonhosted.org/packages/14/15/5574111ae50dd6e879456888c0eadd4c5a869959775854e18e18a6b345f3/propcache-0.5.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f328175a2cde1f0ff2c4ed8ce968b9dcfb55f3a7153f39e2957ed994da13476", size = 61639, upload-time = "2026-05-08T21:00:19.692Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/da/4d775080b1490c0ae604acda868bd71aabe3a89ed16f2aa4339eb8a283e7/propcache-0.5.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5671d09a36b06d0fd4a3da0fccbcae360e9b1570924171a15e9e0997f0249fba", size = 61588, upload-time = "2026-05-08T21:00:21.155Z" },
+    { url = "https://files.pythonhosted.org/packages/04/ac/f076982cbe2195ee9cf32de5a1e46951d9fb399fc207f390562dd0fd8fb2/propcache-0.5.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:80168e2ebe4d3ec6599d10ad8f520304ae1cad9b6c5a95372aef1b66b7bfb53a", size = 60029, upload-time = "2026-05-08T21:00:22.713Z" },
+    { url = "https://files.pythonhosted.org/packages/70/60/189be62e0dd898dce3b331e1b8c7a543cd3a405ac0c81fe8ee8a9d5d77e1/propcache-0.5.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:45f11346f884bc47444f6e6647131055844134c3175b629f84952e2b5cd62b64", size = 56774, upload-time = "2026-05-08T21:00:24.001Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/9e/93377b9c7939c1ffae98f878dee955efadfd638078bc86dbc21f9d52f651/propcache-0.5.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8e778ebd44ef4f66ed60a0416b06b489687db264a9c0b3620362f26489492913", size = 63532, upload-time = "2026-05-08T21:00:25.545Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f9/590ef6cfb9b8028d516d287812ece32bb0bc5f11fbb9c8bf6b2e6313fec8/propcache-0.5.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:c0cb9ed24c8964e172768d455a38254c2dd8a552905729ce006cad3d3dda59b1", size = 61592, upload-time = "2026-05-08T21:00:27.186Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/5e/70958b3034c297a630bba2f17ca7abc2d5f39a803ad7e370ab79d1ecd022/propcache-0.5.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:1d1ad32d9d4355e2be65574fd0bfd3677e7066b009cd5b9b2dee8aa6a6393b33", size = 64788, upload-time = "2026-05-08T21:00:28.8Z" },
+    { url = "https://files.pythonhosted.org/packages/12/fd/77fe5936d8c3086ca9048f7f415f122ed82e53884a9ec193646b42deef06/propcache-0.5.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c80f4ba3e8f00189165999a742ee526ebeccedf6c3f7beb0c7df821e9772435a", size = 62514, upload-time = "2026-05-08T21:00:30.098Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/74/66bd798b5b3be70aa1b391f5cc9d6a0a5532d7fd3b19ec0b213e72e6ad9d/propcache-0.5.2-cp312-cp312-win32.whl", hash = "sha256:8c7972d8f193740d9175f0998ab38717e6cd322d5935c5b0fef8c0d323fd9031", size = 39018, upload-time = "2026-05-08T21:00:31.622Z" },
+    { url = "https://files.pythonhosted.org/packages/61/7c/5c0d34aa3024694d6dcb9271cdbdd08c4e47c1c0ad95ec7e7bc74cdea145/propcache-0.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:d9ee8826a7d47863a08ac44e1a5f611a462eefc3a194b492da242128bec75b42", size = 42322, upload-time = "2026-05-08T21:00:32.918Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/91/875812f1a3feb20ceba818ef39fbe4d92f1081e04ac815c822496d0d038b/propcache-0.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:2800a4a8ead6b28cccd1ec54b59346f0def7922ee1c7598e8499c733cfbb7c84", size = 38172, upload-time = "2026-05-08T21:00:35.124Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
@@ -2032,6 +2318,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2218,6 +2517,18 @@ wheels = [
 ]
 
 [[package]]
+name = "synchronicity"
+version = "0.12.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/d5/e96e6082790c92480380f28aa53e111844cdac7b0f75846f4772cb535a43/synchronicity-0.12.3.tar.gz", hash = "sha256:0d4228b85eaf2805f23b4615b2039a9d24ea811646e2d9f8d0c033094eb85841", size = 60261, upload-time = "2026-05-28T12:33:50.206Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/ea/531a6ea751cbd989da386144810b1b8f529b0aae8c1a9beda8b40966c9c2/synchronicity-0.12.3-py3-none-any.whl", hash = "sha256:e476818cd14102136f41622c619de548f0000c024485fc18521c8fe908ea7574", size = 40982, upload-time = "2026-05-28T12:33:49.125Z" },
+]
+
+[[package]]
 name = "tablib"
 version = "3.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2239,6 +2550,15 @@ wheels = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2248,6 +2568,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "types-certifi"
+version = "2021.10.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/68/943c3aeaf14624712a0357c4a67814dba5cea36d194f5c764dad7959a00c/types-certifi-2021.10.8.3.tar.gz", hash = "sha256:72cf7798d165bc0b76e1c10dd1ea3097c7063c42c21d664523b928e88b554a4f", size = 2095, upload-time = "2022-06-09T15:19:05.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/63/2463d89481e811f007b0e1cd0a91e52e141b47f9de724d20db7b861dcfec/types_certifi-2021.10.8.3-py3-none-any.whl", hash = "sha256:b2d1e325e69f71f7c78e5943d410e650b4707bb0ef32e4ddf3da37f54176e88a", size = 2136, upload-time = "2022-06-09T15:19:03.127Z" },
 ]
 
 [[package]]
@@ -2269,6 +2598,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/69/6a/749dc53a54a3f35842c1f8197b3ca6b54af6d7458a1bfc75f6629b6da666/types_requests-2.33.0.20260408.tar.gz", hash = "sha256:95b9a86376807a216b2fb412b47617b202091c3ea7c078f47cc358d5528ccb7b", size = 23882, upload-time = "2026-04-08T04:34:49.33Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/90/b8/78fd6c037de4788c040fdd323b3369804400351b7827473920f6c1d03c10/types_requests-2.33.0.20260408-py3-none-any.whl", hash = "sha256:81f31d5ea4acb39f03be7bc8bed569ba6d5a9c5d97e89f45ac43d819b68ca50f", size = 20739, upload-time = "2026-04-08T04:34:48.325Z" },
+]
+
+[[package]]
+name = "types-toml"
+version = "0.10.8.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/11/6ece999e91f2ccb848ab4420f3f4816e78ac0541f739e6864affdaaa5737/types_toml-0.10.8.20260518.tar.gz", hash = "sha256:80e10facd24fdeda9d5c672187d72be3ac284843788d67f5aae59e3e016db6fe", size = 9419, upload-time = "2026-05-18T06:02:16.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/25/489751806bf5c95e4007f8e17409199c54d31e49ffbea07c5729b1286c8e/types_toml-0.10.8.20260518-py3-none-any.whl", hash = "sha256:0e564ab05f6fde62a315b3b5a9b6624fda569399795d30a37e64705a70459303", size = 9669, upload-time = "2026-05-18T06:02:15.86Z" },
 ]
 
 [[package]]
@@ -2354,6 +2692,31 @@ wheels = [
 ]
 
 [[package]]
+name = "watchfiles"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/2f/e42c992d2afda3108ea1c02acecc991b9f31d05c14adc2a7cee9ee211fc4/watchfiles-1.2.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:bc13eb17538be00c874699dc0abe4ee2bc8d50bb1166a6b9e175ef3fd7eb8f26", size = 400115, upload-time = "2026-05-18T04:32:02.06Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/8f/6af2ea19065c91d8b0ea3516fdfc8c0d349f407e8e9fbf4e5a17360de8ad/watchfiles-1.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d95ddc1eb6914154253d239089900813f6a767e174b8e6a50e7fdacb7e4236c", size = 393659, upload-time = "2026-05-18T04:30:50.951Z" },
+    { url = "https://files.pythonhosted.org/packages/13/01/b32a967c56fb3e3e5be3db52c3d3b87fa4513aa367d8ed1ad96d42952e5f/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f70d8b291ef6e88d19b1f297a6905ddb978888d9272b0d05e6f53309856bcfc", size = 453207, upload-time = "2026-05-18T04:31:04.231Z" },
+    { url = "https://files.pythonhosted.org/packages/04/98/97557a812180338cb1abd32e1cffcc4588f59b5f23e0cb006b2ba95ba64a/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56d8641cf834c2836922899105bd3ce3d0dfc69291d52edf0b4d0436829b34c0", size = 459273, upload-time = "2026-05-18T04:31:50.377Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a8/b4b08dcb7653b8087c6586f7ce649505900e866bbcfe40dc9587af02e686/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2581a94056e55d7d0a31a823ea92bf73749c489ca2285bfdc0fbe6b2bb49d50c", size = 489927, upload-time = "2026-05-18T04:31:42.485Z" },
+    { url = "https://files.pythonhosted.org/packages/50/94/3dceea03545d2e5ddfd839f0ddd5e1cecbf1697b5a428d5ba11cef6af95d/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:41bc1199f7523b3f82843c88cbb979180c949caef0342cf90968f178e5d49b01", size = 570476, upload-time = "2026-05-18T04:31:03.071Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f2/d39a5450c3532092b91f81d274360e613c2371bc874a89c7a1a3c5e8d138/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7571e4464cb6e434958f867f7f730b8ab0b75e3f8e5eac0499168486ab3c33a8", size = 465650, upload-time = "2026-05-18T04:30:12.701Z" },
+    { url = "https://files.pythonhosted.org/packages/22/24/ed72f68cbc1333ca9b9f2200aa048bb6658ae41709bc1caad4310f4bdffd/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e53a384f76b631c3ae5334ce6a52f0baa3a911eb94a4eac7f160079868b716d5", size = 456398, upload-time = "2026-05-18T04:30:13.784Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/64/982ef4a4e5bab5b6e5b6becc8cd5e732f6130a78b855f0abec6439a9a135/watchfiles-1.2.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:d20029a60a71a052a24c4db7673bc4de39ab89adbaccbfb5d67987c5d73f424d", size = 465140, upload-time = "2026-05-18T04:31:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0c/95282abf4ed680b6096010bcfc30c5fa7a041fc5aa5a2ad17a2cc6c75bba/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:2cb93af48550faf1cea04c303107c8b75833de7013e57ce27d3b8d21d8d0f58c", size = 630259, upload-time = "2026-05-18T04:31:25.676Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/607c1de1530c4bdcf2cf1d1ecc2505ddba5d96bd43ba9f2b0e79876f850f/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2995c176de7692b86a2e4c58d9ec718f753150a979cb4a754e2b4ffa38e70906", size = 659859, upload-time = "2026-05-18T04:30:24.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/08/d9e2e0f9e8e6791d33aefc694ad7eefa7f901f63caff84a81ded38692f9c/watchfiles-1.2.0-cp312-cp312-win32.whl", hash = "sha256:7a2cffd17d27d2ecbb310c2b1d8174f222a5495b1a721894afa88ec11e25b898", size = 275480, upload-time = "2026-05-18T04:30:31.307Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e6/9d42569c0102645cc8cea5d8c7d8a1e9d4ada2cb7f05f75e554b8aa2202a/watchfiles-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:f155b3a1b2a5fc89cdc70d47ee5d54e3b75e88efa34982028a35daef9ba00379", size = 288718, upload-time = "2026-05-18T04:32:10.745Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/26/88e0dc6ee3898169d7fa22bb6a69cabf2502d2ee25cb8c876d1262d204f8/watchfiles-1.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:8fa585ede612ee9f9e91b18bebf9ba11b9ae29a4e3a0d0cf6fca3e382133f0d5", size = 281026, upload-time = "2026-05-18T04:30:22.23Z" },
+]
+
+[[package]]
 name = "wcwidth"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2392,10 +2755,65 @@ wheels = [
 ]
 
 [[package]]
+name = "yarl"
+version = "1.24.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/12/1e8f37460ea0f7eb59c221fdaf0ed75e7ac43e97f8093b9c6f411df50a78/yarl-1.24.2.tar.gz", hash = "sha256:9ac374123c6fd7abf64d1fec93962b0bd4ee2c19751755a762a72dd96c0378f8", size = 210798, upload-time = "2026-05-19T21:31:05.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/da/866bcb01076ba49d2b42b309867bed3826421f1c479655eb7a607b44f20b/yarl-1.24.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b975866c184564c827e0877380f0dae57dcca7e52782128381b72feff6dfceb8", size = 129957, upload-time = "2026-05-19T21:28:51.695Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/1d/fcefb70922ea2268a8971d8e5874d9a8218644200fb8465f1dcad55e6851/yarl-1.24.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3b075301a2836a0e297b1b658cb6d6135df535d62efefdd60366bd589c2c82f2", size = 92164, upload-time = "2026-05-19T21:28:53.242Z" },
+    { url = "https://files.pythonhosted.org/packages/29/b6/170e2b8d4e3bc30e6bfdcca53556537f5bf595e938632dfcb059311f3ff6/yarl-1.24.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8ae44649b00947634ab0dab2a374a638f52923a6e67083f2c156cd5cbd1a881d", size = 91688, upload-time = "2026-05-19T21:28:54.865Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/a5/c9f655d5553ea0b99fdac9d6a99ad3f9b3e73b8e5758bb46f58c9831f74c/yarl-1.24.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:507cc19f0b45454e2d6dcd62ff7d062b9f77a2812404e62dbdaec05b50faa035", size = 102902, upload-time = "2026-05-19T21:28:56.963Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/bc/6b9664d815d79af4ee553337f9d606c56bbf269186ada9172de45f1b5f60/yarl-1.24.2-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c4c17bad5a530912d2111825d3f05e89bab2dd376aaa8cbc77e449e6db63e576", size = 97931, upload-time = "2026-05-19T21:28:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ec/32ba48acae30fecd60928f5791188b80a9d6ee3840507ffda29fecd37b71/yarl-1.24.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f5f0cbb112838a4a293985b6ed73948a547dadcc1ba6d2089938e7abdedceef8", size = 111030, upload-time = "2026-05-19T21:29:00.148Z" },
+    { url = "https://files.pythonhosted.org/packages/82/5a/6f4cd081e5f4934d2ae3a8ef4abe3afacc010d26f0035ee91b35cd7d7c37/yarl-1.24.2-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5ec8356b8a6afcf81fc7aeeef13b1ff7a49dec00f313394bbb9e83830d32ccd7", size = 110392, upload-time = "2026-05-19T21:29:02.155Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/da/323a01c349bd5fb01bb6652e314d9bb218cee630a736bdb810ad50e4013f/yarl-1.24.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e7ebcdef69dec6c6451e616f32b622a6d4a2e92b445c992f7c8e5274a6bbc4c", size = 105612, upload-time = "2026-05-19T21:29:04.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/80/264ab684f181e1a876389374519ff05d10248725535ae2ac4e8ac4e563d6/yarl-1.24.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:47a55d6cf6db2f401017a9e96e5288844e5051911fb4e0c8311a3980f5e59a7d", size = 104487, upload-time = "2026-05-19T21:29:06.491Z" },
+    { url = "https://files.pythonhosted.org/packages/41/07/efabe5df87e96d7ad5959760b888344be48cd6884db127b407c6b5503adc/yarl-1.24.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3065657c80a2321225e804048597ad55658a7e76b32d6f5ee4074d04c50401db", size = 102333, upload-time = "2026-05-19T21:29:08.267Z" },
+    { url = "https://files.pythonhosted.org/packages/44/0c/bcf7c42603e1009295f586d8890f2ba032c8b53310e815adf0a202c73d9f/yarl-1.24.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:cb84b80d88e19ede158619b80813968713d8d008b0e2497a576e6a0557d50712", size = 99025, upload-time = "2026-05-19T21:29:10.682Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/82/84482ab1a57a0f21a08afe6a7004c61d741f8f2ecc3b05c321577c612164/yarl-1.24.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:990de4f680b1c217e77ff0d6aa0029f9eb79889c11fb3e9a3942c7eba29c1996", size = 110507, upload-time = "2026-05-19T21:29:12.954Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8d/a546ba1dfe1b0f290e05fef145cd07614c0f15df1a707195e512d1e39d1d/yarl-1.24.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:abb8ec0323b80161e3802da3150ef660b41d0e9be2048b76a363d93eee992c2b", size = 103719, upload-time = "2026-05-19T21:29:14.893Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b6/267f2a09213138473adfce6b8a6e17791d7fee70bd4d9003218e4dec58b0/yarl-1.24.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:e7977781f83638a4c73e0f88425563d70173e0dfd90ac006a45c65036293ee3c", size = 110438, upload-time = "2026-05-19T21:29:16.485Z" },
+    { url = "https://files.pythonhosted.org/packages/48/2d/1c8d89c7c5f9cad9fb2902445d94e2ab1d7aa35de029afbb8ae95c42d00f/yarl-1.24.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e30dd55825dc554ec5b66a94953b8eda8745926514c5089dfcacecb9c99b5bd1", size = 105719, upload-time = "2026-05-19T21:29:18.367Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/25/722e3b93bd687009afb2d59a35e13d30ddd8f80571445bb0c4e4ce26ec66/yarl-1.24.2-cp312-cp312-win_amd64.whl", hash = "sha256:7dafe10c12ddd4d120d528c4b5599c953bd7b12845347d507b95451195bb6cad", size = 92901, upload-time = "2026-05-19T21:29:20.014Z" },
+    { url = "https://files.pythonhosted.org/packages/39/47/4486ccfb674c04854a1ef8aa77868b6a6f765feaf69633409d7ca4f02cb8/yarl-1.24.2-cp312-cp312-win_arm64.whl", hash = "sha256:044a09d8401fcf8681977faef6d286b8ade1e2d2e9dceda175d1cfa5ca496f30", size = 87229, upload-time = "2026-05-19T21:29:22.1Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/4d/4b880086bd0d3e034d25647be1d830afc3e3f610e98c4ab3490af6b1b6d5/yarl-1.24.2-py3-none-any.whl", hash = "sha256:2783d9226db8797636cd6896e4de81feed252d1db72265686c9558d97a4d94b9", size = 53576, upload-time = "2026-05-19T21:31:03.909Z" },
+]
+
+[[package]]
 name = "zipp"
 version = "3.23.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
+]
+
+[[package]]
+name = "zope-event"
+version = "6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/41/faa10af34d48d9cd6fa0249a1162943ad84a9590bd1a06939981e6640416/zope_event-6.2.tar.gz", hash = "sha256:b97d5d6327067ee6b9dfcbdf606ade9ade70991e19c162e808ea39e5fcf0f8d3", size = 18958, upload-time = "2026-04-28T06:24:10.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/33/848922889e946d4befc415c219fe516af75c49555d8e736e183bfd30db42/zope_event-6.2-py3-none-any.whl", hash = "sha256:5e755153ac4faf64c10a4b6dd3307680166a3edf65b38df22df592610f8fa874", size = 6525, upload-time = "2026-04-28T06:24:09.176Z" },
+]
+
+[[package]]
+name = "zope-interface"
+version = "8.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/dc/50550cfcbb2ea3cbca5f1d7ed05c8aa840f831a0f2d63aec0a953f7c590e/zope_interface-8.5.tar.gz", hash = "sha256:7a3ba1c5877f0f3e3906b02ddf793abed2becc2948116414ce0e1dd820b68d6d", size = 257957, upload-time = "2026-05-26T06:50:14.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/cc/b84123a948f3162a34623e188922827cd845244fdd043ed20f8d02228caa/zope_interface-8.5-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:8e6ee90c2e6de7c37058d5fa41f123c8b13a312db8d1e0fb5840d7f4bcdff9c9", size = 212165, upload-time = "2026-05-26T06:49:26.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/cbceec44f1b27208a76c1a688c131302685852406a23df5aab68324109cc/zope_interface-8.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c1adc90d3576b3b4c4de4953e6002c37bef28b78d7fa54c1bbfd0c50f022fe7c", size = 212341, upload-time = "2026-05-26T06:49:28.182Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/c3/005032195ff3b210c139b7c560ed5c534e844b0907d8e44d2b3d8919305e/zope_interface-8.5-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:e6347b8d8d12c5eca6502450a92be30079b7acfade2c4f693efa0deb8871b06e", size = 265296, upload-time = "2026-05-26T06:49:29.741Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/66/1036543d6a66bc04c19df3cf650f3ad938a002ab0a443c24e23e8de5e8b9/zope_interface-8.5-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5e970dabea777a24b0b0bbf9dae3ab75ce8b2d8e948edf4875627034b21f3560", size = 270689, upload-time = "2026-05-26T06:49:31.767Z" },
+    { url = "https://files.pythonhosted.org/packages/30/4c/8b56259558cace4414e753ca6740396a1f59d4a95ddb55b4658600408670/zope_interface-8.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f0b48ccadaa9839e09ff81e969703cecb3f402c813bfe8b958652e699bea69f5", size = 270280, upload-time = "2026-05-26T06:49:33.489Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ea/649908c83aa8fdb7faf2ddca4d3cf6fb8f2157121267dc56e8f72681e26c/zope_interface-8.5-cp312-cp312-win_amd64.whl", hash = "sha256:e0e311f1277468c08fd59a2b41f71b43d25dff639789d364747acd1705c0df6e", size = 215019, upload-time = "2026-05-26T06:49:35.607Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/97/da13037b4c563e4df32eedbc819f8c00b754af494f68211e3dffd48d52da/zope_interface-8.5-cp312-cp312-win_arm64.whl", hash = "sha256:652b73107a04159ec6c020db6c1543d4f1e8f4d069bd2aac88a947820923517b", size = 213569, upload-time = "2026-05-26T06:49:37.317Z" },
 ]


### PR DESCRIPTION
## Summary

- Offloads all three CPU/memory-intensive Celery tasks to Modal Labs compute using a **metadata-in / metadata-out** interface: Modal fetches source assets from public R2 URLs and PUTs results directly to R2 via presigned PUT URLs — no bytes transit the Celery↔Modal boundary.
- Showcase video output switches from finalized MP4 to **fMP4+sidx** (`frag_keyframe+empty_moov+default_base_moof+dash`), enabling efficient HTTP range-request seeking across Chrome, Safari, Firefox, Android, iOS without a player library.
- Adds a HMAC-authenticated **progress webhook** (`POST /api/tasks/{id}/progress/`) so Modal can report render progress back to the task without holding Django session credentials.
- Celery worker pool switched from `--pool=solo` to `--pool=gevent` to allow concurrent async I/O during Modal dispatch.

## Changes

### Modal compute service (`services/glaze_compute_service.py`)
- New `crop_image`, `convert_to_jpeg`, `render_showcase_video` Modal functions
- `pil_image` container: debian-slim + Pillow + pillow-heif + requests
- `video_image` container: debian-slim + ffmpeg + av + Pillow + numpy + requests
- fMP4+sidx options and fixed GOP size applied in `render_showcase_video`
- Progress callback posts to Django webhook; exceptions swallowed so render isn't aborted by network hiccups

### Celery task rewrites (`api/tasks.py`)
- `generate_cropped_image`, `convert_image_to_jpeg`, `generate_showcase_video` rewritten to use `asyncio.run(modal_fn.remote.aio(...))` for the compute step only — all Django ORM operations remain synchronous
- `_modal_function(app_name, fn_name)` wrapper allows test mocking without needing `modal` installed in the test venv
- `generate_showcase_video` adds idempotent early-exit when R2 object already exists

### Progress webhook (`api/task_views.py`, `api/urls.py`)
- `POST /api/tasks/{id}/progress/` with `AllowAny` permission class — authenticated via HMAC-SHA256 token in `X-Task-Token` header
- Token encodes `task_id + expiry` signed with `SECRET_KEY`; `_verify_progress_token` uses `constant_time_compare`
- Token TTL: 3600s (covers the longest expected video render)

### Infrastructure
- `deployment-worker.yaml`: `--pool=gevent`, `MODAL_TOKEN_ID`/`MODAL_TOKEN_SECRET` env vars
- `pyproject.toml` + `api/BUILD.bazel`: added `modal>=0.74`, `gevent>=24.0`
- `services/BUILD.bazel`: new `py_binary` for `glaze_compute_service`
- `.env.example`: documented `MODAL_TOKEN_ID`/`MODAL_TOKEN_SECRET`

### Tests
- `test_generate_cropped_image.py`: mocks `api.tasks._modal_function` and `r2.generate_presigned_put` instead of `r2.get_object_bytes`/`r2.upload_bytes`
- `test_showcase_video.py`: `_mock_modal_render` helper replaces `upload_showcase_video_to_r2` patches
- `test_task_progress_webhook.py`: new — covers HMAC token round-trip, expiry, mismatch, tampering, and progress validation

## Security

- Progress webhook uses `AllowAny` + HMAC-SHA256. Token replay: 1hr TTL. Token forgery: constant-time compare. Task ID mismatch: encoded in token payload.
- Presigned PUT URL scoped to exact R2 key + content-type + 1hr expiry. Modal holds no long-lived credentials.

## Test plan

- [ ] `rtk bazel test //api:api_model_test` — passes (includes new webhook test)
- [ ] `rtk bazel test //api:api_piece_test` — passes (showcase video tests updated)
- [ ] `rtk bazel build --config=lint //api/...` — passes
- [ ] After deploy: submit a `generate_cropped_image` task via Django admin, verify `SUCCESS` and `cropped_image` FK set
- [ ] Submit a `generate_showcase_video` task, verify progress increments in task detail and final MP4 is seekable in Chrome/Safari/iOS

Closes #903

🤖 Generated with [Claude Code](https://claude.com/claude-code)
