### PR TITLE
feat(api): expose GET /api/workflow/ for LLM/MCP schema discovery

### DIFF
--- a/api/tests/test_workflow_helpers.py
+++ b/api/tests/test_workflow_helpers.py
@@ -682,3 +682,73 @@ def test_build_custom_fields_schema_covers_required_fields(monkeypatch):
     assert "required" in schema
     assert "required_field" in schema["required"]
     assert "optional_field" not in schema["required"]
+
+
+# ---------------------------------------------------------------------------
+# workflow_schema view + build_workflow_schema
+# ---------------------------------------------------------------------------
+
+
+def test_workflow_schema_authenticated_returns_200(monkeypatch):
+    from api.workflow_views import workflow_schema
+
+    monkeypatch.setattr(
+        "api.workflow_views.build_workflow_schema",
+        lambda: {
+            "version": "test",
+            "entry_state": "designed",
+            "states": {},
+            "globals": {},
+        },
+    )
+
+    request = APIRequestFactory().get("/api/workflow/")
+    request.user = SimpleNamespace(is_authenticated=True, is_active=True)
+
+    response = workflow_schema(request)
+
+    assert response.status_code == 200
+    assert response.data["version"] == "test"
+
+
+def test_workflow_schema_anonymous_returns_401():
+    from django.contrib.auth.models import AnonymousUser
+
+    from api.workflow_views import workflow_schema
+
+    request = APIRequestFactory().get("/api/workflow/")
+    request.user = AnonymousUser()
+
+    response = workflow_schema(request)
+
+    assert response.status_code == 401
+
+
+def test_build_workflow_schema_structure():
+    from api.workflow import (
+        VALID_STATES,
+        WORKFLOW_VERSION,
+        build_workflow_schema,
+        get_global_names,
+    )
+
+    result = build_workflow_schema()
+
+    assert result["version"] == WORKFLOW_VERSION
+    assert result["entry_state"] == "designed"
+    assert set(result["states"].keys()) == VALID_STATES
+    assert set(result["globals"].keys()) == set(get_global_names())
+
+    for state_id, state_data in result["states"].items():
+        assert "friendly_name" in state_data
+        assert "terminal" in state_data
+        assert "successors" in state_data
+        assert "schema" in state_data
+
+    for global_name, global_data in result["globals"].items():
+        assert "model" in global_data
+        assert "public" in global_data
+        assert "private" in global_data
+        assert "favoritable" in global_data
+        assert "taggable" in global_data
+        assert "fields" in global_data

--- a/api/urls.py
+++ b/api/urls.py
@@ -110,6 +110,7 @@ urlpatterns = [
         views.r2_convert_image_status,
         name="r2-convert-image-status",
     ),
+    path("workflow/", views.workflow_schema, name="workflow-schema"),
     path(
         "workflow/schema/<str:state_id>/",
         views.workflow_state_schema,

--- a/api/views.py
+++ b/api/views.py
@@ -58,7 +58,7 @@ from .uploads.views import (
     r2_convert_image_status,
     r2_presigned_upload_url,
 )
-from .workflow_views import workflow_state_schema
+from .workflow_views import workflow_schema, workflow_state_schema
 
 __all__ = [
     "CropRunViewSet",
@@ -106,5 +106,6 @@ __all__ = [
     "submit_task",
     "task_detail",
     "browser_traces",
+    "workflow_schema",
     "workflow_state_schema",
 ]

--- a/api/workflow.py
+++ b/api/workflow.py
@@ -259,6 +259,41 @@ def get_global_config(global_name: str) -> dict:
     return dict(_GLOBALS_MAP.get(global_name, {}))
 
 
+def build_workflow_schema() -> dict:
+    """Return the full workflow schema for LLM/MCP discovery.
+
+    Aggregates version, entry state, all states (with their ui schemas), and all
+    globals (with their capabilities and field definitions) into a single dict.
+    Parsed once at import time via cached constants; build_ui_schema is lru_cached.
+    """
+    return {
+        "version": WORKFLOW_VERSION,
+        "entry_state": ENTRY_STATE,
+        "states": {
+            state_id: {
+                "friendly_name": _STATE_MAP[state_id].get("friendly_name", state_id),
+                "description": _STATE_MAP[state_id].get("description", ""),
+                "terminal": state_id in TERMINAL_STATES,
+                "successors": SUCCESSORS.get(state_id, []),
+                "schema": build_ui_schema(state_id),
+            }
+            for state_id in VALID_STATES
+        },
+        "globals": {
+            name: {
+                "model": get_global_config(name).get("model"),
+                "description": get_global_config(name).get("description", ""),
+                "public": is_public_global(name),
+                "private": is_private_global(name),
+                "favoritable": is_favoritable_global(name),
+                "taggable": is_taggable_global(name),
+                "fields": get_global_config(name).get("fields", {}),
+            }
+            for name in get_global_names()
+        },
+    }
+
+
 def get_filterable_ref_fields(global_name: str) -> dict[str, dict]:
     """Return FK filter metadata for global ref fields declared with filterable: true.
 

--- a/api/workflow.py
+++ b/api/workflow.py
@@ -271,13 +271,13 @@ def build_workflow_schema() -> dict:
         "entry_state": ENTRY_STATE,
         "states": {
             state_id: {
-                "friendly_name": _STATE_MAP[state_id].get("friendly_name", state_id),
-                "description": _STATE_MAP[state_id].get("description", ""),
+                "friendly_name": state.get("friendly_name", state_id),
+                "description": state.get("description", ""),
                 "terminal": state_id in TERMINAL_STATES,
                 "successors": SUCCESSORS.get(state_id, []),
                 "schema": build_ui_schema(state_id),
             }
-            for state_id in VALID_STATES
+            for state_id, state in _STATE_MAP.items()
         },
         "globals": {
             name: {

--- a/api/workflow_views.py
+++ b/api/workflow_views.py
@@ -6,7 +6,15 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from .workflow import build_ui_schema
+from .workflow import build_ui_schema, build_workflow_schema
+
+
+@extend_schema(responses={200: Any})
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def workflow_schema(request: Request) -> Response:
+    """Return the full workflow schema: states, successors, field schemas, and globals."""
+    return Response(build_workflow_schema())
 
 
 @extend_schema(responses={200: Any})


### PR DESCRIPTION
## Summary
- Adds `GET /api/workflow/` endpoint returning the complete workflow state machine in a single request
- Response includes `version`, `entry_state`, all `states` (with UI schemas, successors, terminal flags), and all `globals` (with model, capabilities, and field definitions)
- Protected by `IsAuthenticated`; documented via `@extend_schema`
- Resolves #883

## Test plan
- [ ] `test_workflow_schema_authenticated_returns_200` — view returns 200 for auth'd user
- [ ] `test_workflow_schema_anonymous_returns_401` — AnonymousUser gets 401
- [ ] `test_build_workflow_schema_structure` — output contains all VALID_STATES and globals
- [ ] `rtk bazel test //api:api_tests` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)