### PR TITLE
chore(web): add unit tests for untested pure util modules

### DIFF
--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -1319,6 +1319,75 @@ vitest_test(
     ],
 )
 
+vitest_test(
+    name = "web_optional_values_test",
+    srcs = [
+        "src/util/__tests__/optionalValues.test.ts",
+    ],
+    tags = ["ibazel_notify_changes"],
+    deps = [
+        ":util_lib",
+    ],
+    expected_coverage = [
+        "web/src/util/optionalValues*",
+    ],
+)
+
+vitest_test(
+    name = "web_piece_filters_test",
+    srcs = [
+        "src/util/__tests__/pieceFilters.test.ts",
+    ],
+    tags = ["ibazel_notify_changes"],
+    deps = [
+        ":util_lib",
+    ],
+    expected_coverage = [
+        "web/src/util/pieceFilters*",
+    ],
+)
+
+vitest_test(
+    name = "web_graphql_pieces_test",
+    srcs = [
+        "src/util/__tests__/graphqlPieces.test.ts",
+    ],
+    tags = ["ibazel_notify_changes"],
+    deps = [
+        ":util_lib",
+    ],
+    expected_coverage = [
+        "web/src/util/graphqlPieces*",
+    ],
+)
+
+vitest_test(
+    name = "web_music_test",
+    srcs = [
+        "src/util/__tests__/music.test.ts",
+    ],
+    tags = ["ibazel_notify_changes"],
+    deps = [
+        ":util_lib",
+    ],
+    expected_coverage = [
+        "web/src/util/music*",
+    ],
+)
+
+vitest_test(
+    name = "web_preferences_test",
+    srcs = [
+        "src/util/__tests__/preferences.test.ts",
+    ],
+    tags = ["ibazel_notify_changes"],
+    deps = [
+        ":util_lib",
+    ],
+    expected_coverage = [
+        "web/src/util/preferences*",
+    ],
+)
 
 vitest_test(
     name = "web_analysis_test",
@@ -1482,6 +1551,11 @@ test_suite(
         ":web_app_image_test",
         ":web_app_test",
         ":web_format_test",
+        ":web_optional_values_test",
+        ":web_piece_filters_test",
+        ":web_graphql_pieces_test",
+        ":web_music_test",
+        ":web_preferences_test",
         ":web_glaze_gallery_test",
         ":web_glaze_import_test",
         ":web_crop_overlay_test",

--- a/web/src/util/__tests__/graphqlPieces.test.ts
+++ b/web/src/util/__tests__/graphqlPieces.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { PIECE_ORDERING_GQL, PIECES_QUERY } from "../graphqlPieces";
+
+describe("PIECE_ORDERING_GQL", () => {
+  it("maps all six REST sort orders to GraphQL enum values", () => {
+    expect(PIECE_ORDERING_GQL).toEqual({
+      "-last_modified": "LAST_MODIFIED_DESC",
+      last_modified: "LAST_MODIFIED_ASC",
+      name: "NAME_ASC",
+      "-name": "NAME_DESC",
+      created: "CREATED_ASC",
+      "-created": "CREATED_DESC",
+    });
+  });
+
+  it("has exactly six entries", () => {
+    expect(Object.keys(PIECE_ORDERING_GQL)).toHaveLength(6);
+  });
+});
+
+describe("PIECES_QUERY", () => {
+  it("is a string (graphql-request v7 gql returns a string)", () => {
+    expect(typeof PIECES_QUERY).toBe("string");
+  });
+
+  it("declares the Pieces query operation", () => {
+    expect(PIECES_QUERY).toContain("query Pieces");
+  });
+
+  it("selects the pieces field with count and results", () => {
+    expect(PIECES_QUERY).toContain("pieces(");
+    expect(PIECES_QUERY).toContain("count");
+    expect(PIECES_QUERY).toContain("results");
+  });
+});

--- a/web/src/util/__tests__/music.test.ts
+++ b/web/src/util/__tests__/music.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_TRACK_ID,
+  MUSIC_CATALOG,
+  getTrack,
+} from "../music";
+
+describe("MUSIC_CATALOG", () => {
+  it("is non-empty", () => {
+    expect(MUSIC_CATALOG.length).toBeGreaterThan(0);
+  });
+
+  it("contains no duplicate IDs", () => {
+    const ids = MUSIC_CATALOG.map((t) => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("each track has required string fields", () => {
+    for (const track of MUSIC_CATALOG) {
+      expect(typeof track.id).toBe("string");
+      expect(typeof track.title).toBe("string");
+      expect(typeof track.artist).toBe("string");
+      expect(typeof track.license).toBe("string");
+    }
+  });
+});
+
+describe("DEFAULT_TRACK_ID", () => {
+  it("exists as an ID in the catalog", () => {
+    const ids = new Set(MUSIC_CATALOG.map((t) => t.id));
+    expect(ids.has(DEFAULT_TRACK_ID)).toBe(true);
+  });
+});
+
+describe("getTrack", () => {
+  it("returns the track for a known ID", () => {
+    const track = getTrack("adventures-a-himitsu");
+    expect(track).toBeDefined();
+    expect(track?.id).toBe("adventures-a-himitsu");
+    expect(track?.title).toBe("Adventures");
+    expect(track?.artist).toBe("A Himitsu");
+  });
+
+  it("returns undefined for an unknown ID", () => {
+    expect(getTrack("not-a-real-track")).toBeUndefined();
+  });
+
+  it("returns undefined for null", () => {
+    expect(getTrack(null)).toBeUndefined();
+  });
+
+  it("returns undefined for undefined", () => {
+    expect(getTrack(undefined)).toBeUndefined();
+  });
+});

--- a/web/src/util/__tests__/optionalValues.test.ts
+++ b/web/src/util/__tests__/optionalValues.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  entryNameOrEmpty,
+  normalizeOptionalText,
+  undefinedIfBlank,
+} from "../optionalValues";
+
+describe("normalizeOptionalText", () => {
+  it("returns empty string for null", () => {
+    expect(normalizeOptionalText(null)).toBe("");
+  });
+
+  it("returns empty string for undefined", () => {
+    expect(normalizeOptionalText(undefined)).toBe("");
+  });
+
+  it("returns the string as-is for a non-empty value", () => {
+    expect(normalizeOptionalText("hello")).toBe("hello");
+  });
+
+  it("returns whitespace strings unchanged", () => {
+    expect(normalizeOptionalText("   ")).toBe("   ");
+  });
+});
+
+describe("entryNameOrEmpty", () => {
+  it("returns the name from a valid entry", () => {
+    expect(entryNameOrEmpty({ name: "Earthen Red" })).toBe("Earthen Red");
+  });
+
+  it("returns empty string for null", () => {
+    expect(entryNameOrEmpty(null)).toBe("");
+  });
+
+  it("returns empty string for undefined", () => {
+    expect(entryNameOrEmpty(undefined)).toBe("");
+  });
+});
+
+describe("undefinedIfBlank", () => {
+  it("returns undefined for null", () => {
+    expect(undefinedIfBlank(null)).toBeUndefined();
+  });
+
+  it("returns undefined for undefined", () => {
+    expect(undefinedIfBlank(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(undefinedIfBlank("")).toBeUndefined();
+  });
+
+  it("returns undefined for whitespace-only string", () => {
+    expect(undefinedIfBlank("   ")).toBeUndefined();
+  });
+
+  it("returns the trimmed value for a non-blank string", () => {
+    expect(undefinedIfBlank("  hello  ")).toBe("hello");
+  });
+
+  it("returns the value unchanged when no surrounding whitespace", () => {
+    expect(undefinedIfBlank("hello")).toBe("hello");
+  });
+});

--- a/web/src/util/__tests__/pieceFilters.test.ts
+++ b/web/src/util/__tests__/pieceFilters.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { parseFilterParam, parseTagIdsParam } from "../pieceFilters";
+
+describe("parseFilterParam", () => {
+  it("returns empty array for null", () => {
+    expect(parseFilterParam(null)).toEqual([]);
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(parseFilterParam("")).toEqual([]);
+  });
+
+  it("returns a single valid category", () => {
+    expect(parseFilterParam("wip")).toEqual(["wip"]);
+  });
+
+  it("returns multiple valid categories", () => {
+    expect(parseFilterParam("wip,completed")).toEqual(["wip", "completed"]);
+  });
+
+  it("filters out invalid categories", () => {
+    expect(parseFilterParam("wip,invalid,completed")).toEqual([
+      "wip",
+      "completed",
+    ]);
+  });
+
+  it("returns empty array when all categories are invalid", () => {
+    expect(parseFilterParam("unknown,bad")).toEqual([]);
+  });
+
+  it("accepts all valid categories", () => {
+    expect(parseFilterParam("wip,completed,discarded,shared")).toEqual([
+      "wip",
+      "completed",
+      "discarded",
+      "shared",
+    ]);
+  });
+});
+
+describe("parseTagIdsParam", () => {
+  it("returns empty array for null", () => {
+    expect(parseTagIdsParam(null)).toEqual([]);
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(parseTagIdsParam("")).toEqual([]);
+  });
+
+  it("returns a single tag ID", () => {
+    expect(parseTagIdsParam("abc123")).toEqual(["abc123"]);
+  });
+
+  it("splits comma-separated tag IDs", () => {
+    expect(parseTagIdsParam("abc,def,ghi")).toEqual(["abc", "def", "ghi"]);
+  });
+
+  it("filters out empty segments from trailing commas", () => {
+    expect(parseTagIdsParam("abc,,def")).toEqual(["abc", "def"]);
+  });
+});

--- a/web/src/util/__tests__/preferences.test.ts
+++ b/web/src/util/__tests__/preferences.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { PREFERENCES_SCHEMA, getFieldDefinition } from "../preferences";
+
+describe("PREFERENCES_SCHEMA", () => {
+  it("includes a tutorials section", () => {
+    const tutorials = PREFERENCES_SCHEMA.sections.find(
+      (s) => s.id === "tutorials",
+    );
+    expect(tutorials).toBeDefined();
+    expect(tutorials?.title).toBe("Tutorials");
+  });
+
+  it("includes the identity section from the base YAML", () => {
+    const identity = PREFERENCES_SCHEMA.sections.find(
+      (s) => s.id === "identity",
+    );
+    expect(identity).toBeDefined();
+  });
+
+  it("has a non-empty fields record in each section", () => {
+    for (const section of PREFERENCES_SCHEMA.sections) {
+      expect(Object.keys(section.fields).length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("getFieldDefinition", () => {
+  it("returns definition for a base schema field", () => {
+    const field = getFieldDefinition("alias");
+    expect(field).toBeDefined();
+    expect(field?.type).toBe("string");
+  });
+
+  it("returns definition for a tutorial-derived field", () => {
+    const field = getFieldDefinition("summary_customize_popover");
+    expect(field).toBeDefined();
+    expect(field?.type).toBe("boolean");
+    expect(field?.storage).toBe("UserProfile.preferences");
+  });
+
+  it("returns undefined for an unknown field key", () => {
+    expect(getFieldDefinition("nonexistent_key_xyz")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds pure Vitest unit tests for five untested util modules in `web/src/util/`
- Registers all five as `vitest_test` targets in `web/BUILD.bazel` and adds them to the `web_test` suite

**Modules covered:**
- `optionalValues.ts` — `normalizeOptionalText`, `entryNameOrEmpty`, `undefinedIfBlank`
- `pieceFilters.ts` — `parseFilterParam` (valid/invalid/mixed categories), `parseTagIdsParam`
- `graphqlPieces.ts` — `PIECE_ORDERING_GQL` enum mapping, `PIECES_QUERY` string structure
- `music.ts` — `MUSIC_CATALOG` integrity (no duplicates), `DEFAULT_TRACK_ID` membership, `getTrack`
- `preferences.ts` — `PREFERENCES_SCHEMA` structure, tutorials section injection, `getFieldDefinition`

## Test plan
- [x] `rtk bazel test //web:web_optional_values_test //web:web_piece_filters_test //web:web_graphql_pieces_test //web:web_music_test //web:web_preferences_test` — all pass
- [x] `rtk bazel build --config=lint //web/...` — passes

Closes #982
