### PR TITLE
fix(cd): fix helm_deploy.sh silently not applying chart changes

### DIFF
--- a/tools/helm_deploy.sh
+++ b/tools/helm_deploy.sh
@@ -14,9 +14,13 @@ SSH="ssh -o StrictHostKeyChecking=no"
 SCP="scp -o StrictHostKeyChecking=no"
 
 echo "==> Copying chart and values to ${DEPLOY_HOST}..."
-# Replace the chart directory wholesale so deleted templates don't persist
-# across deploys (scp -r merges rather than replacing).
-$SSH "${DEPLOY_HOST}" "rm -rf ~/glaze-chart-deploy/"
+# Keep the parent directory but delete only the chart subdirectory so that
+# deleted templates don't persist across deploys. Deleting the parent would
+# cause `scp -r chart/glaze host:~/glaze-chart-deploy/` to treat the missing
+# path as the chart's new name, placing chart contents at ~/glaze-chart-deploy/
+# instead of ~/glaze-chart-deploy/glaze/ — breaking the helm path.
+CHART_NAME="$(basename "${CHART_DIR}")"
+$SSH "${DEPLOY_HOST}" "mkdir -p ~/glaze-chart-deploy && rm -rf ~/glaze-chart-deploy/${CHART_NAME}"
 $SCP -r "${CHART_DIR}" "${DEPLOY_HOST}":~/glaze-chart-deploy/
 $SCP "${VALUES_FILE}" "${DEPLOY_HOST}":~/glaze-values-override.yaml
 
@@ -48,17 +52,27 @@ $SSH "${DEPLOY_HOST}" << 'ENDSSH'
     done
 
     echo "==> Applying Helm chart (no wait — rollouts are paused)..."
+    # Always resume deployments, even on helm failure, so paused pods don't
+    # get stuck. Capture helm's exit code explicitly — set -e doesn't
+    # propagate into background subshells so we must track it ourselves.
+    helm_exit=0
     helm upgrade --install glaze ~/glaze-chart-deploy/glaze/ \
       -f ~/glaze-values-override.yaml \
-      --timeout 5m
+      --timeout 5m || helm_exit=$?
 
     echo "==> Rolling deployments sequentially..."
     for dep in $SEQUENTIAL_DEPLOYMENTS; do
       echo "--- resuming $dep ---"
       kubectl rollout resume deployment/$dep -n default
-      kubectl rollout status deployment/$dep -n default --timeout=5m
-      echo "--- $dep ready ---"
+      if [ "$helm_exit" -eq 0 ]; then
+        kubectl rollout status deployment/$dep -n default --timeout=5m
+        echo "--- $dep ready ---"
+      else
+        echo "--- skipping rollout status: helm failed (exit $helm_exit) ---"
+      fi
     done
+
+    return $helm_exit
   }
 
   helm_upgrade() {


### PR DESCRIPTION
## Summary

Every Helm chart change since the `rm -rf ~/glaze-chart-deploy/` line was introduced has been silently ignored. The cluster has been running stale chart state across all recent deploys — including the deletion of `deployment-worker.yaml` in #952 and the Modal credential fix in #958.

### Bug 1: Wrong scp destination path

```bash
# Before (broken):
$SSH "${DEPLOY_HOST}" "rm -rf ~/glaze-chart-deploy/"          # deletes parent
$SCP -r "${CHART_DIR}" "${DEPLOY_HOST}":~/glaze-chart-deploy/ # scp treats missing path as new name
# Result: chart contents land at ~/glaze-chart-deploy/ (no glaze/ subdir)
# Helm: "Error: path /root/glaze-chart-deploy/glaze/ not found"

# After (fixed):
$SSH "${DEPLOY_HOST}" "mkdir -p ~/glaze-chart-deploy && rm -rf ~/glaze-chart-deploy/glaze"
$SCP -r "${CHART_DIR}" "${DEPLOY_HOST}":~/glaze-chart-deploy/
# Result: chart lands at ~/glaze-chart-deploy/glaze/ as expected
```

### Bug 2: Helm failure silently swallowed

`rollout_sequential` runs in a background subshell (`&`). `set -e` does not propagate into background subshells in bash, so when `helm upgrade` failed, the function continued, resumed the paused deployment, and returned 0. The retry loop and `show_failure_context` never triggered — CD reported success.

Fix: capture helm's exit code explicitly with `|| helm_exit=$?`, skip `rollout status` when helm failed, and `return $helm_exit` so `wait $HELM_PID` propagates the failure correctly.

## Test plan

- [ ] Merge and observe CD run — "Applying Helm chart" step should succeed (no "path not found" error)
- [ ] Verify `deployment-worker.yaml` deletion from #952 is applied (Celery worker deployment gone from cluster)
- [ ] Verify `MODAL_TOKEN_ID`/`MODAL_TOKEN_SECRET` from #958 are visible in the web pod env
- [ ] Confirm crop tasks succeed end-to-end after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)