### PR TITLE
fix(tools): suppress traceback and guard shared db in gz_start migrate fallback

### DIFF
--- a/tools/gz_start_launcher.py
+++ b/tools/gz_start_launcher.py
@@ -543,7 +543,14 @@ def start_backend(
             raise
         # Don't auto-reset the shared checkout's db — it may contain dev data
         # for other worktrees. Re-raise with a clear diagnostic instead.
-        if roots.workspace != roots.shared and db_path.is_relative_to(roots.shared):
+        # Also require that db_path is NOT inside roots.workspace: in the
+        # .agent-worktrees layout, workspace is a subdir of shared, so a
+        # worktree-local db would satisfy is_relative_to(roots.shared) too.
+        if (
+            roots.workspace != roots.shared
+            and db_path.is_relative_to(roots.shared)
+            and not db_path.is_relative_to(roots.workspace)
+        ):
             print(
                 f"backend: migrate --fake-initial failed on shared db {db_path}; "
                 "cannot auto-reset. Delete it manually or run migrate directly.",

--- a/tools/gz_start_launcher.py
+++ b/tools/gz_start_launcher.py
@@ -516,7 +516,7 @@ def start_backend(
         else roots.workspace / "db.sqlite3"
     )
 
-    def run_migrate(extra_args: list[str]) -> None:
+    def run_migrate(extra_args: list[str], *, capture_output: bool = False) -> None:
         migrate_cmd = [
             sys.executable,
             str(manage_script_path(roots)),
@@ -528,15 +528,27 @@ def start_backend(
             cwd=str(roots.workspace),
             env=backend_env,
             check=True,
+            capture_output=capture_output,
         )
 
     try:
         if db_path.exists():
-            run_migrate(["--fake-initial", "--no-input"])
+            # Suppress output: if --fake-initial fails the fallback handles it
+            # silently, so there is no need to show Django's traceback.
+            run_migrate(["--fake-initial", "--no-input"], capture_output=True)
         else:
             run_migrate(["--no-input"])
     except subprocess.CalledProcessError:
         if not db_path.exists():
+            raise
+        # Don't auto-reset the shared checkout's db — it may contain dev data
+        # for other worktrees. Re-raise with a clear diagnostic instead.
+        if roots.workspace != roots.shared and db_path.is_relative_to(roots.shared):
+            print(
+                f"backend: migrate --fake-initial failed on shared db {db_path}; "
+                "cannot auto-reset. Delete it manually or run migrate directly.",
+                file=sys.stderr,
+            )
             raise
         backup_path = db_path.with_name(
             f"{db_path.stem}.bak.{datetime.now().strftime('%Y%m%dT%H%M%S')}{db_path.suffix}"

--- a/tools/tests/test_gz_start_launcher.py
+++ b/tools/tests/test_gz_start_launcher.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import signal
+import subprocess as _subprocess
 from pathlib import Path
+
+import pytest
 
 from tools import gz_start_launcher as launcher
 
@@ -448,3 +451,98 @@ def test_ensure_local_web_node_modules_replaces_shared_symlink(
     assert not local_nm.is_symlink()
     assert local_nm.exists()
     assert install_calls == [(["npm", "install"], str(local_web))]
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for issue #930
+# ---------------------------------------------------------------------------
+
+
+def test_start_backend_suppresses_output_when_fake_initial_fails(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """migrate --fake-initial failure must be silent; fallback resets the db quietly."""
+    db = tmp_path / "db.sqlite3"
+    db.write_bytes(b"")
+    roots = launcher.Roots(workspace=tmp_path, shared=tmp_path)
+
+    run_calls: list[dict] = []
+
+    def fake_run(cmd, *, cwd, env, check, capture_output=False, **kwargs):
+        run_calls.append({"cmd": list(cmd), "capture_output": capture_output})
+        if "--fake-initial" in cmd:
+            raise _subprocess.CalledProcessError(1, cmd)
+
+    class MockPopen:
+        pid = 42
+
+    monkeypatch.setattr(launcher, "ensure_running", lambda _: (None, False))
+    monkeypatch.setattr(launcher, "rotate_log", lambda _: None)
+    monkeypatch.setattr(launcher.subprocess, "run", fake_run)
+    monkeypatch.setattr(launcher, "launch_child", lambda *a, **kw: MockPopen())
+
+    pid = launcher.start_backend(
+        roots,
+        {},
+        tmp_path / "backend.pid",
+        tmp_path / "backend.port",
+        tmp_path / "backend.log",
+        8080,
+        5173,
+    )
+
+    assert pid == 42
+
+    fake_initial_calls = [c for c in run_calls if "--fake-initial" in c["cmd"]]
+    assert len(fake_initial_calls) == 1, "expected exactly one --fake-initial call"
+    assert fake_initial_calls[0]["capture_output"] is True, (
+        "--fake-initial call must use capture_output=True to suppress the Django traceback"
+    )
+
+    fresh_migrate_calls = [
+        c
+        for c in run_calls
+        if "migrate" in c["cmd"] and "--fake-initial" not in c["cmd"]
+    ]
+    assert len(fresh_migrate_calls) >= 1, "fallback must run a fresh migrate"
+
+    assert not db.exists(), "original db must have been moved to a backup path"
+    backups = list(tmp_path.glob("db.bak.*.sqlite3"))
+    assert len(backups) == 1, "expected exactly one backup file"
+
+
+def test_start_backend_does_not_reset_shared_db_when_fake_initial_fails(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """When --fake-initial fails on the shared db, the fallback must not destroy it."""
+    workspace = tmp_path / "worktree"
+    shared = tmp_path / "repo"
+    workspace.mkdir()
+    shared.mkdir()
+    shared_db = shared / "db.sqlite3"
+    shared_db.write_bytes(b"")
+    roots = launcher.Roots(workspace=workspace, shared=shared)
+
+    def fake_run(cmd, *, cwd, env, check, capture_output=False, **kwargs):
+        if "--fake-initial" in cmd:
+            raise _subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(launcher, "ensure_running", lambda _: (None, False))
+    monkeypatch.setattr(launcher, "rotate_log", lambda _: None)
+    monkeypatch.setattr(launcher.subprocess, "run", fake_run)
+
+    with pytest.raises(_subprocess.CalledProcessError):
+        launcher.start_backend(
+            roots,
+            {},
+            workspace / "backend.pid",
+            workspace / "backend.port",
+            workspace / "backend.log",
+            8080,
+            5173,
+        )
+
+    assert shared_db.exists(), "shared db must not have been deleted or moved"
+    assert not list(shared.glob("db.bak.*.sqlite3")), (
+        "shared db must not have been backed up (backup implies deletion)"
+    )

--- a/tools/tests/test_gz_start_launcher.py
+++ b/tools/tests/test_gz_start_launcher.py
@@ -546,3 +546,50 @@ def test_start_backend_does_not_reset_shared_db_when_fake_initial_fails(
     assert not list(shared.glob("db.bak.*.sqlite3")), (
         "shared db must not have been backed up (backup implies deletion)"
     )
+
+
+def test_start_backend_resets_worktree_local_db_when_workspace_is_under_shared(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """When workspace is a subdir of shared (.agent-worktrees layout) and the db
+    lives inside workspace, --fake-initial failure must still back up and reset it."""
+    shared = tmp_path / "repo"
+    workspace = shared / ".agent-worktrees" / "claude" / "issue-999-foo"
+    workspace.mkdir(parents=True)
+    local_db = workspace / "db.sqlite3"
+    local_db.write_bytes(b"")
+    roots = launcher.Roots(workspace=workspace, shared=shared)
+
+    run_calls: list[dict] = []
+
+    def fake_run(cmd, *, cwd, env, check, capture_output=False, **kwargs):
+        run_calls.append({"cmd": list(cmd), "capture_output": capture_output})
+        if "--fake-initial" in cmd:
+            raise _subprocess.CalledProcessError(1, cmd)
+
+    class MockPopen:
+        pid = 99
+
+    monkeypatch.setattr(launcher, "ensure_running", lambda _: (None, False))
+    monkeypatch.setattr(launcher, "rotate_log", lambda _: None)
+    monkeypatch.setattr(launcher.subprocess, "run", fake_run)
+    monkeypatch.setattr(launcher, "launch_child", lambda *a, **kw: MockPopen())
+
+    pid = launcher.start_backend(
+        roots,
+        {},
+        workspace / "backend.pid",
+        workspace / "backend.port",
+        workspace / "backend.log",
+        8080,
+        5173,
+    )
+
+    assert pid == 99
+    assert not local_db.exists(), "worktree-local db must have been moved to backup"
+    backups = list(workspace.glob("db.bak.*.sqlite3"))
+    assert len(backups) == 1, "expected exactly one backup file in the workspace"
+    fresh_migrate_calls = [
+        c for c in run_calls if "migrate" in c["cmd"] and "--fake-initial" not in c["cmd"]
+    ]
+    assert len(fresh_migrate_calls) >= 1, "fallback must run a fresh migrate after backup"


### PR DESCRIPTION
## Problem

Fixes [#930](https://github.com/shaoster/glaze/issues/930).

`gz_start_launcher.py` calls `manage.py migrate --fake-initial` whenever an
existing `db.sqlite3` is detected. If the database is inconsistent (tables
present but `django_migrations` absent or stale), Django fails and prints a
full `TransactionManagementError` traceback — even though the code already has
a fallback that backs up and re-migrates from scratch. A second bug: the
fallback calls `db_path.replace(backup_path)` without checking whether
`db_path` is the *shared* checkout's `db.sqlite3` (auto-selected for worktrees),
silently destroying another worktree's dev data.

## Fix

**`tools/gz_start_launcher.py`**

1. Add `capture_output=True` to the `--fake-initial` `subprocess.run` call.
   The expected-to-fail probe swallows its own stdout/stderr; the only thing
   shown on failure is the existing `"backend: reset inconsistent SQLite
   database"` message from the fallback.

2. Add a shared-db guard in the `except CalledProcessError` block: if
   `db_path.is_relative_to(roots.shared)` and `roots.workspace != roots.shared`,
   print a short diagnostic and re-raise instead of deleting the shared db.

## Regression Test

Added to `tools/tests/test_gz_start_launcher.py`:

- **`test_start_backend_suppresses_output_when_fake_initial_fails`**: stubs
  `subprocess.run` to raise `CalledProcessError` on `--fake-initial`, then
  asserts the call used `capture_output=True`, the fallback ran a fresh
  migrate, and the original db was backed up (not silently dropped).

- **`test_start_backend_does_not_reset_shared_db_when_fake_initial_fails`**:
  places `db.sqlite3` in the shared directory, stubs the same failure, and
  asserts `CalledProcessError` propagates without touching the shared file.

## Verification

```
//tools:test_gz_start_launcher  PASSED  (22 tests, all passing)
//tools:...                     8 / 8 test targets PASSED
```

Closes #930
