### PR TITLE
fix(helm): add startupProbe to mcp deployment to prevent crash-loop

### DIFF
--- a/chart/glaze/templates/deployment-mcp.yaml
+++ b/chart/glaze/templates/deployment-mcp.yaml
@@ -29,18 +29,28 @@ spec:
           env:
             - name: POTTERDOC_API_URL
               value: "{{ .Values.mcp.apiUrl }}"
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            failureThreshold: 12
+            periodSeconds: 5
+            timeoutSeconds: 3
           livenessProbe:
             httpGet:
               path: /health
               port: 8080
-            initialDelaySeconds: 5
+            initialDelaySeconds: 0
             periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /health
               port: 8080
-            initialDelaySeconds: 5
+            initialDelaySeconds: 0
             periodSeconds: 10
+            timeoutSeconds: 3
           resources:
             {{- toYaml .Values.mcp.resources | nindent 12 }}
 ---


### PR DESCRIPTION
## Summary

- Adds a `startupProbe` to the MCP deployment (60s budget: 12 × 5s) so the liveness probe does not fire until uvicorn is ready
- Sets `timeoutSeconds: 3` on all probes, per the single-node probe tuning guidelines
- Removes `initialDelaySeconds: 5` from liveness/readiness (superseded by the startupProbe)

## Background

After merging #945, the `glaze-mcp` pod entered a crash-loop on first deploy. The liveness probe (5s initial delay, 1s timeout) was killing the container before uvicorn finished starting on the resource-constrained single-core node. The pod self-recovered after 5 restarts once the image was cached and startup was faster, but the next cold start or node restart will reproduce the loop.

## Test plan

- [ ] CD deploys this chart revision
- [ ] `kubectl get pods` shows `glaze-mcp` reaching `1/1 Running` without restarts
- [ ] `kubectl get events | grep mcp` shows no `Killing` or `Unhealthy` liveness events on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)