### PR TITLE
fix: disable "Render again" when piece hash is unchanged

### DIFF
--- a/api/piece/showcase_views.py
+++ b/api/piece/showcase_views.py
@@ -104,8 +104,12 @@ def _status_payload(
     disabled_reason = _video_disabled_reason()
     task_data = task.input_params if task is not None else {}
     stored_input_hash = None
+    stored_excluded_image_keys: list[str] = []
+    stored_excluded_note_keys: list[str] = []
     if isinstance(task_data, dict):
         stored_input_hash = task_data.get("input_hash")
+        stored_excluded_image_keys = task_data.get("excluded_image_keys") or []
+        stored_excluded_note_keys = task_data.get("excluded_note_keys") or []
 
     artifact = None
     task_status = None
@@ -159,6 +163,8 @@ def _status_payload(
         "is_stale": is_stale,
         "stale_reason": stale_reason,
         "music_track_id": music_track_id,
+        "excluded_image_keys": stored_excluded_image_keys,
+        "excluded_note_keys": stored_excluded_note_keys,
         "storyboard": storyboard,
         "artifact": artifact,
         "error": error,

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -638,8 +638,13 @@ function ShowcaseVideoPanel({
   });
 
   const currentStatus = showcaseVideo?.status ?? "idle";
+  const hashUnchanged =
+    currentStatus === "succeeded" &&
+    showcaseVideo?.current_input_hash != null &&
+    showcaseVideo.current_input_hash === showcaseVideo?.stored_input_hash;
   const canGenerate =
     !generating &&
+    !hashUnchanged &&
     (showcaseVideo?.enabled ?? true) &&
     currentStatus !== "pending" &&
     currentStatus !== "running" &&

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -1,7 +1,9 @@
 import {
   type ComponentProps,
   useCallback,
+  useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import {
@@ -610,6 +612,17 @@ function ShowcaseVideoPanel({
     musicTrackId: DEFAULT_TRACK_ID,
   });
 
+  // Piece edits change the render hash server-side; invalidate so the fresh
+  // current_input_hash is fetched and the stale-needs-regeneration status
+  // (or re-enabled button) reflects the updated piece content.
+  const prevPieceRef = useRef(piece);
+  useEffect(() => {
+    if (prevPieceRef.current !== piece) {
+      prevPieceRef.current = piece;
+      queryClient.invalidateQueries({ queryKey: ["showcase-video", piece.id] });
+    }
+  }, [piece, queryClient]);
+
   const {
     data: showcaseVideo,
     error: rawStatusError,
@@ -638,7 +651,15 @@ function ShowcaseVideoPanel({
   });
 
   const currentStatus = showcaseVideo?.status ?? "idle";
+  // True when music track and exclusions match the stored task's defaults
+  // (API doesn't expose stored exclusions, so we treat any non-empty exclusion
+  // as a divergence). Music track is compared exactly against the stored value.
+  const selectionMatchesStoredTask =
+    selection.musicTrackId === (showcaseVideo?.music_track_id ?? DEFAULT_TRACK_ID) &&
+    selection.excludedImageKeys.length === 0 &&
+    selection.excludedNoteKeys.length === 0;
   const hashUnchanged =
+    selectionMatchesStoredTask &&
     currentStatus === "succeeded" &&
     showcaseVideo?.current_input_hash != null &&
     showcaseVideo.current_input_hash === showcaseVideo?.stored_input_hash;

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -9,7 +9,6 @@ import {
 import {
   usePieceHistoryRouting,
   usePieceTagsRouting,
-  usePieceVideoRouting,
 } from "../routing/pieceRouting";
 import RoutedGlobalEntryField from "./RoutedGlobalEntryField";
 import {
@@ -28,6 +27,7 @@ import {
 } from "@mui/material";
 import HistoryIcon from "@mui/icons-material/History";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import { useBlocker, useLocation, useNavigate, Link as RouterLink } from "react-router-dom";
 import type { PieceDetail as PieceDetailType, PieceState } from "../util/types";
 import { DEFAULT_TRACK_ID } from "../util/music";
@@ -124,7 +124,6 @@ function PieceDetailContent({
   const pastHistory = statesHistory.slice(0, -1);
 
   const historyRouting = usePieceHistoryRouting(piece.id);
-  const videoRouting = usePieceVideoRouting(piece.id);
   const tagsRouting = usePieceTagsRouting(piece.id);
 
   const { rewindedStateId } = historyRouting;
@@ -487,8 +486,6 @@ function PieceDetailContent({
               historyLoading={historyLoading}
               historyError={historyError}
               refetchHistory={refetchHistory}
-              atVideo={videoRouting.atVideo}
-              onVideoNavigate={videoRouting.onVideoNavigate}
             />
           </Box>
         )}
@@ -593,19 +590,15 @@ function ShowcaseVideoPanel({
   historyLoading,
   historyError,
   refetchHistory,
-  atVideo,
-  onVideoNavigate,
 }: {
   piece: PieceDetailType;
   history?: PieceState[];
   historyLoading: boolean;
   historyError?: unknown;
   refetchHistory?: () => void;
-  atVideo: boolean;
-  onVideoNavigate: (open: boolean) => void;
 }) {
   const queryClient = useQueryClient();
-  const [userExpanded, setUserExpanded] = useState<boolean | null>(null);
+  const [expanded, setExpanded] = useState(false);
   const [selection, setSelection] = useState<ShowcaseVideoInputSelection>({
     excludedImageKeys: [],
     excludedNoteKeys: [],
@@ -645,19 +638,18 @@ function ShowcaseVideoPanel({
     mutationFn: () => requestPieceShowcaseVideo(piece.id, selection),
     onSuccess: (updated) => {
       queryClient.setQueryData(["showcase-video", piece.id], updated);
-      setUserExpanded(true);
-      onVideoNavigate(true);
     },
   });
 
   const currentStatus = showcaseVideo?.status ?? "idle";
-  // True when music track and exclusions match the stored task's defaults
-  // (API doesn't expose stored exclusions, so we treat any non-empty exclusion
-  // as a divergence). Music track is compared exactly against the stored value.
+  const storedImageKeys = showcaseVideo?.excluded_image_keys ?? [];
+  const storedNoteKeys = showcaseVideo?.excluded_note_keys ?? [];
   const selectionMatchesStoredTask =
     selection.musicTrackId === (showcaseVideo?.music_track_id ?? DEFAULT_TRACK_ID) &&
-    selection.excludedImageKeys.length === 0 &&
-    selection.excludedNoteKeys.length === 0;
+    selection.excludedImageKeys.length === storedImageKeys.length &&
+    selection.excludedImageKeys.every((k) => storedImageKeys.includes(k)) &&
+    selection.excludedNoteKeys.length === storedNoteKeys.length &&
+    selection.excludedNoteKeys.every((k) => storedNoteKeys.includes(k));
   const hashUnchanged =
     selectionMatchesStoredTask &&
     currentStatus === "succeeded" &&
@@ -689,8 +681,6 @@ function ShowcaseVideoPanel({
     currentStatus === "running" ? (showcaseVideo?.progress ?? 0) : null;
 
   const artifact = showcaseVideo?.artifact ?? null;
-  // atVideo (URL) takes strict priority; local pin used for session state.
-  const expanded = atVideo ? true : (userExpanded ?? (artifact === null));
   const errorMessage = rawGenerateError
     ? extractErrorMessage(
         rawGenerateError,
@@ -708,18 +698,19 @@ function ShowcaseVideoPanel({
       title="Showcase Video"
       subtitle="Render a deterministic Keepsake slideshow from the piece history."
       titleAdornment={
-        <IconButton
-          size="small"
-          onClick={() => {
-            const next = !expanded;
-            setUserExpanded(next);
-            onVideoNavigate(next);
-          }}
-          aria-label={expanded ? "Collapse showcase video" : "Expand showcase video"}
-          sx={{ transform: expanded ? "rotate(180deg)" : "rotate(0deg)", transition: "transform 0.2s" }}
-        >
-          <ExpandMoreIcon fontSize="small" />
-        </IconButton>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+          {artifact && !expanded && (
+            <CheckCircleIcon fontSize="small" sx={{ color: "success.main" }} />
+          )}
+          <IconButton
+            size="small"
+            onClick={() => setExpanded((prev) => !prev)}
+            aria-label={expanded ? "Collapse showcase video" : "Expand showcase video"}
+            sx={{ transform: expanded ? "rotate(180deg)" : "rotate(0deg)", transition: "transform 0.2s" }}
+          >
+            <ExpandMoreIcon fontSize="small" />
+          </IconButton>
+        </Box>
       }
     >
       <Collapse in={expanded} unmountOnExit>

--- a/web/src/components/__tests__/PieceDetail.test.tsx
+++ b/web/src/components/__tests__/PieceDetail.test.tsx
@@ -458,6 +458,8 @@ describe("PieceDetail", () => {
       is_stale: false,
       stale_reason: null,
       music_track_id: null,
+      excluded_image_keys: [],
+      excluded_note_keys: [],
       storyboard: null,
       artifact: {
         url: "https://example.com/video.mp4",
@@ -501,6 +503,8 @@ describe("PieceDetail", () => {
       is_stale: false,
       stale_reason: null,
       music_track_id: null,
+      excluded_image_keys: [],
+      excluded_note_keys: [],
       storyboard: null,
       artifact: {
         url: "https://example.com/video.mp4",
@@ -517,8 +521,8 @@ describe("PieceDetail", () => {
       }),
     );
 
-    // Wait for data to load (panel collapses when artifact is present), then expand
-    fireEvent.click(await screen.findByRole("button", { name: "Expand showcase video" }));
+    // Panel always starts collapsed; expand it to reveal the button
+    fireEvent.click(screen.getByRole("button", { name: "Expand showcase video" }));
 
     // Button should be disabled — piece hasn't changed since last render
     await waitFor(() =>

--- a/web/src/components/__tests__/PieceDetail.test.tsx
+++ b/web/src/components/__tests__/PieceDetail.test.tsx
@@ -487,6 +487,47 @@ describe("PieceDetail", () => {
     ).toBeInTheDocument();
   });
 
+  it("disables 'Render again' button when hash is unchanged after a successful render", async () => {
+    vi.mocked(api.fetchPieceShowcaseVideo).mockResolvedValue({
+      piece_id: "piece-id-1",
+      task_id: "task-1",
+      status: "succeeded",
+      task_status: "success",
+      enabled: true,
+      disabled_reason: null,
+      eligible: true,
+      current_input_hash: "abc",
+      stored_input_hash: "abc",
+      is_stale: false,
+      stale_reason: null,
+      music_track_id: null,
+      storyboard: null,
+      artifact: {
+        url: "https://example.com/video.mp4",
+        download_url: "https://example.com/video.mp4?dl=1",
+        filename: "showcase.mp4",
+        content_type: "video/mp4",
+      },
+      error: null,
+    });
+    await renderPieceDetail(
+      makePiece({
+        current_state: makeState({ state: "completed" }),
+        history: [makeState({ state: "completed" })],
+      }),
+    );
+
+    // Wait for data to load (panel collapses when artifact is present), then expand
+    fireEvent.click(await screen.findByRole("button", { name: "Expand showcase video" }));
+
+    // Button should be disabled — piece hasn't changed since last render
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Render again" }),
+      ).toBeDisabled(),
+    );
+  });
+
   it("shares an editable terminal piece through the PieceDetail API interaction", async () => {
     const updated = makePiece({
       shared: true,

--- a/web/src/util/api.ts
+++ b/web/src/util/api.ts
@@ -637,6 +637,8 @@ export type ShowcaseVideoStatus = {
   is_stale: boolean;
   stale_reason: string | null;
   music_track_id: string | null;
+  excluded_image_keys: string[];
+  excluded_note_keys: string[];
   storyboard: Record<string, unknown> | null;
   artifact: ShowcaseVideoArtifact | null;
   error: string | null;


### PR DESCRIPTION
## Problem

Closes https://github.com/shaoster/glaze/issues/924

When a showcase video has `status: "succeeded"` and the piece hasn't changed since the render, pressing "Render again" was a silent no-op — the backend short-circuits and returns the existing task with no visible feedback.

## Fix (3 commits)

**1. Disable button when hash is unchanged**
Added `hashUnchanged` guard to `canGenerate` in `ShowcaseVideoPanel`. Button disabled when piece content and selection match the last successful render.

**2. Re-enable when selection or piece changes** *(PR feedback)*
- `selectionMatchesStoredTask` check for music + exclusion comparison
- `useEffect` to invalidate the query when `piece` prop changes (piece edits)

**3. Expose stored exclusions + simplify collapse** *(additional feedback)*

- *Exact selection comparison*: Added `excluded_image_keys`/`excluded_note_keys` to the API response (`showcase_views.py`) and `ShowcaseVideoStatus` type so the frontend can compare the current selection exactly against what was rendered — no more `length === 0` heuristic.
- *Always-collapsed panel*: Removed `atVideo`/`onVideoNavigate` routing props and the `artifact === null` auto-open logic. Panel now starts collapsed unconditionally and only opens/closes via the toggle button.
- *Green checkmark*: Shows a `CheckCircleIcon` in the panel header when a video exists and the panel is collapsed.
- *No auto-expand on submit*: Removed `setUserExpanded(true)` from `onSuccess`.

## Regression Test

`web/src/components/__tests__/PieceDetail.test.tsx` — "disables 'Render again' button when hash is unchanged after a successful render"

## Verification

```
rtk bazel test //web:web_piece_detail_test  → 55 passed
rtk bazel test //web:web_test //api:api_test → 54 tests pass
```
