### PR TITLE
chore(ci): upgrade GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/actions/collect-failure-diagnostics/action.yml
+++ b/.github/actions/collect-failure-diagnostics/action.yml
@@ -27,7 +27,7 @@ runs:
         ls -la "$d"
 
     - name: Upload
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ github.job }}-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
         path: /tmp/${{ github.job }}-diagnostics/

--- a/.github/actions/setup-bazel-ci/action.yml
+++ b/.github/actions/setup-bazel-ci/action.yml
@@ -20,7 +20,7 @@ runs:
   using: composite
   steps:
     - name: Cache pnpm store
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.local/share/pnpm/store
@@ -29,14 +29,14 @@ runs:
         restore-keys: pnpm-store-${{ runner.os }}-
 
     - name: Cache Bazel Repository
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/bazel-repo
         key: bazel-repo-${{ runner.os }}-${{ inputs.deps-key }}
         restore-keys: bazel-repo-${{ runner.os }}-
 
     - name: Cache Bazel Disk
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/bazel-disk-cache
         key: bazel-disk-${{ runner.os }}-${{ inputs.cache-key-prefix }}-${{ inputs.deps-key }}-${{ github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
 
       - id: lookup
         name: Check for prior successful PR validation
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           ARTIFACT_KEY: ${{ steps.fingerprint.outputs.artifact_key }}
         with:
@@ -199,7 +199,7 @@ jobs:
           buildbuddy-api-key: ${{ secrets.BAZEL_REMOTE_API_KEY }}
           workdir: ${{ steps.worktree.outputs.path }}
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('web/pnpm-lock.yaml') }}
@@ -333,7 +333,7 @@ jobs:
         run: |
           printf '\n# macOS runner overrides\nbuild --jobs=4\nbuild --local_resources=cpu=HOST_CPUS*0.75\nbuild --local_resources=memory=HOST_RAM*0.6\n' >> .bazelrc
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/Library/Caches/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('web/pnpm-lock.yaml') }}
@@ -613,7 +613,7 @@ jobs:
         run: |
           printf '%s\n' '${{ needs.preflight.outputs.fingerprint }}' > ci-fingerprint.txt
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ci-fingerprint-${{ needs.preflight.outputs.artifact_key }}
           path: ci-fingerprint.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
           source env.sh
           gz_test --coverage
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: bazel-out/_coverage/_coverage_report.dat
           flags: code


### PR DESCRIPTION
## Summary

- Upgrades `actions/cache` v4 → v5 (×2 occurrences)
- Upgrades `actions/upload-artifact` v4 → v7
- Upgrades `actions/github-script` v8 → v9

All three actions previously targeted Node.js 20, which GitHub deprecated on 2025-09-19 and is now forcing onto Node.js 24 at runtime. Upgrading to the latest major versions eliminates the warnings across all CI jobs.

## Test plan

- [ ] Verify no "Node.js 20 is deprecated" warnings appear in CI job logs after merge
