### PR TITLE
fix(mcp): add OAuth dynamic client registration endpoint

### DIFF
--- a/potterdoc_mcp/BUILD.bazel
+++ b/potterdoc_mcp/BUILD.bazel
@@ -75,7 +75,7 @@ genrule(
 
 pkg_tar(
     name = "mcp_src_tar",
-    srcs = glob(["**/*.py", "*.svg"], exclude=["tests/**"]),
+    srcs = glob(["**/*.py", "**/*.svg"], exclude=["tests/**"]),
     strip_prefix = ".",
     package_dir = "/app/potterdoc_mcp",
 )

--- a/potterdoc_mcp/BUILD.bazel
+++ b/potterdoc_mcp/BUILD.bazel
@@ -3,11 +3,18 @@ load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//:python.bzl", "pytest_test")
 
+filegroup(
+    name = "potterdoc_mcp_data",
+    srcs = glob(["**/*.svg"]),
+    visibility = ["//visibility:public"],
+)
+
 # Placeholder target matching the uv.override_package() entry in MODULE.bazel.
 # Bazel skips trying to install potterdoc-mcp from PyPI and uses this instead.
 py_library(
     name = "potterdoc_mcp",
     srcs = glob(["**/*.py"], exclude=["tests/**"]),
+    data = [":potterdoc_mcp_data"],
     deps = [
         "@pypi//httpx",
         "@pypi//mcp",

--- a/potterdoc_mcp/BUILD.bazel
+++ b/potterdoc_mcp/BUILD.bazel
@@ -75,7 +75,7 @@ genrule(
 
 pkg_tar(
     name = "mcp_src_tar",
-    srcs = glob(["**/*.py"], exclude=["tests/**"]),
+    srcs = glob(["**/*.py", "*.svg"], exclude=["tests/**"]),
     strip_prefix = ".",
     package_dir = "/app/potterdoc_mcp",
 )

--- a/potterdoc_mcp/__main__.py
+++ b/potterdoc_mcp/__main__.py
@@ -86,11 +86,34 @@ def _build_http_app():
                 "issuer": base,
                 "authorization_endpoint": f"{base}/oauth/authorize",
                 "token_endpoint": f"{base}/oauth/token",
+                "registration_endpoint": f"{base}/oauth/register",
                 "response_types_supported": ["code"],
                 "grant_types_supported": ["authorization_code"],
                 "code_challenge_methods_supported": ["S256"],
                 "token_endpoint_auth_methods_supported": ["none"],
             }
+        )
+
+    async def oauth_register(request: Request) -> JSONResponse:
+        # RFC 7591 Dynamic Client Registration.
+        # We don't persist registrations — redirect_uri is validated at authorize
+        # time against the OAUTH_ALLOWED_REDIRECT_URI_PREFIXES allowlist instead.
+        # Return a stable client_id so the caller can proceed through the flow.
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        redirect_uris = body.get("redirect_uris", [])
+        return JSONResponse(
+            {
+                "client_id": "potterdoc-mcp-client",
+                "client_id_issued_at": int(time.time()),
+                "redirect_uris": redirect_uris,
+                "grant_types": ["authorization_code"],
+                "response_types": ["code"],
+                "token_endpoint_auth_method": "none",
+            },
+            status_code=201,
         )
 
     async def oauth_authorize(request: Request) -> Response:
@@ -244,6 +267,7 @@ def _build_http_app():
                 "/.well-known/oauth-authorization-server",
                 oauth_metadata,
             ),
+            Route("/oauth/register", oauth_register, methods=["POST"]),
             Route("/oauth/authorize", oauth_authorize),
             Route("/oauth/callback", oauth_callback),
             Route("/oauth/token", oauth_token, methods=["POST"]),

--- a/potterdoc_mcp/__main__.py
+++ b/potterdoc_mcp/__main__.py
@@ -108,7 +108,10 @@ def _build_http_app():
         try:
             body = await request.json()
         except Exception:
-            body = {}
+            return JSONResponse(
+                {"error": "invalid_client_metadata", "error_description": "Request body must be valid JSON."},
+                status_code=400,
+            )
         redirect_uris = body.get("redirect_uris", [])
         return JSONResponse(
             {

--- a/potterdoc_mcp/__main__.py
+++ b/potterdoc_mcp/__main__.py
@@ -10,6 +10,7 @@ import os
 import secrets
 import time
 import urllib.parse
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -74,6 +75,11 @@ def _build_http_app():
 
     async def health(request: Request) -> JSONResponse:
         return JSONResponse({"status": "ok"})
+
+    _icon_svg = (Path(__file__).parent / "icon.svg").read_text()
+
+    async def icon_svg(request: Request) -> Response:
+        return Response(_icon_svg, media_type="image/svg+xml")
 
     # ------------------------------------------------------------------
     # OAuth 2.0 Authorization Server endpoints
@@ -263,6 +269,7 @@ def _build_http_app():
         middleware=[Middleware(BearerAuthMiddleware)],
         routes=[
             Route("/health", health),
+            Route("/icon.svg", icon_svg),
             Route(
                 "/.well-known/oauth-authorization-server",
                 oauth_metadata,

--- a/potterdoc_mcp/icon.svg
+++ b/potterdoc_mcp/icon.svg
@@ -1,0 +1,22 @@
+<svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" fill="none">
+
+  <!-- Uniformly scaled group, centered for circular favicon -->
+  <g transform="translate(64 64) scale(1.358) translate(-64 -64)">
+
+    <!-- WHEEL -->
+    <ellipse cx="64" cy="93.2143" rx="42" ry="12" fill="#E6C3A0" stroke="#8A3F1D" stroke-width="1"></ellipse>
+
+    <!-- POT BODY -->
+    <path d="
+        M42 29.2143
+        L86 29.2143
+        L86 93.2143
+        C86 99.2143, 42 99.2143, 42 93.2143
+        Z
+      " fill="#C66A3D" stroke="#8A3F1D" stroke-width="1" stroke-linejoin="round"></path>
+
+    <!-- POT RIM -->
+    <ellipse cx="64" cy="29.2143" rx="22.5" ry="6.4286" fill="#8A3F1D"></ellipse>
+
+  </g>
+</svg>

--- a/potterdoc_mcp/server.py
+++ b/potterdoc_mcp/server.py
@@ -8,6 +8,7 @@ from collections.abc import AsyncIterator
 from typing import Any
 
 from mcp.server.fastmcp import Context, FastMCP
+from mcp.types import Icon
 
 from potterdoc_mcp.client import PotterDocClient
 
@@ -51,6 +52,12 @@ mcp = FastMCP(
         "states and required fields, and transition_piece to advance a piece through "
         "the firing workflow."
     ),
+    icons=[
+        Icon(
+            src=f"{os.environ.get('MCP_BASE_URL', 'https://mcp.potterdoc.com')}/icon.svg",
+            mimeType="image/svg+xml",
+        )
+    ],
     lifespan=_lifespan,
     stateless_http=True,
 )

--- a/potterdoc_mcp/tests/test_oauth.py
+++ b/potterdoc_mcp/tests/test_oauth.py
@@ -37,8 +37,44 @@ def test_oauth_metadata(client, monkeypatch):
     assert body["issuer"] == "https://mcp.example.com"
     assert body["authorization_endpoint"] == "https://mcp.example.com/oauth/authorize"
     assert body["token_endpoint"] == "https://mcp.example.com/oauth/token"
+    assert body["registration_endpoint"] == "https://mcp.example.com/oauth/register"
     assert "S256" in body["code_challenge_methods_supported"]
     assert "authorization_code" in body["grant_types_supported"]
+
+
+# ---------------------------------------------------------------------------
+# /oauth/register
+# ---------------------------------------------------------------------------
+
+
+def test_register_returns_client_id(client, monkeypatch):
+    monkeypatch.setenv("MCP_BASE_URL", "https://mcp.example.com")
+    response = client.post(
+        "/oauth/register",
+        json={"redirect_uris": ["https://claude.ai/oauth/callback"]},
+    )
+    assert response.status_code == 201
+    body = response.json()
+    assert body["client_id"] == "potterdoc-mcp-client"
+    assert body["redirect_uris"] == ["https://claude.ai/oauth/callback"]
+    assert body["grant_types"] == ["authorization_code"]
+    assert body["token_endpoint_auth_method"] == "none"
+    assert "client_id_issued_at" in body
+
+
+def test_register_empty_body(client):
+    response = client.post("/oauth/register", json={})
+    assert response.status_code == 201
+    body = response.json()
+    assert body["client_id"] == "potterdoc-mcp-client"
+    assert body["redirect_uris"] == []
+
+
+def test_register_multiple_redirect_uris(client):
+    uris = ["https://claude.ai/cb1", "https://claude.ai/cb2"]
+    response = client.post("/oauth/register", json={"redirect_uris": uris})
+    assert response.status_code == 201
+    assert response.json()["redirect_uris"] == uris
 
 
 # ---------------------------------------------------------------------------

--- a/potterdoc_mcp/tests/test_oauth.py
+++ b/potterdoc_mcp/tests/test_oauth.py
@@ -77,6 +77,28 @@ def test_register_multiple_redirect_uris(client):
     assert response.json()["redirect_uris"] == uris
 
 
+def test_register_invalid_json_returns_400(client):
+    response = client.post(
+        "/oauth/register",
+        content=b"not json",
+        headers={"content-type": "application/json"},
+    )
+    assert response.status_code == 400
+    assert response.json()["error"] == "invalid_client_metadata"
+
+
+# ---------------------------------------------------------------------------
+# /icon.svg
+# ---------------------------------------------------------------------------
+
+
+def test_icon_svg(client):
+    response = client.get("/icon.svg")
+    assert response.status_code == 200
+    assert "image/svg+xml" in response.headers["content-type"]
+    assert "<svg" in response.text
+
+
 # ---------------------------------------------------------------------------
 # /oauth/authorize
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `POST /oauth/register` implementing RFC 7591 Dynamic Client Registration
- Advertises `registration_endpoint` in `/.well-known/oauth-authorization-server` metadata
- Claude Desktop (and other MCP clients) check for this field before starting the OAuth flow; without it the connector setup fails with `registration_endpoint_missing`

Client registrations are not persisted — `redirect_uri` continues to be validated at authorize-time against the `OAUTH_ALLOWED_REDIRECT_URI_PREFIXES` allowlist, so the security model is unchanged.

## Test plan

- [ ] Connect via Claude Desktop connector UI — should proceed past `start_error` step
- [ ] `curl -s https://mcp.potterdoc.com/.well-known/oauth-authorization-server | jq .registration_endpoint` returns the register URL
- [ ] `POST /oauth/register` with `{"redirect_uris": ["https://claude.ai/..."]}` returns 201 with `client_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)