### PR TITLE
chore: replace multipart FormData with R2-presigned upload in glaze import tool

### DIFF
--- a/api/import_views.py
+++ b/api/import_views.py
@@ -1,9 +1,7 @@
-import json
-
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.decorators import api_view, parser_classes, permission_classes
-from rest_framework.parsers import FormParser, MultiPartParser
+from rest_framework.parsers import JSONParser
 from rest_framework.permissions import IsAdminUser
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -13,38 +11,38 @@ from backend.otel import traced
 
 @extend_schema(
     request={
-        "multipart/form-data": {
+        "application/json": {
             "type": "object",
             "properties": {
-                "payload": {"type": "string"},
+                "records": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "client_id": {"type": "string"},
+                            "filename": {"type": "string"},
+                            "reviewed": {"type": "boolean"},
+                            "r2_key": {"type": "string"},
+                            "parsed_fields": {"type": "object"},
+                        },
+                        "required": ["client_id", "reviewed", "r2_key"],
+                    },
+                },
             },
-            "required": ["payload"],
+            "required": ["records"],
         }
     },
     responses={200: {"type": "object"}},
 )
 @api_view(["POST"])
 @permission_classes([IsAdminUser])
-@parser_classes([MultiPartParser, FormParser])
+@parser_classes([JSONParser])
 @traced
 def admin_manual_square_crop_import(request: Request) -> Response:
-    """Import reviewed manual square crop records from a multipart payload."""
+    """Import reviewed manual square crop records from a JSON payload."""
     from .manual_tile_imports import import_manual_tile_records
 
-    payload_raw = request.data.get("payload", "")
-    if not payload_raw:
-        return Response(
-            {"detail": "payload is required."}, status=status.HTTP_400_BAD_REQUEST
-        )
-    try:
-        payload = json.loads(payload_raw)
-    except json.JSONDecodeError:
-        return Response(
-            {"detail": "payload must be valid JSON."},
-            status=status.HTTP_400_BAD_REQUEST,
-        )
-
-    records = payload.get("records")
+    records = request.data.get("records")
     if not isinstance(records, list) or not records:
         return Response(
             {"detail": "payload.records must be a non-empty list."},
@@ -65,9 +63,9 @@ def admin_manual_square_crop_import(request: Request) -> Response:
                 {"detail": "Each record must include client_id."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        file_obj = request.FILES.get(f"crop_image__{client_id}")
-        if file_obj is not None:
-            uploaded_files[client_id] = file_obj
+        r2_key = record.get("r2_key", "")
+        if r2_key:
+            uploaded_files[client_id] = r2_key
 
     try:
         result = import_manual_tile_records(records, uploaded_files)

--- a/api/manual_tile_imports.py
+++ b/api/manual_tile_imports.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import uuid
 from collections import Counter
 
 from django.db import transaction
-from django.utils.text import slugify
 
 from . import r2
 from .models import GlazeCombination, GlazeCombinationLayer, GlazeType
@@ -18,25 +16,6 @@ from .utils import (
 def _require_r2() -> None:
     if not r2.is_r2_configured():
         raise ValueError("R2 object storage is not configured.")
-
-
-_DEFAULT_BATCH_FOLDER = "manual-square-crop-imports"
-
-
-def _default_batch_folder() -> str:
-    return _DEFAULT_BATCH_FOLDER
-
-
-def _upload_file(uploaded_file, *, kind: str, filename: str, folder: str) -> dict:
-    """Upload a tile image to R2 and return {"url": <public url>}.
-
-    Tile crops are produced by the import tool as WebP.
-    """
-    stem = slugify(filename.rsplit(".", 1)[0]) or "tile"
-    key = f"{folder}/{kind}-{stem}-{uuid.uuid4().hex[:8]}.webp"
-    data = uploaded_file.read() if hasattr(uploaded_file, "read") else uploaded_file
-    url = r2.upload_bytes(key, data, "image/webp")
-    return {"url": url}
 
 
 def _ensure_combination_layers(
@@ -88,12 +67,9 @@ def _result_payload(
 
 def import_manual_tile_records(
     records: list[dict],
-    uploaded_files: dict[str, object],
-    *,
-    batch_folder: str | None = None,
+    uploaded_files: dict[str, str],
 ) -> dict:
     _require_r2()
-    folder = (batch_folder or _default_batch_folder()).strip().strip("/")
     results: list[dict] = []
 
     def import_glaze_type(record: dict) -> dict:
@@ -105,7 +81,7 @@ def import_manual_tile_records(
             return _result_payload(
                 record, status="error", reason="Missing parsed glaze type name."
             )
-        if uploaded is None:
+        if not uploaded:
             return _result_payload(
                 record, status="error", reason="Missing cropped image upload."
             )
@@ -119,16 +95,11 @@ def import_manual_tile_records(
                 image_url=_image_url(existing.test_tile_image),
             )
 
-        upload = _upload_file(
-            uploaded,
-            kind="glaze-type",
-            filename=record.get("filename", name),
-            folder=f"{folder}/final/glaze-types",
-        )
+        image_url = r2.public_url_for_key(uploaded)
         glaze_type = GlazeType.objects.create(
             user=None,
             name=name,
-            test_tile_image=normalize_image_payload({"url": upload["url"]}),
+            test_tile_image=normalize_image_payload({"url": image_url}),
             runs=parsed.get("runs"),
             is_food_safe=parsed.get("is_food_safe"),
         )
@@ -162,7 +133,7 @@ def import_manual_tile_records(
                 status="error",
                 reason="Glaze combinations require first and second glaze names.",
             )
-        if uploaded is None:
+        if not uploaded:
             return _result_payload(
                 record, status="error", reason="Missing cropped image upload."
             )
@@ -186,16 +157,11 @@ def import_manual_tile_records(
                 reason=f"Missing referenced public glaze type: {missing}.",
             )
 
-        upload = _upload_file(
-            uploaded,
-            kind="glaze-combination",
-            filename=record.get("filename", name),
-            folder=f"{folder}/final/glaze-combinations",
-        )
+        image_url = r2.public_url_for_key(uploaded)
         combo = GlazeCombination.objects.create(
             user=None,
             name=name,
-            test_tile_image=normalize_image_payload({"url": upload["url"]}),
+            test_tile_image=normalize_image_payload({"url": image_url}),
             runs=parsed.get("runs"),
             is_food_safe=parsed.get("is_food_safe"),
         )

--- a/api/manual_tile_imports.py
+++ b/api/manual_tile_imports.py
@@ -95,6 +95,12 @@ def import_manual_tile_records(
                 image_url=_image_url(existing.test_tile_image),
             )
 
+        if not r2.object_exists(uploaded):
+            return _result_payload(
+                record,
+                status="error",
+                reason="Cropped image upload not found in storage.",
+            )
         image_url = r2.public_url_for_key(uploaded)
         glaze_type = GlazeType.objects.create(
             user=None,
@@ -157,6 +163,12 @@ def import_manual_tile_records(
                 reason=f"Missing referenced public glaze type: {missing}.",
             )
 
+        if not r2.object_exists(uploaded):
+            return _result_payload(
+                record,
+                status="error",
+                reason="Cropped image upload not found in storage.",
+            )
         image_url = r2.public_url_for_key(uploaded)
         combo = GlazeCombination.objects.create(
             user=None,

--- a/api/tests/test_manual_square_crop_import.py
+++ b/api/tests/test_manual_square_crop_import.py
@@ -1,15 +1,12 @@
-import io
-import json
-
 import pytest
 from django.contrib.auth.models import User
-from django.core.files.uploadedfile import SimpleUploadedFile
-from PIL import Image
 from rest_framework.test import APIClient
 
 from api.models import GlazeCombination, GlazeType
 
 URL = "/api/admin/manual-square-crop-import/"
+
+R2_KEY = "images/test/tile.webp"
 
 
 def _set_r2_env(monkeypatch):
@@ -18,12 +15,6 @@ def _set_r2_env(monkeypatch):
     monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "secret")
     monkeypatch.setenv("R2_BUCKET_NAME", "bucket")
     monkeypatch.setenv("R2_PUBLIC_URL", "https://media.example.com")
-
-
-def _png_upload(name: str = "crop.png") -> SimpleUploadedFile:
-    buf = io.BytesIO()
-    Image.new("RGBA", (16, 16), (255, 0, 0, 0)).save(buf, format="PNG")
-    return SimpleUploadedFile(name, buf.getvalue(), content_type="image/png")
 
 
 @pytest.mark.django_db
@@ -35,7 +26,7 @@ class TestManualSquareCropImport:
         client = APIClient()
         client.force_authenticate(user=user)
 
-        response = client.post(URL, {"payload": json.dumps({"records": []})})
+        response = client.post(URL, {"records": []}, format="json")
 
         assert response.status_code == 403
 
@@ -46,14 +37,7 @@ class TestManualSquareCropImport:
         client = APIClient()
         client.force_authenticate(user=admin)
 
-        upload_calls = []
-
-        def fake_upload(key, data, content_type):
-            upload_calls.append({"key": key, "content_type": content_type})
-            return f"https://media.example.com/{key}"
-
         _set_r2_env(monkeypatch)
-        monkeypatch.setattr("api.manual_tile_imports.r2.upload_bytes", fake_upload)
 
         payload = {
             "records": [
@@ -61,6 +45,7 @@ class TestManualSquareCropImport:
                     "client_id": "rec-1",
                     "filename": "dragon-green.png",
                     "reviewed": True,
+                    "r2_key": R2_KEY,
                     "parsed_fields": {
                         "name": "Dragon Green",
                         "kind": "glaze_type",
@@ -73,14 +58,7 @@ class TestManualSquareCropImport:
             ],
         }
 
-        response = client.post(
-            URL,
-            {
-                "payload": json.dumps(payload),
-                "crop_image__rec-1": _png_upload(),
-            },
-            format="multipart",
-        )
+        response = client.post(URL, payload, format="json")
 
         assert response.status_code == 200
         body = response.json()
@@ -92,8 +70,8 @@ class TestManualSquareCropImport:
         }
         assert body["results"][0]["status"] == "created"
         glaze_type = GlazeType.objects.get(user=None, name="Dragon Green")
-        assert glaze_type.test_tile_image["url"].startswith(
-            "https://media.example.com/manual-square-crop-imports/"
+        assert (
+            glaze_type.test_tile_image["url"] == f"https://media.example.com/{R2_KEY}"
         )
         assert glaze_type.runs is None
         assert glaze_type.is_food_safe is None
@@ -101,7 +79,6 @@ class TestManualSquareCropImport:
         assert list(
             combo.layers.order_by("order").values_list("glaze_type__name", flat=True)
         ) == ["Dragon Green"]
-        assert len(upload_calls) == 1
 
     def test_runs_and_food_safe_written_to_created_glaze_type(self, monkeypatch):
         admin = User.objects.create(
@@ -111,10 +88,6 @@ class TestManualSquareCropImport:
         client.force_authenticate(user=admin)
 
         _set_r2_env(monkeypatch)
-        monkeypatch.setattr(
-            "api.manual_tile_imports.r2.upload_bytes",
-            lambda key, data, content_type: f"https://media.example.com/{key}",
-        )
 
         payload = {
             "records": [
@@ -122,6 +95,7 @@ class TestManualSquareCropImport:
                     "client_id": "rec-runs",
                     "filename": "caution.png",
                     "reviewed": True,
+                    "r2_key": R2_KEY,
                     "parsed_fields": {
                         "name": "Caution Drip",
                         "kind": "glaze_type",
@@ -134,21 +108,14 @@ class TestManualSquareCropImport:
             ],
         }
 
-        response = client.post(
-            URL,
-            {
-                "payload": json.dumps(payload),
-                "crop_image__rec-runs": _png_upload("caution.png"),
-            },
-            format="multipart",
-        )
+        response = client.post(URL, payload, format="json")
 
         assert response.status_code == 200
         glaze_type = GlazeType.objects.get(user=None, name="Caution Drip")
         assert glaze_type.runs is True
         assert glaze_type.is_food_safe is False
 
-    def test_skips_duplicate_public_glaze_type_without_uploading(self, monkeypatch):
+    def test_skips_duplicate_public_glaze_type(self, monkeypatch):
         admin = User.objects.create(
             username="admin2@example.com", email="admin2@example.com", is_staff=True
         )
@@ -160,11 +127,7 @@ class TestManualSquareCropImport:
         client = APIClient()
         client.force_authenticate(user=admin)
 
-        def fail_upload(*args, **kwargs):
-            raise AssertionError("upload should not be called for duplicates")
-
         _set_r2_env(monkeypatch)
-        monkeypatch.setattr("api.manual_tile_imports.r2.upload_bytes", fail_upload)
 
         payload = {
             "records": [
@@ -172,6 +135,7 @@ class TestManualSquareCropImport:
                     "client_id": "rec-dup",
                     "filename": "celadon.png",
                     "reviewed": True,
+                    "r2_key": R2_KEY,
                     "parsed_fields": {
                         "name": "Celadon",
                         "kind": "glaze_type",
@@ -182,14 +146,7 @@ class TestManualSquareCropImport:
             ],
         }
 
-        response = client.post(
-            URL,
-            {
-                "payload": json.dumps(payload),
-                "crop_image__rec-dup": _png_upload("celadon.png"),
-            },
-            format="multipart",
-        )
+        response = client.post(URL, payload, format="json")
 
         assert response.status_code == 200
         body = response.json()
@@ -197,31 +154,7 @@ class TestManualSquareCropImport:
         assert body["results"][0]["status"] == "skipped_duplicate"
         assert body["results"][0]["object_id"] == str(existing.pk)
 
-    def test_rejects_missing_payload(self):
-        admin = User.objects.create(
-            username="admin4@example.com", email="admin4@example.com", is_staff=True
-        )
-        client = APIClient()
-        client.force_authenticate(user=admin)
-
-        response = client.post(URL, {}, format="multipart")
-
-        assert response.status_code == 400
-        assert response.json() == {"detail": "payload is required."}
-
-    def test_rejects_invalid_json_payload(self):
-        admin = User.objects.create(
-            username="admin5@example.com", email="admin5@example.com", is_staff=True
-        )
-        client = APIClient()
-        client.force_authenticate(user=admin)
-
-        response = client.post(URL, {"payload": "{not-json"}, format="multipart")
-
-        assert response.status_code == 400
-        assert response.json() == {"detail": "payload must be valid JSON."}
-
-    def test_rejects_empty_records_payload(self):
+    def test_rejects_empty_records(self):
         admin = User.objects.create(
             username="admin-empty@example.com",
             email="admin-empty@example.com",
@@ -230,9 +163,21 @@ class TestManualSquareCropImport:
         client = APIClient()
         client.force_authenticate(user=admin)
 
-        response = client.post(
-            URL, {"payload": json.dumps({"records": []})}, format="multipart"
+        response = client.post(URL, {"records": []}, format="json")
+
+        assert response.status_code == 400
+        assert response.json() == {
+            "detail": "payload.records must be a non-empty list."
+        }
+
+    def test_rejects_missing_records_key(self):
+        admin = User.objects.create(
+            username="admin4@example.com", email="admin4@example.com", is_staff=True
         )
+        client = APIClient()
+        client.force_authenticate(user=admin)
+
+        response = client.post(URL, {}, format="json")
 
         assert response.status_code == 400
         assert response.json() == {
@@ -256,12 +201,8 @@ class TestManualSquareCropImport:
 
         response = client.post(
             URL,
-            {
-                "payload": json.dumps(
-                    {"records": [{"client_id": "rec-1", "reviewed": True}]}
-                )
-            },
-            format="multipart",
+            {"records": [{"client_id": "rec-1", "reviewed": True, "r2_key": R2_KEY}]},
+            format="json",
         )
 
         assert response.status_code == 400
@@ -276,12 +217,8 @@ class TestManualSquareCropImport:
 
         response = client.post(
             URL,
-            {
-                "payload": json.dumps(
-                    {"records": [{"client_id": "rec-1", "reviewed": False}]}
-                )
-            },
-            format="multipart",
+            {"records": [{"client_id": "rec-1", "reviewed": False, "r2_key": R2_KEY}]},
+            format="json",
         )
 
         assert response.status_code == 400
@@ -298,8 +235,8 @@ class TestManualSquareCropImport:
 
         response = client.post(
             URL,
-            {"payload": json.dumps({"records": [{"reviewed": True}]})},
-            format="multipart",
+            {"records": [{"reviewed": True, "r2_key": R2_KEY}]},
+            format="json",
         )
 
         assert response.status_code == 400
@@ -376,23 +313,15 @@ class TestImportGlazeCombination:
     def _patch_r2(self, monkeypatch):
         _set_r2_env(monkeypatch)
 
-    def _png(self, name: str = "c.png") -> SimpleUploadedFile:
-        buf = io.BytesIO()
-        Image.new("RGBA", (4, 4)).save(buf, format="PNG")
-        return SimpleUploadedFile(name, buf.getvalue(), content_type="image/png")
-
     def test_error_when_combination_missing_name_and_components(self, monkeypatch):
         self._patch_r2(monkeypatch)
-        monkeypatch.setattr(
-            "api.manual_tile_imports.r2.upload_bytes",
-            lambda key, data, content_type: f"https://media.example.com/{key}",
-        )
         payload = {
             "records": [
                 {
                     "client_id": "c1",
                     "filename": "c.png",
                     "reviewed": True,
+                    "r2_key": R2_KEY,
                     "parsed_fields": {
                         "kind": "glaze_combination",
                         "name": "",
@@ -402,11 +331,7 @@ class TestImportGlazeCombination:
                 }
             ]
         }
-        resp = self._admin_client().post(
-            URL,
-            {"payload": json.dumps(payload), "crop_image__c1": self._png()},
-            format="multipart",
-        )
+        resp = self._admin_client().post(URL, payload, format="json")
         assert resp.status_code == 200
         result = resp.json()["results"][0]
         assert result["status"] == "error"
@@ -414,16 +339,13 @@ class TestImportGlazeCombination:
 
     def test_error_when_missing_second_glaze_name(self, monkeypatch):
         self._patch_r2(monkeypatch)
-        monkeypatch.setattr(
-            "api.manual_tile_imports.r2.upload_bytes",
-            lambda key, data, content_type: f"https://media.example.com/{key}",
-        )
         payload = {
             "records": [
                 {
                     "client_id": "c2",
                     "filename": "c.png",
                     "reviewed": True,
+                    "r2_key": R2_KEY,
                     "parsed_fields": {
                         "kind": "glaze_combination",
                         "name": "A!B",
@@ -433,11 +355,7 @@ class TestImportGlazeCombination:
                 }
             ]
         }
-        resp = self._admin_client().post(
-            URL,
-            {"payload": json.dumps(payload), "crop_image__c2": self._png()},
-            format="multipart",
-        )
+        resp = self._admin_client().post(URL, payload, format="json")
         assert resp.status_code == 200
         result = resp.json()["results"][0]
         assert result["status"] == "error"
@@ -445,16 +363,13 @@ class TestImportGlazeCombination:
 
     def test_error_when_referenced_glaze_type_does_not_exist(self, monkeypatch):
         self._patch_r2(monkeypatch)
-        monkeypatch.setattr(
-            "api.manual_tile_imports.r2.upload_bytes",
-            lambda key, data, content_type: f"https://media.example.com/{key}",
-        )
         payload = {
             "records": [
                 {
                     "client_id": "c3",
                     "filename": "c.png",
                     "reviewed": True,
+                    "r2_key": R2_KEY,
                     "parsed_fields": {
                         "kind": "glaze_combination",
                         "name": "Ghost!Void",
@@ -464,11 +379,7 @@ class TestImportGlazeCombination:
                 }
             ]
         }
-        resp = self._admin_client().post(
-            URL,
-            {"payload": json.dumps(payload), "crop_image__c3": self._png()},
-            format="multipart",
-        )
+        resp = self._admin_client().post(URL, payload, format="json")
         assert resp.status_code == 200
         result = resp.json()["results"][0]
         assert result["status"] == "error"
@@ -476,10 +387,6 @@ class TestImportGlazeCombination:
 
     def test_creates_combination_with_layers_and_flags(self, monkeypatch):
         self._patch_r2(monkeypatch)
-        monkeypatch.setattr(
-            "api.manual_tile_imports.r2.upload_bytes",
-            lambda key, data, content_type: f"https://media.example.com/{key}",
-        )
         GlazeType.objects.create(user=None, name="Alpha")
         GlazeType.objects.create(user=None, name="Beta")
         payload = {
@@ -488,6 +395,7 @@ class TestImportGlazeCombination:
                     "client_id": "c4",
                     "filename": "c.png",
                     "reviewed": True,
+                    "r2_key": R2_KEY,
                     "parsed_fields": {
                         "kind": "glaze_combination",
                         "name": "Alpha!Beta",
@@ -499,11 +407,7 @@ class TestImportGlazeCombination:
                 }
             ]
         }
-        resp = self._admin_client().post(
-            URL,
-            {"payload": json.dumps(payload), "crop_image__c4": self._png()},
-            format="multipart",
-        )
+        resp = self._admin_client().post(URL, payload, format="json")
         assert resp.status_code == 200
         assert resp.json()["results"][0]["status"] == "created"
         combo = GlazeCombination.objects.get(user=None, name="Alpha!Beta")
@@ -513,18 +417,12 @@ class TestImportGlazeCombination:
             combo.layers.order_by("order").values_list("glaze_type__name", flat=True)
         ) == ["Alpha", "Beta"]
 
-    def test_skips_duplicate_combination_without_uploading(self, monkeypatch):
+    def test_skips_duplicate_combination(self, monkeypatch):
         self._patch_r2(monkeypatch)
         existing = GlazeCombination.objects.create(
             user=None,
             name="X!Y",
             test_tile_image={"url": "https://x.com/old.png"},
-        )
-        monkeypatch.setattr(
-            "api.manual_tile_imports.r2.upload_bytes",
-            lambda key, data, content_type: (_ for _ in ()).throw(
-                AssertionError("should not upload")
-            ),
         )
         payload = {
             "records": [
@@ -532,6 +430,7 @@ class TestImportGlazeCombination:
                     "client_id": "c5",
                     "filename": "c.png",
                     "reviewed": True,
+                    "r2_key": R2_KEY,
                     "parsed_fields": {
                         "kind": "glaze_combination",
                         "name": "X!Y",
@@ -541,37 +440,26 @@ class TestImportGlazeCombination:
                 }
             ]
         }
-        resp = self._admin_client().post(
-            URL,
-            {"payload": json.dumps(payload), "crop_image__c5": self._png()},
-            format="multipart",
-        )
+        resp = self._admin_client().post(URL, payload, format="json")
         assert resp.status_code == 200
         result = resp.json()["results"][0]
         assert result["status"] == "skipped_duplicate"
         assert result["object_id"] == str(existing.pk)
 
-    def test_error_when_glaze_type_missing_crop_image(self, monkeypatch):
+    def test_error_when_glaze_type_missing_r2_key(self, monkeypatch):
         self._patch_r2(monkeypatch)
-        monkeypatch.setattr(
-            "api.manual_tile_imports.r2.upload_bytes",
-            lambda key, data, content_type: f"https://media.example.com/{key}",
-        )
         payload = {
             "records": [
                 {
                     "client_id": "c6",
                     "filename": "missing.png",
                     "reviewed": True,
+                    "r2_key": "",
                     "parsed_fields": {"kind": "glaze_type", "name": "SomeName"},
                 }
             ]
         }
-        resp = self._admin_client().post(
-            URL,
-            {"payload": json.dumps(payload)},
-            format="multipart",
-        )
+        resp = self._admin_client().post(URL, payload, format="json")
         assert resp.status_code == 200
         result = resp.json()["results"][0]
         assert result["status"] == "error"

--- a/api/tests/test_manual_square_crop_import.py
+++ b/api/tests/test_manual_square_crop_import.py
@@ -38,6 +38,7 @@ class TestManualSquareCropImport:
         client.force_authenticate(user=admin)
 
         _set_r2_env(monkeypatch)
+        monkeypatch.setattr("api.manual_tile_imports.r2.object_exists", lambda key: True)
 
         payload = {
             "records": [
@@ -88,6 +89,7 @@ class TestManualSquareCropImport:
         client.force_authenticate(user=admin)
 
         _set_r2_env(monkeypatch)
+        monkeypatch.setattr("api.manual_tile_imports.r2.object_exists", lambda key: True)
 
         payload = {
             "records": [
@@ -153,6 +155,42 @@ class TestManualSquareCropImport:
         assert body["summary"]["skipped_duplicates"] == 1
         assert body["results"][0]["status"] == "skipped_duplicate"
         assert body["results"][0]["object_id"] == str(existing.pk)
+
+    def test_errors_when_r2_key_does_not_exist_in_storage(self, monkeypatch):
+        admin = User.objects.create(
+            username="admin-bad-key@example.com",
+            email="admin-bad-key@example.com",
+            is_staff=True,
+        )
+        client = APIClient()
+        client.force_authenticate(user=admin)
+
+        _set_r2_env(monkeypatch)
+        monkeypatch.setattr("api.manual_tile_imports.r2.object_exists", lambda key: False)
+
+        payload = {
+            "records": [
+                {
+                    "client_id": "rec-missing",
+                    "filename": "missing.png",
+                    "reviewed": True,
+                    "r2_key": "images/does-not-exist.webp",
+                    "parsed_fields": {
+                        "name": "Phantom Blue",
+                        "kind": "glaze_type",
+                        "first_glaze": "",
+                        "second_glaze": "",
+                    },
+                }
+            ]
+        }
+
+        response = client.post(URL, payload, format="json")
+
+        assert response.status_code == 200
+        result = response.json()["results"][0]
+        assert result["status"] == "error"
+        assert "not found in storage" in result["reason"]
 
     def test_rejects_empty_records(self):
         admin = User.objects.create(
@@ -312,6 +350,7 @@ class TestImportGlazeCombination:
 
     def _patch_r2(self, monkeypatch):
         _set_r2_env(monkeypatch)
+        monkeypatch.setattr("api.manual_tile_imports.r2.object_exists", lambda key: True)
 
     def test_error_when_combination_missing_name_and_components(self, monkeypatch):
         self._patch_r2(monkeypatch)

--- a/web/src/pages/GlazeImportToolPage.tsx
+++ b/web/src/pages/GlazeImportToolPage.tsx
@@ -17,8 +17,10 @@ import TextSnippetIcon from "@mui/icons-material/TextSnippet";
 import FactCheckIcon from "@mui/icons-material/FactCheck";
 import CloudUploadIcon from "@mui/icons-material/CloudUpload";
 import MergeIcon from "@mui/icons-material/MergeType";
+import axios from "axios";
 import {
   extractErrorMessage,
+  fetchR2PresignedUrl,
   importManualSquareCropRecords,
   type ManualSquareCropImportResponse,
 } from "../util/api";
@@ -385,7 +387,7 @@ export default function GlazeImportToolPage({
       })),
     );
     try {
-      const cropFiles: Record<string, File> = {};
+      const r2Keys: Record<string, string> = {};
       for (const record of records) {
         setImportBuildProgress((current) =>
           current.map((entry) =>
@@ -394,7 +396,7 @@ export default function GlazeImportToolPage({
               : entry,
           ),
         );
-        cropFiles[record.id] = await buildCropFile(record);
+        const cropFile = await buildCropFile(record);
         setImportBuildProgress((current) =>
           current.map((entry) =>
             entry.id === record.id
@@ -402,15 +404,21 @@ export default function GlazeImportToolPage({
               : entry,
           ),
         );
+        const presigned = await fetchR2PresignedUrl("image/webp");
+        const form = new FormData();
+        Object.entries(presigned.fields).forEach(([k, v]) => form.append(k, v));
+        form.append("file", cropFile);
+        await axios.post(presigned.upload_url, form);
+        r2Keys[record.id] = presigned.key;
       }
       const result = await importManualSquareCropRecords(
         records.map((record) => ({
           client_id: record.id,
           filename: record.filename,
           reviewed: record.reviewed,
+          r2_key: r2Keys[record.id] ?? "",
           parsed_fields: record.parsedFields,
         })),
-        cropFiles,
       );
       setImportBuildProgress((current) =>
         current.map((entry) => ({ ...entry, status: "ready", progress: 100 })),

--- a/web/src/pages/__tests__/GlazeImportToolPage.test.tsx
+++ b/web/src/pages/__tests__/GlazeImportToolPage.test.tsx
@@ -12,6 +12,10 @@ import GlazeImportToolPage from "../GlazeImportToolPage";
 import { importManualSquareCropRecords } from "../../util/api";
 import { uploadImageToR2 } from "../../util/r2Upload";
 
+vi.mock("axios", () => ({
+  default: { post: vi.fn().mockResolvedValue({}) },
+}));
+
 vi.mock("../../util/api", () => ({
   extractErrorMessage: vi.fn((error: unknown, defaultMessage: string) => {
     const data = (error as { response?: { data?: unknown } }).response?.data;
@@ -23,6 +27,14 @@ vi.mock("../../util/api", () => ({
       }
     }
     return error instanceof Error ? error.message : defaultMessage;
+  }),
+  fetchR2PresignedUrl: vi.fn().mockResolvedValue({
+    upload_url: "https://r2.example.com/upload",
+    fields: {},
+    key: "images/test/crop.webp",
+    public_url: "https://media.example.com/images/test/crop.webp",
+    expires_in: 3600,
+    max_bytes: 10485760,
   }),
   importManualSquareCropRecords: vi.fn(),
 }));

--- a/web/src/util/__tests__/api.test.ts
+++ b/web/src/util/__tests__/api.test.ts
@@ -846,7 +846,7 @@ describe("upload endpoints", () => {
     });
   });
 
-  it("importManualSquareCropRecords posts multipart data with payload and matching files", async () => {
+  it("importManualSquareCropRecords posts JSON with r2_key per record", async () => {
     const { importManualSquareCropRecords } = await loadApiModule();
     mockClient.post.mockResolvedValue({
       data: {
@@ -860,12 +860,12 @@ describe("upload endpoints", () => {
       },
     });
 
-    const file = new File(["image"], "crop.jpg", { type: "image/jpeg" });
     const records = [
       {
         client_id: "one",
         filename: "crop.jpg",
         reviewed: true,
+        r2_key: "images/user1/abc.webp",
         parsed_fields: {
           name: "Tenmoku",
           kind: "glaze_type" as const,
@@ -875,31 +875,13 @@ describe("upload endpoints", () => {
           is_food_safe: false,
         },
       },
-      {
-        client_id: "two",
-        filename: "skip.jpg",
-        reviewed: false,
-        parsed_fields: {
-          name: "Clear / Iron",
-          kind: "glaze_combination" as const,
-          first_glaze: "Clear",
-          second_glaze: "Iron",
-          runs: null,
-          is_food_safe: null,
-        },
-      },
     ];
 
-    await importManualSquareCropRecords(records, { one: file });
+    await importManualSquareCropRecords(records);
 
-    const [path, form] = mockClient.post.mock.calls[0] as [string, FormData];
+    const [path, body] = mockClient.post.mock.calls[0] as [string, unknown];
     expect(path).toBe("admin/manual-square-crop-import/");
-    expect(form).toBeInstanceOf(FormData);
-    expect(form.get("payload")).toBe(JSON.stringify({ records }));
-    const uploadedFile = form.get("crop_image__one");
-    expect(uploadedFile).toBeInstanceOf(File);
-    expect((uploadedFile as File).name).toBe(file.name);
-    expect(form.get("crop_image__two")).toBeNull();
+    expect(body).toEqual({ records });
   });
 });
 

--- a/web/src/util/api.ts
+++ b/web/src/util/api.ts
@@ -957,6 +957,7 @@ export type ManualSquareCropImportRecordPayload = {
   client_id: string;
   filename: string;
   reviewed: boolean;
+  r2_key: string;
   parsed_fields: {
     name: string;
     kind: "glaze_type" | "glaze_combination";
@@ -988,19 +989,10 @@ export type ManualSquareCropImportResponse = {
 
 export async function importManualSquareCropRecords(
   records: ManualSquareCropImportRecordPayload[],
-  cropFiles: Record<string, File>,
 ): Promise<ManualSquareCropImportResponse> {
-  const form = new FormData();
-  form.append("payload", JSON.stringify({ records }));
-  for (const record of records) {
-    const file = cropFiles[record.client_id];
-    if (file) {
-      form.append(`crop_image__${record.client_id}`, file, file.name);
-    }
-  }
   const { data } = await client.post<ManualSquareCropImportResponse>(
     "admin/manual-square-crop-import/",
-    form,
+    { records },
   );
   return data;
 }


### PR DESCRIPTION
## Summary

- Replaces multipart `FormData` upload to Django with a presigned R2 upload in the glaze import tool — the only remaining endpoint that sent binary files directly to the backend
- No user-visible behavior changes; purely internal plumbing

## What changed

**Backend**
- `api/import_views.py`: switched from `MultiPartParser`/`FormParser` to `JSONParser`; reads `r2_key` per record from the JSON body instead of `request.FILES`
- `api/manual_tile_imports.py`: removed `_upload_file()` (and `_default_batch_folder`); derives the public image URL directly via `r2.public_url_for_key(r2_key)` — no server-side upload

**Frontend**
- `web/src/util/api.ts`: added `r2_key: string` to `ManualSquareCropImportRecordPayload`; `importManualSquareCropRecords` now sends plain JSON, no `FormData`
- `web/src/pages/GlazeImportToolPage.tsx`: `runImport()` uploads each WebP crop blob directly to R2 via `fetchR2PresignedUrl` + presigned POST before submitting the import JSON payload

**Tests**: updated to `format="json"` throughout; removed `_png_upload()` helper and `upload_bytes` patches; added `fetchR2PresignedUrl` and `axios` mocks to the page test

## Test plan

- [x] `//api:api_glaze_test` passes
- [x] `//web:web_test` (all 41 targets) passes
- [x] `gz_lint` (mypy, ruff, tsc, eslint) passes
- [x] `gz_format` clean

Closes #917

🤖 Generated with [Claude Code](https://claude.com/claude-code)
