### PR TITLE
fix(api): clamp crop bounds instead of rejecting pixel-rounding overflow

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -279,10 +279,6 @@ class ImageCropInputSerializer(ImageCropSerializer):
     only as the direct request body for PATCH /api/images/{image_id}/crop/.
     """
 
-    # Tolerance for floating-point round-off when the client computes x and width
-    # independently from pixel coordinates (e.g. 0.9/23 + 22.1/23 ≈ 1.0 + ε).
-    _EPSILON = 1e-9
-
     def validate(self, data):
         errors = {}
         for field in ("x", "y", "width", "height"):
@@ -293,12 +289,15 @@ class ImageCropInputSerializer(ImageCropSerializer):
                 errors["width"] = "Must be greater than 0."
             if data["height"] <= 0:
                 errors["height"] = "Must be greater than 0."
-            if data["x"] + data["width"] > 1.0 + self._EPSILON:
-                errors["width"] = "x + width must not exceed 1.0."
-            if data["y"] + data["height"] > 1.0 + self._EPSILON:
-                errors["height"] = "y + height must not exceed 1.0."
         if errors:
             raise serializers.ValidationError(errors)
+        # Clamp the sum to 1.0 rather than reject. The crop UI computes
+        # coordinates as pixel/imageDimension; a single-pixel rounding error
+        # pushes the sum above 1.0 by up to ~1/imageDimension (e.g. 1e-3 for
+        # a 1000px image), which is larger than any fixed epsilon can safely
+        # allow without becoming meaningless.
+        data["width"] = min(data["width"], 1.0 - data["x"])
+        data["height"] = min(data["height"], 1.0 - data["y"])
         return data
 
 

--- a/api/tests/test_patch_image_crop.py
+++ b/api/tests/test_patch_image_crop.py
@@ -174,8 +174,6 @@ class TestPatchImageCrop:
         {"x": 0.0, "y": 0.0, "width": 0.5, "height": 1.1},
         {"x": 0.0, "y": 0.0, "width": 0.0, "height": 0.5},
         {"x": 0.0, "y": 0.0, "width": 0.5, "height": 0.0},
-        {"x": 0.6, "y": 0.0, "width": 0.5, "height": 0.5},  # x + width > 1
-        {"x": 0.0, "y": 0.6, "width": 0.5, "height": 0.5},  # y + height > 1
     ],
 )
 class TestPatchImageCropValidation:
@@ -192,12 +190,12 @@ class TestPatchImageCropValidation:
 
 
 @pytest.mark.django_db
-class TestPatchImageCropEpsilonTolerance:
+class TestPatchImageCropClamp:
     def test_floating_point_sum_just_over_one_is_accepted(
         self, client, image_in_editable_piece
     ):
         # 0.9/23 + 22.1/23 produces a sum slightly above 1.0 due to float division;
-        # the endpoint must tolerate this rather than returning 400.
+        # the endpoint must accept this (pixel-level rounding from the crop UI).
         x = 0.9 / 23
         width = 22.1 / 23
         assert x + width > 1.0, "precondition: sum exceeds 1.0 due to float round-off"
@@ -207,3 +205,27 @@ class TestPatchImageCropEpsilonTolerance:
             format="json",
         )
         assert response.status_code == 200
+
+    def test_width_clamped_to_one_minus_x(self, client, image_in_editable_piece):
+        # x=0.6 + width=0.5 = 1.1; width should be clamped to 0.4.
+        image = image_in_editable_piece
+        response = client.patch(
+            f"/api/images/{image.id}/crop/",
+            {"x": 0.6, "y": 0.0, "width": 0.5, "height": 0.5},
+            format="json",
+        )
+        assert response.status_code == 200
+        link = PieceStateImage.objects.get(image=image)
+        assert link.crop["width"] == pytest.approx(0.4)
+
+    def test_height_clamped_to_one_minus_y(self, client, image_in_editable_piece):
+        # y=0.6 + height=0.5 = 1.1; height should be clamped to 0.4.
+        image = image_in_editable_piece
+        response = client.patch(
+            f"/api/images/{image.id}/crop/",
+            {"x": 0.0, "y": 0.6, "width": 0.5, "height": 0.5},
+            format="json",
+        )
+        assert response.status_code == 200
+        link = PieceStateImage.objects.get(image=image)
+        assert link.crop["height"] == pytest.approx(0.4)


### PR DESCRIPTION
## Summary

- `ImageCropInputSerializer.validate()` was rejecting crops where `y + height > 1.0 + 1e-9`, returning HTTP 400
- The crop UI in `CropOverlay.tsx` computes normalized coordinates as `pixel / imageDimension`; for a 1000px image, a single-pixel rounding error pushes the sum above 1.0 by ~0.001 — far larger than any fixed epsilon can safely gate
- Fix: replace the sum-rejection with a clamp (`width = min(width, 1.0 - x)`, `height = min(height, 1.0 - y)`) so a rounding-induced overflow is silently corrected rather than surfaced as an error

## Test plan

- Removed the two parametrized `TestPatchImageCropValidation` cases that tested `x + width > 1` and `y + height > 1` as invalid (they are now accepted and clamped)
- Added `TestPatchImageCropClamp` with three regression tests:
  - Float-rounding scenario (`0.9/23 + 22.1/23 > 1.0`) returns 200
  - `x=0.6 + width=0.5` is accepted and `width` is clamped to 0.4
  - `y=0.6 + height=0.5` is accepted and `height` is clamped to 0.4
- All 12 `//api:api_test` targets pass

Fixes #961

🤖 Generated with [Claude Code](https://claude.com/claude-code)