### PR TITLE
fix(storybook): resolve GlazeCombinationGallery crash and PiecePhotoGallery nested router

### DIFF
--- a/web/.storybook/preview.tsx
+++ b/web/.storybook/preview.tsx
@@ -99,7 +99,7 @@ const preview: Preview = {
     },
   },
   decorators: [
-    (Story) => {
+    (Story, context) => {
       const [{ layoutMode }] = useGlobals();
       const [viewportReady, setViewportReady] = useState(false);
 
@@ -117,7 +117,7 @@ const preview: Preview = {
       if (!viewportReady) return null;
 
       return (
-        <StorybookProviders>
+        <StorybookProviders skipRouter={!!context.parameters.noGlobalRouter}>
           <Story />
         </StorybookProviders>
       );

--- a/web/.storybook/providers.tsx
+++ b/web/.storybook/providers.tsx
@@ -39,21 +39,26 @@ export const DARK_THEME = createTheme({
 
 interface StorybookProvidersProps {
   children: React.ReactNode;
+  /** When true, omit the RouterProvider wrapper. Use for stories that create their own data router. */
+  skipRouter?: boolean;
 }
 
 /**
  * Wraps children with all providers required by Glaze's Storybook stories.
  * Used by preview.tsx and storybook-smoke.test.tsx.
+ *
+ * Set skipRouter={true} for stories whose decorator already creates a data router
+ * (e.g. PiecePhotoGallery) to prevent the "nested Router" error.
  */
-export function StorybookProviders({ children }: StorybookProvidersProps) {
-  const router = createMemoryRouter([{ path: "/", element: <>{children}</> }], {
+export function StorybookProviders({ children, skipRouter }: StorybookProvidersProps) {
+  const router = createMemoryRouter([{ path: "/*", element: <>{children}</> }], {
     initialEntries: ["/"],
   });
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider theme={DARK_THEME}>
         <CssBaseline />
-        <RouterProvider router={router} />
+        {skipRouter ? children : <RouterProvider router={router} />}
       </ThemeProvider>
     </QueryClientProvider>
   );

--- a/web/src/components/GlazeCombinationGallery.tsx
+++ b/web/src/components/GlazeCombinationGallery.tsx
@@ -159,7 +159,7 @@ function ComboCard({
         }
         subheader={
           <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5, mt: 0.5 }}>
-            {combo.glaze_types.map((gt) => (
+            {(combo.glaze_types ?? []).map((gt) => (
               <Chip
                 key={gt.id}
                 label={gt.name}

--- a/web/src/components/__tests__/GlazeCombinationGallery.test.tsx
+++ b/web/src/components/__tests__/GlazeCombinationGallery.test.tsx
@@ -373,4 +373,24 @@ describe("GlazeCombinationGallery", () => {
       );
     });
   });
+
+  describe("regression #975 — missing glaze_types", () => {
+    it("renders without crashing when glaze_types is absent from the API response", async () => {
+      const entryWithoutGlazeTypes = {
+        ...MOCK_COMBO_ENTRY,
+        glaze_combination: {
+          ...MOCK_COMBO_ENTRY.glaze_combination,
+          glaze_types: undefined,
+        },
+      };
+      vi.mocked(api.fetchGlazeCombinationImages).mockResolvedValue([
+        entryWithoutGlazeTypes as any,
+      ]);
+      renderGallery();
+      await waitFor(() =>
+        expect(screen.getByText("Ash ! Shino")).toBeInTheDocument(),
+      );
+      expect(screen.queryByText(/Something went wrong/i)).not.toBeInTheDocument();
+    });
+  });
 });

--- a/web/src/stories/GlazeCombinationGallery.stories.tsx
+++ b/web/src/stories/GlazeCombinationGallery.stories.tsx
@@ -67,7 +67,7 @@ export const Default: Story = {
         http.get("/api/analysis/glaze-combination-images/", () => {
           return HttpResponse.json(
             mockCombos.map((c) => ({
-              glaze_combination: { id: c.id, name: c.name, is_public: true },
+              glaze_combination: { id: c.id, name: c.name, is_public: true, glaze_types: c.glaze_types },
               pieces: c.pieces.map((p) => ({
                 ...p,
                 state: "completed",

--- a/web/src/stories/PiecePhotoGallery.stories.tsx
+++ b/web/src/stories/PiecePhotoGallery.stories.tsx
@@ -38,6 +38,7 @@ const meta = {
   parameters: {
     layout: "centered",
     docs: { inlineStories: false, iframeHeight: 600 },
+    noGlobalRouter: true,
   },
   tags: ["autodocs"],
   decorators: [
@@ -196,18 +197,7 @@ export const SinglePhotoAutoLightbox: Story = {
  * hero, always mounted) owns the Dialog and Lightbox.
  */
 export const ButtonStandalone: StoryObj<typeof PiecePhotoGalleryButton> = {
-  render: (args) => {
-    const router = createMemoryRouter(
-      [
-        {
-          path: "/pieces/:id/*",
-          element: <PiecePhotoGalleryButton {...args} />,
-        },
-      ],
-      { initialEntries: ["/pieces/p1"] },
-    );
-    return <RouterProvider router={router} />;
-  },
+  render: (args) => <PiecePhotoGalleryButton {...args} />,
   args: {
     images: mockImages,
     pieceId: "p1",

--- a/web/src/stories/storybook-smoke.test.tsx
+++ b/web/src/stories/storybook-smoke.test.tsx
@@ -26,19 +26,24 @@ const storyModules = import.meta.glob<StoryModule>("./*.stories.tsx", {
   eager: true,
 });
 
-const allStories: [string, React.ComponentType][] = Object.entries(storyModules)
+type ComposedStory = React.ComponentType & { parameters?: Record<string, unknown> };
+
+const allStories: [string, ComposedStory][] = Object.entries(storyModules)
   .filter(([path]) => !path.includes("ErrorBoundary"))
   .flatMap(([path, module]) => {
     const group = path.replace(/^\.\//, "").replace(/\.stories\.tsx$/, "");
     const composed = composeStories(module);
     return Object.entries(composed).map(([name, Story]) => [
       `${group}/${name}`,
-      Story as React.ComponentType,
+      Story as ComposedStory,
     ]);
   });
 
 describe("Storybook smoke tests — no story should trigger ErrorBoundary", () => {
   it.each(allStories)("%s renders without error boundary", async (_, Story) => {
+    // Stories that provide their own data router set noGlobalRouter: true to
+    // avoid "You cannot render a <Router> inside another <Router>" errors.
+    const skipRouter = !!Story.parameters?.noGlobalRouter;
     const consoleSpy = vi
       .spyOn(console, "error")
       .mockImplementation(() => {});
@@ -46,7 +51,7 @@ describe("Storybook smoke tests — no story should trigger ErrorBoundary", () =
     try {
       await act(async () => {
         ({ container } = render(
-          <StorybookProviders>
+          <StorybookProviders skipRouter={skipRouter}>
             <Story />
           </StorybookProviders>,
         ));
@@ -56,6 +61,9 @@ describe("Storybook smoke tests — no story should trigger ErrorBoundary", () =
     }
     expect(container!.textContent).not.toContain(
       "Something went wrong. Please reload the page.",
+    );
+    expect(container!.textContent).not.toContain(
+      "Unexpected Application Error!",
     );
   });
 });


### PR DESCRIPTION
## Problem

Two Storybook stories crash on load, found via Playwright story crawl ([#975](https://github.com/shaoster/glaze/issues/975), [#976](https://github.com/shaoster/glaze/issues/976)).

## Fix

### #975 — GlazeCombinationGallery/Default

`ComboCard` called `combo.glaze_types.map(...)` unconditionally, but the story's MSW mock omitted `glaze_types` from the `glaze_combination` response object.

- `GlazeCombinationGallery.tsx`: `combo.glaze_types.map(...)` → `(combo.glaze_types ?? []).map(...)` — defensive guard so the component doesn't crash on partial API data.
- `GlazeCombinationGallery.stories.tsx`: added `glaze_types: c.glaze_types` to the mocked `glaze_combination` so the mock matches the real API response shape.

### #976 — PiecePhotoGallery (all 8 stories)

`StorybookProviders` already wraps every story in a data router. The `PiecePhotoGallery` meta decorator creates a second data router for `/pieces/:id/*`, triggering react-router-dom's "nested Router" error.

- `providers.tsx`: added `skipRouter?: boolean` prop — when `true`, omits the `RouterProvider` wrapper while keeping `QueryClientProvider` + `ThemeProvider`.
- `preview.tsx`: global decorator now passes `skipRouter={!!context.parameters.noGlobalRouter}`.
- `PiecePhotoGallery.stories.tsx`: added `noGlobalRouter: true` to meta parameters; simplified `ButtonStandalone.render` to return `<PiecePhotoGalleryButton {...args} />` directly (relying on the meta decorator's router instead of creating a second one).

## Regression Tests

- `GlazeCombinationGallery.test.tsx`: new `"regression #975 — missing glaze_types"` test renders the component with `glaze_types: undefined` and asserts no error boundary — failed before the `?? []` guard.
- `storybook-smoke.test.tsx`: expanded to check `"Unexpected Application Error!"` alongside `"Something went wrong."`, and passes `skipRouter` from `Story.parameters.noGlobalRouter` — failed for all 8 PiecePhotoGallery stories before the fix.

## Verification

```
rtk bazel test //web:web_test  →  42/42 pass
```

Closes #975
Closes #976
