### PR TITLE
feat(graphql): improve LLM agent discoverability for piece search

### DIFF
--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -114,5 +114,15 @@ class Query:
     ) -> PiecePage:
         return _resolve_pieces(info, filter, ordering, limit, offset)
 
+    @strawberry.field(
+        description=(
+            "Return the full GraphQL SDL (Schema Definition Language) as a string. "
+            "LLM agents can call this query to discover all available types, fields, "
+            "and descriptions in a single request without running multi-step introspection queries."
+        )
+    )
+    def schema_sdl(self) -> str:
+        return str(schema)
+
 
 schema = strawberry.Schema(query=Query)

--- a/api/graphql/types.py
+++ b/api/graphql/types.py
@@ -25,10 +25,18 @@ def _to_iso(value: Any) -> str | None:
 
 @strawberry.type
 class ImageCropType:
-    x: float
-    y: float
-    width: float
-    height: float
+    x: float = strawberry.field(
+        description="Left edge of the crop region as a fraction of the image width (0–1)."
+    )
+    y: float = strawberry.field(
+        description="Top edge of the crop region as a fraction of the image height (0–1)."
+    )
+    width: float = strawberry.field(
+        description="Width of the crop region as a fraction of the image width (0–1)."
+    )
+    height: float = strawberry.field(
+        description="Height of the crop region as a fraction of the image height (0–1)."
+    )
 
     @classmethod
     def from_dict(cls, data: dict[str, Any] | None) -> ImageCropType | None:
@@ -39,14 +47,33 @@ class ImageCropType:
 
 @strawberry.type
 class ThumbnailType:
-    url: str
-    image_id: str | None = None
-    width: int | None = None
-    height: int | None = None
-    crop: ImageCropType | None = None
-    cropped_url: str | None = None
-    r2_key: str | None = None
-    crop_task_failed: bool = False
+    url: str = strawberry.field(
+        description="Public URL of the original (uncropped) image."
+    )
+    image_id: str | None = strawberry.field(
+        default=None, description="Internal image record ID."
+    )
+    width: int | None = strawberry.field(
+        default=None, description="Original image width in pixels."
+    )
+    height: int | None = strawberry.field(
+        default=None, description="Original image height in pixels."
+    )
+    crop: ImageCropType | None = strawberry.field(
+        default=None,
+        description="User-defined crop region applied to the original image.",
+    )
+    cropped_url: str | None = strawberry.field(
+        default=None,
+        description="Public URL of the cropped thumbnail, or null if no crop has been applied.",
+    )
+    r2_key: str | None = strawberry.field(
+        default=None, description="Cloudflare R2 storage key for the original image."
+    )
+    crop_task_failed: bool = strawberry.field(
+        default=False,
+        description="True if the background crop task for this thumbnail failed.",
+    )
 
     @classmethod
     def from_dict(cls, data: dict[str, Any] | None) -> ThumbnailType | None:
@@ -67,10 +94,15 @@ class ThumbnailType:
 
 @strawberry.type
 class TagType:
-    id: strawberry.ID
-    name: str
-    color: str
-    is_public: bool = False
+    id: strawberry.ID = strawberry.field(description="Unique tag identifier.")
+    name: str = strawberry.field(description="Human-readable tag label.")
+    color: str = strawberry.field(
+        description="Hex color string for the tag chip (e.g. '#4caf50')."
+    )
+    is_public: bool = strawberry.field(
+        default=False,
+        description="True if this tag belongs to the public library rather than the user.",
+    )
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> TagType:
@@ -86,25 +118,49 @@ class TagType:
 class CurrentStateType:
     """The piece's current workflow state name (e.g. "completed")."""
 
-    state: str
+    state: str = strawberry.field(
+        description='Workflow state name (e.g. "designed", "bisque", "glazed", "completed").'
+    )
 
 
 @strawberry.type
 class PieceType:
-    id: strawberry.ID
-    name: str
-    created: str | None
-    last_modified: str | None
-    photo_count: int
-    shared: bool
-    is_editable: bool
-    can_edit: bool
-    showcase_story: str
-    showcase_fields: list[str]
-    current_location: str | None
-    current_state: CurrentStateType
-    thumbnail: ThumbnailType | None
-    tags: list[TagType]
+    id: strawberry.ID = strawberry.field(description="Unique piece identifier (UUID).")
+    name: str = strawberry.field(description="User-given name of the piece.")
+    created: str | None = strawberry.field(
+        description="ISO 8601 timestamp when the piece was first created."
+    )
+    last_modified: str | None = strawberry.field(
+        description="ISO 8601 timestamp of the most recent change to the piece or any of its states."
+    )
+    photo_count: int = strawberry.field(
+        description="Total number of photos attached to this piece across all states."
+    )
+    shared: bool = strawberry.field(
+        description="True if the piece is publicly visible via a share link."
+    )
+    is_editable: bool = strawberry.field(
+        description="True if the piece can have new states added (not in a terminal workflow state)."
+    )
+    can_edit: bool = strawberry.field(
+        description="True if the authenticated user has write permission on this piece."
+    )
+    showcase_story: str = strawberry.field(
+        description="Free-text story field displayed on the public showcase page."
+    )
+    showcase_fields: list[str] = strawberry.field(
+        description="Ordered list of field names shown on the public showcase page."
+    )
+    current_location: str | None = strawberry.field(
+        description="Human-readable label of the kiln or shelf where the piece currently resides, if any."
+    )
+    current_state: CurrentStateType = strawberry.field(
+        description="The piece's current workflow state."
+    )
+    thumbnail: ThumbnailType | None = strawberry.field(
+        description="Thumbnail image for the piece, or null if no photo has been uploaded."
+    )
+    tags: list[TagType] = strawberry.field(description="Tags attached to this piece.")
 
     @classmethod
     def from_summary(cls, data: dict[str, Any]) -> PieceType:
@@ -132,5 +188,7 @@ class PieceType:
 class PiecePage:
     """A page of pieces plus the total count of the filtered set."""
 
-    count: int
-    results: list[PieceType]
+    count: int = strawberry.field(
+        description="Total number of pieces matching the applied filters (before pagination)."
+    )
+    results: list[PieceType] = strawberry.field(description="The pieces on this page.")

--- a/api/piece/views.py
+++ b/api/piece/views.py
@@ -121,9 +121,11 @@ def pieces(request: Request) -> Response:
         photo_counts = _piece_photo_counts([piece.id for piece in page_qs])
         for piece in page_qs:
             piece.photo_count = photo_counts.get(piece.id, 0)
-        return Response(
+        response = Response(
             {"count": count, "results": _serialize_piece_summary(page_qs, request)}
         )
+        response["X-GraphQL-Endpoint"] = "/api/graphql/"
+        return response
 
     serializer = PieceCreateSerializer(data=request.data, context={"request": request})
     serializer.is_valid(raise_exception=True)

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -402,7 +402,11 @@ def generate_cropped_image(task: AsyncTask) -> dict:
 
     presigned_put = r2.generate_presigned_put(key, "image/jpeg")
     crop_image_fn = _modal_function("glaze-compute", "crop_image")
-    asyncio.run(crop_image_fn.remote.aio(r2.public_url_for_key(image.r2_key), crop, presigned_put))
+    asyncio.run(
+        crop_image_fn.remote.aio(
+            r2.public_url_for_key(image.r2_key), crop, presigned_put
+        )
+    )
     updated = set_cropped_fields(image, crop, r2_key=key, url=url)
     return {
         "status": "success",
@@ -507,6 +511,7 @@ def generate_showcase_video(task: AsyncTask) -> dict:
     """
     from django.conf import settings
 
+    from . import r2
     from .showcase import (
         SHOWCASE_VIDEO_RENDER_VERSION,
         compute_storyboard_hash,
@@ -515,7 +520,6 @@ def generate_showcase_video(task: AsyncTask) -> dict:
     )
     from .showcase.music import get_track
     from .showcase.render import showcase_video_key
-    from . import r2
     from .task_views import _make_progress_token
 
     params = task.input_params or {}
@@ -562,7 +566,11 @@ def generate_showcase_video(task: AsyncTask) -> dict:
     music_url = track.audio.url if track else None
 
     render_fn = _modal_function("glaze-compute", "render_showcase_video")
-    asyncio.run(render_fn.remote.aio(storyboard, presigned_put, progress_webhook_url, progress_token, music_url))
+    asyncio.run(
+        render_fn.remote.aio(
+            storyboard, presigned_put, progress_webhook_url, progress_token, music_url
+        )
+    )
 
     return {
         "status": "success",

--- a/api/tests/test_convert_image_to_jpeg.py
+++ b/api/tests/test_convert_image_to_jpeg.py
@@ -65,7 +65,8 @@ class TestConvertImageToJpegTask:
             fn_mock.remote = MagicMock()
             fn_mock.remote.aio = AsyncMock(
                 return_value={"width": width, "height": height},
-                side_effect=lambda *a, **kw: modal_calls.append(a) or {"width": width, "height": height},
+                side_effect=lambda *a, **kw: modal_calls.append(a)
+                or {"width": width, "height": height},
             )
             return fn_mock
 

--- a/api/tests/test_graphql_pieces.py
+++ b/api/tests/test_graphql_pieces.py
@@ -9,6 +9,7 @@ session via ``force_login`` rather than DRF's ``force_authenticate``.
 """
 
 import pytest
+from django.test import Client
 from rest_framework.test import APIClient
 
 from api.models import ENTRY_STATE, Piece, PieceState, Tag
@@ -188,3 +189,40 @@ class TestGraphQLPieces:
         body = response.json()
         assert not body.get("errors"), body
         assert body["data"]["pieces"]["count"] == 1
+
+    def test_schema_sdl_query_returns_valid_sdl(self, gql_client):
+        """The schemaSdl field lets an LLM agent fetch the full SDL in one call."""
+        response = gql_client.post(
+            "/api/graphql/",
+            {"query": "{ schemaSdl }"},
+            format="json",
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert not body.get("errors"), body
+        sdl = body["data"]["schemaSdl"]
+        assert "type PieceType" in sdl
+        assert "pieces(" in sdl
+        assert "schemaSdl" in sdl
+
+    def test_sparse_fields_graphql(self, gql_client, user):
+        """Clients can request only the fields they need — GraphQL sparse selection."""
+        _make_piece(user, "Teapot")
+        response = gql_client.post(
+            "/api/graphql/",
+            {"query": "{ pieces { count results { id name } } }"},
+            format="json",
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert not body.get("errors"), body
+        result = body["data"]["pieces"]["results"][0]
+        assert set(result.keys()) == {"id", "name"}
+
+    def test_rest_list_includes_graphql_endpoint_header(self, user):
+        """GET /api/pieces/ advertises the GraphQL endpoint via a response header."""
+        client = Client()
+        client.force_login(user)
+        response = client.get("/api/pieces/")
+        assert response.status_code == 200
+        assert response["X-GraphQL-Endpoint"] == "/api/graphql/"

--- a/api/tests/test_task_progress_webhook.py
+++ b/api/tests/test_task_progress_webhook.py
@@ -1,6 +1,5 @@
 """Tests for the Modal→Django progress webhook endpoint."""
 
-import time
 import uuid
 
 import pytest
@@ -72,9 +71,7 @@ class TestReportTaskProgressEndpoint:
         assert task.progress == 42
 
     def test_missing_token_returns_403(self, client, task):
-        resp = client.post(
-            self._url(task.id), {"progress": 10}, format="json"
-        )
+        resp = client.post(self._url(task.id), {"progress": 10}, format="json")
         assert resp.status_code == 403
 
     def test_wrong_task_id_in_token_returns_403(self, client, task):

--- a/api/urls.py
+++ b/api/urls.py
@@ -59,7 +59,11 @@ urlpatterns = [
     path("health/ready/", views.health_ready, name="health-ready"),
     path("tasks/", views.submit_task, name="tasks-submit"),
     path("tasks/<uuid:task_id>/", views.task_detail, name="tasks-detail"),
-    path("tasks/<uuid:task_id>/progress/", views.report_task_progress, name="tasks-progress"),
+    path(
+        "tasks/<uuid:task_id>/progress/",
+        views.report_task_progress,
+        name="tasks-progress",
+    ),
     path("telemetry/traces/", views.browser_traces, name="telemetry-traces"),
     path("pieces/", views.pieces, name="pieces"),
     path("pieces/<uuid:piece_id>/", views.piece_detail, name="piece-detail"),

--- a/services/glaze_compute_service.py
+++ b/services/glaze_compute_service.py
@@ -27,15 +27,12 @@ logger = logging.getLogger(__name__)
 try:
     import modal
 
-    _pil_image = (
-        modal.Image.debian_slim()
-        .pip_install(
-            # Versions must stay in sync with pyproject.toml — enforced by
-            # tools/check_modal_deps.py in CI.
-            "pillow==12.2.0",
-            "pillow-heif==1.3.0",
-            "requests==2.33.1",
-        )
+    _pil_image = modal.Image.debian_slim().pip_install(
+        # Versions must stay in sync with pyproject.toml — enforced by
+        # tools/check_modal_deps.py in CI.
+        "pillow==12.2.0",
+        "pillow-heif==1.3.0",
+        "requests==2.33.1",
     )
 
     _video_image = (
@@ -177,7 +174,9 @@ def _convert_to_jpeg_bytes(original_bytes: bytes) -> tuple[bytes, int, int]:
 # ── Showcase video helpers (mirrors api/showcase/render.py) ──────────────────
 
 
-def _slide_start_times(durations: list[float], transition_seconds: float) -> list[float]:
+def _slide_start_times(
+    durations: list[float], transition_seconds: float
+) -> list[float]:
     starts = []
     t = 0.0
     for i, d in enumerate(durations):
@@ -210,8 +209,9 @@ def _load_font(path: str, size: int) -> Any:
         return ImageFont.load_default()
 
 
-def _draw_text_centered(draw: Any, text: str, font: Any, canvas_w: int, y: int, color: tuple) -> None:
-    from PIL import ImageDraw
+def _draw_text_centered(
+    draw: Any, text: str, font: Any, canvas_w: int, y: int, color: tuple
+) -> None:
 
     bbox = draw.textbbox((0, 0), text, font=font)
     text_w = bbox[2] - bbox[0]
@@ -250,10 +250,10 @@ def _draw_text_wrapped(
 
 def _render_slide_canvas(slide: dict) -> Any:
     """Render a single slide dict (cover/image/note) to a PIL image at canvas size."""
+    import requests
     from PIL import Image as PILImage
     from PIL import ImageDraw, ImageOps
     from pillow_heif import register_heif_opener
-    import requests
 
     register_heif_opener()
 
@@ -292,26 +292,67 @@ def _render_slide_canvas(slide: dict) -> Any:
         font_title = _load_font(_FONT_BOLD, 56)
         font_sub = _load_font(_FONT_REGULAR, 28)
         if heading:
-            _draw_text_centered(draw, heading, font_title, canvas_w, canvas_h // 2 - 40, _TEXT_COLOR_PRIMARY)
+            _draw_text_centered(
+                draw,
+                heading,
+                font_title,
+                canvas_w,
+                canvas_h // 2 - 40,
+                _TEXT_COLOR_PRIMARY,
+            )
         if state_label:
-            _draw_text_centered(draw, state_label, font_sub, canvas_w, canvas_h // 2 + 30, _TEXT_COLOR_SECONDARY)
+            _draw_text_centered(
+                draw,
+                state_label,
+                font_sub,
+                canvas_w,
+                canvas_h // 2 + 30,
+                _TEXT_COLOR_SECONDARY,
+            )
 
     elif kind == "note":
         font_label = _load_font(_FONT_REGULAR, 22)
         font_body = _load_font(_FONT_REGULAR, 30)
         margin = 80
         if state_label:
-            _draw_text_centered(draw, state_label.upper(), font_label, canvas_w, 40, _TEXT_COLOR_SECONDARY)
+            _draw_text_centered(
+                draw,
+                state_label.upper(),
+                font_label,
+                canvas_w,
+                40,
+                _TEXT_COLOR_SECONDARY,
+            )
         if text:
-            _draw_text_wrapped(draw, text, font_body, canvas_w - margin * 2, margin, 100, _TEXT_COLOR_PRIMARY)
+            _draw_text_wrapped(
+                draw,
+                text,
+                font_body,
+                canvas_w - margin * 2,
+                margin,
+                100,
+                _TEXT_COLOR_PRIMARY,
+            )
 
     else:  # "image"
         font_caption = _load_font(_FONT_REGULAR, 24)
         font_label = _load_font(_FONT_REGULAR, 20)
         if caption:
-            _draw_text_centered(draw, caption, font_caption, canvas_w, canvas_h - 52, _TEXT_COLOR_SECONDARY)
+            _draw_text_centered(
+                draw,
+                caption,
+                font_caption,
+                canvas_w,
+                canvas_h - 52,
+                _TEXT_COLOR_SECONDARY,
+            )
         if state_label:
-            draw.text((22, canvas_h - 52), state_label, font=font_label, fill=_TEXT_COLOR_SECONDARY)
+            draw.text(
+                (22, canvas_h - 52),
+                state_label,
+                font=font_label,
+                fill=_TEXT_COLOR_SECONDARY,
+            )
 
     return canvas
 
@@ -326,8 +367,17 @@ def _render_closing_canvas() -> Any:
     draw = ImageDraw.Draw(canvas)
     font = _load_font(_FONT_BOLD, 64)
     font_sub = _load_font(_FONT_REGULAR, 28)
-    _draw_text_centered(draw, "PotterDoc", font, canvas_w, canvas_h // 2 - 48, _TEXT_COLOR_PRIMARY)
-    _draw_text_centered(draw, "potterdoc.com", font_sub, canvas_w, canvas_h // 2 + 28, _TEXT_COLOR_SECONDARY)
+    _draw_text_centered(
+        draw, "PotterDoc", font, canvas_w, canvas_h // 2 - 48, _TEXT_COLOR_PRIMARY
+    )
+    _draw_text_centered(
+        draw,
+        "potterdoc.com",
+        font_sub,
+        canvas_w,
+        canvas_h // 2 + 28,
+        _TEXT_COLOR_SECONDARY,
+    )
     return canvas
 
 
@@ -401,6 +451,7 @@ def _render_to_file(
             total_frames = max(1, math.ceil(effective_duration * _SHOWCASE_VIDEO_FPS))
 
         import time as _time
+
         last_reported = _time.monotonic()
         frame_count = 0
         video_packets: list[Any] = []
@@ -448,10 +499,14 @@ def _render_to_file(
                         resampled = audio_resampler.resample(frame)
                         if resampled is None:
                             continue
-                        for rf in resampled if isinstance(resampled, list) else [resampled]:
+                        for rf in (
+                            resampled if isinstance(resampled, list) else [resampled]
+                        ):
                             samples = np.array(rf.to_ndarray(), dtype=np.float32)
                             if samples_written + samples.shape[-1] > target_samples:
-                                samples = samples[..., : target_samples - samples_written]
+                                samples = samples[
+                                    ..., : target_samples - samples_written
+                                ]
                             audio_frame = av.AudioFrame.from_ndarray(
                                 samples, format="fltp", layout=layout
                             )
@@ -571,10 +626,7 @@ def _iter_video_frames(
         current = slide_canvases[active_idx]
 
         # Transition blend with next slide
-        if (
-            active_idx < n - 1
-            and slide_t >= durations[active_idx] - transition_seconds
-        ):
+        if active_idx < n - 1 and slide_t >= durations[active_idx] - transition_seconds:
             blend_t = (slide_t - (durations[active_idx] - transition_seconds)) / max(
                 transition_seconds, 1e-9
             )
@@ -584,8 +636,8 @@ def _iter_video_frames(
             frame = current.copy()
 
         # Fade out at end
-        global_fade_start = effective_duration - durations[-1] + (
-            durations[-1] - fade_seconds
+        global_fade_start = (
+            effective_duration - durations[-1] + (durations[-1] - fade_seconds)
         )
         alpha = _fade_alpha(t, global_fade_start, fade_seconds)
         if alpha < 1.0:
@@ -654,7 +706,9 @@ if app is not None:
             output_path = Path(tf.name)
 
         try:
-            _render_to_file(storyboard, output_path, music_url=music_url, on_progress=on_progress)
+            _render_to_file(
+                storyboard, output_path, music_url=music_url, on_progress=on_progress
+            )
             mp4_bytes = output_path.read_bytes()
             _put_bytes(presigned_put_url, mp4_bytes, "video/mp4")
         finally:

--- a/tools/tests/test_tutorials_schema.py
+++ b/tools/tests/test_tutorials_schema.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import pathlib
 
 import jsonschema
@@ -33,7 +32,5 @@ def test_tutorials_yml_is_valid_against_schema() -> None:
 
     errors = list(validator.iter_errors(data))
     if errors:
-        messages = "\n".join(
-            f"  {e.json_path}: {e.message}" for e in errors
-        )
+        messages = "\n".join(f"  {e.json_path}: {e.message}" for e in errors)
         pytest.fail(f"tutorials.yml failed schema validation:\n{messages}")


### PR DESCRIPTION
## Summary

`GET /api/pieces/` already has a GraphQL counterpart at `/api/graphql/` (Strawberry) that supports search, state filtering, ordering, pagination, and inherently sparse field selection. Rather than duplicating that surface on REST, this PR makes the GraphQL endpoint self-documenting and discoverable by LLM agents.

- **Field descriptions on all GraphQL types** — `ImageCropType`, `ThumbnailType`, `TagType`, `CurrentStateType`, `PieceType`, and `PiecePage` now carry `description=` on every field. Introspection output is fully self-documenting.
- **`schemaSdl` query field** — returns the full SDL as a string. An LLM agent can call `{ schemaSdl }` to get the complete schema in one round-trip instead of running multi-step introspection queries.
- **`X-GraphQL-Endpoint` response header** — `GET /api/pieces/` now includes `X-GraphQL-Endpoint: /api/graphql/` so any HTTP client inspecting REST response headers finds the GraphQL URL without reading docs.
- **New tests** — SDL smoke test, sparse-field selection test, and REST header assertion added to `test_graphql_pieces.py`.

## Test plan

- [x] `//api:api_piece_test` — all existing + new tests pass
- [x] `//api:api_mypy` — no type errors
- [x] `gz_format` — no lint issues

Closes #880
