### PR TITLE
fix(web): remove excess vertical spacing in WorkflowState; add util test coverage

### DIFF
--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -1568,6 +1568,52 @@ vitest_test(
     ],
 )
 
+vitest_test(
+    name = "web_r2_upload_test",
+    srcs = [
+        "src/util/__tests__/r2Upload.test.ts",
+    ],
+    tags = ["ibazel_notify_changes"],
+    deps = [
+        ":util_lib",
+        ":node_modules/axios",
+    ],
+    expected_coverage = [
+        "web/src/util/r2Upload*",
+    ],
+)
+
+vitest_test(
+    name = "web_use_toggle_global_entry_favorite_test",
+    srcs = [
+        "src/util/__tests__/useToggleGlobalEntryFavorite.test.ts",
+    ],
+    tags = ["ibazel_notify_changes"],
+    deps = [
+        ":util_lib",
+        ":node_modules/@tanstack/react-query",
+        ":node_modules/@testing-library/react",
+        ":node_modules/react",
+    ],
+    expected_coverage = [
+        "web/src/util/useToggleGlobalEntryFavorite*",
+    ],
+)
+
+vitest_test(
+    name = "web_query_keys_test",
+    srcs = [
+        "src/util/__tests__/queryKeys.test.ts",
+    ],
+    tags = ["ibazel_notify_changes"],
+    deps = [
+        ":util_lib",
+    ],
+    expected_coverage = [
+        "web/src/util/queryKeys*",
+    ],
+)
+
 # ── Web test suite ────────────────────────────────────────────────────────────
 # Aggregate target: `bazel test //web:web_test` runs all web tests.
 # Individual targets above run only when their inputs change.
@@ -1624,6 +1670,9 @@ test_suite(
         ":web_tutorial_manager_test",
         ":web_workflow_summary_test",
         ":workflow_test",
+        ":web_r2_upload_test",
+        ":web_use_toggle_global_entry_favorite_test",
+        ":web_query_keys_test",
     ],
 )
 

--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -182,7 +182,6 @@ export default function WorkflowState({
           fullWidth
           disabled={readOnly}
           sx={{
-            mb: 1.5,
             "& .MuiInputBase-root": { fontSize: "0.875rem" },
             "& .MuiInputLabel-root": { fontSize: "0.875rem" },
           }}
@@ -194,7 +193,6 @@ export default function WorkflowState({
             display: "grid",
             gap: 2,
             gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
-            pt: 3, // Increased padding above the custom fields interior
             alignItems: "start",
           }}
         >

--- a/web/src/util/__tests__/api.test.ts
+++ b/web/src/util/__tests__/api.test.ts
@@ -200,6 +200,81 @@ describe("auth token wiring", () => {
     expect(retriedConfig.headers.get("X-Request-ID")).toBe("abc123");
     expect(result).toEqual({ data: "retried" });
   });
+
+  it("passes through non-401 errors without refreshing", async () => {
+    await loadApiModule();
+    const responseUse = mockClient.interceptors.response.use.mock.calls[0]?.[1];
+
+    const error = {
+      isAxiosError: true,
+      response: { status: 500 },
+      config: { url: "pieces/piece-1/" },
+    };
+
+    await expect(responseUse?.(error)).rejects.toMatchObject({
+      response: { status: 500 },
+    });
+    expect(mockClient.post).not.toHaveBeenCalled();
+  });
+
+  it("clears the access token when refresh fails", async () => {
+    await loadApiModule();
+    const { getAccessToken, setAccessToken } = await import("../authTokenStore");
+    setAccessToken("stale-token");
+    const responseUse = mockClient.interceptors.response.use.mock.calls[0]?.[1];
+
+    mockClient.get.mockRejectedValueOnce(new Error("CSRF fetch failed"));
+
+    const error = {
+      isAxiosError: true,
+      response: { status: 401 },
+      config: { url: "pieces/piece-1/" },
+    };
+
+    await expect(responseUse?.(error)).rejects.toBeDefined();
+    expect(getAccessToken()).toBeNull();
+  });
+
+  it("passes the success response through unchanged", async () => {
+    await loadApiModule();
+    const successHandler =
+      mockClient.interceptors.response.use.mock.calls[0]?.[0];
+    const response = { data: "ok", status: 200 };
+
+    expect(successHandler?.(response)).toBe(response);
+  });
+
+  it("rejects immediately when _retry is already set", async () => {
+    await loadApiModule();
+    const responseUse = mockClient.interceptors.response.use.mock.calls[0]?.[1];
+
+    const error = {
+      isAxiosError: true,
+      response: { status: 401 },
+      config: { url: "pieces/piece-1/", _retry: true },
+    };
+
+    await expect(responseUse?.(error)).rejects.toMatchObject({
+      response: { status: 401 },
+    });
+    expect(mockClient.post).not.toHaveBeenCalled();
+  });
+
+  it("rejects immediately for auth endpoints", async () => {
+    await loadApiModule();
+    const responseUse = mockClient.interceptors.response.use.mock.calls[0]?.[1];
+
+    const error = {
+      isAxiosError: true,
+      response: { status: 401 },
+      config: { url: "auth/token/refresh/" },
+    };
+
+    await expect(responseUse?.(error)).rejects.toMatchObject({
+      response: { status: 401 },
+    });
+    expect(mockClient.post).not.toHaveBeenCalled();
+  });
 });
 
 describe("piece endpoints", () => {
@@ -902,5 +977,377 @@ describe("extractErrorMessage", () => {
     expect(extractErrorMessage({}, "Something went wrong")).toBe(
       "Something went wrong",
     );
+  });
+});
+
+describe("fetchAppInit", () => {
+  it("maps the AppInit response and normalizes the user", async () => {
+    const { fetchAppInit } = await loadApiModule();
+    mockClient.get.mockResolvedValue({
+      data: {
+        googleOauthClientId: "client-id",
+        mockIdpUrl: null,
+        adminBaseUrl: "https://admin.example.com",
+        user: {
+          id: "u1",
+          email: "user@example.com",
+          first_name: "Alice",
+          last_name: "Smith",
+          is_staff: false,
+        },
+      },
+    });
+
+    const result = await fetchAppInit();
+
+    expect(mockClient.get).toHaveBeenCalledWith("auth/me/");
+    expect(result.googleOauthClientId).toBe("client-id");
+    expect(result.mockIdpUrl).toBeNull();
+    expect(result.user?.email).toBe("user@example.com");
+  });
+});
+
+describe("isAuthError", () => {
+  it("returns true for 401 responses", async () => {
+    const { isAuthError } = await loadApiModule();
+    mockIsAxiosError.mockReturnValue(true);
+
+    expect(isAuthError({ isAxiosError: true, response: { status: 401 } })).toBe(
+      true,
+    );
+  });
+
+  it("returns true for 403 responses", async () => {
+    const { isAuthError } = await loadApiModule();
+    mockIsAxiosError.mockReturnValue(true);
+
+    expect(isAuthError({ isAxiosError: true, response: { status: 403 } })).toBe(
+      true,
+    );
+  });
+
+  it("returns false for non-auth errors", async () => {
+    const { isAuthError } = await loadApiModule();
+    mockIsAxiosError.mockReturnValue(false);
+
+    expect(isAuthError(new Error("network"))).toBe(false);
+  });
+});
+
+describe("getImageCropRuns", () => {
+  it("maps an array of crop run wire objects to domain objects", async () => {
+    const { getImageCropRuns } = await loadApiModule();
+    const wireCropRun = {
+      id: "crop-1",
+      crop: { x: 0.1, y: 0.1, width: 0.8, height: 0.8 },
+      created: "2024-01-01T00:00:00Z",
+    };
+    mockClient.get.mockResolvedValue({ data: [wireCropRun] });
+
+    const result = await getImageCropRuns("img-id");
+
+    expect(mockClient.get).toHaveBeenCalledWith("images/img-id/crop-runs/");
+    expect(result).toHaveLength(1);
+    expect(result[0].created).toBeInstanceOf(Date);
+  });
+});
+
+describe("auth endpoint functions", () => {
+  it("downloadUserData navigates to the export URL", async () => {
+    const { downloadUserData } = await loadApiModule();
+    const mockAssign = vi.fn();
+    vi.stubGlobal("window", {
+      location: { assign: mockAssign, origin: "http://localhost" },
+    });
+
+    downloadUserData();
+
+    expect(mockAssign).toHaveBeenCalledWith("/api/auth/export/");
+    vi.unstubAllGlobals();
+  });
+
+  it("deleteAccount revokes the token and deletes the account", async () => {
+    const { deleteAccount } = await loadApiModule();
+    mockClient.get.mockResolvedValue({ data: undefined });
+    mockClient.post.mockResolvedValue({});
+    mockClient.delete.mockResolvedValue({});
+
+    await deleteAccount();
+
+    expect(mockClient.post).toHaveBeenCalledWith("auth/token/revoke/", {});
+    expect(mockClient.delete).toHaveBeenCalledWith("auth/account/");
+  });
+
+  it("issueAuthTokens posts to token endpoint and sets the access token", async () => {
+    const { issueAuthTokens } = await loadApiModule();
+    mockClient.get.mockResolvedValue({ data: undefined });
+    mockClient.post.mockResolvedValue({
+      data: { accessToken: "new-token" },
+    });
+
+    const result = await issueAuthTokens();
+
+    expect(result.accessToken).toBe("new-token");
+    expect(mockClient.post).toHaveBeenCalledWith("auth/token/", {});
+  });
+
+  it("refreshAuthToken delegates to refreshAccessToken", async () => {
+    const { refreshAuthToken } = await loadApiModule();
+    mockClient.get.mockResolvedValue({ data: undefined });
+    mockClient.post.mockResolvedValue({
+      data: { accessToken: "refreshed-token" },
+    });
+
+    const result = await refreshAuthToken();
+
+    expect(result).toBe("refreshed-token");
+  });
+
+  it("revokeAuthToken revokes the session token", async () => {
+    const { revokeAuthToken } = await loadApiModule();
+    mockClient.get.mockResolvedValue({ data: undefined });
+    mockClient.post.mockResolvedValue({});
+
+    await revokeAuthToken();
+
+    expect(mockClient.post).toHaveBeenCalledWith("auth/token/revoke/", {});
+  });
+
+  it("getStaffInviteCode fetches the current invite code", async () => {
+    const { getStaffInviteCode } = await loadApiModule();
+    mockClient.get.mockResolvedValue({
+      data: { code: "INVITE-123", expires_at: "2025-01-01T00:00:00Z" },
+    });
+
+    const result = await getStaffInviteCode();
+
+    expect(result.code).toBe("INVITE-123");
+    expect(mockClient.get).toHaveBeenCalledWith("staff/invite-code/");
+  });
+
+  it("generateStaffInviteCode posts to generate a new code", async () => {
+    const { generateStaffInviteCode } = await loadApiModule();
+    mockClient.get.mockResolvedValue({ data: undefined });
+    mockClient.post.mockResolvedValue({
+      data: { code: "NEW-CODE", expires_at: "2025-01-01T00:00:00Z" },
+    });
+
+    const result = await generateStaffInviteCode();
+
+    expect(result.code).toBe("NEW-CODE");
+    expect(mockClient.post).toHaveBeenCalledWith("staff/invite-code/", {});
+  });
+
+  it("generateInviteBatch posts the count and returns the created count", async () => {
+    const { generateInviteBatch } = await loadApiModule();
+    mockClient.get.mockResolvedValue({ data: undefined });
+    mockClient.post.mockResolvedValue({ data: { created: 5 } });
+
+    const result = await generateInviteBatch(5);
+
+    expect(result.created).toBe(5);
+    expect(mockClient.post).toHaveBeenCalledWith("staff/invite-batch/", {
+      count: 5,
+    });
+  });
+
+  it("sendEmailInvite posts the email address", async () => {
+    const { sendEmailInvite } = await loadApiModule();
+    mockClient.get.mockResolvedValue({ data: undefined });
+    mockClient.post.mockResolvedValue({});
+
+    await sendEmailInvite("user@example.com");
+
+    expect(mockClient.post).toHaveBeenCalledWith("auth/invite/send/", {
+      email: "user@example.com",
+    });
+  });
+});
+
+describe("piece history and schema endpoints", () => {
+  it("fetchPieceHistory maps wire piece states to domain objects", async () => {
+    const { fetchPieceHistory } = await loadApiModule();
+    mockClient.get.mockResolvedValue({
+      data: [
+        {
+          ...wirePieceState,
+          previous_state: null,
+          next_state: null,
+        },
+      ],
+    });
+
+    const result = await fetchPieceHistory("piece-1");
+
+    expect(mockClient.get).toHaveBeenCalledWith("pieces/piece-1/history/");
+    expect(result).toHaveLength(1);
+    expect(result[0].created).toBeInstanceOf(Date);
+  });
+
+  it("fetchWorkflowStateSchema returns the raw schema from the API", async () => {
+    const { fetchWorkflowStateSchema } = await loadApiModule();
+    const schema = {
+      type: "object",
+      properties: { clay_weight_lbs: { type: "number" } },
+    };
+    mockClient.get.mockResolvedValue({ data: schema });
+
+    const result = await fetchWorkflowStateSchema("wheel_thrown");
+
+    expect(mockClient.get).toHaveBeenCalledWith(
+      "workflow/schema/wheel_thrown/",
+    );
+    expect(result).toEqual(schema);
+  });
+
+  it("fetchPieceShowcaseVideo fetches the showcase video status", async () => {
+    const { fetchPieceShowcaseVideo } = await loadApiModule();
+    mockClient.get.mockResolvedValue({
+      data: { status: "ready", url: "https://cdn.example.com/video.mp4" },
+    });
+
+    const result = await fetchPieceShowcaseVideo("piece-1");
+
+    expect(mockClient.get).toHaveBeenCalledWith(
+      "pieces/piece-1/showcase-video/",
+    );
+    expect(result).toMatchObject({ status: "ready" });
+  });
+
+  it("requestPieceShowcaseVideo posts the payload and returns status", async () => {
+    const { requestPieceShowcaseVideo } = await loadApiModule();
+    mockClient.get.mockResolvedValue({ data: undefined });
+    mockClient.post.mockResolvedValue({
+      data: { status: "processing" },
+    });
+
+    const result = await requestPieceShowcaseVideo("piece-1", {
+      excludedImageKeys: ["key1"],
+      excludedNoteKeys: [],
+      musicTrackId: "track-1",
+    });
+
+    expect(mockClient.post).toHaveBeenCalledWith(
+      "pieces/piece-1/showcase-video/",
+      {
+        excluded_image_keys: ["key1"],
+        excluded_note_keys: [],
+        music_track_id: "track-1",
+      },
+    );
+    expect(result).toMatchObject({ status: "processing" });
+  });
+
+  it("moveImage patches the image piece_state and returns updated piece", async () => {
+    const { moveImage } = await loadApiModule();
+    mockClient.patch.mockResolvedValue({ data: wirePieceDetail });
+
+    const result = await moveImage("img-1", "designed", "wheel_thrown");
+
+    expect(mockClient.patch).toHaveBeenCalledWith(
+      "images/img-1/piece_state/designed/",
+      { piece_state_id: "wheel_thrown" },
+    );
+    expect(result.id).toBe("piece-1");
+  });
+
+  it("updateImageCrop patches the crop and returns updated piece", async () => {
+    const { updateImageCrop } = await loadApiModule();
+    mockClient.patch.mockResolvedValue({ data: wirePieceDetail });
+    const crop = { x: 0.1, y: 0.2, width: 0.8, height: 0.7 };
+
+    const result = await updateImageCrop("img-1", crop);
+
+    expect(mockClient.patch).toHaveBeenCalledWith("images/img-1/crop/", crop);
+    expect(result.id).toBe("piece-1");
+  });
+
+  it("triggerR2ImageConversion posts to the convert-image endpoint", async () => {
+    const { triggerR2ImageConversion } = await loadApiModule();
+    mockClient.get.mockResolvedValue({ data: undefined });
+    mockClient.post.mockResolvedValue({
+      data: { task_id: "task-xyz", needs_conversion: true },
+    });
+
+    const result = await triggerR2ImageConversion("images/abc.jpg", "img-id");
+
+    expect(mockClient.post).toHaveBeenCalledWith("uploads/r2/convert-image/", {
+      key: "images/abc.jpg",
+      image_id: "img-id",
+    });
+    expect(result.task_id).toBe("task-xyz");
+    expect(result.needs_conversion).toBe(true);
+  });
+
+  it("getR2ConversionStatus fetches conversion task status by task ID", async () => {
+    const { getR2ConversionStatus } = await loadApiModule();
+    mockClient.get.mockResolvedValue({
+      data: { status: "success", result: { url: "https://cdn.example.com/img.jpg", width: 800, height: 600 } },
+    });
+
+    const result = await getR2ConversionStatus("task-abc");
+
+    expect(mockClient.get).toHaveBeenCalledWith(
+      "uploads/r2/convert-image/task-abc/",
+    );
+    expect(result.status).toBe("success");
+  });
+
+  it("listAgentTokens fetches the agent token list", async () => {
+    const { listAgentTokens } = await loadApiModule();
+    mockClient.get.mockResolvedValue({
+      data: [{ id: "tok-1", name: "My Token", created_at: "2024-01-01T00:00:00Z" }],
+    });
+
+    const result = await listAgentTokens();
+
+    expect(mockClient.get).toHaveBeenCalledWith("auth/agent-tokens/");
+    expect(result).toHaveLength(1);
+  });
+
+  it("createAgentToken posts the name and returns the new token", async () => {
+    const { createAgentToken } = await loadApiModule();
+    mockClient.get.mockResolvedValue({ data: undefined });
+    mockClient.post.mockResolvedValue({
+      data: { id: "tok-2", name: "CI Token", token: "secret-value", created_at: "2024-01-01T00:00:00Z" },
+    });
+
+    const result = await createAgentToken("CI Token");
+
+    expect(mockClient.post).toHaveBeenCalledWith("auth/agent-tokens/", {
+      name: "CI Token",
+    });
+    expect(result.token).toBe("secret-value");
+  });
+
+  it("revokeAgentToken deletes the token by ID", async () => {
+    const { revokeAgentToken } = await loadApiModule();
+    mockClient.get.mockResolvedValue({ data: undefined });
+    mockClient.delete.mockResolvedValue({});
+
+    await revokeAgentToken("tok-1");
+
+    expect(mockClient.delete).toHaveBeenCalledWith("auth/agent-tokens/tok-1/");
+  });
+
+  it("createHumanCropRun posts a crop run and maps the result", async () => {
+    const { createHumanCropRun } = await loadApiModule();
+    mockClient.get.mockResolvedValue({ data: undefined });
+    mockClient.post.mockResolvedValue({
+      data: {
+        id: "crop-run-1",
+        crop: { x: 0.1, y: 0.1, width: 0.8, height: 0.8 },
+        created: "2024-01-01T00:00:00Z",
+      },
+    });
+    const payload = {
+      piece_state_image_id: 42,
+      crop: { x: 0.1, y: 0.1, width: 0.8, height: 0.8 },
+    };
+
+    const result = await createHumanCropRun(payload);
+
+    expect(mockClient.post).toHaveBeenCalledWith("crop-runs/", payload);
+    expect(result.created).toBeInstanceOf(Date);
   });
 });

--- a/web/src/util/__tests__/authTokenStore.test.ts
+++ b/web/src/util/__tests__/authTokenStore.test.ts
@@ -58,4 +58,25 @@ describe("authTokenStore", () => {
 
     expect(getAccessToken()).toBeNull();
   });
+
+  it("notifies subscribers when the access token changes", async () => {
+    const { setAccessToken, subscribeAccessToken } = await loadStore();
+    const listener = vi.fn();
+    subscribeAccessToken(listener);
+
+    setAccessToken("new-token");
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops notifying after unsubscribe", async () => {
+    const { setAccessToken, subscribeAccessToken } = await loadStore();
+    const listener = vi.fn();
+    const unsubscribe = subscribeAccessToken(listener);
+    unsubscribe();
+
+    setAccessToken("another-token");
+
+    expect(listener).not.toHaveBeenCalled();
+  });
 });

--- a/web/src/util/__tests__/graphqlClient.test.ts
+++ b/web/src/util/__tests__/graphqlClient.test.ts
@@ -1,6 +1,4 @@
 import {
-  afterEach,
-  beforeEach,
   describe,
   expect,
   it,

--- a/web/src/util/__tests__/graphqlClient.test.ts
+++ b/web/src/util/__tests__/graphqlClient.test.ts
@@ -1,4 +1,12 @@
-import { describe, expect, it } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { ClientError } from "graphql-request";
 
 import { graphqlClient } from "../graphqlClient";
 
@@ -11,5 +19,123 @@ describe("graphqlClient", () => {
     expect(graphqlClient.url).toMatch(/\/api\/graphql\/$/);
     // Sanity: `new URL` must accept it without a base.
     expect(() => new URL(graphqlClient.url)).not.toThrow();
+  });
+
+  it("derives the endpoint from the Expo base URL env var when present", async () => {
+    vi.resetModules();
+    process.env.EXPO_PUBLIC_API_BASE_URL = "https://api.example.com/";
+    const { graphqlClient: expoClient } = await import("../graphqlClient");
+    expect(expoClient.url).toBe("https://api.example.com/graphql/");
+    delete process.env.EXPO_PUBLIC_API_BASE_URL;
+    vi.resetModules();
+  });
+
+  it("appends trailing slash to Expo base URL when missing", async () => {
+    vi.resetModules();
+    process.env.EXPO_PUBLIC_API_BASE_URL = "https://api.example.com";
+    const { graphqlClient: expoClient } = await import("../graphqlClient");
+    expect(expoClient.url).toBe("https://api.example.com/graphql/");
+    delete process.env.EXPO_PUBLIC_API_BASE_URL;
+    vi.resetModules();
+  });
+
+  it("derives the endpoint from window.location.origin when no Expo env var is set", async () => {
+    vi.resetModules();
+    delete process.env.EXPO_PUBLIC_API_BASE_URL;
+    vi.stubGlobal("window", { location: { origin: "https://app.example.com" } });
+    const { graphqlClient: windowClient } = await import("../graphqlClient");
+    expect(windowClient.url).toBe("https://app.example.com/api/graphql/");
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+});
+
+describe("graphqlRequest", () => {
+  it("returns data on a successful request", async () => {
+    vi.resetModules();
+    const { graphqlClient: client, graphqlRequest } =
+      await import("../graphqlClient");
+    const mockReq = vi.fn().mockResolvedValueOnce({ pieces: [] });
+    vi.spyOn(client, "request").mockImplementation(mockReq);
+
+    const result = await graphqlRequest<{ pieces: unknown[] }>("query { }");
+
+    expect(result).toEqual({ pieces: [] });
+    vi.restoreAllMocks();
+  });
+
+  it("rethrows non-auth errors without refresh", async () => {
+    vi.resetModules();
+    const { graphqlClient: client, graphqlRequest } =
+      await import("../graphqlClient");
+    const networkError = new Error("network failure");
+    const mockReq = vi.fn().mockRejectedValueOnce(networkError);
+    vi.spyOn(client, "request").mockImplementation(mockReq);
+
+    await expect(graphqlRequest("query { }")).rejects.toThrow("network failure");
+    expect(mockReq).toHaveBeenCalledTimes(1);
+    vi.restoreAllMocks();
+  });
+
+  it("clears the access token and rethrows when refresh fails", async () => {
+    vi.resetModules();
+    const { setAccessToken, getAccessToken } = await import("../authTokenStore");
+    setAccessToken("expired-token");
+
+    const { graphqlClient: client, graphqlRequest } =
+      await import("../graphqlClient");
+    const authError = new ClientError(
+      { errors: [{ message: "not authenticated" }], status: 401 } as never,
+      { query: "query { }" },
+    );
+    const mockReq = vi.fn().mockRejectedValue(authError);
+    vi.spyOn(client, "request").mockImplementation(mockReq);
+
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+
+    await expect(graphqlRequest("query { }")).rejects.toBeDefined();
+    expect(getAccessToken()).toBeNull();
+
+    setAccessToken(null);
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("refreshes the token and retries when an auth error is returned", async () => {
+    vi.resetModules();
+    const { setAccessToken } = await import("../authTokenStore");
+    setAccessToken("expired-token");
+
+    const { graphqlClient: client, graphqlRequest } =
+      await import("../graphqlClient");
+    const authError = new ClientError(
+      { errors: [{ message: "not authenticated" }], status: 401 } as never,
+      { query: "query { }" },
+    );
+    const mockReq = vi
+      .fn()
+      .mockRejectedValueOnce(authError)
+      .mockResolvedValueOnce({ pieces: [] });
+    vi.spyOn(client, "request").mockImplementation(mockReq);
+
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce({ ok: true })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ accessToken: "fresh-token" }),
+        }),
+    );
+
+    const result = await graphqlRequest<{ pieces: unknown[] }>("query { }");
+
+    expect(result).toEqual({ pieces: [] });
+    expect(mockReq).toHaveBeenCalledTimes(2);
+
+    setAccessToken(null);
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 });

--- a/web/src/util/__tests__/postLoginRedirect.test.ts
+++ b/web/src/util/__tests__/postLoginRedirect.test.ts
@@ -32,4 +32,34 @@ describe("getPostLoginRedirectTarget", () => {
       getPostLoginRedirectTarget("localhost", PROTO, "/pieces/abc/showcase"),
     ).toBeNull();
   });
+
+  it("redirects to admin subdomain when next targets admin.<apex>", () => {
+    expect(
+      getPostLoginRedirectTarget(
+        HOST,
+        PROTO,
+        "https://admin.potterdoc.com/dashboard",
+      ),
+    ).toBe("https://admin.potterdoc.com/dashboard");
+  });
+
+  it("strips www. prefix when checking admin subdomain eligibility", () => {
+    expect(
+      getPostLoginRedirectTarget(
+        "www.potterdoc.com",
+        PROTO,
+        "https://admin.potterdoc.com/dashboard",
+      ),
+    ).toBe("https://admin.potterdoc.com/dashboard");
+  });
+
+  it("returns null when current host is already admin.", () => {
+    expect(
+      getPostLoginRedirectTarget(
+        "admin.potterdoc.com",
+        PROTO,
+        "/pieces/abc/showcase",
+      ),
+    ).toBeNull();
+  });
 });

--- a/web/src/util/__tests__/queryKeys.test.ts
+++ b/web/src/util/__tests__/queryKeys.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { GLAZE_COMBINATION_IMAGES_QUERY_KEY } from "../queryKeys";
+
+describe("GLAZE_COMBINATION_IMAGES_QUERY_KEY", () => {
+  it("is a tuple with the expected key string", () => {
+    expect(GLAZE_COMBINATION_IMAGES_QUERY_KEY).toEqual(["glazeCombinationImages"]);
+  });
+});

--- a/web/src/util/__tests__/r2Upload.test.ts
+++ b/web/src/util/__tests__/r2Upload.test.ts
@@ -1,0 +1,315 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("axios");
+vi.mock("../api", () => ({
+  fetchR2PresignedUrl: vi.fn(),
+  getR2ConversionStatus: vi.fn(),
+  triggerR2ImageConversion: vi.fn(),
+}));
+
+import axios from "axios";
+import {
+  fetchR2PresignedUrl,
+  getR2ConversionStatus,
+  triggerR2ImageConversion,
+} from "../api";
+import { MAX_UPLOAD_LONG_EDGE, uploadImageToR2 } from "../r2Upload";
+
+const mockAxiosPost = vi.mocked(axios.post);
+const mockFetchPresigned = vi.mocked(fetchR2PresignedUrl);
+const mockGetConversionStatus = vi.mocked(getR2ConversionStatus);
+const mockTriggerConversion = vi.mocked(triggerR2ImageConversion);
+
+const PRESIGNED = {
+  upload_url: "https://r2.example.com/upload",
+  public_url: "https://cdn.example.com/image.jpg",
+  key: "images/abc.jpg",
+  fields: { key: "images/abc.jpg", policy: "base64policy" },
+};
+
+function makeJpegFile(name = "photo.jpg", size = 100): File {
+  return new File(["x".repeat(size)], name, { type: "image/jpeg" });
+}
+
+function makeFile(name: string, type: string): File {
+  return new File(["x"], name, { type });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAxiosPost.mockResolvedValue({});
+  mockFetchPresigned.mockResolvedValue(PRESIGNED);
+});
+
+describe("MAX_UPLOAD_LONG_EDGE", () => {
+  it("is exported as 2560", () => {
+    expect(MAX_UPLOAD_LONG_EDGE).toBe(2560);
+  });
+});
+
+describe("uploadImageToR2 — browser-decodable JPEG within size cap", () => {
+  it("uploads via presigned POST and returns the public URL without conversion", async () => {
+    const bitmap = {
+      width: 800,
+      height: 600,
+      close: vi.fn(),
+    } as unknown as ImageBitmap;
+    vi.stubGlobal("createImageBitmap", vi.fn().mockResolvedValue(bitmap));
+
+    const canvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn().mockReturnValue({
+        fillStyle: "",
+        fillRect: vi.fn(),
+        drawImage: vi.fn(),
+      }),
+      toBlob: vi.fn(
+        (
+          cb: (b: Blob | null) => void,
+          _type: string,
+          _quality: number,
+        ) => cb(new Blob(["img"], { type: "image/jpeg" })),
+      ),
+    };
+    vi.stubGlobal(
+      "document",
+      Object.assign({}, globalThis.document, {
+        createElement: () => canvas,
+        cookie: "",
+      }),
+    );
+
+    const file = makeJpegFile();
+    const result = await uploadImageToR2(file);
+
+    expect(mockFetchPresigned).toHaveBeenCalledWith("image/jpeg");
+    expect(mockAxiosPost).toHaveBeenCalledWith(
+      PRESIGNED.upload_url,
+      expect.any(FormData),
+    );
+    expect(result.url).toBe(PRESIGNED.public_url);
+    vi.unstubAllGlobals();
+  });
+});
+
+describe("uploadImageToR2 — non-JPEG re-encodes via canvas", () => {
+  it("canvas-encodes a PNG and returns the presigned URL directly", async () => {
+    const bitmap = {
+      width: 800,
+      height: 600,
+      close: vi.fn(),
+    } as unknown as ImageBitmap;
+    vi.stubGlobal("createImageBitmap", vi.fn().mockResolvedValue(bitmap));
+
+    const mockBlob = new Blob(["img"], { type: "image/jpeg" });
+    const canvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn().mockReturnValue({
+        fillStyle: "",
+        fillRect: vi.fn(),
+        drawImage: vi.fn(),
+      }),
+      toBlob: vi.fn(
+        (cb: (b: Blob | null) => void) => cb(mockBlob),
+      ),
+    };
+    vi.stubGlobal(
+      "document",
+      Object.assign({}, globalThis.document, {
+        createElement: () => canvas,
+        cookie: "",
+      }),
+    );
+
+    const pngFile = makeFile("photo.png", "image/png");
+    const result = await uploadImageToR2(pngFile);
+
+    expect(result.url).toBe(PRESIGNED.public_url);
+    expect(result.width).toBe(800);
+    expect(result.height).toBe(600);
+    vi.unstubAllGlobals();
+  });
+
+  it("falls back to server conversion when canvas.getContext returns null", async () => {
+    const bitmap = {
+      width: 800,
+      height: 600,
+      close: vi.fn(),
+    } as unknown as ImageBitmap;
+    vi.stubGlobal("createImageBitmap", vi.fn().mockResolvedValue(bitmap));
+
+    const canvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn().mockReturnValue(null),
+    };
+    vi.stubGlobal(
+      "document",
+      Object.assign({}, globalThis.document, {
+        createElement: () => canvas,
+        cookie: "",
+      }),
+    );
+
+    const pngFile = makeFile("photo.png", "image/png");
+    mockTriggerConversion.mockResolvedValue({
+      task_id: "task-ctx",
+      needs_conversion: true,
+    });
+    mockGetConversionStatus.mockResolvedValue({
+      status: "success",
+      result: {
+        url: "https://cdn.example.com/converted.jpg",
+        width: 800,
+        height: 600,
+      },
+    });
+
+    vi.useFakeTimers();
+    const resultPromise = uploadImageToR2(pngFile);
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result.url).toBe("https://cdn.example.com/converted.jpg");
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("downscales oversized images before canvas-encoding", async () => {
+    const bitmap = {
+      width: 4000,
+      height: 3000,
+      close: vi.fn(),
+    } as unknown as ImageBitmap;
+    vi.stubGlobal("createImageBitmap", vi.fn().mockResolvedValue(bitmap));
+
+    const mockBlob = new Blob(["img"], { type: "image/jpeg" });
+    const canvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn().mockReturnValue({
+        fillStyle: "",
+        fillRect: vi.fn(),
+        drawImage: vi.fn(),
+      }),
+      toBlob: vi.fn(
+        (cb: (b: Blob | null) => void) => cb(mockBlob),
+      ),
+    };
+    vi.stubGlobal(
+      "document",
+      Object.assign({}, globalThis.document, {
+        createElement: () => canvas,
+        cookie: "",
+      }),
+    );
+
+    const jpegFile = makeJpegFile("large.jpg");
+    const result = await uploadImageToR2(jpegFile);
+
+    expect(result.url).toBe(PRESIGNED.public_url);
+    expect(result.width).toBe(Math.round(4000 * (2560 / 4000)));
+    expect(result.height).toBe(Math.round(3000 * (2560 / 4000)));
+    vi.unstubAllGlobals();
+  });
+});
+
+describe("uploadImageToR2 — browser-opaque format triggers server conversion", () => {
+  it("polls until conversion succeeds and returns the converted URL", async () => {
+    vi.stubGlobal(
+      "createImageBitmap",
+      vi.fn().mockRejectedValue(new Error("unsupported format")),
+    );
+
+    const heicFile = makeFile("photo.heic", "image/heic");
+    mockTriggerConversion.mockResolvedValue({
+      task_id: "task-123",
+      needs_conversion: true,
+    });
+    mockGetConversionStatus
+      .mockResolvedValueOnce({ status: "pending" })
+      .mockResolvedValueOnce({
+        status: "success",
+        result: {
+          url: "https://cdn.example.com/converted.jpg",
+          width: 1024,
+          height: 768,
+        },
+      });
+
+    vi.useFakeTimers();
+
+    const resultPromise = uploadImageToR2(heicFile, "img-id");
+
+    await vi.runAllTimersAsync();
+
+    const result = await resultPromise;
+
+    expect(result.url).toBe("https://cdn.example.com/converted.jpg");
+    expect(result.width).toBe(1024);
+    expect(result.height).toBe(768);
+    expect(mockTriggerConversion).toHaveBeenCalledWith("images/abc.jpg", "img-id");
+
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("throws when the conversion task fails", async () => {
+    vi.stubGlobal(
+      "createImageBitmap",
+      vi.fn().mockRejectedValue(new Error("unsupported")),
+    );
+
+    const heicFile = makeFile("photo.heic", "image/heic");
+    mockTriggerConversion.mockResolvedValue({
+      task_id: "task-456",
+      needs_conversion: true,
+    });
+    mockGetConversionStatus.mockResolvedValue({
+      status: "failure",
+      error: "conversion failed",
+    });
+
+    vi.useFakeTimers();
+
+    const resultPromise = uploadImageToR2(heicFile).catch((e: unknown) => e);
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result).toBeInstanceOf(Error);
+    expect((result as Error).message).toBe(
+      "Image conversion failed: conversion failed",
+    );
+
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("infers MIME type from extension when file.type is blank", async () => {
+    vi.stubGlobal(
+      "createImageBitmap",
+      vi.fn().mockRejectedValue(new Error("unsupported")),
+    );
+
+    const noTypeFile = new File(["x"], "image.heic", { type: "" });
+    mockTriggerConversion.mockResolvedValue({
+      task_id: "task-789",
+      needs_conversion: false,
+    });
+
+    vi.useFakeTimers();
+
+    const resultPromise = uploadImageToR2(noTypeFile);
+    await vi.runAllTimersAsync();
+
+    const result = await resultPromise;
+
+    expect(mockFetchPresigned).toHaveBeenCalledWith("image/heic");
+    expect(result.url).toBe(PRESIGNED.public_url);
+
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+});

--- a/web/src/util/__tests__/r2Upload.test.ts
+++ b/web/src/util/__tests__/r2Upload.test.ts
@@ -65,11 +65,8 @@ describe("uploadImageToR2 — browser-decodable JPEG within size cap", () => {
         drawImage: vi.fn(),
       }),
       toBlob: vi.fn(
-        (
-          cb: (b: Blob | null) => void,
-          _type: string,
-          _quality: number,
-        ) => cb(new Blob(["img"], { type: "image/jpeg" })),
+        (cb: (b: Blob | null) => void) =>
+          cb(new Blob(["img"], { type: "image/jpeg" })),
       ),
     };
     vi.stubGlobal(

--- a/web/src/util/__tests__/telemetry.test.ts
+++ b/web/src/util/__tests__/telemetry.test.ts
@@ -1,5 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const mockSpanEnd = vi.fn();
+const mockRecordException = vi.fn();
+const mockSetStatus = vi.fn();
+const mockSetAttribute = vi.fn();
+const mockStartSpan = vi.fn(() => ({
+  end: mockSpanEnd,
+  recordException: mockRecordException,
+  setStatus: mockSetStatus,
+  setAttribute: mockSetAttribute,
+}));
+
+vi.mock("@opentelemetry/api", () => ({
+  trace: { getTracer: vi.fn(() => ({ startSpan: mockStartSpan })) },
+  SpanStatusCode: { ERROR: 2 },
+}));
+
 const mockRegister = vi.fn();
 const mockRegisterInstrumentations = vi.fn();
 const mockWebTracerProvider = vi.fn(function WebTracerProvider() {
@@ -150,5 +166,78 @@ describe("initializeFrontendTelemetry", () => {
 
     expect(mockWebTracerProvider).toHaveBeenCalledTimes(1);
     expect(mockRegisterInstrumentations).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits the CSRF header when the cookie is not set", async () => {
+    document.cookie =
+      "potterdoc_csrftoken=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/";
+    const { initializeFrontendTelemetry } = await loadTelemetryModule();
+
+    initializeFrontendTelemetry();
+
+    expect(mockOTLPTraceExporter).toHaveBeenCalledWith(
+      expect.objectContaining({ headers: undefined }),
+    );
+  });
+
+  it("forwards window.error events to reportFrontendError", async () => {
+    const { initializeFrontendTelemetry } = await loadTelemetryModule();
+    initializeFrontendTelemetry();
+
+    const err = new Error("uncaught");
+    window.dispatchEvent(Object.assign(new Event("error"), { error: err }));
+
+    expect(mockStartSpan).toHaveBeenCalledWith("frontend.error");
+    expect(mockRecordException).toHaveBeenCalledWith(err);
+  });
+
+  it("forwards unhandledrejection events to reportFrontendError", async () => {
+    const { initializeFrontendTelemetry } = await loadTelemetryModule();
+    initializeFrontendTelemetry();
+
+    window.dispatchEvent(
+      Object.assign(new Event("unhandledrejection"), {
+        reason: new Error("unhandled promise"),
+      }),
+    );
+
+    expect(mockStartSpan).toHaveBeenCalledWith("frontend.error");
+  });
+});
+
+describe("reportFrontendError", () => {
+  it("records an Error instance as an exception span", async () => {
+    const { reportFrontendError } = await loadTelemetryModule();
+    const err = new Error("test failure");
+
+    reportFrontendError(err);
+
+    expect(mockStartSpan).toHaveBeenCalledWith("frontend.error");
+    expect(mockRecordException).toHaveBeenCalledWith(err);
+    expect(mockSetStatus).toHaveBeenCalledWith({ code: 2 });
+    expect(mockSpanEnd).toHaveBeenCalled();
+  });
+
+  it("coerces non-Error values to string before recording", async () => {
+    const { reportFrontendError } = await loadTelemetryModule();
+
+    reportFrontendError("something went wrong");
+
+    expect(mockRecordException).toHaveBeenCalledWith("something went wrong");
+    expect(mockSetStatus).toHaveBeenCalledWith({ code: 2 });
+  });
+
+  it("attaches context key-value pairs as span attributes", async () => {
+    const { reportFrontendError } = await loadTelemetryModule();
+
+    reportFrontendError(new Error("ctx error"), {
+      "error.source": "window.onerror",
+    });
+
+    expect(mockSetAttribute).toHaveBeenCalledWith(
+      "error.source",
+      "window.onerror",
+    );
+    expect(mockSpanEnd).toHaveBeenCalled();
   });
 });

--- a/web/src/util/__tests__/useToggleGlobalEntryFavorite.test.ts
+++ b/web/src/util/__tests__/useToggleGlobalEntryFavorite.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+vi.mock("../api", () => ({
+  toggleGlobalEntryFavorite: vi.fn(),
+}));
+
+import { toggleGlobalEntryFavorite } from "../api";
+import { useToggleGlobalEntryFavorite } from "../useToggleGlobalEntryFavorite";
+
+const mockToggle = vi.mocked(toggleGlobalEntryFavorite);
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useToggleGlobalEntryFavorite", () => {
+  it("optimistically flips is_favorite and sets save status to saved", async () => {
+    mockToggle.mockResolvedValue(undefined);
+    const queryKey = ["entries"];
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    queryClient.setQueryData(queryKey, [
+      { id: "entry-1", is_favorite: false },
+      { id: "entry-2", is_favorite: true },
+    ]);
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+    const { result } = renderHook(
+      () => useToggleGlobalEntryFavorite("glaze_combination", queryKey),
+      { wrapper },
+    );
+
+    expect(result.current.saveStatus).toBe("idle");
+
+    await act(async () => {
+      await result.current.toggleFavorite({ id: "entry-1", is_favorite: false });
+    });
+
+    await waitFor(() => expect(result.current.saveStatus).toBe("saved"));
+    expect(mockToggle).toHaveBeenCalledWith("glaze_combination", "entry-1", true);
+    expect(result.current.togglingId).toBeNull();
+    expect(result.current.lastSavedAt).toBeInstanceOf(Date);
+    expect(result.current.saveError).toBeNull();
+
+    const updated = queryClient.getQueryData<{ id: string; is_favorite: boolean }[]>(queryKey);
+    expect(updated?.find((e) => e.id === "entry-1")?.is_favorite).toBe(true);
+    expect(updated?.find((e) => e.id === "entry-2")?.is_favorite).toBe(true);
+  });
+
+  it("sets saveStatus to error and records the message when the API call fails", async () => {
+    mockToggle.mockRejectedValue(new Error("network error"));
+    const queryKey = ["entries"];
+    const wrapper = makeWrapper();
+
+    const { result } = renderHook(
+      () => useToggleGlobalEntryFavorite("glaze_combination", queryKey),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.toggleFavorite({ id: "entry-2", is_favorite: true });
+    });
+
+    await waitFor(() => expect(result.current.saveStatus).toBe("error"));
+    expect(result.current.saveError).toBe(
+      "Failed to update favorite. Please try again.",
+    );
+    expect(result.current.togglingId).toBeNull();
+  });
+});

--- a/web/src/util/workflow.test.ts
+++ b/web/src/util/workflow.test.ts
@@ -123,6 +123,7 @@ vi.mock("../../../workflow.yml", () => ({
                 ],
               },
             },
+            { label: "Unrecognized summary item type" },
           ],
         },
       ],
@@ -234,6 +235,27 @@ vi.mock("../../../workflow.yml", () => ({
           cyclic_b: {
             $ref: "edge_cases.cyclic_a",
           },
+          thumbnail_image: {
+            type: "image",
+          },
+          concat_label: {
+            compute: {
+              op: "concat",
+              args: ["edge_cases.required_notes", "edge_cases.required_notes"],
+            },
+          },
+          bool_flag: {
+            compute: { constant: true },
+          },
+          string_const: {
+            compute: { constant: "fixed" },
+          },
+          field_ref_known: {
+            compute: { field: "wheel_thrown.clay_weight_lbs" },
+          },
+          field_ref_unknown: {
+            compute: { field: "nonexistent_state.some_field" },
+          },
         },
       },
       {
@@ -341,6 +363,7 @@ import {
   isTaggableGlobal,
   insertableStatesBetween,
   getDefinitionsFromSchema,
+  validateHistorySequence,
 } from "./workflow";
 
 describe("getDefinitionsFromSchema", () => {
@@ -868,6 +891,34 @@ describe("getProcessSummaryFieldOptions", () => {
       options.find((option) => option.ref === "piece.thumbnail"),
     ).toBeUndefined();
   });
+
+  it("excludes image-type state fields from options", () => {
+    const options = getProcessSummaryFieldOptions();
+    expect(
+      options.find((option) => option.ref === "edge_cases.thumbnail_image"),
+    ).toBeUndefined();
+  });
+
+  it("includes non-arithmetic compute fields with string type", () => {
+    const options = getProcessSummaryFieldOptions();
+    expect(
+      options.find((option) => option.ref === "edge_cases.concat_label"),
+    ).toBeDefined();
+  });
+});
+
+describe("getProcessSummaryDefinition without process_summary", () => {
+  it("returns [] when workflow has no process_summary", async () => {
+    vi.resetModules();
+    vi.doMock("../../../workflow.yml", () => ({
+      default: { version: "0.0.2", globals: {}, states: [] },
+    }));
+    const { getProcessSummaryDefinition: getSummary } = await import(
+      "./workflow"
+    );
+    expect(getSummary()).toEqual([]);
+    vi.resetModules();
+  });
 });
 
 describe("getFilterableFields", () => {
@@ -979,5 +1030,29 @@ describe("insertableStatesBetween", () => {
       new Set(["designed", "completed"]),
     );
     expect(result).toEqual([]);
+  });
+});
+
+describe("validateHistorySequence", () => {
+  it("returns null for a valid state history", () => {
+    const history = [
+      { state: "designed" as const },
+      { state: "wheel_thrown" as const },
+      { state: "trimmed" as const },
+    ];
+    expect(validateHistorySequence(history)).toBeNull();
+  });
+
+  it("returns an error string when a transition is invalid", () => {
+    const history = [
+      { state: "designed" as const },
+      { state: "trimmed" as const },
+    ];
+    const result = validateHistorySequence(history);
+    expect(result).toMatch(/not a valid successor/);
+  });
+
+  it("returns null for a single-state history", () => {
+    expect(validateHistorySequence([{ state: "designed" as const }])).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Remove `mb: 1.5` from the Notes `TextField` and `pt: 3` from the custom fields grid in `WorkflowState` — the parent `Box` already applies `gap: 1` uniformly between all children, so these extra margins were creating ~44px of dead space below the Notes field
- Add unit test coverage for `api`, `authTokenStore`, `graphqlClient`, `postLoginRedirect`, `telemetry`, `workflow`, `queryKeys`, `r2Upload`, and `useToggleGlobalEntryFavorite` util modules
- Wire three new test targets (`web_r2_upload_test`, `web_use_toggle_global_entry_favorite_test`, `web_query_keys_test`) into `web/BUILD.bazel`

## Test plan

- [ ] Open a piece with a Notes field (e.g. `/pieces/93e9b6ba-85be-4dbd-b1cc-77689add838c`) and confirm the vertical gap below Notes is reduced to a single uniform gap
- [ ] `bazel test //web:web_test` passes with the new targets included

🤖 Generated with [Claude Code](https://claude.com/claude-code)