### PR TITLE
fix(cd): clear stale chart templates before each deploy

### DIFF
--- a/tools/helm_deploy.sh
+++ b/tools/helm_deploy.sh
@@ -14,6 +14,9 @@ SSH="ssh -o StrictHostKeyChecking=no"
 SCP="scp -o StrictHostKeyChecking=no"
 
 echo "==> Copying chart and values to ${DEPLOY_HOST}..."
+# Replace the chart directory wholesale so deleted templates don't persist
+# across deploys (scp -r merges rather than replacing).
+$SSH "${DEPLOY_HOST}" "rm -rf ~/glaze-chart-deploy/"
 $SCP -r "${CHART_DIR}" "${DEPLOY_HOST}":~/glaze-chart-deploy/
 $SCP "${VALUES_FILE}" "${DEPLOY_HOST}":~/glaze-values-override.yaml
 


### PR DESCRIPTION
## Summary

- `scp -r` in `helm_deploy.sh` merges into the destination rather than replacing it, so templates deleted from the chart linger on the prod host across deploys
- This caused the CD for PR #955 to fail with `UPGRADE FAILED: template: glaze/templates/deployment-worker.yaml:8:22: nil pointer evaluating interface {}.replicaCount` — `deployment-worker.yaml` was deleted in commit 75528cf1 but still existed at `~/glaze-chart-deploy/glaze/templates/` on the host
- The failed upgrade left the MCP pod on the old image (`ccbd63ab`) without the DNS rebinding fix, causing every `POST /mcp` to return `421 Misdirected Request`
- Fix: `ssh rm -rf ~/glaze-chart-deploy/` before the `scp` so each deploy starts from a clean slate

## Test plan

- [ ] Merge this and verify the next CD run creates a new Helm revision without template errors
- [ ] Confirm `~/glaze-chart-deploy/glaze/templates/` on the prod host contains only the templates present in the current chart after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
