### PR TITLE
fix(images): resolve jpeg_conversion derivative in normalize_image_payload

### DIFF
--- a/api/tests/test_piece_detail.py
+++ b/api/tests/test_piece_detail.py
@@ -485,6 +485,32 @@ class TestPieceDetail:
         }
         assert piece.thumbnail == {"url": thumbnail["url"], "r2_key": None}
 
+    def test_patch_thumbnail_resolves_to_jpeg_derivative(self, client, piece, monkeypatch):
+        """Sending the pre-normalization URL must result in thumbnail pointing at the derivative."""
+        from api.models import Image
+
+        monkeypatch.setattr("api.r2.key_for_public_url", lambda url: None)
+
+        source = Image.objects.create(
+            user=piece.user, url="https://media.example.com/images/1/orig.jpg"
+        )
+        derivative = Image.objects.create(
+            user=piece.user,
+            url="https://media.example.com/images/1/new.jpg",
+            derived_from=source,
+            derived_type="jpeg_conversion",
+        )
+
+        response = client.patch(
+            f"/api/pieces/{piece.id}/",
+            {"thumbnail": {"url": source.url}},
+            format="json",
+        )
+
+        assert response.status_code == 200
+        piece.refresh_from_db()
+        assert piece.thumbnail_id == derivative.id
+
     def test_owner_can_share_completed_piece(self, client, piece):
         PieceState.objects.create(
             user=piece.user,

--- a/api/tests/test_utils.py
+++ b/api/tests/test_utils.py
@@ -13,6 +13,7 @@ from api.models import (
 from api.utils import (
     _is_crop_task_failed,
     crop_to_dict,
+    normalize_image_payload,
     replace_piece_state_images,
     sync_glaze_type_singleton_combination,
 )
@@ -279,3 +280,40 @@ class TestIsCropTaskFailed:
         image = self._make_image(user)
         self._make_task(user, image, CROP_A, AsyncTask.Status.FAILURE)
         assert not _is_crop_task_failed(image.id, image.r2_key, None)
+
+
+@pytest.mark.django_db
+class TestNormalizeImagePayload:
+    def test_resolves_to_jpeg_conversion_derivative(self, user, monkeypatch):
+        """normalize_image_payload must return the jpeg_conversion derivative, not the source."""
+        monkeypatch.setattr("api.r2.key_for_public_url", lambda url: None)
+
+        source = Image.objects.create(
+            user=user, url="https://media.example.com/images/1/orig.jpg"
+        )
+        derivative = Image.objects.create(
+            user=user,
+            url="https://media.example.com/images/1/new.jpg",
+            derived_from=source,
+            derived_type="jpeg_conversion",
+        )
+
+        result = normalize_image_payload(source.url, user=user)
+        assert result.id == derivative.id
+
+    def test_does_not_resolve_non_jpeg_derivative(self, user, monkeypatch):
+        """normalize_image_payload must NOT resolve crop or other derivative types."""
+        monkeypatch.setattr("api.r2.key_for_public_url", lambda url: None)
+
+        source = Image.objects.create(
+            user=user, url="https://media.example.com/images/1/orig.jpg"
+        )
+        Image.objects.create(
+            user=user,
+            url="https://media.example.com/images/1/crop.jpg",
+            derived_from=source,
+            derived_type="crop",
+        )
+
+        result = normalize_image_payload(source.url, user=user)
+        assert result.id == source.id

--- a/api/utils.py
+++ b/api/utils.py
@@ -314,7 +314,13 @@ def normalize_image_payload(payload: object, user=None):
     if not created and image.r2_key is None and defaults["r2_key"]:
         image.r2_key = defaults["r2_key"]
         image.save(update_fields=["r2_key"])
-    return image
+    # Always resolve to the jpeg_conversion derivative when one exists so that
+    # crop lookups (which join on thumbnail_id / image_id) remain valid after
+    # JPEG normalization redirects PieceStateImage rows to the derivative.
+    jpeg_derivative = (
+        image.derivatives.filter(derived_type="jpeg_conversion").order_by("id").first()
+    )
+    return jpeg_derivative if jpeg_derivative is not None else image
 
 
 def _is_crop_task_failed(image_id, r2_key: str | None, crop: dict | None) -> bool:


### PR DESCRIPTION
## Problem

When a user sets a piece thumbnail via the API, \`normalize_image_payload\` looks up the Image by URL using \`get_or_create\`. If the client sends the pre-normalization URL (i.e. the original JPEG before the EXIF backfill ran), it returns the pre-normalization Image row — not the \`jpeg_conversion\` derivative that all \`PieceStateImage\` rows now reference. The crop lookup matches on \`thumbnail_id\`, so it finds no PSI link and returns \`crop=null\`, silently breaking cropped display for that thumbnail.

This is the companion to the \`convert_image_to_jpeg\` task fix (which now also redirects \`Piece.thumbnail\` after normalization). Together they close all three paths through which a stale thumbnail FK can arise:

1. ✅ Task runs → now updates \`Piece.thumbnail\` atomically with PSI rows
2. ✅ Client sends pre-normalization URL to set thumbnail → this PR resolves to derivative
3. ✅ Stale production rows → bulk-fixed in prod (37 pieces)

## Fix

In \`api/utils.py\` → \`normalize_image_payload\`, after \`get_or_create\`, check for a \`jpeg_conversion\` derivative and return it if found. One extra query, no-op for fresh or already-normalized images.

## Regression Tests

- \`TestNormalizeImagePayload::test_resolves_to_jpeg_conversion_derivative\` — unit test verifying the derivative is returned when one exists
- \`TestNormalizeImagePayload::test_does_not_resolve_non_jpeg_derivative\` — confirms crop derivatives are not incorrectly resolved
- \`TestPieceDetailUpdate::test_patch_thumbnail_resolves_to_jpeg_derivative\` — integration test through the full PATCH endpoint

## Verification

```
//api:api_model_test   PASSED
//api:api_piece_test   PASSED
//api:api_test (all 12) PASSED
```

Closes #971