### PR TITLE
fix: remove django.contrib.sites; clear stale PSI crops on JPEG normalization

### DIFF
--- a/api/tasks.py
+++ b/api/tasks.py
@@ -412,7 +412,8 @@ def convert_image_to_jpeg(task: AsyncTask) -> dict:
     # Re-enqueue a crop task for each affected (jpeg_image, crop) pair so the
     # correct derivative is materialized from the normalized JPEG pixel data.
     for crop in crops_to_reenqueue:
-        enqueue_generate_cropped_image(jpeg_image, crop, user=task.user)
+        if isinstance(crop, dict):
+            enqueue_generate_cropped_image(jpeg_image, crop, user=task.user)
 
     return {
         "status": "success",

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -394,7 +394,11 @@ def convert_image_to_jpeg(task: AsyncTask) -> dict:
     )
     # Redirect any existing PSI rows that reference the HEIC/AVIF/non-JPEG
     # source to the new JPEG so they immediately serve a browser-renderable URL.
-    PieceStateImage.objects.filter(image=source_image).update(image=jpeg_image)
+    # Clear cropped_image so that stale crop derivatives (computed from the old
+    # EXIF-intact source) are not served after normalization (#974).
+    PieceStateImage.objects.filter(image=source_image).update(
+        image=jpeg_image, cropped_image=None
+    )
 
     return {
         "status": "success",

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -381,6 +381,7 @@ def convert_image_to_jpeg(task: AsyncTask) -> dict:
             defaults={"r2_key": source_key, "user": task.user},
         )
 
+    from .crops import enqueue_generate_cropped_image  # noqa: PLC0415
     from .models import PieceStateImage  # noqa: PLC0415
 
     jpeg_image = Image.objects.create(
@@ -392,6 +393,15 @@ def convert_image_to_jpeg(task: AsyncTask) -> dict:
         derived_from=source_image,
         derived_type="jpeg_conversion",
     )
+    # Collect distinct crop values from affected PSIs before the bulk update so
+    # we can re-enqueue generate_cropped_image tasks after the redirect.  Doing
+    # this before the update avoids a second query on the now-redirected rows.
+    crops_to_reenqueue = list(
+        PieceStateImage.objects.filter(image=source_image)
+        .exclude(crop=None)
+        .values_list("crop", flat=True)
+        .distinct()
+    )
     # Redirect any existing PSI rows that reference the HEIC/AVIF/non-JPEG
     # source to the new JPEG so they immediately serve a browser-renderable URL.
     # Clear cropped_image so that stale crop derivatives (computed from the old
@@ -399,6 +409,10 @@ def convert_image_to_jpeg(task: AsyncTask) -> dict:
     PieceStateImage.objects.filter(image=source_image).update(
         image=jpeg_image, cropped_image=None
     )
+    # Re-enqueue a crop task for each affected (jpeg_image, crop) pair so the
+    # correct derivative is materialized from the normalized JPEG pixel data.
+    for crop in crops_to_reenqueue:
+        enqueue_generate_cropped_image(jpeg_image, crop, user=task.user)
 
     return {
         "status": "success",

--- a/api/tests/test_admin_scope.py
+++ b/api/tests/test_admin_scope.py
@@ -9,7 +9,22 @@ from django.test import Client
 from api.models import AsyncTask, Image
 
 
+@pytest.mark.django_db
 class TestAuthAdminLogin:
+    def test_admin_login_does_not_500_without_site_record(self):
+        """Regression for #973: admin login must not 500 when no Site DB record exists.
+
+        django.contrib.sites was in INSTALLED_APPS but unused; its domain-based
+        Site lookup in LoginView.get_context_data raised Site.DoesNotExist → 500.
+        Fix: remove django.contrib.sites from INSTALLED_APPS so get_current_site
+        falls back to RequestSite (no DB lookup).
+        """
+        browser = Client()
+        response = browser.get("/admin/login/")
+        assert response.status_code != 500, (
+            "admin login returned 500 — Site.DoesNotExist from django.contrib.sites"
+        )
+
     def test_admin_login_redirects_to_apex_bootstrap(self, settings):
         settings.ADMIN_INGRESS_HOST = "admin.potterdoc.com"
         settings.ALLOWED_HOSTS = [

--- a/api/tests/test_convert_image_to_jpeg.py
+++ b/api/tests/test_convert_image_to_jpeg.py
@@ -191,6 +191,61 @@ class TestConvertImageToJpegTask:
         assert jpeg_image.derived_from_id == source_image.id
         assert jpeg_image.derived_type == "jpeg_conversion"
 
+    def test_clears_cropped_image_when_redirecting_psi_to_jpeg(
+        self, user, r2_env, monkeypatch
+    ):
+        """Regression for #974: stale crop derivatives must be cleared on redirect.
+
+        convert_image_to_jpeg redirects PSI.image to the new JPEG but must also
+        clear PSI.cropped_image so that the stale crop (derived from the old
+        EXIF-intact source) is not served after normalization.
+        """
+        from api.crops import crop_key_for
+        from api.models import AsyncTask, Image, Piece, PieceState, PieceStateImage
+        from api.tasks import convert_image_to_jpeg
+        from api.workflow import ENTRY_STATE
+
+        source_image = Image.objects.create(
+            user=user,
+            url=f"https://media.example.com/images/{user.id}/orig.jpg",
+            r2_key=f"images/{user.id}/orig.jpg",
+        )
+        # Simulate a pre-existing crop derivative computed from the old source.
+        crop_def = {"x": 0.1, "y": 0.2, "width": 0.6, "height": 0.5}
+        stale_crop = Image.objects.create(
+            user=user,
+            url=f"https://media.example.com/{crop_key_for(source_image.r2_key, crop_def)}",
+            r2_key=crop_key_for(source_image.r2_key, crop_def),
+            derived_from=source_image,
+            derived_type="crop",
+        )
+        piece = Piece.objects.create(user=user, name="Test", is_editable=True)
+        state = PieceState.objects.create(
+            piece=piece, user=user, state=ENTRY_STATE, order=1
+        )
+        psi = PieceStateImage.objects.create(
+            piece_state=state,
+            image=source_image,
+            crop=crop_def,
+            cropped_image=stale_crop,
+            order=0,
+        )
+        assert psi.cropped_image_id == stale_crop.id  # sanity
+
+        self._mock_modal(monkeypatch)
+        task = AsyncTask.objects.create(
+            user=user,
+            task_type="convert_image_to_jpeg",
+            input_params={"key": source_image.r2_key, "image_id": str(source_image.id)},
+        )
+        convert_image_to_jpeg(task)
+
+        psi.refresh_from_db()
+        assert psi.cropped_image_id is None, (
+            "stale crop derivative must be cleared when PSI is redirected to the "
+            "normalized JPEG"
+        )
+
 
 # ---------------------------------------------------------------------------
 # POST /api/uploads/r2/convert-image/

--- a/api/tests/test_convert_image_to_jpeg.py
+++ b/api/tests/test_convert_image_to_jpeg.py
@@ -245,6 +245,14 @@ class TestConvertImageToJpegTask:
             "stale crop derivative must be cleared when PSI is redirected to the "
             "normalized JPEG"
         )
+        # A generate_cropped_image task must be enqueued for the new JPEG so
+        # the correct crop is materialized rather than left pending indefinitely.
+        jpeg_image = Image.objects.get(url__endswith=".jpg", derived_type="jpeg_conversion")
+        assert AsyncTask.objects.filter(
+            task_type="generate_cropped_image",
+            input_params__image_id=str(jpeg_image.id),
+            input_params__crop=crop_def,
+        ).exists(), "generate_cropped_image task must be enqueued for the new JPEG"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -97,7 +97,6 @@ INSTALLED_APPS = [
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.humanize",
-    "django.contrib.sites",
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",

--- a/backend/test_settings.py
+++ b/backend/test_settings.py
@@ -80,7 +80,6 @@ INSTALLED_APPS = [
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.humanize",
-    "django.contrib.sites",
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",


### PR DESCRIPTION
## Problem

Two bugs found via proactive code audit + Grafana log review:

- [#973](https://github.com/shaoster/glaze/issues/973): `django.contrib.sites` was in `INSTALLED_APPS` but never used. Django's admin `LoginView` calls `get_current_site(request)`, which does a domain-based DB lookup when the app is installed — raising `Site.DoesNotExist` → HTTP 500. Confirmed in production Grafana logs (2026-06-17).
- [#974](https://github.com/shaoster/glaze/issues/974): `convert_image_to_jpeg` redirected `PieceStateImage.image` to the normalized JPEG but left `PSI.cropped_image` pointing to a crop derivative computed from the old EXIF-intact source. After the backfill (#968), users would see the wrong crop region until manually re-cropping.

## Fix

**#973** (`backend/settings.py`, `backend/test_settings.py`): Remove `"django.contrib.sites"` from `INSTALLED_APPS` in both files. When the app is absent, `get_current_site(request)` falls back to `RequestSite(request)` — no DB lookup, no crash. Confirmed safe: no project code imports the app, no api migrations depend on it, and no helpdesk migrations reference it.

**#974** (`api/tasks.py`): Add `cropped_image=None` to the `PieceStateImage.objects.filter(image=source_image).update(...)` call. This clears the stale crop FK so the frontend falls back to the raw image until a fresh `generate_cropped_image` task materializes a correct derivative from the normalized JPEG.

## Regression Tests

- `api/tests/test_admin_scope.py::TestAuthAdminLogin::test_admin_login_does_not_500_without_site_record` — `GET /admin/login/` with no `Site` record → assert status ≠ 500. Failed before fix (raised `Site.DoesNotExist` → 500), passes after.
- `api/tests/test_convert_image_to_jpeg.py::TestConvertImageToJpegTask::test_clears_cropped_image_when_redirecting_psi_to_jpeg` — PSI with pre-set `cropped_image` → run `convert_image_to_jpeg` → assert `psi.cropped_image_id is None`. Failed before fix, passes after.

## Verification

```
rtk bazel test //api:api_test
→ 12 test suites, all pass (102 tests)
```

Closes #973
Closes #974
