### PR TITLE
feat: enable mcp server packaging and stateless routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -601,6 +601,9 @@ jobs:
           bazel run --config=ci --stamp //:push_worker -- \
             --tag latest \
             --tag ${{ github.sha }}
+          bazel run --config=ci --stamp //potterdoc_mcp:push_mcp -- \
+            --tag latest \
+            --tag ${{ github.sha }}
 
   record-fingerprint:
     name: Record successful fingerprint

--- a/api/tests/test_manual_square_crop_import.py
+++ b/api/tests/test_manual_square_crop_import.py
@@ -38,7 +38,9 @@ class TestManualSquareCropImport:
         client.force_authenticate(user=admin)
 
         _set_r2_env(monkeypatch)
-        monkeypatch.setattr("api.manual_tile_imports.r2.object_exists", lambda key: True)
+        monkeypatch.setattr(
+            "api.manual_tile_imports.r2.object_exists", lambda key: True
+        )
 
         payload = {
             "records": [
@@ -89,7 +91,9 @@ class TestManualSquareCropImport:
         client.force_authenticate(user=admin)
 
         _set_r2_env(monkeypatch)
-        monkeypatch.setattr("api.manual_tile_imports.r2.object_exists", lambda key: True)
+        monkeypatch.setattr(
+            "api.manual_tile_imports.r2.object_exists", lambda key: True
+        )
 
         payload = {
             "records": [
@@ -166,7 +170,9 @@ class TestManualSquareCropImport:
         client.force_authenticate(user=admin)
 
         _set_r2_env(monkeypatch)
-        monkeypatch.setattr("api.manual_tile_imports.r2.object_exists", lambda key: False)
+        monkeypatch.setattr(
+            "api.manual_tile_imports.r2.object_exists", lambda key: False
+        )
 
         payload = {
             "records": [
@@ -350,7 +356,9 @@ class TestImportGlazeCombination:
 
     def _patch_r2(self, monkeypatch):
         _set_r2_env(monkeypatch)
-        monkeypatch.setattr("api.manual_tile_imports.r2.object_exists", lambda key: True)
+        monkeypatch.setattr(
+            "api.manual_tile_imports.r2.object_exists", lambda key: True
+        )
 
     def test_error_when_combination_missing_name_and_components(self, monkeypatch):
         self._patch_r2(monkeypatch)

--- a/api/tests/test_patch_image_crop.py
+++ b/api/tests/test_patch_image_crop.py
@@ -179,7 +179,9 @@ class TestPatchImageCrop:
     ],
 )
 class TestPatchImageCropValidation:
-    def test_out_of_bounds_crop_returns_400(self, client, image_in_editable_piece, crop):
+    def test_out_of_bounds_crop_returns_400(
+        self, client, image_in_editable_piece, crop
+    ):
         image = image_in_editable_piece
         response = client.patch(
             f"/api/images/{image.id}/crop/",

--- a/chart/glaze/templates/deployment-mcp.yaml
+++ b/chart/glaze/templates/deployment-mcp.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: mcp
-          image: "{{ .Values.mcp.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.mcp.image.repository }}:{{ .Values.mcp.image.tag | default .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/potterdoc_mcp/BUILD.bazel
+++ b/potterdoc_mcp/BUILD.bazel
@@ -1,4 +1,6 @@
-load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_library")
+load("@aspect_rules_py//py:defs.bzl", "py_binary", "py_image_layer", "py_library")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//:python.bzl", "pytest_test")
 
 # Placeholder target matching the uv.override_package() entry in MODULE.bazel.
@@ -31,4 +33,77 @@ pytest_test(
     deps = [":potterdoc_mcp"],
     expected_coverage = ["potterdoc_mcp/client.py", "potterdoc_mcp/server.py"],
     visibility = ["//visibility:public"],
+)
+
+py_image_layer(
+    name = "mcp_python_layer",
+    binary = ":potterdoc_mcp_server",
+    root = "/app",
+)
+
+genrule(
+    name = "mcp_python_layer_tar",
+    srcs = [
+        ":mcp_python_layer",
+    ],
+    outs = ["mcp_python_layer.tar"],
+    cmd = """
+        set -e
+        tmp=$$(mktemp -d)
+        dest=$$(mktemp -d)
+        for layer in $(locations :mcp_python_layer); do
+            tar -xf "$$layer" -C "$$tmp"
+        done
+        mkdir -p "$$dest/app/site-packages"
+        copied=0
+        while IFS= read -r site_packages; do
+            cp -a "$$site_packages"/. "$$dest/app/site-packages"/
+            copied=1
+        done < <(find "$$tmp" -type d -path '*/site-packages' | sort)
+        if [ "$$copied" -ne 1 ]; then
+            echo "No site-packages directories were found in the py_image_layer output" >&2
+            rm -rf "$$tmp" "$$dest"
+            exit 1
+        fi
+        OUT_TAR="$$PWD/$@"
+        tar -C "$$dest" -cf "$$OUT_TAR" app/site-packages
+        rm -rf "$$tmp" "$$dest"
+    """,
+    tags = ["no-sandbox"],
+)
+
+pkg_tar(
+    name = "mcp_src_tar",
+    srcs = glob(["**/*.py"], exclude=["tests/**"]),
+    strip_prefix = ".",
+    package_dir = "/app/potterdoc_mcp",
+)
+
+oci_image(
+    name = "image_mcp",
+    base = "@python312_slim",
+    entrypoint = [
+        "python",
+        "-m",
+        "potterdoc_mcp",
+        "--transport",
+        "http",
+    ],
+    env = {
+        "PYTHONPATH": "/app:/app/site-packages",
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "PYTHONUNBUFFERED": "1",
+    },
+    exposed_ports = ["8080/tcp"],
+    tars = [
+        ":mcp_python_layer_tar",
+        ":mcp_src_tar",
+    ],
+    workdir = "/app",
+)
+
+oci_push(
+    name = "push_mcp",
+    image = ":image_mcp",
+    repository = "ghcr.io/shaoster/glaze-mcp",
 )

--- a/potterdoc_mcp/BUILD.bazel
+++ b/potterdoc_mcp/BUILD.bazel
@@ -49,8 +49,10 @@ genrule(
     outs = ["mcp_python_layer.tar"],
     cmd = """
         set -e
-        tmp=$$(mktemp -d)
-        dest=$$(mktemp -d)
+        tmp="$$PWD/$(RULEDIR)/mcp_tmp"
+        dest="$$PWD/$(RULEDIR)/mcp_dest"
+        rm -rf "$$tmp" "$$dest"
+        mkdir -p "$$tmp" "$$dest"
         for layer in $(locations :mcp_python_layer); do
             tar -xf "$$layer" -C "$$tmp"
         done
@@ -69,7 +71,6 @@ genrule(
         tar -C "$$dest" -cf "$$OUT_TAR" app/site-packages
         rm -rf "$$tmp" "$$dest"
     """,
-    tags = ["no-sandbox"],
 )
 
 pkg_tar(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,6 @@ dependencies = [
     "boto3>=1.43.27",
     "modal>=1.5.0",
     "gevent>=26.5.0",
-    "mcp>=1.0.0",
 ]
 
 [tool.uv]

--- a/services/glaze_compute_service.py
+++ b/services/glaze_compute_service.py
@@ -212,7 +212,6 @@ def _load_font(path: str, size: int) -> Any:
 def _draw_text_centered(
     draw: Any, text: str, font: Any, canvas_w: int, y: int, color: tuple
 ) -> None:
-
     bbox = draw.textbbox((0, 0), text, font=font)
     text_w = bbox[2] - bbox[0]
     x = max(0, (canvas_w - text_w) // 2)

--- a/services/tests/test_glaze_compute_service.py
+++ b/services/tests/test_glaze_compute_service.py
@@ -2,7 +2,6 @@ import ast
 
 import services.glaze_compute_service as _compute_service
 
-
 # Modal enforces this server-side; values below this are rejected at deploy time.
 MODAL_DISK_MIN_MIB = 524288
 

--- a/tools/render_values.sh
+++ b/tools/render_values.sh
@@ -43,4 +43,5 @@ mcp:
   apiUrl: "${APP_ORIGIN}"
   image:
     repository: "ghcr.io/shaoster/glaze-mcp"
+    tag: "${IMAGE_TAG}"
 EOF

--- a/tools/render_values.sh
+++ b/tools/render_values.sh
@@ -37,4 +37,10 @@ ingress:
     - secretName: glaze-tls
       hosts:
         - "${ALLOWED_HOST}"
+mcp:
+  enabled: true
+  host: "mcp.potterdoc.com"
+  apiUrl: "${APP_ORIGIN}"
+  image:
+    repository: "ghcr.io/shaoster/glaze-mcp"
 EOF

--- a/tools/tests/test_gz_start_launcher.py
+++ b/tools/tests/test_gz_start_launcher.py
@@ -590,6 +590,10 @@ def test_start_backend_resets_worktree_local_db_when_workspace_is_under_shared(
     backups = list(workspace.glob("db.bak.*.sqlite3"))
     assert len(backups) == 1, "expected exactly one backup file in the workspace"
     fresh_migrate_calls = [
-        c for c in run_calls if "migrate" in c["cmd"] and "--fake-initial" not in c["cmd"]
+        c
+        for c in run_calls
+        if "migrate" in c["cmd"] and "--fake-initial" not in c["cmd"]
     ]
-    assert len(fresh_migrate_calls) >= 1, "fallback must run a fresh migrate after backup"
+    assert len(fresh_migrate_calls) >= 1, (
+        "fallback must run a fresh migrate after backup"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -515,6 +515,9 @@ source = { registry = "third_party/python" }
 dependencies = [
     { name = "django" },
 ]
+# DO NOT MODIFY the wheels entry below — uv rewrites the url to a relative
+# path which breaks aspect_rules_py's lockfile parser. See:
+# https://github.com/shaoster/glaze/issues/792
 wheels = [
     { url = "https://raw.githubusercontent.com/shaoster/glaze/7e899ff17dc550446652fa813f38ab5331e6db1f/third_party/python/django_bootstrap4_form-4.0.2-py3-none-any.whl", hash = "sha256:ed4bcfc1246e449d61b6d946c8c918e48b6d239c504fcf03cd711108c20c5555", size = 7071 },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -515,9 +515,6 @@ source = { registry = "third_party/python" }
 dependencies = [
     { name = "django" },
 ]
-# DO NOT MODIFY the wheels entry below — uv rewrites the url to a relative
-# path which breaks aspect_rules_py's lockfile parser. See:
-# https://github.com/shaoster/glaze/issues/792
 wheels = [
     { url = "https://raw.githubusercontent.com/shaoster/glaze/7e899ff17dc550446652fa813f38ab5331e6db1f/third_party/python/django_bootstrap4_form-4.0.2-py3-none-any.whl", hash = "sha256:ed4bcfc1246e449d61b6d946c8c918e48b6d239c504fcf03cd711108c20c5555", size = 7071 },
 ]
@@ -852,7 +849,6 @@ dependencies = [
     { name = "lazy-loader" },
     { name = "librt" },
     { name = "llvmlite" },
-    { name = "mcp" },
     { name = "modal" },
     { name = "msgpack" },
     { name = "mypy" },
@@ -961,7 +957,6 @@ requires-dist = [
     { name = "lazy-loader", specifier = "==0.5" },
     { name = "librt", specifier = "==0.8.1" },
     { name = "llvmlite", specifier = "==0.47.0" },
-    { name = "mcp", specifier = ">=1.0.0" },
     { name = "modal", specifier = ">=1.5.0" },
     { name = "msgpack", specifier = "==1.1.2" },
     { name = "mypy", specifier = "==1.20.0" },
@@ -1971,12 +1966,16 @@ source = { editable = "potterdoc_mcp" }
 dependencies = [
     { name = "httpx" },
     { name = "mcp" },
+    { name = "starlette" },
+    { name = "uvicorn" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp", specifier = ">=1.0.0" },
+    { name = "starlette", specifier = ">=0.41.0" },
+    { name = "uvicorn", specifier = ">=0.32.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #944

### Summary of Changes
- **Workspace Decoupling**: Removed `"mcp>=1.0.0"` from the root workspace `pyproject.toml` and verified it is only declared in `potterdoc_mcp/pyproject.toml` so that main web/worker images do not package it. Regenerated `uv.lock`.
- **Bazel Packaging Targets**: Added `py_image_layer`, `genrule` (dependency tar extraction), `pkg_tar` (sources), `oci_image`, and `oci_push` rules to `potterdoc_mcp/BUILD.bazel` to build and publish the independent `ghcr.io/shaoster/glaze-mcp` OCI image.
- **CI/CD Integration**: Integrated `//potterdoc_mcp:push_mcp` into the `image` job in `.github/workflows/ci.yml`.
- **Helm Values**: Updated `tools/render_values.sh` to output the `mcp` block with `enabled: true`, `host: "mcp.potterdoc.com"`, and `image.repository: "ghcr.io/shaoster/glaze-mcp"`.
- **Verification**: All Bazel tests (`//...`) and linters pass cleanly.
