### PR TITLE
refactor(autosave): replace custom dirty guard with TanStack mutation state

### DIFF
--- a/web/src/components/NavigationBlocker.tsx
+++ b/web/src/components/NavigationBlocker.tsx
@@ -20,10 +20,11 @@ export default function NavigationBlocker({
 }: NavigationBlockerProps) {
   return (
     <Dialog open={open}>
-      <DialogTitle>Unsaved Changes</DialogTitle>
+      <DialogTitle>Save Failed</DialogTitle>
       <DialogContent>
         <DialogContentText>
-          You have unsaved changes. Are you sure you want to leave?
+          Your recent changes couldn't be saved automatically. Leave anyway and
+          lose those changes?
         </DialogContentText>
       </DialogContent>
       <DialogActions>

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -32,7 +32,7 @@ import { useBlocker, useLocation, useNavigate, Link as RouterLink } from "react-
 import type { PieceDetail as PieceDetailType, PieceState } from "../util/types";
 import { DEFAULT_TRACK_ID } from "../util/music";
 import { formatState, isTerminalState, getCustomFieldDefinitions } from "../util/workflow";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useIsMutating, useMutation, useMutationState, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   fetchPieceShowcaseVideo,
   requestPieceShowcaseVideo,
@@ -104,8 +104,13 @@ function PieceDetailContent({
   refetchHistory,
   onPieceUpdated,
 }: PieceDetailProps) {
-  const [isDirty, setIsDirty] = useState(false);
   const pieceDetailSaveStatus = usePieceDetailSaveStatus();
+  const isSaving = useIsMutating({ mutationKey: ["autosave"] }) > 0;
+  const hasSaveError =
+    useMutationState({
+      filters: { mutationKey: ["autosave"], status: "error" },
+    }).length > 0;
+  const pendingTransitionRef = useRef<string | null>(null);
 
   const currentState = piece.current_state;
   const isTerminal = isTerminalState(currentState.state);
@@ -163,7 +168,7 @@ function PieceDetailContent({
   const blocker = useBlocker(
     useCallback(
       ({ nextLocation }: { nextLocation: { pathname: string } }) => {
-        if (!canEdit || !isDirty) return false;
+        if (!canEdit || !hasSaveError) return false;
         const next = nextLocation.pathname;
         const base = `/pieces/${piece.id}`;
         if (next === base) return false;
@@ -173,17 +178,37 @@ function PieceDetailContent({
         if (next.startsWith(`${base}/state/fields/`)) return false;
         return true;
       },
-      [canEdit, isDirty, piece.id],
+      [canEdit, hasSaveError, piece.id],
     ),
   );
 
 
 
-  const { mutate: handleTransition, isPending: transitioning, error: rawTransitionError } = useMutation({
+  const { mutate: transitionMutate, isPending: transitioning, error: rawTransitionError } = useMutation({
     mutationFn: (nextState: string) =>
       addPieceState(piece.id, { state: nextState as PieceDetailType["current_state"]["state"] }),
-    onSuccess: (updated) => { onPieceUpdated(updated); setIsDirty(false); },
+    onSuccess: (updated) => onPieceUpdated(updated),
   });
+
+  // If a save is in progress when the user clicks a transition button, defer
+  // the transition until the save completes rather than prompting the user.
+  useEffect(() => {
+    if (!isSaving && pendingTransitionRef.current) {
+      transitionMutate(pendingTransitionRef.current);
+      pendingTransitionRef.current = null;
+    }
+  }, [isSaving, transitionMutate]);
+
+  const handleTransition = useCallback(
+    (nextState: string) => {
+      if (isSaving) {
+        pendingTransitionRef.current = nextState;
+      } else {
+        transitionMutate(nextState);
+      }
+    },
+    [isSaving, transitionMutate],
+  );
   const transitionError = rawTransitionError
     ? extractErrorMessage(rawTransitionError, "Failed to transition state. Please try again.")
     : null;
@@ -287,11 +312,13 @@ function PieceDetailContent({
               <Box sx={{ mt: 2, mb: 1.5 }}>
                 <StateTransition
                   currentStateName={currentState.state}
-                  disabled={isDirty || piece.is_editable}
+                  disabled={hasSaveError || piece.is_editable}
                   disabledHint={
                     piece.is_editable
                       ? "Seal edit mode before transitioning to a new state."
-                      : undefined
+                      : hasSaveError
+                        ? "Auto-save failed. Your changes may not be saved."
+                        : undefined
                   }
                   transitioning={transitioning}
                   transitionError={transitionError}
@@ -461,7 +488,6 @@ function PieceDetailContent({
               initialPieceState={currentState}
               pieceId={piece.id}
               onSaved={onPieceUpdated}
-              onDirtyChange={setIsDirty}
               readOnly={!canEdit}
               hideNotes={!canEdit}
             />

--- a/web/src/components/PieceDetailSaveStatusContext.tsx
+++ b/web/src/components/PieceDetailSaveStatusContext.tsx
@@ -1,3 +1,4 @@
+import { useMutationState } from "@tanstack/react-query";
 import {
   useCallback,
   useEffect,
@@ -51,16 +52,42 @@ export function PieceDetailSaveStatusProvider({
 }: {
   children: ReactNode;
 }) {
-  const [workflowStatus, setWorkflowStatus] =
-    useState<SaveStatusSnapshot>(defaultSnapshot);
   const [manualStatus, setManualStatus] =
     useState<SaveStatusSnapshot>(defaultSnapshot);
   const manualRunIdRef = useRef(0);
   const { clearResetTimer, scheduleReset } = useResetTimer();
 
-  const publishWorkflowStatus = useCallback((snapshot: SaveStatusSnapshot) => {
-    setWorkflowStatus(snapshot);
-  }, []);
+  // Derive workflow save status from the TanStack mutation cache so WorkflowState
+  // doesn't need to push status through a separate context channel.
+  const autosaveMutationStates = useMutationState({
+    filters: { mutationKey: ["autosave"] },
+    select: (m) => ({
+      status: m.state.status,
+      error: m.state.error,
+      submittedAt: m.state.submittedAt,
+    }),
+  });
+  const latest = autosaveMutationStates.at(-1);
+  const workflowStatus: SaveStatusSnapshot = latest
+    ? {
+        status:
+          latest.status === "pending"
+            ? "saving"
+            : latest.status === "success"
+              ? "saved"
+              : latest.status === "error"
+                ? "error"
+                : "idle",
+        error:
+          latest.status === "error"
+            ? "Autosave failed. Your changes are still here."
+            : null,
+        lastSavedAt:
+          latest.status === "success" && latest.submittedAt
+            ? new Date(latest.submittedAt)
+            : null,
+      }
+    : defaultSnapshot;
 
   const runManualSave = useCallback(
     async <T,>(save: () => Promise<T>) => {
@@ -118,10 +145,9 @@ export function PieceDetailSaveStatusProvider({
 
   const value = useMemo(
     () => ({
-      publishWorkflowStatus,
       runManualSave,
     }),
-    [publishWorkflowStatus, runManualSave],
+    [runManualSave],
   );
 
   return (

--- a/web/src/components/PieceHistory.tsx
+++ b/web/src/components/PieceHistory.tsx
@@ -139,8 +139,8 @@ function EditablePieceStateListItem({
 
   const { status } = useAutosave({
     dirty: localDate !== (ps.created ? toDatetimeLocal(ps.created) : ""),
-    saveKey: localDate,
     save,
+    mutationKey: ["autosave", pieceId, ps.id],
   });
 
   return (

--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -147,37 +147,14 @@ export default function WorkflowState({
     onSaved(result);
   }, [pieceId, initialPieceState.id, onSaved, saveStateFn, currentPayload]);
 
-  const autosaveKey = useMemo(
-    () =>
-      JSON.stringify({
-        notes,
-        images,
-        custom_fields: normalizedCustomFields,
-      }),
-    [images, normalizedCustomFields, notes],
-  );
-
   const autosave = useAutosave({
     dirty: !readOnly && isDirty && !disableAutosave,
-    saveKey: autosaveKey,
     save: saveWorkflowState,
     delayMs: autosaveDelayMs,
+    mutationKey: ["autosave", pieceId],
   });
+  // Used only to suppress the standalone toast when the provider handles it.
   const pieceDetailSaveStatus = usePieceDetailSaveStatus();
-
-
-  useEffect(() => {
-    pieceDetailSaveStatus?.publishWorkflowStatus({
-      status: autosave.status,
-      error: autosave.error,
-      lastSavedAt: autosave.lastSavedAt,
-    });
-  }, [
-    autosave.error,
-    autosave.lastSavedAt,
-    autosave.status,
-    pieceDetailSaveStatus,
-  ]);
 
   function handleFieldChange(name: string, value: string) {
     dispatch({ type: "set_custom_field", name, value });

--- a/web/src/components/__tests__/PieceDetail.test.tsx
+++ b/web/src/components/__tests__/PieceDetail.test.tsx
@@ -8,7 +8,12 @@ import {
   within,
 } from "@testing-library/react";
 import { ThemeProvider, createTheme } from "@mui/material/styles";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  QueryClient,
+  QueryClientProvider,
+  useIsMutating,
+  useMutationState,
+} from "@tanstack/react-query";
 import { createMemoryRouter, RouterProvider } from "react-router-dom";
 import PieceDetail from "../PieceDetail";
 import { PieceDetailSaveStatusProvider } from "../PieceDetailSaveStatusContext";
@@ -35,6 +40,17 @@ vi.mock("masonic", () => ({
     </div>
   ),
 }));
+
+// Mock the autosave-related TanStack hooks so tests can simulate save error/pending
+// states without running real mutations. Default: no active saves, no errors.
+vi.mock("@tanstack/react-query", async (importActual) => {
+  const actual = await importActual<typeof import("@tanstack/react-query")>();
+  return {
+    ...actual,
+    useIsMutating: vi.fn(() => 0),
+    useMutationState: vi.fn(() => []),
+  };
+});
 
 const { mockWorkflow } = vi.hoisted(() => ({
   mockWorkflow: {
@@ -163,11 +179,9 @@ vi.mock("../../util/api", () => ({
 // in WorkflowState.test.tsx.
 vi.mock("../WorkflowState", () => ({
   default: ({
-    onDirtyChange,
     readOnly,
     saveStateFn,
   }: {
-    onDirtyChange?: (dirty: boolean) => void;
     readOnly?: boolean;
     saveStateFn?: (payload: any) => Promise<any>;
   }) => {
@@ -179,7 +193,6 @@ vi.mock("../WorkflowState", () => ({
           <input
             aria-label="Notes"
             onChange={(e) => {
-              onDirtyChange?.(true);
               if (saveStateFn) {
                 // Simulate autosave delay
                 setTimeout(() => {
@@ -271,6 +284,9 @@ beforeEach(() => {
   vi.mocked(api.fetchGlobalEntries).mockResolvedValue([]);
   vi.mocked(api.fetchGlobalEntriesWithFilters).mockResolvedValue([]);
   vi.mocked(api.fetchPieceShowcaseVideo).mockResolvedValue(null);
+  // Reset autosave state mocks to defaults (no active saves, no errors).
+  vi.mocked(useIsMutating).mockReturnValue(0);
+  vi.mocked(useMutationState).mockReturnValue([]);
 });
 
 describe("PieceDetail", () => {
@@ -648,13 +664,16 @@ describe("PieceDetail", () => {
     expect(screen.queryByLabelText("Notes")).not.toBeInTheDocument();
   });
 
-  it("transition buttons disabled when there are unsaved changes", async () => {
+  it("transition buttons enabled during active auto-save", async () => {
+    vi.mocked(useIsMutating).mockReturnValue(1);
     await renderPieceDetail();
-    fireEvent.change(screen.getByLabelText("Notes"), {
-      target: { value: "Dirty notes" },
-    });
-    const transitionBtn = screen.getByRole("button", { name: "Throwing" });
-    expect(transitionBtn).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Throwing" })).toBeEnabled();
+  });
+
+  it("transition buttons disabled when auto-save fails", async () => {
+    vi.mocked(useMutationState).mockReturnValue([{} as any]);
+    await renderPieceDetail();
+    expect(screen.getByRole("button", { name: "Throwing" })).toBeDisabled();
   });
 
   it("clicking transition button opens confirmation dialog", async () => {
@@ -864,29 +883,36 @@ describe("PieceDetail", () => {
   });
 
   describe("navigation blocker", () => {
-    it("lets the user stay on the page when blocked navigation is canceled", async () => {
+    it("does not block navigation when auto-save is clean", async () => {
+      const { router } = await renderPieceDetail();
+      await act(async () => {
+        await router.navigate("/other");
+      });
+      expect(screen.queryByText("Save Failed")).not.toBeInTheDocument();
+      await waitFor(() =>
+        expect(screen.getByText("Elsewhere")).toBeInTheDocument(),
+      );
+    });
+
+    it("lets the user stay on the page when save-failure block is canceled", async () => {
+      vi.mocked(useMutationState).mockReturnValue([{} as any]);
       const { router } = await renderPieceDetail();
 
-      fireEvent.change(screen.getByLabelText("Notes"), {
-        target: { value: "Unsaved notes" },
-      });
       await act(async () => {
         await router.navigate("/other");
       });
 
-      expect(screen.getByText("Unsaved Changes")).toBeInTheDocument();
+      expect(screen.getByText("Save Failed")).toBeInTheDocument();
       fireEvent.click(screen.getByRole("button", { name: "Stay" }));
 
       expect(screen.queryByText("Elsewhere")).not.toBeInTheDocument();
       expect(screen.getByLabelText("Notes")).toBeInTheDocument();
     });
 
-    it("allows leaving after confirmation when there are unsaved changes", async () => {
+    it("allows leaving after confirmation when auto-save has failed", async () => {
+      vi.mocked(useMutationState).mockReturnValue([{} as any]);
       const { router } = await renderPieceDetail();
 
-      fireEvent.change(screen.getByLabelText("Notes"), {
-        target: { value: "Unsaved notes" },
-      });
       await act(async () => {
         await router.navigate("/other");
       });

--- a/web/src/components/useAutosave.ts
+++ b/web/src/components/useAutosave.ts
@@ -1,12 +1,13 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { useCallback, useEffect, useState } from "react";
 
 export type AutosaveStatus = "idle" | "pending" | "saving" | "saved" | "error";
 
 type UseAutosaveOptions = {
   dirty: boolean;
-  saveKey: string;
   save: () => Promise<void>;
   delayMs?: number;
+  mutationKey: unknown[];
 };
 
 type UseAutosaveResult = {
@@ -20,68 +21,46 @@ const DEFAULT_AUTOSAVE_DELAY_MS = 700;
 
 export function useAutosave({
   dirty,
-  saveKey,
   save,
   delayMs = DEFAULT_AUTOSAVE_DELAY_MS,
+  mutationKey,
 }: UseAutosaveOptions): UseAutosaveResult {
-  const [status, setStatus] = useState<AutosaveStatus>("idle");
-  const [error, setError] = useState<string | null>(null);
   const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
-  const [lastSavedKey, setLastSavedKey] = useState<string | null>(null);
-  const [failedKey, setFailedKey] = useState<string | null>(null);
-  const saveRef = useRef(save);
-  const runIdRef = useRef(0);
 
-  useEffect(() => {
-    saveRef.current = save;
-  }, [save]);
-
-  const saveNow = useCallback(async () => {
-    if (!dirty) {
-      setError(null);
-      return;
-    }
-    const runId = runIdRef.current + 1;
-    runIdRef.current = runId;
-    setStatus("saving");
-    setError(null);
-    try {
-      await saveRef.current();
-      if (runIdRef.current !== runId) return;
-      setLastSavedKey(saveKey);
-      setFailedKey(null);
-      setLastSavedAt(new Date());
-      setStatus("saved");
-    } catch {
-      if (runIdRef.current !== runId) return;
-      setFailedKey(saveKey);
-      setStatus("error");
-      setError("Autosave failed. Your changes are still here.");
-    }
-  }, [dirty, saveKey]);
+  const { mutate, mutateAsync, status } = useMutation({
+    mutationFn: save,
+    mutationKey,
+    onSuccess: () => setLastSavedAt(new Date()),
+  });
 
   useEffect(() => {
     if (!dirty) return;
+    const timer = window.setTimeout(() => mutate(), delayMs);
+    return () => window.clearTimeout(timer);
+  }, [dirty, delayMs, mutate]);
 
-    const timeoutId = window.setTimeout(() => {
-      void saveNow();
-    }, delayMs);
+  const displayStatus: AutosaveStatus =
+    dirty && status === "idle"
+      ? "pending"
+      : status === "pending"
+        ? "saving"
+        : status === "success"
+          ? "saved"
+          : status === "error"
+            ? "error"
+            : lastSavedAt
+              ? "saved"
+              : "idle";
 
-    return () => window.clearTimeout(timeoutId);
-  }, [delayMs, dirty, saveNow]);
+  const saveNow = useCallback(() => mutateAsync(), [mutateAsync]);
 
-  let displayStatus: AutosaveStatus = lastSavedAt ? "saved" : "idle";
-  if (dirty) {
-    if (status === "saving") {
-      displayStatus = "saving";
-    } else if (failedKey === saveKey) {
-      displayStatus = "error";
-    } else if (lastSavedKey === saveKey) {
-      displayStatus = "saved";
-    } else {
-      displayStatus = "pending";
-    }
-  }
-
-  return { status: displayStatus, error, lastSavedAt, saveNow };
+  return {
+    status: displayStatus,
+    error:
+      status === "error"
+        ? "Autosave failed. Your changes are still here."
+        : null,
+    lastSavedAt,
+    saveNow,
+  };
 }

--- a/web/src/components/usePieceDetailSaveStatus.ts
+++ b/web/src/components/usePieceDetailSaveStatus.ts
@@ -8,7 +8,6 @@ export type SaveStatusSnapshot = {
 };
 
 export type PieceDetailSaveStatusContextValue = {
-  publishWorkflowStatus: (snapshot: SaveStatusSnapshot) => void;
   runManualSave: <T>(save: () => Promise<T>) => Promise<T>;
 };
 


### PR DESCRIPTION
## Summary

- `useAutosave` is refactored to use TanStack Query's `useMutation` (with `mutationKey`), replacing ~40 lines of hand-rolled state management (`runIdRef`, `saveKey`, `failedKey`, `lastSavedKey`). TanStack handles run cancellation internally.
- `PieceDetail` now reads save status from `useIsMutating` and `useMutationState` instead of a custom `isDirty` → context pipeline: navigation and transition guards activate **only on save failure**, not on every keystroke.
- If a transition is clicked while an autosave is in progress, it waits silently (via a ref + `useEffect`) for the save to finish before proceeding — no user prompt.
- `PieceDetailSaveStatusContext` drops `publishWorkflowStatus` entirely; the floating toast reads from `useMutationState` directly.
- `NavigationBlocker` dialog text updated to "Save Failed" to reflect the new semantics.
- `PieceHistory.tsx` updated to the new `useAutosave` API (`mutationKey` replaces `saveKey`).

## Acceptance criteria

- [x] Transition buttons in `PieceDetail` are enabled during active auto-save operations.
- [x] Navigation away from a piece does not show the "Unsaved Changes" dialog if all changes were successfully auto-saved.
- [x] The guard correctly activates if an auto-save operation fails.
- [x] Tests updated: `useIsMutating`/`useMutationState` mocked at module level; new test for "enabled during save"; navigation blocker tests use save-error state directly.

## Test plan

- [x] All 49 web tests pass (`rtk bazel test //web:web_test`)
- [x] ESLint + TypeScript type-check pass (`rtk bazel build --config=lint //web/...`)
- [ ] Manual: open a piece, edit notes → transition buttons stay enabled → network disconnect → edit notes → transition buttons disable + navigation shows "Save Failed"

Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)
