### PR TITLE
fix(crop): expose Modal SDK credentials to web pod, fail PENDING tasks on restart

### DIFF
--- a/api/apps.py
+++ b/api/apps.py
@@ -2,16 +2,20 @@ from django.apps import AppConfig
 
 
 def _fail_running_tasks_on_startup() -> int:
-    """Mark every RUNNING AsyncTask as FAILURE.
+    """Mark every RUNNING or PENDING AsyncTask as FAILURE.
 
     Called on web server startup so tasks stranded by a pod restart don't block
-    the frontend spinner forever. Returns the count of tasks updated.
+    the frontend spinner forever. PENDING tasks are also stranded because the
+    in-memory thread pool they were submitted to no longer exists. Returns the
+    count of tasks updated.
     """
     from .models import AsyncTask
 
-    return AsyncTask.objects.filter(status=AsyncTask.Status.RUNNING).update(
+    return AsyncTask.objects.filter(
+        status__in=[AsyncTask.Status.RUNNING, AsyncTask.Status.PENDING]
+    ).update(
         status=AsyncTask.Status.FAILURE,
-        error="Server restarted while task was running.",
+        error="Server restarted while task was pending or running.",
     )
 
 

--- a/api/tests/test_async_maintenance.py
+++ b/api/tests/test_async_maintenance.py
@@ -81,8 +81,12 @@ class TestAsyncMaintenance:
 
 @pytest.mark.django_db
 class TestStartupRecovery:
-    def test_marks_running_tasks_as_failure_on_startup(self, user):
-        """Bug regression: RUNNING tasks stranded by a web pod restart must be failed."""
+    def test_marks_running_and_pending_tasks_as_failure_on_startup(self, user):
+        """RUNNING and PENDING tasks stranded by a web pod restart must both be failed.
+
+        PENDING tasks are stranded too: the in-memory thread pool they were submitted
+        to no longer exists after a restart, so they will never be picked up.
+        """
         running = AsyncTask.objects.create(
             user=user, task_type="ping", status=AsyncTask.Status.RUNNING
         )
@@ -101,5 +105,6 @@ class TestStartupRecovery:
 
         assert running.status == AsyncTask.Status.FAILURE
         assert "restarted" in running.error.lower()
-        assert pending.status == AsyncTask.Status.PENDING
+        assert pending.status == AsyncTask.Status.FAILURE
+        assert "restarted" in pending.error.lower()
         assert success.status == AsyncTask.Status.SUCCESS

--- a/chart/glaze/templates/deployment-web.yaml
+++ b/chart/glaze/templates/deployment-web.yaml
@@ -87,6 +87,16 @@ spec:
                   name: glaze-secrets
                   key: EMAIL_HOST_PASSWORD
                   optional: true
+            - name: MODAL_TOKEN_ID
+              valueFrom:
+                secretKeyRef:
+                  name: glaze-secrets
+                  key: MODAL_TOKEN_ID
+            - name: MODAL_TOKEN_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: glaze-secrets
+                  key: MODAL_TOKEN_SECRET
             - name: MODAL_AUTH_TOKEN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary

- **Root cause of immediate crop failures**: When Celery was dropped in #952, `modal.Function.from_name()` calls moved into the web pod's `ThreadPoolExecutor`. But `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` were only wired into the (now-deleted) worker deployment — the web pod never had them. Every `generate_cropped_image` task was failing immediately with a Modal authentication error.
- **Fix**: Add `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` to `deployment-web.yaml` from `glaze-secrets`.
- **Bonus fix**: Expand `_fail_running_tasks_on_startup()` to also mark `PENDING` tasks as `FAILURE`. After a pod restart the in-memory thread pool is gone, so PENDING tasks were orphaned and would spin forever rather than surfacing `crop_task_failed: true` to the frontend.

## Test plan

- [ ] Deploy to production; specify a crop on an image with an R2 key; skeleton appears and then resolves to the cropped image (no immediate failure)
- [ ] Verify `//api:api_test` passes (all 12 targets green in CI)
- [ ] Restart the web pod with a PENDING `AsyncTask` in the DB; confirm it is marked FAILURE on next startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)