### PR TITLE
fix: disable babel plugin source maps to prevent JS .map 404 in production

### DIFF
--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -1466,6 +1466,15 @@ vitest_test(
     ],
 )
 
+vitest_test(
+    name = "web_vite_config_test",
+    srcs = ["src/vite-config.test.ts"],
+    tags = ["ibazel_notify_changes"],
+    deps = [
+        ":web_prod_lib",
+    ],
+)
+
 # ── Web test suite ────────────────────────────────────────────────────────────
 # Aggregate target: `bazel test //web:web_test` runs all web tests.
 # Individual targets above run only when their inputs change.
@@ -1474,6 +1483,7 @@ test_suite(
     name = "web_test",
     tests = [
         ":web_storybook_smoke_test",
+        ":web_vite_config_test",
         ":web_admin_test",
         ":web_analysis_test",
         ":web_coverage_audit_test",

--- a/web/src/vite-config.test.ts
+++ b/web/src/vite-config.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Regression test for #809: @rolldown/plugin-babel defaults sourceMap:true,
+// causing Rolldown to embed //# sourceMappingURL= in the production bundle even
+// when build.sourcemap is false. The .map files are not deployed, so the
+// reference produces a 404. Guard that the babel plugin is always explicitly
+// told not to emit source maps.
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const configSource = readFileSync(
+  resolve(__dirname, "../vite.config.ts"),
+  "utf8",
+);
+
+describe("vite.config.ts source map configuration", () => {
+  it("disables source maps in the babel plugin to prevent sourceMappingURL 404s", () => {
+    expect(configSource).toMatch(/babel\([\s\S]*?sourceMap:\s*false/);
+  });
+
+  it("explicitly disables build.sourcemap", () => {
+    expect(configSource).toMatch(/sourcemap:\s*false/);
+  });
+});

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -25,8 +25,17 @@ export default defineConfig(() => {
         axios: path.resolve(root, "node_modules/axios"),
       },
     },
-    plugins: [yaml(), react(), babel({ presets: [reactCompilerPreset()] })],
+    plugins: [
+      yaml(),
+      react(),
+      // sourceMap:false prevents @rolldown/plugin-babel (which defaults to true)
+      // from passing source maps back to Rolldown and embedding a
+      // //# sourceMappingURL= reference in the production bundle. The .map
+      // files are not deployed, so that reference causes a 404 (#809).
+      babel({ presets: [reactCompilerPreset()], sourceMap: false }),
+    ],
     build: {
+      sourcemap: false,
       // root is the real (symlink-resolved) path; write output to the sandbox
       // CWD so Bazel's declared output tree artifact is populated correctly.
       outDir: path.resolve(process.cwd(), "dist"),


### PR DESCRIPTION
## Problem

The production JS bundle contained a `//# sourceMappingURL=main-<hash>.js.map` reference, but `.map` files are not deployed via WhiteNoise, causing a 404 on every page load. See [#809](https://github.com/shaoster/glaze/issues/809).

## Fix

`@rolldown/plugin-babel` defaults to `sourceMap: true`, which passes source maps back to Rolldown even when `build.sourcemap` is `false`. Rolldown then embeds the `sourceMappingURL` comment in the bundle output. The fix:

- Pass `sourceMap: false` explicitly to the `babel()` plugin call — this is the root cause
- Set `build.sourcemap: false` explicitly to document intent and prevent future drift

## Regression Test

Added `web/src/vite-config.test.ts` (`//web:web_vite_config_test`), which asserts:
- The babel plugin call includes `sourceMap: false`
- The build config includes `sourcemap: false`

The test failed on the unfixed config and passes after the fix.

## Verification

```
rtk bazel test //web:web_vite_config_test --test_output=all  # PASSED
rtk bazel test //web:web_test --test_output=errors           # 43/43 PASSED
rtk bazel build --config=lint //web/...                      # no lint errors
```

Closes #809
