### PR TITLE
fix(modal): remove ephemeral_disk=2048 below Modal server-side minimum

### DIFF
--- a/services/glaze_compute_service.py
+++ b/services/glaze_compute_service.py
@@ -683,7 +683,7 @@ if app is not None:
         _put_bytes(presigned_put_url, jpeg_bytes, "image/jpeg")
         return {"width": width, "height": height}
 
-    @app.function(image=_video_image, ephemeral_disk=2048, timeout=900)
+    @app.function(image=_video_image, timeout=900)
     def render_showcase_video(
         storyboard: dict,
         presigned_put_url: str,

--- a/services/tests/BUILD.bazel
+++ b/services/tests/BUILD.bazel
@@ -1,6 +1,20 @@
 load("//:python.bzl", "pytest_test")
 
 pytest_test(
+    name = "test_glaze_compute_service",
+    srcs = [
+        "test_glaze_compute_service.py",
+        "//tools:pytest_main.py",
+    ],
+    main = "//tools:pytest_main.py",
+    args = ["services/tests/test_glaze_compute_service.py"],
+    deps = [
+        "//services:glaze_compute_service",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+pytest_test(
     name = "test_piece_image_segment_service",
     cov_src = "services.piece_image_segment_service",
     srcs = [

--- a/services/tests/BUILD.bazel
+++ b/services/tests/BUILD.bazel
@@ -2,6 +2,7 @@ load("//:python.bzl", "pytest_test")
 
 pytest_test(
     name = "test_glaze_compute_service",
+    cov_src = "services.glaze_compute_service",
     srcs = [
         "test_glaze_compute_service.py",
         "//tools:pytest_main.py",

--- a/services/tests/test_glaze_compute_service.py
+++ b/services/tests/test_glaze_compute_service.py
@@ -1,0 +1,20 @@
+import ast
+import pathlib
+
+
+# Modal enforces this server-side; values below this are rejected at deploy time.
+MODAL_DISK_MIN_MIB = 524288
+
+
+def test_no_invalid_ephemeral_disk_values():
+    src = (pathlib.Path(__file__).parent.parent / "glaze_compute_service.py").read_text()
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            for kw in node.keywords:
+                if kw.arg == "ephemeral_disk" and isinstance(kw.value, ast.Constant):
+                    assert kw.value.value >= MODAL_DISK_MIN_MIB, (
+                        f"ephemeral_disk={kw.value.value} MiB is below Modal's "
+                        f"minimum of {MODAL_DISK_MIN_MIB} MiB (512 GiB). "
+                        f"Remove the parameter or raise it to at least {MODAL_DISK_MIN_MIB}."
+                    )

--- a/services/tests/test_glaze_compute_service.py
+++ b/services/tests/test_glaze_compute_service.py
@@ -1,5 +1,6 @@
 import ast
-import pathlib
+
+import services.glaze_compute_service as _compute_service
 
 
 # Modal enforces this server-side; values below this are rejected at deploy time.
@@ -7,8 +8,8 @@ MODAL_DISK_MIN_MIB = 524288
 
 
 def test_no_invalid_ephemeral_disk_values():
-    src = (pathlib.Path(__file__).parent.parent / "glaze_compute_service.py").read_text()
-    tree = ast.parse(src)
+    src = _compute_service.__file__
+    tree = ast.parse(open(src).read())
     for node in ast.walk(tree):
         if isinstance(node, ast.Call):
             for kw in node.keywords:


### PR DESCRIPTION
## Problem

Modal CD was broken: `ephemeral_disk=2048` (MiB) on `render_showcase_video` is below Modal's server-side minimum of 524288 MiB (512 GiB). The `ephemeral_disk` parameter provisions a dedicated NVMe scratch volume — values outside [524288, 3145728] MiB are rejected at deploy time. See #925.

## Fix

Remove `ephemeral_disk=2048` from `@app.function` on `render_showcase_video` in `services/glaze_compute_service.py`. Default container storage is sufficient for video assembly.

## Regression Test

`services/tests/test_glaze_compute_service.py::test_no_invalid_ephemeral_disk_values` — parses the source with `ast` and asserts no `ephemeral_disk` keyword argument is below 524288 MiB. Fails before the fix (2048 < 524288), passes after.

New BUILD target: `//services/tests:test_glaze_compute_service`.

## Verification

```
//services/tests:test_glaze_compute_service   PASSED in 2.8s
//services/tests:test_piece_image_segment_service  (cached) PASSED in 13.4s
```

Closes #925