### PR TITLE
fix(web): update positioner at image-load time to prevent "End of pieces" overlap

### DIFF
--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -534,9 +534,7 @@ const PieceList = (props: PieceListProps) => {
     [positioner],
   );
 
-  // Must be stable: masonic's trieMemoize keys on the render function reference;
-  // a new reference on each forceUpdate causes PieceCard to unmount/remount and
-  // re-fires onLoad on cached images, creating an infinite update loop.
+  // Stable ref required: trieMemoize keys on render function; a new ref unmounts/remounts PieceCard and re-fires onLoad.
   const renderPieceCard = useCallback(
     ({
       data,

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -522,6 +522,8 @@ const PieceList = (props: PieceListProps) => {
   const resizeObserver = useResizeObserver(positioner);
 
   const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
+  // masonic always passes positioner.columnWidth as the card's width prop, so
+  // using positioner.columnWidth here matches the rendered card width exactly.
   const onCardDimensionsLoaded = useCallback(
     (idx: number, naturalWidth: number, naturalHeight: number) => {
       const newHeight =

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -2,6 +2,7 @@ import React, {
   useCallback,
   useEffect,
   useMemo,
+  useReducer,
   useRef,
   useState,
 } from "react";
@@ -34,6 +35,7 @@ import {
   useResizeObserver,
 } from "masonic";
 import {
+  CARD_CHROME_HEIGHT,
   DEFAULT_CARD_HEIGHT_ESTIMATE,
   getPieceCardLayout,
 } from "./pieceCardHeight";
@@ -118,10 +120,16 @@ function daysSince(date: Date): number {
 interface PieceCardProps {
   piece: PieceSummary;
   width: number;
+  index: number;
   returnTo: { pathname: string; search: string; hash: string } | null;
+  onDimensionsLoaded?: (
+    index: number,
+    naturalWidth: number,
+    naturalHeight: number,
+  ) => void;
 }
 
-const PieceCard = ({ piece, width, returnTo }: PieceCardProps) => {
+const PieceCard = ({ piece, width, index, returnTo, onDimensionsLoaded }: PieceCardProps) => {
   const theme = useTheme();
   const isTerminal = isTerminalState(piece.current_state.state);
   const days = daysSince(new Date(piece.last_modified));
@@ -198,6 +206,7 @@ const PieceCard = ({ piece, width, returnTo }: PieceCardProps) => {
               setThumbnailAspectRatio(
                 `${img.naturalWidth} / ${img.naturalHeight}`,
               );
+              onDimensionsLoaded?.(index, img.naturalWidth, img.naturalHeight);
             }
           }}
         />
@@ -511,6 +520,18 @@ const PieceList = (props: PieceListProps) => {
     return nextPositioner;
   }, [pieces, masonryWidth, columnWidth, isMobile]);
   const resizeObserver = useResizeObserver(positioner);
+
+  const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
+  const onCardDimensionsLoaded = useCallback(
+    (idx: number, naturalWidth: number, naturalHeight: number) => {
+      const newHeight =
+        Math.round((positioner.columnWidth * naturalHeight) / naturalWidth) +
+        CARD_CHROME_HEIGHT;
+      positioner.update([idx, newHeight]);
+      forceUpdate();
+    },
+    [positioner],
+  );
 
   const toggleFilter = useCallback(
     (filter: FilterCategory) => {
@@ -914,6 +935,7 @@ const PieceList = (props: PieceListProps) => {
                 items={pieces}
                 render={({
                   data,
+                  index,
                   width,
                 }: {
                   data: PieceSummary;
@@ -922,7 +944,9 @@ const PieceList = (props: PieceListProps) => {
                 }) => (
                   <PieceCard
                     piece={data}
+                    index={index}
                     width={width}
+                    onDimensionsLoaded={onCardDimensionsLoaded}
                     returnTo={{
                       pathname: location.pathname,
                       search: location.search,

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -530,14 +530,39 @@ const PieceList = (props: PieceListProps) => {
         Math.round((positioner.columnWidth * naturalHeight) / naturalWidth) +
         CARD_CHROME_HEIGHT;
       positioner.update([idx, newHeight]);
-      // Defer the re-render to a separate task so it doesn't batch with
-      // setThumbnailAspectRatio. Batching both would cause masonic to re-render
-      // with updated positions in the same commit as the card growing, shifting
-      // items below the changed card out of the virtual viewport range and
-      // causing them to be unmounted mid-click by Playwright.
-      setTimeout(forceUpdate, 0);
+      forceUpdate();
     },
     [positioner],
+  );
+
+  // Stable render prop — must be memoized so createRenderElement (trieMemoize)
+  // gets a consistent function reference across forceUpdate re-renders.
+  // A changing reference causes React to see a type mismatch on the inner
+  // element, unmounting and remounting PieceCard, which re-fires onLoad on
+  // cached images and creates an infinite re-render loop.
+  const renderPieceCard = useCallback(
+    ({
+      data,
+      index,
+      width,
+    }: {
+      data: PieceSummary;
+      index: number;
+      width: number;
+    }) => (
+      <PieceCard
+        piece={data}
+        index={index}
+        width={width}
+        onDimensionsLoaded={onCardDimensionsLoaded}
+        returnTo={{
+          pathname: location.pathname,
+          search: location.search,
+          hash: location.hash,
+        }}
+      />
+    ),
+    [onCardDimensionsLoaded, location.pathname, location.search, location.hash],
   );
 
   const toggleFilter = useCallback(
@@ -940,27 +965,7 @@ const PieceList = (props: PieceListProps) => {
                 positioner={positioner}
                 resizeObserver={resizeObserver}
                 items={pieces}
-                render={({
-                  data,
-                  index,
-                  width,
-                }: {
-                  data: PieceSummary;
-                  index: number;
-                  width: number;
-                }) => (
-                  <PieceCard
-                    piece={data}
-                    index={index}
-                    width={width}
-                    onDimensionsLoaded={onCardDimensionsLoaded}
-                    returnTo={{
-                      pathname: location.pathname,
-                      search: location.search,
-                      hash: location.hash,
-                    }}
-                  />
-                )}
+                render={renderPieceCard}
                 itemKey={(piece) => piece.id}
                 itemHeightEstimate={DEFAULT_CARD_HEIGHT_ESTIMATE}
                 offset={masonryOffset}

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -530,7 +530,12 @@ const PieceList = (props: PieceListProps) => {
         Math.round((positioner.columnWidth * naturalHeight) / naturalWidth) +
         CARD_CHROME_HEIGHT;
       positioner.update([idx, newHeight]);
-      forceUpdate();
+      // Defer the re-render to a separate task so it doesn't batch with
+      // setThumbnailAspectRatio. Batching both would cause masonic to re-render
+      // with updated positions in the same commit as the card growing, shifting
+      // items below the changed card out of the virtual viewport range and
+      // causing them to be unmounted mid-click by Playwright.
+      setTimeout(forceUpdate, 0);
     },
     [positioner],
   );

--- a/web/src/components/PieceList.tsx
+++ b/web/src/components/PieceList.tsx
@@ -522,8 +522,7 @@ const PieceList = (props: PieceListProps) => {
   const resizeObserver = useResizeObserver(positioner);
 
   const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
-  // masonic always passes positioner.columnWidth as the card's width prop, so
-  // using positioner.columnWidth here matches the rendered card width exactly.
+  // positioner.columnWidth matches the width masonic passes to each card.
   const onCardDimensionsLoaded = useCallback(
     (idx: number, naturalWidth: number, naturalHeight: number) => {
       const newHeight =
@@ -535,11 +534,9 @@ const PieceList = (props: PieceListProps) => {
     [positioner],
   );
 
-  // Stable render prop — must be memoized so createRenderElement (trieMemoize)
-  // gets a consistent function reference across forceUpdate re-renders.
-  // A changing reference causes React to see a type mismatch on the inner
-  // element, unmounting and remounting PieceCard, which re-fires onLoad on
-  // cached images and creates an infinite re-render loop.
+  // Must be stable: masonic's trieMemoize keys on the render function reference;
+  // a new reference on each forceUpdate causes PieceCard to unmount/remount and
+  // re-fires onLoad on cached images, creating an infinite update loop.
   const renderPieceCard = useCallback(
     ({
       data,

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -466,9 +466,6 @@ describe("PieceList", () => {
     });
 
     it("calls positioner.update() with actual height when a tall image loads without stored dimensions", () => {
-      // Regression: without this fix, the masonic container's height CSS stayed at
-      // the pre-seeded 4:3 estimate until the ResizeObserver fired (~16ms later),
-      // letting tall cards overflow and overlap the "End of pieces" footer.
       const piece = makePiece({
         thumbnail: { url: "https://cdn.example.com/img.jpg" },
       });
@@ -479,8 +476,6 @@ describe("PieceList", () => {
       Object.defineProperty(img, "naturalHeight", { value: 300 });
       fireEvent.load(img);
 
-      // positioner.update([index, height]) must fire so that the masonic container
-      // height and the card's aspect ratio update in the same React commit.
       const expectedHeight =
         Math.round((mockPositioner.columnWidth * 300) / 100) +
         CARD_CHROME_HEIGHT;
@@ -488,7 +483,6 @@ describe("PieceList", () => {
     });
 
     it("does not call positioner.update() on image load when stored dimensions are present", () => {
-      // When dimensions are stored, the pre-seeded height is already correct.
       const piece = makePiece({
         thumbnail: {
           url: "https://cdn.example.com/img.jpg",

--- a/web/src/components/__tests__/PieceList.test.tsx
+++ b/web/src/components/__tests__/PieceList.test.tsx
@@ -464,6 +464,47 @@ describe("PieceList", () => {
         Number(cards[0].getAttribute("data-estimated-height")),
       ).toBeGreaterThan(DEFAULT_CARD_HEIGHT_ESTIMATE);
     });
+
+    it("calls positioner.update() with actual height when a tall image loads without stored dimensions", () => {
+      // Regression: without this fix, the masonic container's height CSS stayed at
+      // the pre-seeded 4:3 estimate until the ResizeObserver fired (~16ms later),
+      // letting tall cards overflow and overlap the "End of pieces" footer.
+      const piece = makePiece({
+        thumbnail: { url: "https://cdn.example.com/img.jpg" },
+      });
+      const { container } = renderPieceList([piece]);
+
+      const img = container.querySelector("img")!;
+      Object.defineProperty(img, "naturalWidth", { value: 100 });
+      Object.defineProperty(img, "naturalHeight", { value: 300 });
+      fireEvent.load(img);
+
+      // positioner.update([index, height]) must fire so that the masonic container
+      // height and the card's aspect ratio update in the same React commit.
+      const expectedHeight =
+        Math.round((mockPositioner.columnWidth * 300) / 100) +
+        CARD_CHROME_HEIGHT;
+      expect(mockPositioner.update).toHaveBeenCalledWith([0, expectedHeight]);
+    });
+
+    it("does not call positioner.update() on image load when stored dimensions are present", () => {
+      // When dimensions are stored, the pre-seeded height is already correct.
+      const piece = makePiece({
+        thumbnail: {
+          url: "https://cdn.example.com/img.jpg",
+          width: 100,
+          height: 300,
+        },
+      });
+      const { container } = renderPieceList([piece]);
+
+      const img = container.querySelector("img")!;
+      Object.defineProperty(img, "naturalWidth", { value: 100 });
+      Object.defineProperty(img, "naturalHeight", { value: 300 });
+      fireEvent.load(img);
+
+      expect(mockPositioner.update).not.toHaveBeenCalled();
+    });
   });
 
   describe("estimateCardHeight", () => {


### PR DESCRIPTION
## Problem

Closes #960

When pieces have no stored `thumbnail.width`/`thumbnail.height`, the masonry
positioner is pre-seeded with a 4:3 fallback height. On image load,
`setThumbnailAspectRatio` grows the card to its actual (possibly much taller)
dimensions, but the masonic container's `height` CSS value didn't update until the
`ResizeObserver` fired ~16ms later. During that window, tall cards overflowed the
container's clipped bounds and visually overlapped the "End of pieces" footer placed
immediately after in normal flow.

## Fix

Add an `onDimensionsLoaded` callback threaded from `PieceListContent` down to
`PieceCard`. When `onLoad` fires with actual image dimensions, `PieceCard` calls this
callback alongside `setThumbnailAspectRatio`. The callback eagerly calls
`positioner.update([index, newHeight])` and triggers a local `forceUpdate`. React 18
automatic batching applies both updates — the card's aspect ratio and the masonic
container height — in a single DOM commit, eliminating the overflow window entirely.

**Changed files:** `web/src/components/PieceList.tsx` only.

## Regression Test

`web/src/components/__tests__/PieceList.test.tsx` — two new tests in the
`"masonry height pre-seeding"` describe block:

1. **`calls positioner.update() with actual height when a tall image loads without stored dimensions`** — simulates `fireEvent.load` with `naturalWidth=100, naturalHeight=300` on a piece without stored dimensions; asserts `positioner.update([0, expectedHeight])` is called.
2. **`does not call positioner.update() on image load when stored dimensions are present`** — same load event on a piece with stored dimensions; asserts `positioner.update` is NOT called.

## Verification

```
//web:web_piece_list_test   PASSED  (63/63 tests)
//web:web_test              PASSED  (42/42 targets)
//web:...lint               PASSED  (tsc + eslint)
```
