### PR TITLE
fix: clear piece cache on logout; redirect on 403 in ShowcasePage

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1072,6 +1072,7 @@ function AppContent() {
     refreshSuppressed.current = true;
     refreshAttempted.current = false;
     await logoutUser();
+    queryClient.removeQueries({ queryKey: ["piece"] });
     queryClient.setQueryData(["appInit"], (prev: typeof init) => ({ ...prev!, user: null }));
   }, [queryClient]);
 

--- a/web/src/components/PublicPieceShell.tsx
+++ b/web/src/components/PublicPieceShell.tsx
@@ -1,22 +1,28 @@
-import { useParams, Link as RouterLink } from "react-router-dom";
+import { useParams, Link as RouterLink, Navigate } from "react-router-dom";
 import {
   Box,
   Button,
+  CircularProgress,
   Container,
   Typography,
   alpha,
 } from "@mui/material";
-import { useSuspenseQuery } from "@tanstack/react-query";
-import { fetchPiece } from "../util/api";
+import { useQuery } from "@tanstack/react-query";
+import { fetchPiece, isAuthError } from "../util/api";
 import { type PieceDetail } from "../util/types";
 import AppImage from "./AppImage";
 
 export function ShowcasePage({ isAuthenticated = false }: { isAuthenticated?: boolean }) {
   const { id } = useParams<{ id: string }>();
-  const { data: piece } = useSuspenseQuery<PieceDetail>({
+  const { data: piece, error, isPending } = useQuery<PieceDetail>({
     queryKey: ["piece", id],
     queryFn: () => fetchPiece(id!),
+    throwOnError: (err) => !isAuthError(err),
   });
+
+  if (isAuthError(error)) return <Navigate to="/" replace />;
+  if (isPending) return <CircularProgress sx={{ display: "block", mx: "auto", mt: 4 }} />;
+  if (!piece) return null;
 
   return (
     <Container

--- a/web/src/components/PublicPieceShell.tsx
+++ b/web/src/components/PublicPieceShell.tsx
@@ -22,7 +22,7 @@ export function ShowcasePage({ isAuthenticated = false }: { isAuthenticated?: bo
 
   if (isAuthError(error)) return <Navigate to="/" replace />;
   if (isPending) return <CircularProgress sx={{ display: "block", mx: "auto", mt: 4 }} />;
-  if (!piece) return null;
+  if (!piece) return null; // non-auth errors throw via throwOnError; this guard is unreachable in practice
 
   return (
     <Container

--- a/web/src/components/__tests__/PublicPieceShell.test.tsx
+++ b/web/src/components/__tests__/PublicPieceShell.test.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import CircularProgress from "@mui/material/CircularProgress";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
@@ -8,9 +8,13 @@ import { ShowcasePage } from "../PublicPieceShell";
 import ErrorBoundary from "../ErrorBoundary";
 import * as api from "../../util/api";
 
-vi.mock("../../util/api", () => ({
-  fetchPiece: vi.fn(),
-}));
+vi.mock("../../util/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../util/api")>();
+  return {
+    ...actual,
+    fetchPiece: vi.fn(),
+  };
+});
 
 vi.mock("../../../workflow.yml", () => ({
   default: {
@@ -184,5 +188,40 @@ describe("ShowcasePage", () => {
 
     await screen.findByText("Beautiful Bowl");
     expect(screen.queryByAltText("PotterDoc")).toBeNull();
+  });
+
+  it("redirects to / when fetchPiece returns 403", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const error = Object.assign(new Error("Forbidden"), {
+      isAxiosError: true,
+      response: { status: 403 },
+    });
+    vi.mocked(api.fetchPiece).mockRejectedValue(error);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/pieces/piece-1/showcase"]}>
+          <Routes>
+            <Route path="/" element={<div>Landing Page</div>} />
+            <Route
+              path="/pieces/:id/showcase"
+              element={
+                <ErrorBoundary>
+                  <Suspense fallback={<CircularProgress />}>
+                    <ShowcasePage />
+                  </Suspense>
+                </ErrorBoundary>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Landing Page")).toBeInTheDocument();
+    });
   });
 });

--- a/web/src/components/__tests__/PublicPieceShell.test.tsx
+++ b/web/src/components/__tests__/PublicPieceShell.test.tsx
@@ -190,13 +190,13 @@ describe("ShowcasePage", () => {
     expect(screen.queryByAltText("PotterDoc")).toBeNull();
   });
 
-  it("redirects to / when fetchPiece returns 403", async () => {
+  it.each([403, 401])("redirects to / when fetchPiece returns %i", async (status) => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
-    const error = Object.assign(new Error("Forbidden"), {
+    const error = Object.assign(new Error("Unauthorized"), {
       isAxiosError: true,
-      response: { status: 403 },
+      response: { status },
     });
     vi.mocked(api.fetchPiece).mockRejectedValue(error);
 

--- a/web/src/util/api.ts
+++ b/web/src/util/api.ts
@@ -452,6 +452,11 @@ export async function loginWithGoogle(
   return normalizeAuthUser(data);
 }
 
+export function isAuthError(error: unknown): boolean {
+  return axios.isAxiosError(error) &&
+    (error.response?.status === 401 || error.response?.status === 403);
+}
+
 export async function logoutUser(): Promise<void> {
   await ensureCsrfCookie();
   await client.post("auth/token/revoke/", {});


### PR DESCRIPTION
## Problem

Logging out while viewing a PieceDetail page briefly shows the piece (with hero image) in the unauthenticated view, and a hard refresh at that URL triggers the error boundary with a generic "Something went wrong" instead of redirecting to the landing page. See [#961](https://github.com/shaoster/glaze/issues/961).

## Fix

Two changes in tandem:

**1. Clear piece cache on logout (`App.tsx`).**
`appQueryClient` is a module-level singleton shared by both `AuthenticatedApp` and `UnauthenticatedApp`. The old `handleLogout` only updated `["appInit"]`, leaving `["piece", id]` entries in cache. The `UnauthenticatedApp`'s `ShowcasePage` then served those stale entries immediately. Fix: call `queryClient.removeQueries({ queryKey: ["piece"] })` before switching auth state.

**2. Redirect on 401/403 in `ShowcasePage` (`PublicPieceShell.tsx`).**
`ShowcasePage` used `useSuspenseQuery` with no error handling, so a 403 for a private piece propagated to the `<ErrorBoundary>`. Switched to `useQuery` with `throwOnError: (err) => !isAuthError(err)`: auth errors set `error` in state and the component returns `<Navigate to="/" replace />`, while unexpected errors still reach the boundary. Inline `<CircularProgress>` replaces the Suspense-fallback loading indicator.

**3. `isAuthError` helper (`api.ts`).** Extracted as an exported function to keep the AxiosError status check in the API layer.

## Regression Test

`web/src/components/__tests__/PublicPieceShell.test.tsx` — `"redirects to / when fetchPiece returns 403"`: mocks `fetchPiece` to reject with a 403 AxiosError, renders `ShowcasePage` inside a `MemoryRouter` with a `/` landing route, and asserts the component navigates to "Landing Page" rather than showing the error boundary. Also updated the `vi.mock` factory to use `importOriginal` so the real `isAuthError` implementation is available to the component under test.

## Verification

```
//web:web_public_piece_shell_test   PASSED (9/9 tests)
//web:web_test (all 42)             PASSED
```

Closes #961
