### PR TITLE
fix(mcp): propagate lifespan to parent Starlette app

### DIFF
--- a/potterdoc_mcp/__main__.py
+++ b/potterdoc_mcp/__main__.py
@@ -109,7 +109,10 @@ def _build_http_app():
             body = await request.json()
         except Exception:
             return JSONResponse(
-                {"error": "invalid_client_metadata", "error_description": "Request body must be valid JSON."},
+                {
+                    "error": "invalid_client_metadata",
+                    "error_description": "Request body must be valid JSON.",
+                },
                 status_code=400,
             )
         redirect_uris = body.get("redirect_uris", [])
@@ -143,7 +146,10 @@ def _build_http_app():
         client_redirect_uri = request.query_params.get("redirect_uri", "")
         if not any(client_redirect_uri.startswith(p) for p in allowed_prefixes):
             return JSONResponse(
-                {"error": "invalid_request", "error_description": "redirect_uri not allowed"},
+                {
+                    "error": "invalid_request",
+                    "error_description": "redirect_uri not allowed",
+                },
                 status_code=400,
             )
 
@@ -268,6 +274,15 @@ def _build_http_app():
             }
         )
 
+    from contextlib import asynccontextmanager
+
+    mcp_app = mcp.streamable_http_app()
+
+    @asynccontextmanager
+    async def lifespan(app: Starlette):
+        async with mcp_app.router.lifespan_context(mcp_app):
+            yield
+
     return Starlette(
         middleware=[Middleware(BearerAuthMiddleware)],
         routes=[
@@ -281,8 +296,9 @@ def _build_http_app():
             Route("/oauth/authorize", oauth_authorize),
             Route("/oauth/callback", oauth_callback),
             Route("/oauth/token", oauth_token, methods=["POST"]),
-            Mount("/", mcp.streamable_http_app()),
+            Mount("/", mcp_app),
         ],
+        lifespan=lifespan,
     )
 
 

--- a/potterdoc_mcp/tests/test_http_transport.py
+++ b/potterdoc_mcp/tests/test_http_transport.py
@@ -33,11 +33,15 @@ def test_mcp_missing_token_returns_401() -> None:
 
 
 def test_mcp_with_bearer_token_passes_auth() -> None:
-    """MCP request with a Bearer token passes the auth middleware (not 401)."""
-    http_client = TestClient(_build_http_app(), raise_server_exceptions=False)
-    response = http_client.post(
-        "/mcp",
-        json=_INITIALIZE_PAYLOAD,
-        headers={"Authorization": "Bearer pdagent_testtoken"},
-    )
-    assert response.status_code != 401
+    """MCP request with a Bearer token passes the auth middleware and reaches MCP app."""
+    with TestClient(
+        _build_http_app(),
+        base_url="http://localhost:8080",
+        raise_server_exceptions=True,
+    ) as http_client:
+        response = http_client.post(
+            "/mcp",
+            json=_INITIALIZE_PAYLOAD,
+            headers={"Authorization": "Bearer pdagent_testtoken"},
+        )
+        assert response.status_code == 406


### PR DESCRIPTION
## Problem
When mounting the `FastMCP` sub-application (`mcp.streamable_http_app()`) to a parent Starlette application in `potterdoc_mcp/__main__.py`, the parent app constructor did not declare a `lifespan` parameter. As a result, the sub-app's lifespan startup events never ran, leading to:
`RuntimeError: Task group is not initialized. Make sure to use run().`
whenever a request was made to `/mcp` (such as during connector setup/registration in Claude Desktop).

This was uncaught by the existing test suite because the HTTP transport test set `raise_server_exceptions=False` and only asserted `response.status_code != 401`. When the server returned a 500 error instead of a 401, the test still passed.

## Solution
1. Modified `potterdoc_mcp/__main__.py` to wrap the MCP sub-app's lifespan context manager and pass it to the parent `Starlette` app instance.
2. Updated `test_mcp_with_bearer_token_passes_auth` in `potterdoc_mcp/tests/test_http_transport.py` to act as a proper regression test:
   * Wrapped the client request in a `with TestClient(...)` context to properly trigger lifespan startup/shutdown events.
   * Enabled `raise_server_exceptions=True` to immediately catch initialization crashes.
   * Preserved the port in the `base_url` to bypass DNS rebinding protection host checks in tests.
   * Asserted `response.status_code == 406` (instead of `!= 401`) to verify successful routing to the FastMCP application.

All tests and linters pass.
