### PR TITLE
feat(llm): add openaiFileIdRefs upload endpoint; drop crop from LLM schema

### DIFF
--- a/api/llm_schema.py
+++ b/api/llm_schema.py
@@ -22,15 +22,20 @@ _AGENT_AUTH_SCHEME = {
 
 def _is_llm_endpoint(path: str) -> bool:
     if path.startswith("/api/pieces/"):
+        # Exclude multipart upload-image — ChatGPT cannot bind chat attachments
+        # to multipart file fields in custom actions. Use upload-image-refs instead.
+        if path.endswith("/upload-image/"):
+            return False
+        # Exclude crop — actions cannot return images, so the LLM cannot verify
+        # the result; the crop workflow is inherently visual.
+        if path.endswith("/crop/"):
+            return False
         return True
     if path.startswith("/api/globals/"):
         # Extract the global name (third path segment).
         parts = path.split("/")  # ['', 'api', 'globals', '<name>', ...]
         global_name = parts[3] if len(parts) > 3 else ""
         return global_name in _INCLUDED_GLOBALS
-    # Only the specific crop endpoint, not piece_state or crop-runs.
-    if path.endswith("/crop/"):
-        return True
     return False
 
 

--- a/api/piece/image_views.py
+++ b/api/piece/image_views.py
@@ -6,6 +6,7 @@ on piece list/detail/state behavior.
 
 import uuid
 
+import httpx
 from django.db import transaction
 from django.db.models import Max
 from django.http import Http404
@@ -119,10 +120,97 @@ def _needs_jpeg_conversion(key: str) -> bool:
     return ext in _NON_JPEG_IMAGE_EXTENSIONS
 
 
-def _upload_image_to_piece_state(request: Request, piece_state) -> Response:
-    """Shared implementation for direct multipart image upload to a piece state."""
+def _fetch_url_to_r2(url: str, user_id: "int | None") -> "tuple[str, str] | Response":
+    """Fetch *url* (HTTPS only) and upload the bytes to R2.
+
+    Returns ``(public_url, key)`` on success, or an error ``Response``.
+    Enforces a 10 MB cap without streaming the full body before the check.
+    """
+    if not url.startswith("https://"):
+        return Response(
+            {"detail": "Only HTTPS download URLs are supported."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    try:
+        resp = httpx.get(url, timeout=15, follow_redirects=True)
+        resp.raise_for_status()
+    except Exception:
+        return Response(
+            {"detail": "Failed to fetch image from download URL."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    content_type = resp.headers.get("content-type", "image/jpeg").split(";")[0].strip()
+    ext = _ext_for_content_type(content_type)
+    data = resp.content
+    if len(data) > _MAX_UPLOAD_BYTES:
+        return Response(
+            {"detail": "Image exceeds 10 MB size limit."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    key = f"images/{user_id}/{uuid.uuid4()}.{ext}"
+    public_url = r2.upload_bytes(key, data, content_type)
+    return public_url, key
+
+
+_UPLOAD_IMAGE_RESPONSES = {
+    201: {
+        "type": "object",
+        "properties": {
+            "piece_state_image": {"type": "object"},
+            "background_tasks": {
+                "type": "object",
+                "properties": {
+                    "conversion_task_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "nullable": True,
+                    }
+                },
+            },
+        },
+    },
+    400: {"type": "object"},
+    403: {"type": "object"},
+    404: {"type": "object"},
+    503: {"type": "object"},
+}
+
+
+def _attach_image_to_piece_state(
+    piece_state, public_url: str, key: str, caption: str, user
+) -> Response:
+    """Create PieceStateImage from an already-uploaded R2 key and return 201."""
     from ..tasks import get_task_interface
 
+    conversion_task_id = None
+    if _needs_jpeg_conversion(key):
+        task = AsyncTask.objects.create(
+            user=user,
+            task_type="convert_image_to_jpeg",
+            input_params={"key": key, "image_id": None},
+        )
+        get_task_interface().submit(task)
+        conversion_task_id = str(task.id)
+
+    image = normalize_image_payload(public_url, user=user)
+    next_order = (piece_state.image_links.aggregate(m=Max("order"))["m"] or -1) + 1
+    link = PieceStateImage.objects.create(
+        piece_state=piece_state,
+        image=image,
+        caption=caption,
+        order=next_order,
+    )
+    return Response(
+        {
+            "piece_state_image": captioned_image_to_dict(link),
+            "background_tasks": {"conversion_task_id": conversion_task_id},
+        },
+        status=status.HTTP_201_CREATED,
+    )
+
+
+def _upload_image_to_piece_state(request: Request, piece_state) -> Response:
+    """Shared implementation for direct multipart image upload to a piece state."""
     serializer = UploadImageSerializer(data=request.data)
     serializer.is_valid(raise_exception=True)
 
@@ -150,60 +238,45 @@ def _upload_image_to_piece_state(request: Request, piece_state) -> Response:
     ext = _ext_for_content_type(content_type)
     key = f"images/{request.user.id}/{uuid.uuid4()}.{ext}"
     public_url = r2.upload_bytes(key, file_obj.read(), content_type)
-
-    conversion_task_id = None
-    if _needs_jpeg_conversion(key):
-        task = AsyncTask.objects.create(  # type: ignore[misc]
-            user=request.user,
-            task_type="convert_image_to_jpeg",
-            input_params={"key": key, "image_id": None},
-        )
-        get_task_interface().submit(task)
-        conversion_task_id = str(task.id)
-
-    image = normalize_image_payload(public_url, user=request.user)
-    next_order = (piece_state.image_links.aggregate(m=Max("order"))["m"] or -1) + 1
-    link = PieceStateImage.objects.create(
-        piece_state=piece_state,
-        image=image,
-        caption=caption,
-        order=next_order,
+    return _attach_image_to_piece_state(
+        piece_state, public_url, key, caption, request.user
     )
 
-    return Response(
-        {
-            "piece_state_image": captioned_image_to_dict(link),
-            "background_tasks": {"conversion_task_id": conversion_task_id},
-        },
-        status=status.HTTP_201_CREATED,
+
+def _upload_image_from_refs_to_piece_state(request: Request, piece_state) -> Response:
+    """Upload the first openaiFileIdRefs entry's download_link to R2."""
+    if not r2.is_r2_configured():
+        return Response(
+            {"detail": "Object storage is not configured on the server."},
+            status=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+    refs = request.data.get("openaiFileIdRefs")
+    if not refs or not isinstance(refs, list):
+        return Response(
+            {"detail": "openaiFileIdRefs must be a non-empty list."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    first = refs[0]
+    download_link = first.get("download_link") if isinstance(first, dict) else None
+    if not download_link:
+        return Response(
+            {"detail": "openaiFileIdRefs[0] must contain a download_link."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    caption = request.data.get("caption", "")
+    result = _fetch_url_to_r2(download_link, request.user.id)
+    if isinstance(result, Response):
+        return result
+    public_url, key = result
+    return _attach_image_to_piece_state(
+        piece_state, public_url, key, caption, request.user
     )
 
 
 @extend_schema(
     operation_id="pieces_past_state_upload_image",
     request={"multipart/form-data": UploadImageSerializer},
-    responses={
-        201: {
-            "type": "object",
-            "properties": {
-                "piece_state_image": {"type": "object"},
-                "background_tasks": {
-                    "type": "object",
-                    "properties": {
-                        "conversion_task_id": {
-                            "type": "string",
-                            "format": "uuid",
-                            "nullable": True,
-                        }
-                    },
-                },
-            },
-        },
-        400: {"type": "object"},
-        403: {"type": "object"},
-        404: {"type": "object"},
-        503: {"type": "object"},
-    },
+    responses=_UPLOAD_IMAGE_RESPONSES,
     description=(
         "Upload an image file to a specific past state. "
         "Requires the piece to be in editable mode. "
@@ -230,28 +303,7 @@ def upload_image_to_past_state(request: Request, piece_id, state_id) -> Response
 @extend_schema(
     operation_id="pieces_current_state_upload_image",
     request={"multipart/form-data": UploadImageSerializer},
-    responses={
-        201: {
-            "type": "object",
-            "properties": {
-                "piece_state_image": {"type": "object"},
-                "background_tasks": {
-                    "type": "object",
-                    "properties": {
-                        "conversion_task_id": {
-                            "type": "string",
-                            "format": "uuid",
-                            "nullable": True,
-                        }
-                    },
-                },
-            },
-        },
-        400: {"type": "object"},
-        403: {"type": "object"},
-        404: {"type": "object"},
-        503: {"type": "object"},
-    },
+    responses=_UPLOAD_IMAGE_RESPONSES,
     description=(
         "Upload an image file to the current unsealed state. "
         "Send as multipart/form-data with a `file` field (JPEG, PNG, WebP, HEIC, max 10 MB) "
@@ -272,6 +324,79 @@ def upload_image_to_current_state(request: Request, piece_id) -> Response:
             status=status.HTTP_404_NOT_FOUND,
         )
     return _upload_image_to_piece_state(request, piece_state)
+
+
+_OPENAI_FILE_REFS_REQUEST = {
+    "application/json": {
+        "type": "object",
+        "properties": {
+            "openaiFileIdRefs": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "OpenAI file references injected by the ChatGPT runtime. "
+                    "Each entry is an object with name, id, mime_type, and download_link. "
+                    "Pass the chat-attached image here."
+                ),
+            },
+            "caption": {"type": "string", "default": ""},
+        },
+        "required": ["openaiFileIdRefs"],
+    }
+}
+
+
+@extend_schema(
+    operation_id="pieces_past_state_upload_image_from_refs",
+    request=_OPENAI_FILE_REFS_REQUEST,
+    responses=_UPLOAD_IMAGE_RESPONSES,
+    description=(
+        "Upload a chat-attached image to a specific past state via OpenAI file references. "
+        "Pass the image attached in the ChatGPT conversation as `openaiFileIdRefs`. "
+        "The runtime injects download URLs automatically. "
+        "Requires the piece to be in editable mode."
+    ),
+)
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+@traced
+def upload_image_from_refs_to_past_state(
+    request: Request, piece_id, state_id
+) -> Response:
+    """Upload a chat-attached image to a specific past piece state."""
+    piece = get_object_or_404(piece_queryset(request), pk=piece_id)
+    if not piece.is_editable:
+        return Response(
+            {"detail": "Piece is not in editable mode."},
+            status=status.HTTP_403_FORBIDDEN,
+        )
+    piece_state = get_object_or_404(piece.states, pk=state_id)
+    return _upload_image_from_refs_to_piece_state(request, piece_state)
+
+
+@extend_schema(
+    operation_id="pieces_current_state_upload_image_from_refs",
+    request=_OPENAI_FILE_REFS_REQUEST,
+    responses=_UPLOAD_IMAGE_RESPONSES,
+    description=(
+        "Upload a chat-attached image to the current unsealed state via OpenAI file references. "
+        "Pass the image attached in the ChatGPT conversation as `openaiFileIdRefs`. "
+        "The runtime injects download URLs automatically."
+    ),
+)
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+@traced
+def upload_image_from_refs_to_current_state(request: Request, piece_id) -> Response:
+    """Upload a chat-attached image to the piece's current (unsealed) state."""
+    piece = get_object_or_404(piece_queryset(request), pk=piece_id)
+    piece_state = piece.current_state
+    if piece_state is None:
+        return Response(
+            {"detail": "Piece has no current state."},
+            status=status.HTTP_404_NOT_FOUND,
+        )
+    return _upload_image_from_refs_to_piece_state(request, piece_state)
 
 
 @extend_schema(

--- a/api/piece/image_views.py
+++ b/api/piece/image_views.py
@@ -140,13 +140,18 @@ def _fetch_url_to_r2(url: str, user_id: "int | None") -> "tuple[str, str] | Resp
             status=status.HTTP_400_BAD_REQUEST,
         )
     content_type = resp.headers.get("content-type", "image/jpeg").split(";")[0].strip()
-    ext = _ext_for_content_type(content_type)
+    if content_type not in _IMAGE_CONTENT_TYPE_TO_EXT:
+        return Response(
+            {"detail": f"Unsupported image type: {content_type}."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
     data = resp.content
     if len(data) > _MAX_UPLOAD_BYTES:
         return Response(
             {"detail": "Image exceeds 10 MB size limit."},
             status=status.HTTP_400_BAD_REQUEST,
         )
+    ext = _ext_for_content_type(content_type)
     key = f"images/{user_id}/{uuid.uuid4()}.{ext}"
     public_url = r2.upload_bytes(key, data, content_type)
     return public_url, key

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1273,7 +1273,7 @@ class CropRunCreateSerializer(serializers.ModelSerializer):
         fields = ["piece_state_image_id", "crop", "notes"]
 
 
-@extend_schema_field({"type": "string"})
+@extend_schema_field({"type": "string", "format": "binary"})
 class _BinaryFileField(serializers.FileField):
     pass
 

--- a/api/tests/test_llm_schema.py
+++ b/api/tests/test_llm_schema.py
@@ -16,6 +16,11 @@ _EXCLUDED_PREFIXES = (
 _EXCLUDED_IMAGE_PATHS = (
     "/api/images/{image_id}/piece_state/{piece_state_id}/",
     "/api/images/{image_id}/crop-runs/",
+    # crop excluded: actions cannot return images; workflow is inherently visual
+    "/api/images/{image_id}/crop/",
+    # multipart upload excluded: ChatGPT cannot bind chat attachments to multipart fields
+    "/api/pieces/{piece_id}/state/upload-image/",
+    "/api/pieces/{piece_id}/states/{state_id}/upload-image/",
 )
 
 _EXPECTED_PATHS = (
@@ -23,7 +28,8 @@ _EXPECTED_PATHS = (
     "/api/pieces/{piece_id}/states/",
     "/api/pieces/{piece_id}/current_state/",
     "/api/pieces/{piece_id}/state/",
-    "/api/images/{image_id}/crop/",
+    "/api/pieces/{piece_id}/state/upload-image-refs/",
+    "/api/pieces/{piece_id}/states/{state_id}/upload-image-refs/",
 )
 
 

--- a/api/tests/test_upload_image.py
+++ b/api/tests/test_upload_image.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -181,3 +181,212 @@ class TestUploadImageEndpoints:
 
         assert response.status_code == 201
         assert PieceStateImage.objects.get().caption == "my caption"
+
+
+def _mock_httpx_response(
+    content=_SMALL_JPEG, content_type="image/jpeg", status_code=200
+):
+    resp = Mock()
+    resp.content = content
+    resp.headers = {"content-type": content_type}
+    resp.status_code = status_code
+    resp.raise_for_status = Mock()
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = Exception("HTTP error")
+    return resp
+
+
+@pytest.mark.django_db
+class TestUploadImageFromRefsEndpoints:
+    @pytest.fixture
+    def auth_client(self, user):
+        c = APIClient()
+        c.force_authenticate(user=user)
+        return c
+
+    @pytest.fixture
+    def piece_with_state(self, user):
+        piece = Piece.objects.create(user=user, name="Bowl")
+        state = PieceState.objects.create(piece=piece, state=ENTRY_STATE, order=0)
+        return piece, state
+
+    @pytest.fixture
+    def editable_piece_with_state(self, user):
+        piece = Piece.objects.create(user=user, name="Bowl", is_editable=True)
+        state = PieceState.objects.create(piece=piece, state=ENTRY_STATE, order=0)
+        return piece, state
+
+    def _current_url(self, piece_id):
+        return f"/api/pieces/{piece_id}/state/upload-image-refs/"
+
+    def _past_url(self, piece_id, state_id):
+        return f"/api/pieces/{piece_id}/states/{state_id}/upload-image-refs/"
+
+    def _refs_payload(
+        self, download_link="https://cdn.openai.com/files/img.jpg", caption=""
+    ):
+        return {
+            "openaiFileIdRefs": [
+                {
+                    "name": "photo.jpg",
+                    "id": "file-abc123",
+                    "mime_type": "image/jpeg",
+                    "download_link": download_link,
+                }
+            ],
+            "caption": caption,
+        }
+
+    @patch("api.piece.image_views.r2.is_r2_configured", return_value=True)
+    @patch("api.piece.image_views.r2.upload_bytes", return_value=_FAKE_PUBLIC_URL)
+    @patch("api.piece.image_views.httpx.get")
+    def test_jpeg_ref_succeeds(
+        self, mock_get, mock_upload, mock_r2, auth_client, piece_with_state
+    ):
+        mock_get.return_value = _mock_httpx_response()
+        piece, _ = piece_with_state
+
+        with patch("api.tasks.get_task_interface"):
+            response = auth_client.post(
+                self._current_url(piece.id), self._refs_payload(), format="json"
+            )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert "piece_state_image" in data
+        assert data["background_tasks"]["conversion_task_id"] is None
+
+    @patch("api.piece.image_views.r2.is_r2_configured", return_value=True)
+    @patch("api.piece.image_views.r2.upload_bytes", return_value=_FAKE_PNG_URL)
+    @patch("api.piece.image_views.httpx.get")
+    def test_png_ref_enqueues_conversion(
+        self, mock_get, mock_upload, mock_r2, auth_client, piece_with_state
+    ):
+        mock_get.return_value = _mock_httpx_response(_SMALL_PNG, "image/png")
+        piece, _ = piece_with_state
+
+        with patch("api.tasks.get_task_interface") as mock_iface:
+            mock_iface.return_value.submit = MagicMock()
+            response = auth_client.post(
+                self._current_url(piece.id), self._refs_payload(), format="json"
+            )
+
+        assert response.status_code == 201
+        assert response.json()["background_tasks"]["conversion_task_id"] is not None
+
+    @patch("api.piece.image_views.r2.is_r2_configured", return_value=True)
+    @patch("api.piece.image_views.httpx.get")
+    def test_unsupported_content_type_returns_400(
+        self, mock_get, mock_r2, auth_client, piece_with_state
+    ):
+        mock_get.return_value = _mock_httpx_response(b"%PDF", "application/pdf")
+        piece, _ = piece_with_state
+        response = auth_client.post(
+            self._current_url(piece.id), self._refs_payload(), format="json"
+        )
+        assert response.status_code == 400
+
+    @patch("api.piece.image_views.r2.is_r2_configured", return_value=True)
+    @patch("api.piece.image_views.httpx.get")
+    def test_oversized_image_returns_400(
+        self, mock_get, mock_r2, auth_client, piece_with_state
+    ):
+        from api.piece.image_views import _MAX_UPLOAD_BYTES
+
+        mock_get.return_value = _mock_httpx_response(b"\x00" * (_MAX_UPLOAD_BYTES + 1))
+        piece, _ = piece_with_state
+        response = auth_client.post(
+            self._current_url(piece.id), self._refs_payload(), format="json"
+        )
+        assert response.status_code == 400
+
+    @patch("api.piece.image_views.r2.is_r2_configured", return_value=True)
+    @patch("api.piece.image_views.httpx.get")
+    def test_failed_fetch_returns_400(
+        self, mock_get, mock_r2, auth_client, piece_with_state
+    ):
+        mock_get.side_effect = Exception("network error")
+        piece, _ = piece_with_state
+        response = auth_client.post(
+            self._current_url(piece.id), self._refs_payload(), format="json"
+        )
+        assert response.status_code == 400
+
+    @patch("api.piece.image_views.r2.is_r2_configured", return_value=True)
+    def test_http_download_link_returns_400(
+        self, mock_r2, auth_client, piece_with_state
+    ):
+        piece, _ = piece_with_state
+        response = auth_client.post(
+            self._current_url(piece.id),
+            self._refs_payload(download_link="http://evil.com/img.jpg"),
+            format="json",
+        )
+        assert response.status_code == 400
+
+    @patch("api.piece.image_views.r2.is_r2_configured", return_value=True)
+    def test_missing_refs_returns_400(self, mock_r2, auth_client, piece_with_state):
+        piece, _ = piece_with_state
+        response = auth_client.post(
+            self._current_url(piece.id), {"caption": "no refs"}, format="json"
+        )
+        assert response.status_code == 400
+
+    def test_unauthenticated_returns_401(self, piece_with_state):
+        piece, _ = piece_with_state
+        response = APIClient().post(
+            self._current_url(piece.id), self._refs_payload(), format="json"
+        )
+        assert response.status_code == 401
+
+    def test_other_users_piece_returns_404(self, other_user, piece_with_state):
+        piece, _ = piece_with_state
+        other_client = APIClient()
+        other_client.force_authenticate(user=other_user)
+        response = other_client.post(
+            self._current_url(piece.id), self._refs_payload(), format="json"
+        )
+        assert response.status_code == 404
+
+    def test_past_state_non_editable_returns_403(self, auth_client, piece_with_state):
+        piece, state = piece_with_state
+        response = auth_client.post(
+            self._past_url(piece.id, state.id), self._refs_payload(), format="json"
+        )
+        assert response.status_code == 403
+
+    @patch("api.piece.image_views.r2.is_r2_configured", return_value=True)
+    @patch("api.piece.image_views.r2.upload_bytes", return_value=_FAKE_PUBLIC_URL)
+    @patch("api.piece.image_views.httpx.get")
+    def test_past_state_editable_succeeds(
+        self, mock_get, mock_upload, mock_r2, auth_client, editable_piece_with_state
+    ):
+        mock_get.return_value = _mock_httpx_response()
+        piece, state = editable_piece_with_state
+
+        with patch("api.tasks.get_task_interface"):
+            response = auth_client.post(
+                self._past_url(piece.id, state.id), self._refs_payload(), format="json"
+            )
+
+        assert response.status_code == 201
+        assert PieceStateImage.objects.filter(piece_state=state).count() == 1
+
+    @patch("api.piece.image_views.r2.is_r2_configured", return_value=True)
+    @patch("api.piece.image_views.r2.upload_bytes", return_value=_FAKE_PUBLIC_URL)
+    @patch("api.piece.image_views.httpx.get")
+    def test_caption_stored(
+        self, mock_get, mock_upload, mock_r2, auth_client, piece_with_state
+    ):
+        mock_get.return_value = _mock_httpx_response()
+        piece, _ = piece_with_state
+
+        with patch("api.tasks.get_task_interface"):
+            response = auth_client.post(
+                self._current_url(piece.id),
+                self._refs_payload(caption="pottery photo"),
+                format="json",
+            )
+
+        assert response.status_code == 201
+        assert PieceStateImage.objects.get().caption == "pottery photo"

--- a/api/urls.py
+++ b/api/urls.py
@@ -86,9 +86,19 @@ urlpatterns = [
         name="piece-past-state-upload-image",
     ),
     path(
+        "pieces/<uuid:piece_id>/states/<uuid:state_id>/upload-image-refs/",
+        views.upload_image_from_refs_to_past_state,
+        name="piece-past-state-upload-image-refs",
+    ),
+    path(
         "pieces/<uuid:piece_id>/state/upload-image/",
         views.upload_image_to_current_state,
         name="piece-current-state-upload-image",
+    ),
+    path(
+        "pieces/<uuid:piece_id>/state/upload-image-refs/",
+        views.upload_image_from_refs_to_current_state,
+        name="piece-current-state-upload-image-refs",
     ),
     path(
         "pieces/<uuid:piece_id>/current_state/",

--- a/api/views.py
+++ b/api/views.py
@@ -41,6 +41,8 @@ from .import_views import admin_manual_square_crop_import
 from .piece.image_views import (
     patch_image_crop,
     piece_image_detail,
+    upload_image_from_refs_to_current_state,
+    upload_image_from_refs_to_past_state,
     upload_image_to_current_state,
     upload_image_to_past_state,
 )
@@ -94,6 +96,8 @@ __all__ = [
     "piece_current_state",
     "piece_current_state_detail",
     "patch_image_crop",
+    "upload_image_from_refs_to_current_state",
+    "upload_image_from_refs_to_past_state",
     "upload_image_to_current_state",
     "upload_image_to_past_state",
     "piece_detail",


### PR DESCRIPTION
## Problem

ChatGPT custom GPT actions cannot bind chat-attached files to multipart form fields — the runtime never bridges the attachment to the `file` parameter. The correct mechanism is OpenAI's documented `openaiFileIdRefs` parameter ([sending-files docs](https://developers.openai.com/api/docs/actions/sending-files)), where the runtime injects an array of objects containing a `download_link` the server can fetch.

Also: the crop endpoint was in the LLM schema but actions cannot return images back to ChatGPT (only non-image file types are supported), making the crop workflow unverifiable and useless for an LLM client.

## Changes

- **New endpoints**: `POST /api/pieces/{id}/state/upload-image-refs/` and `POST /api/pieces/{id}/states/{state_id}/upload-image-refs/` accept a JSON body with `openaiFileIdRefs` (array of strings per schema, array of objects at runtime). The server takes `openaiFileIdRefs[0].download_link`, fetches it via `httpx`, and uploads to R2 — same pipeline as the multipart path.
- **Restored `_fetch_url_to_r2`** (removed in #936), now using `httpx` instead of `requests`, buffering up to the 10 MB cap.
- **Extracted shared helpers** `_attach_image_to_piece_state` and `_UPLOAD_IMAGE_RESPONSES` to eliminate duplication between the two upload paths.
- **LLM schema**: exclude multipart `upload-image/` (unusable by ChatGPT) and `/crop/` (images can't be returned to ChatGPT). Refs endpoints auto-included via the `/api/pieces/` prefix rule.
- **Reverted experiment** commit that changed `_BinaryFileField` to `type:string` — restored `format:binary` for the multipart endpoint.

## Testing

- `//api:api_mypy` ✅
- `//api:api_llm_schema_test` ✅ (updated to assert refs present, multipart/crop excluded)
- `//api:api_piece_test` ✅
