### PR TITLE
fix(ci): fix macOS smoke test repository cache

### DIFF
--- a/.github/actions/setup-bazel-ci/action.yml
+++ b/.github/actions/setup-bazel-ci/action.yml
@@ -31,9 +31,9 @@ runs:
     - name: Cache Bazel Repository
       uses: actions/cache@v4
       with:
-        path: ~/.cache/bazel/_bazel_runner/cache/repos/v1
-        key: bazel-repo-${{ inputs.deps-key }}
-        restore-keys: bazel-repo-
+        path: ~/.cache/bazel-repo
+        key: bazel-repo-${{ runner.os }}-${{ inputs.deps-key }}
+        restore-keys: bazel-repo-${{ runner.os }}-
 
     - name: Cache Bazel Disk
       uses: actions/cache@v4
@@ -44,9 +44,10 @@ runs:
           bazel-disk-${{ inputs.cache-key-prefix }}-${{ inputs.deps-key }}-
           bazel-disk-
 
-    - name: Inject BuildBuddy API key into .bazelrc
+    - name: Inject BuildBuddy API key and repo cache path into .bazelrc
       shell: bash
       working-directory: ${{ inputs.workdir }}
       run: |
         echo "" >> .bazelrc
         echo "common:ci --remote_header=x-buildbuddy-api-key=${{ inputs.buildbuddy-api-key }}" >> .bazelrc
+        echo "common --repository_cache=~/.cache/bazel-repo" >> .bazelrc


### PR DESCRIPTION
## Summary

This PR fixes the repository cache behavior on macOS runners.

- **Unified Cache Path**: Redirected the repository cache to `~/.cache/bazel-repo` via dynamically appending `common --repository_cache=~/.cache/bazel-repo` to `.bazelrc` in the `setup-bazel-ci` composite action.
- **Runner OS Cache Keys**: Keyed the repository cache using `${{ runner.os }}`. Previously, the key was shared, causing macOS runners to restore or save into mismatched locations/keys, and ultimately hit cache-saving skips because GHA caches are immutable.

This addresses the long external package re-pulls observed on the macOS smoke test in [run 27452651636](https://github.com/shaoster/glaze/actions/runs/27452651636/job/81150957362?pr=909).

## Test plan

- [x] All tests (`gz_test`) and linters (`gz_lint`) pass locally.
- [ ] Verify that macOS smoke test successfully caches and restores its repository cache in GHA.
