### PR TITLE
feat: replace URL-fetch image upload with multipart file upload

### DIFF
--- a/api/piece/image_views.py
+++ b/api/piece/image_views.py
@@ -6,7 +6,6 @@ on piece list/detail/state behavior.
 
 import uuid
 
-import requests as _requests
 from django.db import transaction
 from django.db.models import Max
 from django.http import Http404
@@ -120,41 +119,8 @@ def _needs_jpeg_conversion(key: str) -> bool:
     return ext in _NON_JPEG_IMAGE_EXTENSIONS
 
 
-def _stream_url_to_r2(url: str, user_id: int | None) -> tuple[str, str] | Response:
-    """Fetch *url* and stream it directly to R2 via multipart upload.
-
-    Returns ``(public_url, key)`` on success, or an error ``Response``.
-    Enforces HTTPS-only and a 10 MB cap without buffering the full body.
-    """
-    if not url.startswith("https://"):
-        return Response(
-            {"detail": "Only HTTPS URLs are supported."},
-            status=status.HTTP_400_BAD_REQUEST,
-        )
-    try:
-        resp = _requests.get(url, timeout=10, stream=True)
-        resp.raise_for_status()
-    except Exception:
-        return Response(
-            {"detail": "Failed to fetch image from URL."},
-            status=status.HTTP_400_BAD_REQUEST,
-        )
-    content_type = resp.headers.get("Content-Type", "image/jpeg")
-    ext = _ext_for_content_type(content_type)
-    key = f"images/{user_id}/{uuid.uuid4()}.{ext}"
-    try:
-        with resp:
-            public_url = r2.upload_stream(key, resp, content_type, _MAX_UPLOAD_BYTES)
-    except r2.UploadTooLargeError:
-        return Response(
-            {"detail": "Image exceeds 10 MB size limit."},
-            status=status.HTTP_400_BAD_REQUEST,
-        )
-    return public_url, key
-
-
 def _upload_image_to_piece_state(request: Request, piece_state) -> Response:
-    """Shared implementation for server-side image upload to a piece state."""
+    """Shared implementation for direct multipart image upload to a piece state."""
     from ..tasks import get_task_interface
 
     serializer = UploadImageSerializer(data=request.data)
@@ -167,11 +133,23 @@ def _upload_image_to_piece_state(request: Request, piece_state) -> Response:
         )
     validated = serializer.validated_data
     caption = validated.get("caption", "")
+    file_obj = validated["file"]
 
-    result = _stream_url_to_r2(validated["url"], request.user.id)
-    if isinstance(result, Response):
-        return result
-    public_url, key = result
+    content_type = file_obj.content_type or "image/jpeg"
+    if content_type not in _IMAGE_CONTENT_TYPE_TO_EXT:
+        return Response(
+            {"detail": f"Unsupported image type: {content_type}."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    if file_obj.size > _MAX_UPLOAD_BYTES:
+        return Response(
+            {"detail": "Image exceeds 10 MB size limit."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    ext = _ext_for_content_type(content_type)
+    key = f"images/{request.user.id}/{uuid.uuid4()}.{ext}"
+    public_url = r2.upload_bytes(key, file_obj.read(), content_type)
 
     conversion_task_id = None
     if _needs_jpeg_conversion(key):
@@ -203,7 +181,7 @@ def _upload_image_to_piece_state(request: Request, piece_state) -> Response:
 
 @extend_schema(
     operation_id="pieces_past_state_upload_image",
-    request=UploadImageSerializer,
+    request={"multipart/form-data": UploadImageSerializer},
     responses={
         201: {
             "type": "object",
@@ -227,9 +205,10 @@ def _upload_image_to_piece_state(request: Request, piece_state) -> Response:
         503: {"type": "object"},
     },
     description=(
-        "Upload an image (via URL or base64) to a specific past state. "
+        "Upload an image file to a specific past state. "
         "Requires the piece to be in editable mode. "
-        "Exactly one of `url` or `base64` must be provided. "
+        "Send as multipart/form-data with a `file` field (JPEG, PNG, WebP, HEIC, max 10 MB) "
+        "and an optional `caption`. "
         "Returns the created `PieceStateImage` and background task IDs."
     ),
 )
@@ -250,7 +229,7 @@ def upload_image_to_past_state(request: Request, piece_id, state_id) -> Response
 
 @extend_schema(
     operation_id="pieces_current_state_upload_image",
-    request=UploadImageSerializer,
+    request={"multipart/form-data": UploadImageSerializer},
     responses={
         201: {
             "type": "object",
@@ -274,8 +253,9 @@ def upload_image_to_past_state(request: Request, piece_id, state_id) -> Response
         503: {"type": "object"},
     },
     description=(
-        "Upload an image (via URL or base64) to the current unsealed state. "
-        "Exactly one of `url` or `base64` must be provided. "
+        "Upload an image file to the current unsealed state. "
+        "Send as multipart/form-data with a `file` field (JPEG, PNG, WebP, HEIC, max 10 MB) "
+        "and an optional `caption`. "
         "Returns the created `PieceStateImage` and background task IDs."
     ),
 )

--- a/api/piece/image_views.py
+++ b/api/piece/image_views.py
@@ -141,7 +141,7 @@ def _upload_image_to_piece_state(request: Request, piece_state) -> Response:
             {"detail": f"Unsupported image type: {content_type}."},
             status=status.HTTP_400_BAD_REQUEST,
         )
-    if file_obj.size > _MAX_UPLOAD_BYTES:
+    if (file_obj.size or 0) > _MAX_UPLOAD_BYTES:
         return Response(
             {"detail": "Image exceeds 10 MB size limit."},
             status=status.HTTP_400_BAD_REQUEST,

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1274,7 +1274,7 @@ class CropRunCreateSerializer(serializers.ModelSerializer):
 
 
 class UploadImageSerializer(serializers.Serializer):
-    url = serializers.CharField()
+    file = serializers.FileField()
     caption = serializers.CharField(required=False, default="", allow_blank=True)
 
 

--- a/api/tests/test_upload_image.py
+++ b/api/tests/test_upload_image.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
 from rest_framework.test import APIClient
 
 from api.models import ENTRY_STATE, AsyncTask, Piece, PieceState, PieceStateImage
@@ -11,14 +12,12 @@ _SMALL_JPEG = b"\xff\xd8\xff\xe0" + b"\x00" * 16
 _SMALL_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
 
 
-def _mock_requests_get(url, **kwargs):
-    mock_resp = MagicMock()
-    content_type = "image/png" if url.endswith(".png") else "image/jpeg"
-    data = _SMALL_PNG if content_type == "image/png" else _SMALL_JPEG
-    mock_resp.headers = {"Content-Type": content_type}
-    mock_resp.iter_content.return_value = [data]
-    mock_resp.raise_for_status.return_value = None
-    return mock_resp
+def _jpeg_file(name="photo.jpg"):
+    return SimpleUploadedFile(name, _SMALL_JPEG, content_type="image/jpeg")
+
+
+def _png_file(name="photo.png"):
+    return SimpleUploadedFile(name, _SMALL_PNG, content_type="image/png")
 
 
 @pytest.mark.django_db
@@ -48,18 +47,16 @@ class TestUploadImageEndpoints:
         return f"/api/pieces/{piece_id}/states/{state_id}/upload-image/"
 
     @patch("api.piece.image_views.r2.is_r2_configured", return_value=True)
-    @patch("api.piece.image_views.r2.upload_stream", return_value=_FAKE_PUBLIC_URL)
-    @patch("api.piece.image_views._requests.get", side_effect=_mock_requests_get)
+    @patch("api.piece.image_views.r2.upload_bytes", return_value=_FAKE_PUBLIC_URL)
     def test_jpeg_upload_no_conversion_task(
-        self, mock_get, mock_upload, mock_r2, auth_client, piece_with_state
+        self, mock_upload, mock_r2, auth_client, piece_with_state
     ):
         piece, _ = piece_with_state
 
         with patch("api.tasks.get_task_interface"):
             response = auth_client.post(
                 self._current_url(piece.id),
-                {"url": "https://example.com/photo.jpg"},
-                format="json",
+                {"file": _jpeg_file()},
             )
 
         assert response.status_code == 201
@@ -69,10 +66,9 @@ class TestUploadImageEndpoints:
         assert not AsyncTask.objects.filter(task_type="convert_image_to_jpeg").exists()
 
     @patch("api.piece.image_views.r2.is_r2_configured", return_value=True)
-    @patch("api.piece.image_views.r2.upload_stream", return_value=_FAKE_PNG_URL)
-    @patch("api.piece.image_views._requests.get", side_effect=_mock_requests_get)
+    @patch("api.piece.image_views.r2.upload_bytes", return_value=_FAKE_PNG_URL)
     def test_png_upload_enqueues_conversion_task(
-        self, mock_get, mock_upload, mock_r2, auth_client, piece_with_state
+        self, mock_upload, mock_r2, auth_client, piece_with_state
     ):
         piece, _ = piece_with_state
 
@@ -80,8 +76,7 @@ class TestUploadImageEndpoints:
             mock_iface.return_value.submit = MagicMock()
             response = auth_client.post(
                 self._current_url(piece.id),
-                {"url": "https://example.com/photo.png"},
-                format="json",
+                {"file": _png_file()},
             )
 
         assert response.status_code == 201
@@ -90,54 +85,33 @@ class TestUploadImageEndpoints:
         task = AsyncTask.objects.get(id=data["background_tasks"]["conversion_task_id"])
         assert task.task_type == "convert_image_to_jpeg"
 
-    def test_missing_url_returns_400(self, auth_client, piece_with_state):
+    def test_missing_file_returns_400(self, auth_client, piece_with_state):
         piece, _ = piece_with_state
         response = auth_client.post(
             self._current_url(piece.id),
-            {"caption": "no url"},
+            {"caption": "no file"},
             format="json",
         )
         assert response.status_code == 400
 
     @patch("api.piece.image_views.r2.is_r2_configured", return_value=True)
-    def test_non_https_url_returns_400(self, mock_r2, auth_client, piece_with_state):
-        piece, _ = piece_with_state
-        response = auth_client.post(
-            self._current_url(piece.id),
-            {"url": "http://example.com/img.jpg"},
-            format="json",
-        )
-        assert response.status_code == 400
-
-    @patch("api.piece.image_views.r2.is_r2_configured", return_value=True)
-    @patch("api.piece.image_views._requests.get", side_effect=_mock_requests_get)
-    def test_oversized_image_returns_400(
-        self, mock_get, mock_r2, auth_client, piece_with_state
-    ):
-        from api.r2 import UploadTooLargeError
-
-        piece, _ = piece_with_state
-        with patch(
-            "api.piece.image_views.r2.upload_stream", side_effect=UploadTooLargeError()
-        ):
-            response = auth_client.post(
-                self._current_url(piece.id),
-                {"url": "https://example.com/huge.jpg"},
-                format="json",
-            )
-        assert response.status_code == 400
-
-    @patch("api.piece.image_views.r2.is_r2_configured", return_value=True)
-    @patch("api.piece.image_views._requests.get", side_effect=Exception("timeout"))
-    def test_url_fetch_failure_returns_400(
-        self, mock_get, mock_r2, auth_client, piece_with_state
+    def test_unsupported_content_type_returns_400(
+        self, mock_r2, auth_client, piece_with_state
     ):
         piece, _ = piece_with_state
-        response = auth_client.post(
-            self._current_url(piece.id),
-            {"url": "https://example.com/broken.jpg"},
-            format="json",
+        f = SimpleUploadedFile("doc.pdf", b"%PDF", content_type="application/pdf")
+        response = auth_client.post(self._current_url(piece.id), {"file": f})
+        assert response.status_code == 400
+
+    @patch("api.piece.image_views.r2.is_r2_configured", return_value=True)
+    def test_oversized_image_returns_400(self, mock_r2, auth_client, piece_with_state):
+        from api.piece.image_views import _MAX_UPLOAD_BYTES
+
+        piece, _ = piece_with_state
+        big_file = SimpleUploadedFile(
+            "huge.jpg", b"\x00" * (_MAX_UPLOAD_BYTES + 1), content_type="image/jpeg"
         )
+        response = auth_client.post(self._current_url(piece.id), {"file": big_file})
         assert response.status_code == 400
 
     def test_other_users_piece_returns_404(self, other_user, piece_with_state):
@@ -146,8 +120,7 @@ class TestUploadImageEndpoints:
         other_client.force_authenticate(user=other_user)
         response = other_client.post(
             self._current_url(piece.id),
-            {"url": "https://example.com/img.jpg"},
-            format="json",
+            {"file": _jpeg_file()},
         )
         assert response.status_code == 404
 
@@ -157,8 +130,7 @@ class TestUploadImageEndpoints:
         piece, state = piece_with_state
         response = auth_client.post(
             self._past_url(piece.id, state.id),
-            {"url": "https://example.com/img.jpg"},
-            format="json",
+            {"file": _jpeg_file()},
         )
         assert response.status_code == 403
 
@@ -168,42 +140,35 @@ class TestUploadImageEndpoints:
         client.force_authenticate(user=user)
         response = client.post(
             self._current_url(piece.id),
-            {"url": "https://example.com/img.jpg"},
-            format="json",
+            {"file": _jpeg_file()},
         )
         assert response.status_code == 404
 
     @patch("api.piece.image_views.r2.is_r2_configured", return_value=True)
-    @patch("api.piece.image_views.r2.upload_stream", return_value=_FAKE_PUBLIC_URL)
-    @patch("api.piece.image_views._requests.get", side_effect=_mock_requests_get)
+    @patch("api.piece.image_views.r2.upload_bytes", return_value=_FAKE_PUBLIC_URL)
     def test_past_state_editable_piece_succeeds(
-        self, mock_get, mock_upload, mock_r2, auth_client, editable_piece_with_state
+        self, mock_upload, mock_r2, auth_client, editable_piece_with_state
     ):
         piece, state = editable_piece_with_state
 
         with patch("api.tasks.get_task_interface"):
             response = auth_client.post(
                 self._past_url(piece.id, state.id),
-                {"url": "https://example.com/img.jpg"},
-                format="json",
+                {"file": _jpeg_file()},
             )
 
         assert response.status_code == 201
         assert PieceStateImage.objects.filter(piece_state=state).count() == 1
 
     @patch("api.piece.image_views.r2.is_r2_configured", return_value=True)
-    @patch("api.piece.image_views.r2.upload_stream", return_value=_FAKE_PUBLIC_URL)
-    @patch("api.piece.image_views._requests.get", side_effect=_mock_requests_get)
-    def test_caption_stored(
-        self, mock_get, mock_upload, mock_r2, auth_client, piece_with_state
-    ):
+    @patch("api.piece.image_views.r2.upload_bytes", return_value=_FAKE_PUBLIC_URL)
+    def test_caption_stored(self, mock_upload, mock_r2, auth_client, piece_with_state):
         piece, _ = piece_with_state
 
         with patch("api.tasks.get_task_interface"):
             response = auth_client.post(
                 self._current_url(piece.id),
-                {"url": "https://example.com/img.jpg", "caption": "my caption"},
-                format="json",
+                {"file": _jpeg_file(), "caption": "my caption"},
             )
 
         assert response.status_code == 201

--- a/api/tests/test_upload_image.py
+++ b/api/tests/test_upload_image.py
@@ -94,6 +94,14 @@ class TestUploadImageEndpoints:
         )
         assert response.status_code == 400
 
+    def test_unauthenticated_returns_401(self, piece_with_state):
+        piece, _ = piece_with_state
+        response = APIClient().post(
+            self._current_url(piece.id),
+            {"file": _jpeg_file()},
+        )
+        assert response.status_code == 401
+
     @patch("api.piece.image_views.r2.is_r2_configured", return_value=True)
     def test_unsupported_content_type_returns_400(
         self, mock_r2, auth_client, piece_with_state

--- a/docs/integrations/chatgpt-action.md
+++ b/docs/integrations/chatgpt-action.md
@@ -116,12 +116,12 @@ To attach an existing global to the current state, use `PATCH /api/pieces/{piece
 
 ## Image and Crop Control
 
-Upload images by providing a publicly accessible URL — the server fetches and stores the image itself:
+Upload images directly as file attachments using multipart/form-data:
 
-- **Current state:** `POST /api/pieces/{piece_id}/state/upload-image/` with `{"url": "<image_url>", "caption": "optional caption"}`
-- **Past state:** `POST /api/pieces/{piece_id}/states/{state_id}/upload-image/` with the same body
+- **Current state:** `POST /api/pieces/{piece_id}/state/upload-image/` with `file` (image bytes) and optional `caption`
+- **Past state:** `POST /api/pieces/{piece_id}/states/{state_id}/upload-image/` with the same fields
 
-When the user shares a photo link or a URL they have copied, pass it directly as `url`. The server accepts JPEG, PNG, WebP, and HEIC; images over 10 MB are rejected. If the image needs format conversion a background task ID is returned in `background_tasks.conversion_task_id` — you can ignore it unless the user asks about processing status.
+When the user attaches a photo in the chat, send it directly as the `file` field. The server accepts JPEG, PNG, WebP, and HEIC; images over 10 MB are rejected. If the image needs format conversion a background task ID is returned in `background_tasks.conversion_task_id` — you can ignore it unless the user asks about processing status.
 
 Adjust crop coordinates on an uploaded image: `PATCH /api/images/{image_id}/crop/` with `{"left": 0.0, "top": 0.0, "right": 1.0, "bottom": 1.0}` where values are fractions of image dimensions (0.0–1.0).
 
@@ -131,7 +131,7 @@ Adjust crop coordinates on an uploaded image: `PATCH /api/images/{image_id}/crop
 - When the user says "next state" or "advance" without specifying a target, list the available successors and ask which one they want.
 - When a required field is ambiguous (e.g., a glaze type name that partially matches multiple options), list the candidates and ask the user to choose.
 - If you do not recognize a piece name, search for it before reporting it as not found.
-- When the user says "add a photo" or "upload this image", ask them to share a direct URL to the image (e.g. from their camera roll via a sharing service, or a web URL).
+- When the user says "add a photo" or "upload this image", ask them to attach the image directly in the chat.
 ```
 
 ---
@@ -153,7 +153,7 @@ You can also preview the current schema at any time by opening `https://potterdo
 
 | Limitation | Workaround |
 |---|---|
-| Image uploads require a public URL — direct camera capture is not supported via ChatGPT Actions | Share the photo to a service that provides a direct link (e.g. iCloud shared link, Google Photos, Imgur), then tell the GPT the URL |
+| Images must be attached directly in the chat — the API does not accept external URLs | Attach the photo as a file in the ChatGPT conversation; the GPT will upload it to PotterDoc |
 | Public library objects (clay bodies, glaze types, firing temperatures) cannot be created or edited by agents | Request additions from your PotterDoc administrator |
 | Agent tokens cannot revoke themselves | Revoke tokens from Settings → Agent Tokens in the web UI |
 | State transitions are permanent (append-only history) | The assistant will always ask for confirmation before transitioning |
@@ -169,5 +169,5 @@ After completing setup, confirm each item works in the GPT Builder preview pane:
 - [ ] "What states can my Test piece move to?" → GPT fetches the piece and lists `successors`
 - [ ] "Transition Test to wheel_thrown" → GPT asks for confirmation, then executes the transition
 - [ ] "What clay bodies are available?" → GPT fetches `GET /api/globals/clay_body/` and lists results
-- [ ] "Add this photo: https://example.com/bowl.jpg" → GPT calls the upload endpoint and confirms the image was added
+- [ ] Attach a photo and say "Add this to my Test piece" → GPT calls the upload endpoint and confirms the image was added
 - [ ] "Crop the image to show just the top half" → GPT calls `PATCH /api/images/{id}/crop/` with appropriate coordinates


### PR DESCRIPTION
## Summary

- Replaces the URL-fetch image upload mechanism with direct `multipart/form-data` file upload
- Removes `_stream_url_to_r2`, the `requests` import, and all URL-validation logic from `api/piece/image_views.py`
- `UploadImageSerializer.url` → `file = FileField()`; both upload-image endpoints now declare `multipart/form-data` in the OpenAPI schema
- Integration guide updated: users attach photos directly in the ChatGPT chat instead of providing a URL

## Why

The URL-based path was built for ChatGPT Actions on the false assumption that they can't send binary files. They can. In practice, conversation attachments have no public HTTPS URL, so the URL path was both more complex and less functional than direct upload.

## Test plan

- [x] `rtk bazel test //api:api_piece_test` — all tests pass
- [x] `rtk bazel build --config=lint //api:api_lib //api:api_piece_test` — no lint errors
- [ ] Verify `GET /api/schema/llm/` shows `multipart/form-data` for both upload-image operations
- [ ] Re-import schema in GPT Builder and confirm image attachment works end-to-end

Closes #936
