### PR TITLE
fix(ci): activate disk cache for all Bazel invocations, key by OS

### DIFF
--- a/.github/actions/setup-bazel-ci/action.yml
+++ b/.github/actions/setup-bazel-ci/action.yml
@@ -39,15 +39,16 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.cache/bazel-disk-cache
-        key: bazel-disk-${{ inputs.cache-key-prefix }}-${{ inputs.deps-key }}-${{ github.run_id }}
+        key: bazel-disk-${{ runner.os }}-${{ inputs.cache-key-prefix }}-${{ inputs.deps-key }}-${{ github.run_id }}
         restore-keys: |
-          bazel-disk-${{ inputs.cache-key-prefix }}-${{ inputs.deps-key }}-
-          bazel-disk-
+          bazel-disk-${{ runner.os }}-${{ inputs.cache-key-prefix }}-${{ inputs.deps-key }}-
+          bazel-disk-${{ runner.os }}-
 
-    - name: Inject BuildBuddy API key and repo cache path into .bazelrc
+    - name: Inject BuildBuddy API key, repo cache, and disk cache paths into .bazelrc
       shell: bash
       working-directory: ${{ inputs.workdir }}
       run: |
         echo "" >> .bazelrc
         echo "common:ci --remote_header=x-buildbuddy-api-key=${{ inputs.buildbuddy-api-key }}" >> .bazelrc
         echo "common --repository_cache=~/.cache/bazel-repo" >> .bazelrc
+        echo "build --disk_cache=~/.cache/bazel-disk-cache" >> .bazelrc


### PR DESCRIPTION
## Summary

- `gz_start` calls `bazel run //tools:gz_start_launcher` without `--config=ci`, so `build:ci --disk_cache` in the static `.bazelrc` was never activated for the smoke test. Bazel rebuilt **1,118 actions from scratch** (~125 s) on every run with zero cache hits.
- The fix injects `build --disk_cache=~/.cache/bazel-disk-cache` unconditionally from `setup-bazel-ci`, alongside the existing repository cache injection. This applies to all Bazel invocations in CI regardless of whether `--config=ci` is passed.
- Also keys the disk cache restore-keys on `runner.os` (matching the existing pattern for the repo cache) to prevent macOS and Linux jobs from restoring each other's caches via the broad `bazel-disk-` fallback key.

Fixes #919.

## Test plan

- [ ] Trigger a PR CI run and confirm `dev-smoke-macos` Bootstrap step shows `action cache hit` entries in the `gz_start_launcher` build on the **second** run for the same deps key
- [ ] Confirm `dev-smoke` (Linux) still passes
- [ ] Confirm no other CI jobs regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)