### PR TITLE
fix(openapi): register AgentTokenAuthentication security scheme extension

### DIFF
--- a/api/auth/agent_auth.py
+++ b/api/auth/agent_auth.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import hashlib
 
 from django.utils import timezone
+from drf_spectacular.extensions import OpenApiAuthenticationExtension
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
 
@@ -18,6 +19,19 @@ from api.models import AgentToken
 
 _PREFIX = "Bearer pdagent_"
 _LAST_USED_DEBOUNCE_SECONDS = 60
+
+
+class AgentTokenAuthenticationExtension(OpenApiAuthenticationExtension):
+    target_class = "api.auth.agent_auth.AgentTokenAuthentication"
+    name = "agentTokenAuth"
+
+    def get_security_definition(self, auto_schema):
+        return {
+            "type": "http",
+            "scheme": "bearer",
+            "bearerFormat": "pdagent_<token>",
+            "description": "Long-lived API token. Pass as Authorization: Bearer pdagent_<token>.",
+        }
 
 
 class AgentTokenAuthentication(BaseAuthentication):

--- a/api/auth/agent_token_views.py
+++ b/api/auth/agent_token_views.py
@@ -13,7 +13,12 @@ import secrets
 from typing import cast
 
 from django.contrib.auth.models import User
-from drf_spectacular.utils import OpenApiExample, OpenApiResponse, extend_schema
+from drf_spectacular.utils import (
+    OpenApiExample,
+    OpenApiResponse,
+    extend_schema,
+    inline_serializer,
+)
 from rest_framework import serializers, status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.decorators import (
@@ -68,7 +73,9 @@ class AgentTokenCreatedSerializer(serializers.ModelSerializer):
         "and will not be accessible again — store it securely. Tokens authenticate "
         "via ``Authorization: Bearer pdagent_<token>``."
     ),
-    request=serializers.Serializer,
+    request=inline_serializer(
+        "AgentTokenCreate", fields={"name": serializers.CharField()}
+    ),
     responses={
         201: AgentTokenCreatedSerializer,
         400: OpenApiResponse(description="Missing or invalid name."),

--- a/api/tests/test_health.py
+++ b/api/tests/test_health.py
@@ -98,3 +98,27 @@ class TestHealthReady:
         assert len(schema["paths"]) > 0
         for path in schema["paths"].keys():
             assert path.startswith("/api/")
+
+    def test_openapi_schema_registers_agent_token_security_scheme(self):
+        from drf_spectacular.generators import SchemaGenerator
+
+        generator = SchemaGenerator()
+        schema = generator.get_schema(request=None, public=True)
+        security_schemes = schema.get("components", {}).get("securitySchemes", {})
+        assert "agentTokenAuth" in security_schemes, (
+            f"Expected 'agentTokenAuth' in securitySchemes, got: {list(security_schemes.keys())}"
+        )
+
+    def test_openapi_schema_no_illegal_component_names(self):
+        import re
+
+        from drf_spectacular.generators import SchemaGenerator
+
+        generator = SchemaGenerator()
+        schema = generator.get_schema(request=None, public=True)
+        component_names = list(schema.get("components", {}).get("schemas", {}).keys())
+        legal_pattern = re.compile(r"^[A-Za-z0-9_.\-]+$")
+        illegal = [name for name in component_names if not legal_pattern.match(name)]
+        assert illegal == [], (
+            f"Expected all component names to be legal identifiers, got illegal: {illegal}"
+        )


### PR DESCRIPTION
## Problem

`AgentTokenAuthentication` had no `OpenApiAuthenticationExtension` registered,
causing drf-spectacular to emit ~35 "could not resolve authenticator" warnings
during schema generation and omit the security scheme from the output schema.
Additionally, `POST /api/auth/agent-tokens/` used `request=serializers.Serializer`
(bare anonymous class), which caused a "Component name '' contains illegal
characters" warning.

## Fix

- Added `AgentTokenAuthenticationExtension` in `api/auth/agent_auth.py`,
  following the same pattern as `JWTCookieAuthenticationExtension` in
  `jwt_auth.py`. This registers an `agentTokenAuth` HTTP Bearer security
  scheme in the generated schema.
- Replaced `request=serializers.Serializer` with
  `inline_serializer("AgentTokenCreate", fields={"name": serializers.CharField()})`
  in `agent_token_views.py`, giving the request body a legal, meaningful
  component name.

## Regression Test

Added two tests in `api/tests/test_health.py::TestHealthReady`:

- `test_openapi_schema_registers_agent_token_security_scheme` — asserts
  `agentTokenAuth` appears in `components.securitySchemes` after schema
  generation. This test **failed** before the fix and **passes** after.
- `test_openapi_schema_no_illegal_component_names` — asserts all component
  names in `components.schemas` match `[A-Za-z0-9_.\-]+`. Guards against
  anonymous serializers being registered with illegal names.

## Verification

```
rtk bazel test //api:api_test --test_output=summary
# 11/11 pass, no regressions
```
