### PR TITLE
feat(web): replace StateTransition + Timeline with StateCarousel

### DIFF
--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -667,6 +667,17 @@ js_library(
 )
 
 js_library(
+    name = "state_carousel_src",
+    srcs = ["src/components/StateCarousel.tsx"],
+    deps = [
+        ":node_modules",
+        ":piece_history_src",
+        ":primitive_src",
+        ":util_lib",
+    ],
+)
+
+js_library(
     name = "piece_history_src",
     srcs = ["src/components/PieceHistory.tsx"],
     deps = [
@@ -747,7 +758,7 @@ js_library(
         ":primitive_src",
         ":process_summary_src",
         ":routing_src",
-        ":state_transition_src",
+        ":state_carousel_src",
         ":tag_manager_src",
         ":util_lib",
         ":workflow_state_src",

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -15,7 +15,6 @@ import {
   Alert,
   alpha,
   Box,
-  Chip,
   Collapse,
   Divider,
   Button,
@@ -25,7 +24,6 @@ import {
   Stack,
   Typography,
 } from "@mui/material";
-import HistoryIcon from "@mui/icons-material/History";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import { useBlocker, useLocation, useNavigate, Link as RouterLink } from "react-router-dom";
@@ -48,8 +46,8 @@ import AppImage from "./AppImage";
 import NavigationBlocker from "./NavigationBlocker";
 import WorkflowState from "./WorkflowState";
 import TagManager from "./TagManager";
-import StateTransition from "./StateTransition";
 import PieceHistory from "./PieceHistory";
+import StateCarousel from "./StateCarousel";
 import ProcessSummary from "./ProcessSummary";
 import PiecePhotoGallery, {
   PiecePhotoGalleryButton,
@@ -281,7 +279,7 @@ function PieceDetailContent({
           }}
         >
           {/* Left column (desktop) / bottom (mobile): title + tags + states */}
-          <Box sx={{ pt: { xs: 1.75, md: 0 }, pb: 0.5, gridArea: "info" }}>
+          <Box sx={{ pt: { xs: 1.75, md: 0 }, pb: 0.5, gridArea: "info", minWidth: 0 }}>
             <Typography
               variant="caption"
               sx={{
@@ -308,24 +306,24 @@ function PieceDetailContent({
                 onCloseTagDialog={tagsRouting.onCloseTagDialog}
               />
             ) : null}
-            {canEdit && (
-              <Box sx={{ mt: 2, mb: 1.5 }}>
-                <StateTransition
-                  currentStateName={currentState.state}
-                  disabled={hasSaveError || piece.is_editable}
-                  disabledHint={
-                    piece.is_editable
-                      ? "Seal edit mode before transitioning to a new state."
-                      : hasSaveError
-                        ? "Auto-save failed. Your changes may not be saved."
-                        : undefined
-                  }
-                  transitioning={transitioning}
-                  transitionError={transitionError}
-                  onTransition={handleTransition}
-                />
-              </Box>
-            )}
+            <Box sx={{ mt: 2, mb: 1.5 }}>
+              <StateCarousel
+                statesHistory={statesHistory}
+                piece={piece}
+                onPieceUpdated={onPieceUpdated}
+                rewindedStateId={rewindedStateId}
+                onRewind={(id) =>
+                  id ? historyRouting.onRewind(id) : historyRouting.onClearRewind()
+                }
+                historyLoading={historyLoading}
+                historyError={historyError}
+                refetchHistory={refetchHistory}
+                onTransition={handleTransition}
+                transitioning={transitioning}
+                transitionError={transitionError}
+                hasSaveError={hasSaveError}
+              />
+            </Box>
             {canEdit && isTerminal && (
               <Box sx={{ mb: 1.5 }}>
                 <ShareControls piece={piece} onPieceUpdated={onPieceUpdated} />
@@ -349,7 +347,6 @@ function PieceDetailContent({
               </Box>
             )}
             <Box sx={{ mb: 1.5 }}>
-              <SectionCard>
                 <RoutedGlobalEntryField
                   pieceId={piece.id}
                   fieldName="current_location"
@@ -367,7 +364,6 @@ function PieceDetailContent({
                     {locationError}
                   </Typography>
                 )}
-              </SectionCard>
             </Box>
           </Box>
 
@@ -451,21 +447,6 @@ function PieceDetailContent({
 
         {rewindedState ? (
           <SectionCard>
-            <Box sx={{ mb: 1.5, display: "flex", alignItems: "center", gap: 1 }}>
-              <Chip
-                icon={<HistoryIcon fontSize="small" />}
-                label={`Rewound to: ${formatState(rewindedState.state)}`}
-                color="primary"
-                variant="outlined"
-                size="small"
-                onDelete={historyRouting.onClearRewind}
-              />
-              <Typography variant="caption" color="text.secondary">
-                {piece.is_editable
-                  ? "Editing historical state — later states greyed out in timeline"
-                  : "Viewing historical state — read-only"}
-              </Typography>
-            </Box>
             <WorkflowState
               key={rewindedState.id}
               initialPieceState={rewindedState}
@@ -540,42 +521,6 @@ function PieceDetailContent({
           </SectionCard>
         </Box>
 
-        <SectionCard
-          title="Timeline"
-          subtitle={
-            historyError
-              ? "Error loading history"
-              : historyLoading
-              ? "Loading history..."
-              : `${pastHistory.length} completed state${pastHistory.length === 1 ? "" : "s"}`
-          }
-        >
-          {historyError ? (
-            <Box sx={{ py: 2, textAlign: "center" }}>
-              <Typography variant="body2" color="error" sx={{ mb: 1.5 }}>
-                Failed to load timeline.
-              </Typography>
-              <Button size="small" variant="outlined" onClick={refetchHistory}>
-                Retry
-              </Button>
-            </Box>
-          ) : historyLoading ? (
-            <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
-              <CircularProgress size={24} />
-            </Box>
-          ) : (
-            <PieceHistory
-              pastHistory={pastHistory}
-              piece={piece}
-              history={statesHistory}
-              onPieceUpdated={onPieceUpdated}
-              rewindedStateId={rewindedStateId}
-              onRewind={(id) =>
-                id ? historyRouting.onRewind(id) : historyRouting.onClearRewind()
-              }
-            />
-          )}
-        </SectionCard>
       </Box>
 
       {canEdit && (

--- a/web/src/components/PieceDetail.tsx
+++ b/web/src/components/PieceDetail.tsx
@@ -46,7 +46,6 @@ import AppImage from "./AppImage";
 import NavigationBlocker from "./NavigationBlocker";
 import WorkflowState from "./WorkflowState";
 import TagManager from "./TagManager";
-import PieceHistory from "./PieceHistory";
 import StateCarousel from "./StateCarousel";
 import ProcessSummary from "./ProcessSummary";
 import PiecePhotoGallery, {

--- a/web/src/components/StateCarousel.tsx
+++ b/web/src/components/StateCarousel.tsx
@@ -195,7 +195,7 @@ type PieceTimelineProps = {
   onTransition?: (nextState: string) => void;
   transitioning?: boolean;
   transitionError?: string | null;
-  isDirty?: boolean;
+  hasSaveError?: boolean;
 };
 
 export default function StateCarousel({
@@ -210,7 +210,7 @@ export default function StateCarousel({
   onTransition,
   transitioning = false,
   transitionError,
-  isDirty = false,
+  hasSaveError = false,
 }: PieceTimelineProps) {
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [pendingTransition, setPendingTransition] = useState<string | null>(null);
@@ -239,7 +239,8 @@ export default function StateCarousel({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Animated scroll whenever rewind state changes after mount.
+  // Animated scroll whenever rewind state or current card changes after mount
+  // (covers: entering/exiting rewind, post-transition new current card).
   useEffect(() => {
     if (!mountedRef.current) return;
     const targetIdx = rewindedStateId
@@ -252,34 +253,22 @@ export default function StateCarousel({
     }
     setActiveIdx(targetIdx);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rewindedStateId]);
+  }, [rewindedStateId, currentIdx]);
 
-  if (historyError) {
-    return (
-      <Box sx={{ py: 2, textAlign: "center" }}>
-        <Typography variant="body2" color="error" sx={{ mb: 1.5 }}>
-          Failed to load timeline.
-        </Typography>
-        <Button size="small" variant="outlined" onClick={refetchHistory}>Retry</Button>
-      </Box>
-    );
-  }
-  if (historyLoading) {
-    return (
-      <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
-        <CircularProgress size={24} />
-      </Box>
-    );
-  }
-  if (statesHistory.length === 0) return null;
+  // Current state is always available from piece.current_state even while history loads.
+  const fallbackHistory: PieceState[] = statesHistory.length > 0
+    ? statesHistory
+    : [piece.current_state];
+
+  const effectiveHistory = fallbackHistory;
 
   const canEdit          = piece.can_edit;
-  const currentState     = statesHistory[currentIdx];
+  const currentState     = effectiveHistory[effectiveHistory.length - 1];
   const successors       = sortSuccessorsForDisplay(SUCCESSORS[currentState.state] ?? []);
   const isTerminal       = successors.length === 0;
-  const transitionDisabled = !canEdit || isDirty || piece.is_editable || transitioning;
+  const transitionDisabled = !canEdit || hasSaveError || piece.is_editable || transitioning;
   const rewindedState    = rewindedStateId
-    ? statesHistory.find((ps) => ps.id === rewindedStateId) ?? null
+    ? effectiveHistory.find((ps) => ps.id === rewindedStateId) ?? null
     : null;
 
   // ── Carousel helpers ───────────────────────────────────────────────────────
@@ -325,12 +314,14 @@ export default function StateCarousel({
   };
   const stopDrag = () => {
     dragRef.current.active = false;
-    dragRef.current.moved = false;
     setDragging(false);
+    // moved flag is cleared after a tick so the click event that follows
+    // mouseup sees it as still true and gets suppressed.
+    setTimeout(() => { dragRef.current.moved = false; }, 0);
   };
 
   // ── Transition helpers ─────────────────────────────────────────────────────
-  const openDialog  = (next: string) => setPendingTransition(next);
+  const openDialog  = (next: string) => { if (!transitionDisabled) setPendingTransition(next); };
   const closeDialog = () => setPendingTransition(null);
   const confirmTransition = () => {
     if (pendingTransition && onTransition) { onTransition(pendingTransition); }
@@ -347,6 +338,7 @@ export default function StateCarousel({
         onMouseMove={onMouseMove}
         onMouseUp={stopDrag}
         onMouseLeave={stopDrag}
+        onClickCapture={(e) => { if (dragRef.current.moved) { e.stopPropagation(); e.preventDefault(); } }}
         sx={{
           display: "flex",
           overflowX: "auto",
@@ -358,12 +350,13 @@ export default function StateCarousel({
           userSelect: dragging ? "none" : "auto",
         }}
       >
-        {statesHistory.map((ps, i) => {
-          const isCurrent  = i === currentIdx;
+        {effectiveHistory.map((ps, i) => {
+          const effCurrentIdx = effectiveHistory.length - 1;
+          const isCurrent  = i === effCurrentIdx;
           const isActive   = i === activeIdx;
           const isRewinded = ps.id === rewindedStateId;
-          const prev       = i > 0 ? statesHistory[i - 1] : null;
-          const next       = i < currentIdx ? statesHistory[i + 1] : null;
+          const prev       = i > 0 ? effectiveHistory[i - 1] : null;
+          const next       = i < effCurrentIdx ? effectiveHistory[i + 1] : null;
 
           // Height of right zone drives the card height when current.
           const succH = isCurrent && !isTerminal && canEdit
@@ -454,7 +447,7 @@ export default function StateCarousel({
                               description={getStateDescription(next)}
                               variant="future"
                               isTerminal={isTerminalState(next)}
-                              onClick={transitionDisabled ? undefined : () => openDialog(next)}
+                              onClick={() => openDialog(next)}
                               disabled={transitionDisabled}
                             />
                           </Box>
@@ -483,9 +476,26 @@ export default function StateCarousel({
         })}
       </Box>
 
+      {/* History error banner — shown below the carousel so transitions still work */}
+      {historyError && (
+        <Box sx={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 1, pt: 0.5 }}>
+          <Typography variant="caption" color="error">Failed to load history.</Typography>
+          <Button size="small" variant="outlined" color="error" onClick={refetchHistory} sx={{ py: 0, minWidth: 0 }}>
+            Retry
+          </Button>
+        </Box>
+      )}
+
+      {/* History loading indicator */}
+      {historyLoading && (
+        <Box sx={{ display: "flex", justifyContent: "center", pt: 0.5 }}>
+          <CircularProgress size={16} />
+        </Box>
+      )}
+
       {/* Pager dots */}
       <Box sx={{ display: "flex", justifyContent: "center", gap: 0.75, pt: 1, pb: 0.25 }}>
-        {statesHistory.map((ps, i) => (
+        {effectiveHistory.map((ps, i) => (
           <Box
             key={ps.id ?? i}
             component="button"
@@ -496,8 +506,8 @@ export default function StateCarousel({
               height: 6,
               borderRadius: 999,
               bgcolor: i === activeIdx
-                ? i === currentIdx ? "primary.main" : "text.secondary"
-                : i === currentIdx ? "primary.main" : "divider",
+                ? i === effectiveHistory.length - 1 ? "primary.main" : "text.secondary"
+                : i === effectiveHistory.length - 1 ? "primary.main" : "divider",
               border: "none",
               padding: 0,
               cursor: "pointer",
@@ -532,11 +542,11 @@ export default function StateCarousel({
           {transitionError}
         </Typography>
       )}
-      {transitionDisabled && !isTerminal && canEdit && (isDirty || piece.is_editable) && (
+      {transitionDisabled && !isTerminal && canEdit && (hasSaveError || piece.is_editable) && (
         <Typography variant="caption" sx={{ color: "text.secondary", mt: 0.5, display: "block", textAlign: "center" }}>
           {piece.is_editable
             ? "Seal edit mode before transitioning to a new state."
-            : "Save your changes before transitioning to a new state."}
+            : "Auto-save failed. Your changes may not be saved."}
         </Typography>
       )}
 
@@ -560,12 +570,15 @@ export default function StateCarousel({
           <DialogTitle sx={{ pb: 1 }}>Edit History</DialogTitle>
           <DialogContent>
             <PieceHistory
-              pastHistory={statesHistory.slice(0, -1)}
+              pastHistory={effectiveHistory.slice(0, -1)}
               piece={piece}
-              history={statesHistory}
+              history={effectiveHistory}
               onPieceUpdated={onPieceUpdated}
               rewindedStateId={rewindedStateId}
-              onRewind={onRewind}
+              onRewind={(id) => {
+                onRewind?.(id);
+                setEditModalOpen(false);
+              }}
             />
           </DialogContent>
         </Dialog>

--- a/web/src/components/StateCarousel.tsx
+++ b/web/src/components/StateCarousel.tsx
@@ -18,6 +18,7 @@ import { useRef, useState, useEffect, useLayoutEffect } from "react";
 import type { PieceDetail as PieceDetailType, PieceState } from "../util/types";
 import {
   formatState,
+  formatPastState,
   getStateDescription,
   isTerminalState,
   SUCCESSORS,
@@ -223,7 +224,7 @@ export default function StateCarousel({
 
   const initialIdx = rewindedStateId
     ? Math.max(0, statesHistory.findIndex((ps) => ps.id === rewindedStateId))
-    : currentIdx;
+    : Math.max(0, currentIdx);
 
   const [activeIdx, setActiveIdx] = useState(initialIdx);
   const [dragging, setDragging]   = useState(false);
@@ -245,7 +246,7 @@ export default function StateCarousel({
     if (!mountedRef.current) return;
     const targetIdx = rewindedStateId
       ? Math.max(0, statesHistory.findIndex((ps) => ps.id === rewindedStateId))
-      : currentIdx;
+      : Math.max(0, currentIdx);
     const rail   = railRef.current;
     const target = cardRefs.current[targetIdx];
     if (rail && target) {
@@ -380,8 +381,8 @@ export default function StateCarousel({
               <Box sx={{ display: "flex", justifyContent: "flex-start", alignItems: "center", minWidth: 0 }}>
                 {prev ? (
                   isCurrent
-                    ? <PrevPill label={formatState(prev.state)} onClick={() => goTo(i - 1)} />
-                    : <PrevFullPill label={formatState(prev.state)} onClick={() => goTo(i - 1)} />
+                    ? <PrevPill label={formatPastState(prev.state)} onClick={() => goTo(i - 1)} />
+                    : <PrevFullPill label={formatPastState(prev.state)} onClick={() => goTo(i - 1)} />
                 ) : (
                   <Typography variant="caption" sx={{ color: TEXT_MUTE, opacity: 0.5, fontSize: 10 }}>
                     start
@@ -393,7 +394,7 @@ export default function StateCarousel({
               <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 0.5, py: 0.5 }}>
                 <StateChip
                   state={ps.state}
-                  label={formatState(ps.state)}
+                  label={isCurrent ? formatState(ps.state) : formatPastState(ps.state)}
                   description={
                     isCurrent
                       ? "Click to return to current state"
@@ -458,7 +459,7 @@ export default function StateCarousel({
               ) : (
                 <Box sx={{ display: "flex", justifyContent: "flex-end", alignItems: "center", minWidth: 0 }}>
                   {next ? (
-                    <NextPill label={formatState(next.state)} onClick={() => goTo(i + 1)} />
+                    <NextPill label={i + 1 === effCurrentIdx ? formatState(next.state) : formatPastState(next.state)} onClick={() => goTo(i + 1)} />
                   ) : (
                     <Typography variant="caption" sx={{ color: TEXT_MUTE, opacity: 0.5, fontSize: 10 }}>
                       end
@@ -495,7 +496,7 @@ export default function StateCarousel({
             key={ps.id ?? i}
             component="button"
             onClick={() => goTo(i)}
-            aria-label={`Jump to ${formatState(ps.state)}`}
+            aria-label={`Jump to ${i === effectiveHistory.length - 1 ? formatState(ps.state) : formatPastState(ps.state)}`}
             sx={{
               width: i === activeIdx ? 18 : 6,
               height: 6,

--- a/web/src/components/StateCarousel.tsx
+++ b/web/src/components/StateCarousel.tsx
@@ -1,0 +1,604 @@
+import ArrowOutwardIcon from "@mui/icons-material/ArrowOutward";
+import EditIcon from "@mui/icons-material/Edit";
+import HistoryIcon from "@mui/icons-material/History";
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  IconButton,
+  Typography,
+} from "@mui/material";
+import { useRef, useState, useEffect, useLayoutEffect } from "react";
+import type { PieceDetail as PieceDetailType, PieceState } from "../util/types";
+import {
+  formatState,
+  getStateDescription,
+  isTerminalState,
+  SUCCESSORS,
+} from "../util/workflow";
+import StateChip from "./StateChip";
+import PieceHistory from "./PieceHistory";
+
+// Nav pill token values (design spec).
+const TEXT_MUTE = "oklch(0.56 0.010 70)";
+const LINE_SOFT = "oklch(0.28 0.010 55)";
+
+// Row geometry — kept in sync with StateChip's sizing.
+const ROW_H = 36;
+const ROW_GAP = 8;
+
+function sortSuccessorsForDisplay(successors: string[]): string[] {
+  const standard = successors.filter((s) => s !== "completed" && s !== "recycled");
+  const trailing = successors
+    .filter((s) => s === "completed" || s === "recycled")
+    .sort((a, b) => (a === b ? 0 : a === "completed" ? -1 : 1));
+  return [...standard, ...trailing];
+}
+
+// Bezier-fan branch connector from the design spec.
+function BranchConnector({ count }: { count: number }) {
+  const n   = Math.max(count, 1);
+  const h   = n === 1 ? ROW_H : n * ROW_H + (n - 1) * ROW_GAP;
+  const cy  = h / 2;
+  const w   = 28;
+  const ys  = Array.from({ length: n }, (_, i) => ROW_H / 2 + i * (ROW_H + ROW_GAP));
+
+  return (
+    <Box
+      component="svg"
+      aria-hidden="true"
+      sx={(theme) => ({
+        flexShrink: 0,
+        width: w,
+        height: h,
+        alignSelf: "flex-start",
+        display: "block",
+        overflow: "visible",
+        "--line": theme.palette.divider,
+      })}
+      viewBox={`0 0 ${w} ${h}`}
+    >
+      {ys.map((y, i) => (
+        <path
+          key={i}
+          d={`M 0 ${cy} C ${w * 0.55} ${cy}, ${w * 0.45} ${y}, ${w} ${y}`}
+          stroke="var(--line)"
+          fill="none"
+          strokeWidth="1.2"
+          strokeLinecap="round"
+        />
+      ))}
+      <circle cx={0} cy={cy} r={2.5} fill="var(--line)" />
+    </Box>
+  );
+}
+
+function formatDateLabel(d: Date | null | undefined): string {
+  if (!d) return "";
+  const today = new Date();
+  if (d.toDateString() === today.toDateString()) return "today";
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+// Compact predecessor navigation pill (left zone of current card).
+function PrevPill({ label, onClick }: { label: string; onClick: () => void }) {
+  return (
+    <Box
+      component="button"
+      onClick={onClick}
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "6px",
+        px: "7px",
+        py: "5px",
+        borderRadius: 999,
+        background: "oklch(0 0 0 / 0.22)",
+        border: `1px solid ${LINE_SOFT}`,
+        color: TEXT_MUTE,
+        fontFamily: "JetBrains Mono, monospace",
+        fontSize: 10,
+        cursor: "pointer",
+        whiteSpace: "nowrap",
+        flexShrink: 0,
+        "&:hover": { borderColor: TEXT_MUTE },
+      }}
+    >
+      <Box component="span" sx={{ fontSize: 14, lineHeight: 1 }}>‹</Box>
+      <Box component="span" sx={{ width: 6, height: 6, borderRadius: "50%", bgcolor: TEXT_MUTE, flexShrink: 0 }} />
+    </Box>
+  );
+}
+
+// Full predecessor pill (left zone of past cards).
+function PrevFullPill({ label, onClick }: { label: string; onClick: () => void }) {
+  return (
+    <Box
+      component="button"
+      onClick={onClick}
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "6px",
+        px: "9px",
+        py: "5px",
+        borderRadius: 999,
+        background: "oklch(0 0 0 / 0.22)",
+        border: `1px solid ${LINE_SOFT}`,
+        color: TEXT_MUTE,
+        fontFamily: "JetBrains Mono, monospace",
+        fontSize: 10,
+        cursor: "pointer",
+        whiteSpace: "nowrap",
+        maxWidth: "100%",
+        overflow: "hidden",
+        flexShrink: 0,
+        "&:hover": { borderColor: TEXT_MUTE },
+      }}
+    >
+      <Box component="span" sx={{ fontSize: 14, lineHeight: 1 }}>‹</Box>
+      <Box component="span" sx={{ width: 6, height: 6, borderRadius: "50%", bgcolor: TEXT_MUTE, flexShrink: 0 }} />
+      <Box component="span" sx={{ overflow: "hidden", textOverflow: "ellipsis", maxWidth: 90 }}>{label}</Box>
+    </Box>
+  );
+}
+
+// Next-state navigation pill (right zone of past cards).
+function NextPill({ label, onClick }: { label: string; onClick: () => void }) {
+  return (
+    <Box
+      component="button"
+      onClick={onClick}
+      sx={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "6px",
+        px: "9px",
+        py: "5px",
+        borderRadius: 999,
+        background: "oklch(0 0 0 / 0.22)",
+        border: `1px solid ${LINE_SOFT}`,
+        color: TEXT_MUTE,
+        fontFamily: "JetBrains Mono, monospace",
+        fontSize: 10,
+        cursor: "pointer",
+        whiteSpace: "nowrap",
+        maxWidth: "100%",
+        overflow: "hidden",
+        flexShrink: 0,
+        "&:hover": { borderColor: TEXT_MUTE },
+      }}
+    >
+      <Box component="span" sx={{ overflow: "hidden", textOverflow: "ellipsis", maxWidth: 90 }}>{label}</Box>
+      <Box component="span" sx={{ width: 6, height: 6, borderRadius: "50%", bgcolor: TEXT_MUTE, flexShrink: 0 }} />
+      <Box component="span" sx={{ fontSize: 14, lineHeight: 1 }}>›</Box>
+    </Box>
+  );
+}
+
+// ── Props ─────────────────────────────────────────────────────────────────────
+type PieceTimelineProps = {
+  statesHistory: PieceState[];
+  piece: PieceDetailType;
+  onPieceUpdated: (updated: PieceDetailType) => void;
+  rewindedStateId?: string | null;
+  onRewind?: (id: string | null) => void;
+  historyLoading?: boolean;
+  historyError?: unknown;
+  refetchHistory?: () => void;
+  onTransition?: (nextState: string) => void;
+  transitioning?: boolean;
+  transitionError?: string | null;
+  isDirty?: boolean;
+};
+
+export default function StateCarousel({
+  statesHistory,
+  piece,
+  onPieceUpdated,
+  rewindedStateId,
+  onRewind,
+  historyLoading = false,
+  historyError = null,
+  refetchHistory,
+  onTransition,
+  transitioning = false,
+  transitionError,
+  isDirty = false,
+}: PieceTimelineProps) {
+  const [editModalOpen, setEditModalOpen] = useState(false);
+  const [pendingTransition, setPendingTransition] = useState<string | null>(null);
+
+  const railRef     = useRef<HTMLDivElement>(null);
+  const cardRefs    = useRef<(HTMLDivElement | null)[]>([]);
+  const dragRef     = useRef({ startX: 0, startScroll: 0, active: false, moved: false });
+  const mountedRef  = useRef(false);
+  const currentIdx  = statesHistory.length - 1;
+
+  const initialIdx = rewindedStateId
+    ? Math.max(0, statesHistory.findIndex((ps) => ps.id === rewindedStateId))
+    : currentIdx;
+
+  const [activeIdx, setActiveIdx] = useState(initialIdx);
+  const [dragging, setDragging]   = useState(false);
+
+  // Instant scroll to the correct card before first paint.
+  useLayoutEffect(() => {
+    const rail   = railRef.current;
+    const target = cardRefs.current[initialIdx];
+    if (rail && target) {
+      rail.scrollLeft = target.offsetLeft;
+    }
+    mountedRef.current = true;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Animated scroll whenever rewind state changes after mount.
+  useEffect(() => {
+    if (!mountedRef.current) return;
+    const targetIdx = rewindedStateId
+      ? Math.max(0, statesHistory.findIndex((ps) => ps.id === rewindedStateId))
+      : currentIdx;
+    const rail   = railRef.current;
+    const target = cardRefs.current[targetIdx];
+    if (rail && target) {
+      rail.scrollTo({ left: target.offsetLeft, behavior: "smooth" });
+    }
+    setActiveIdx(targetIdx);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rewindedStateId]);
+
+  if (historyError) {
+    return (
+      <Box sx={{ py: 2, textAlign: "center" }}>
+        <Typography variant="body2" color="error" sx={{ mb: 1.5 }}>
+          Failed to load timeline.
+        </Typography>
+        <Button size="small" variant="outlined" onClick={refetchHistory}>Retry</Button>
+      </Box>
+    );
+  }
+  if (historyLoading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
+  }
+  if (statesHistory.length === 0) return null;
+
+  const canEdit          = piece.can_edit;
+  const currentState     = statesHistory[currentIdx];
+  const successors       = sortSuccessorsForDisplay(SUCCESSORS[currentState.state] ?? []);
+  const isTerminal       = successors.length === 0;
+  const transitionDisabled = !canEdit || isDirty || piece.is_editable || transitioning;
+  const rewindedState    = rewindedStateId
+    ? statesHistory.find((ps) => ps.id === rewindedStateId) ?? null
+    : null;
+
+  // ── Carousel helpers ───────────────────────────────────────────────────────
+  const onScroll = () => {
+    const rail = railRef.current;
+    if (!rail) return;
+    const center = rail.scrollLeft + rail.clientWidth / 2;
+    let best = 0, bestDist = Infinity;
+    cardRefs.current.forEach((el, i) => {
+      if (!el) return;
+      const dist = Math.abs(el.offsetLeft + el.clientWidth / 2 - center);
+      if (dist < bestDist) { bestDist = dist; best = i; }
+    });
+    setActiveIdx(best);
+  };
+
+  const goTo = (idx: number) => {
+    const rail   = railRef.current;
+    const target = cardRefs.current[idx];
+    if (rail && target) {
+      rail.scrollTo({
+        left: target.offsetLeft - (rail.clientWidth - target.clientWidth) / 2,
+        behavior: "smooth",
+      });
+    }
+  };
+
+  const DRAG_THRESHOLD = 5;
+
+  const onMouseDown = (e: React.MouseEvent) => {
+    const rail = railRef.current;
+    if (!rail) return;
+    dragRef.current = { startX: e.clientX, startScroll: rail.scrollLeft, active: true, moved: false };
+  };
+  const onMouseMove = (e: React.MouseEvent) => {
+    const drag = dragRef.current;
+    if (!drag.active) return;
+    const delta = e.clientX - drag.startX;
+    if (!drag.moved && Math.abs(delta) < DRAG_THRESHOLD) return;
+    if (!drag.moved) { drag.moved = true; setDragging(true); }
+    const rail = railRef.current;
+    if (rail) rail.scrollLeft = drag.startScroll - delta;
+  };
+  const stopDrag = () => {
+    dragRef.current.active = false;
+    dragRef.current.moved = false;
+    setDragging(false);
+  };
+
+  // ── Transition helpers ─────────────────────────────────────────────────────
+  const openDialog  = (next: string) => setPendingTransition(next);
+  const closeDialog = () => setPendingTransition(null);
+  const confirmTransition = () => {
+    if (pendingTransition && onTransition) { onTransition(pendingTransition); }
+    setPendingTransition(null);
+  };
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+  return (
+    <>
+      <Box
+        ref={railRef}
+        onScroll={onScroll}
+        onMouseDown={onMouseDown}
+        onMouseMove={onMouseMove}
+        onMouseUp={stopDrag}
+        onMouseLeave={stopDrag}
+        sx={{
+          display: "flex",
+          overflowX: "auto",
+          scrollSnapType: "x mandatory",
+          scrollbarWidth: "none",
+          msOverflowStyle: "none",
+          "&::-webkit-scrollbar": { display: "none" },
+          cursor: dragging ? "grabbing" : "grab",
+          userSelect: dragging ? "none" : "auto",
+        }}
+      >
+        {statesHistory.map((ps, i) => {
+          const isCurrent  = i === currentIdx;
+          const isActive   = i === activeIdx;
+          const isRewinded = ps.id === rewindedStateId;
+          const prev       = i > 0 ? statesHistory[i - 1] : null;
+          const next       = i < currentIdx ? statesHistory[i + 1] : null;
+
+          // Height of right zone drives the card height when current.
+          const succH = isCurrent && !isTerminal && canEdit
+            ? successors.length * ROW_H + (successors.length - 1) * ROW_GAP
+            : ROW_H;
+
+          return (
+            <Box
+              key={ps.id ?? i}
+              ref={(el) => { cardRefs.current[i] = el as HTMLDivElement | null; }}
+              sx={{
+                flex: "0 0 100%",
+                scrollSnapAlign: "center",
+                scrollSnapStop: "always",
+                display: "grid",
+                gridTemplateColumns: (isCurrent && !isTerminal) ? "auto auto minmax(0, 1fr)" : "minmax(0, 1fr) auto minmax(0, 1fr)",
+                alignItems: "center",
+                gap: "8px",
+                px: 0,
+                py: 1,
+                opacity: isActive ? 1 : 0.45,
+                transition: "opacity 0.25s ease",
+              }}
+            >
+              {/* Left: predecessor */}
+              <Box sx={{ display: "flex", justifyContent: "flex-start", alignItems: "center", minWidth: 0 }}>
+                {prev ? (
+                  isCurrent
+                    ? <PrevPill label={formatState(prev.state)} onClick={() => goTo(i - 1)} />
+                    : <PrevFullPill label={formatState(prev.state)} onClick={() => goTo(i - 1)} />
+                ) : (
+                  <Typography variant="caption" sx={{ color: TEXT_MUTE, opacity: 0.5, fontSize: 10 }}>
+                    start
+                  </Typography>
+                )}
+              </Box>
+
+              {/* Center: state chip + date */}
+              <Box sx={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 0.5, py: 0.5 }}>
+                <StateChip
+                  state={ps.state}
+                  label={formatState(ps.state)}
+                  description={
+                    isCurrent
+                      ? "Click to return to current state"
+                      : isRewinded
+                        ? "Click to stop viewing this state"
+                        : "Click to view this state"
+                  }
+                  variant={isCurrent ? "current" : "past"}
+                  isTerminal={isTerminalState(ps.state)}
+                  muted={isCurrent && !!rewindedStateId}
+                  rewindSelected={!isCurrent && isRewinded}
+                  onClick={
+                    isCurrent && onRewind
+                      ? () => onRewind(null)
+                      : !isCurrent && onRewind
+                        ? () => onRewind(isRewinded ? null : ps.id)
+                        : undefined
+                  }
+                />
+                <Typography
+                  variant="caption"
+                  sx={{
+                    fontSize: 10,
+                    color: isCurrent ? "primary.main" : TEXT_MUTE,
+                    fontWeight: isCurrent ? 600 : 400,
+                    letterSpacing: isCurrent ? "0.04em" : 0,
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {formatDateLabel(ps.created)}
+                </Typography>
+              </Box>
+
+              {/* Right: next navigation (past) or successor branch (current) */}
+              {isCurrent ? (
+                <Box sx={{ display: "flex", alignItems: "flex-start", minWidth: 0, overflow: "hidden" }}>
+                  {!isTerminal && canEdit ? (
+                    <>
+                      <BranchConnector count={successors.length} />
+                      <Box sx={{ display: "flex", flexDirection: "column", gap: `${ROW_GAP}px`, pl: "4px", minWidth: 0, overflow: "hidden", flex: 1 }}>
+                        {successors.map((next) => (
+                          <Box key={next} sx={{ height: ROW_H, display: "flex", alignItems: "center", minWidth: 0, overflow: "hidden" }}>
+                            <StateChip
+                              state={next}
+                              label={formatState(next)}
+                              description={getStateDescription(next)}
+                              variant="future"
+                              isTerminal={isTerminalState(next)}
+                              onClick={transitionDisabled ? undefined : () => openDialog(next)}
+                              disabled={transitionDisabled}
+                            />
+                          </Box>
+                        ))}
+                      </Box>
+                    </>
+                  ) : (
+                    <Typography variant="caption" sx={{ color: TEXT_MUTE, opacity: 0.5, fontSize: 10, alignSelf: "center" }}>
+                      end
+                    </Typography>
+                  )}
+                </Box>
+              ) : (
+                <Box sx={{ display: "flex", justifyContent: "flex-end", alignItems: "center", minWidth: 0 }}>
+                  {next ? (
+                    <NextPill label={formatState(next.state)} onClick={() => goTo(i + 1)} />
+                  ) : (
+                    <Typography variant="caption" sx={{ color: TEXT_MUTE, opacity: 0.5, fontSize: 10 }}>
+                      end
+                    </Typography>
+                  )}
+                </Box>
+              )}
+            </Box>
+          );
+        })}
+      </Box>
+
+      {/* Pager dots */}
+      <Box sx={{ display: "flex", justifyContent: "center", gap: 0.75, pt: 1, pb: 0.25 }}>
+        {statesHistory.map((ps, i) => (
+          <Box
+            key={ps.id ?? i}
+            component="button"
+            onClick={() => goTo(i)}
+            aria-label={`Jump to ${formatState(ps.state)}`}
+            sx={{
+              width: i === activeIdx ? 18 : 6,
+              height: 6,
+              borderRadius: 999,
+              bgcolor: i === activeIdx
+                ? i === currentIdx ? "primary.main" : "text.secondary"
+                : i === currentIdx ? "primary.main" : "divider",
+              border: "none",
+              padding: 0,
+              cursor: "pointer",
+              transition: "all 0.25s ease",
+            }}
+          />
+        ))}
+      </Box>
+
+      {/* Rewind indicator — integrated so user doesn't have to scroll */}
+      {rewindedState && (
+        <Box sx={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 1, pt: 0.5, pb: 0.25 }}>
+          <Chip
+            icon={<HistoryIcon sx={{ fontSize: "14px !important" }} />}
+            label={`Viewing: ${formatState(rewindedState.state)}`}
+            size="small"
+            color="primary"
+            variant="outlined"
+            onDelete={() => onRewind?.(null)}
+            sx={{ fontSize: "0.75rem" }}
+          />
+          {piece.is_editable && (
+            <Typography variant="caption" color="text.secondary" sx={{ fontSize: "0.7rem" }}>
+              editing historical state
+            </Typography>
+          )}
+        </Box>
+      )}
+
+      {transitionError && (
+        <Typography color="error" variant="body2" sx={{ mt: 0.5, textAlign: "center" }}>
+          {transitionError}
+        </Typography>
+      )}
+      {transitionDisabled && !isTerminal && canEdit && (isDirty || piece.is_editable) && (
+        <Typography variant="caption" sx={{ color: "text.secondary", mt: 0.5, display: "block", textAlign: "center" }}>
+          {piece.is_editable
+            ? "Seal edit mode before transitioning to a new state."
+            : "Save your changes before transitioning to a new state."}
+        </Typography>
+      )}
+
+      {/* Edit history button */}
+      {piece.is_editable && (
+        <Box sx={{ display: "flex", justifyContent: "center", mt: 0.5 }}>
+          <IconButton
+            size="small"
+            onClick={() => setEditModalOpen(true)}
+            aria-label="Edit history"
+            sx={{ opacity: 0.6, "&:hover": { opacity: 1 } }}
+          >
+            <EditIcon fontSize="small" />
+          </IconButton>
+        </Box>
+      )}
+
+      {/* Edit history modal */}
+      {piece.is_editable && (
+        <Dialog open={editModalOpen} onClose={() => setEditModalOpen(false)} maxWidth="sm" fullWidth>
+          <DialogTitle sx={{ pb: 1 }}>Edit History</DialogTitle>
+          <DialogContent>
+            <PieceHistory
+              pastHistory={statesHistory.slice(0, -1)}
+              piece={piece}
+              history={statesHistory}
+              onPieceUpdated={onPieceUpdated}
+              rewindedStateId={rewindedStateId}
+              onRewind={onRewind}
+            />
+          </DialogContent>
+        </Dialog>
+      )}
+
+      {/* Transition confirmation dialog */}
+      <Dialog
+        open={pendingTransition !== null}
+        onClose={closeDialog}
+        TransitionProps={{ onExited: () => setPendingTransition(null) }}
+      >
+        <DialogTitle>Confirm State Transition</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Transition <strong>{formatState(currentState.state)}</strong> →{" "}
+            <strong>{pendingTransition ? formatState(pendingTransition) : ""}</strong>?
+            <br /><br />
+            Once transitioned, the current state will be sealed and can no longer be edited.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={closeDialog}>Cancel</Button>
+          <Button
+            onClick={confirmTransition}
+            variant="contained"
+            color={pendingTransition === "recycled" ? "error" : "primary"}
+            endIcon={pendingTransition !== "recycled" ? <ArrowOutwardIcon fontSize="small" /> : undefined}
+            disabled={transitioning}
+          >
+            Confirm
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/web/src/components/StateCarousel.tsx
+++ b/web/src/components/StateCarousel.tsx
@@ -87,7 +87,7 @@ function formatDateLabel(d: Date | null | undefined): string {
 }
 
 // Compact predecessor navigation pill (left zone of current card).
-function PrevPill({ label, onClick }: { label: string; onClick: () => void }) {
+function PrevPill({ onClick }: { label: string; onClick: () => void }) {
   return (
     <Box
       component="button"
@@ -357,11 +357,6 @@ export default function StateCarousel({
           const isRewinded = ps.id === rewindedStateId;
           const prev       = i > 0 ? effectiveHistory[i - 1] : null;
           const next       = i < effCurrentIdx ? effectiveHistory[i + 1] : null;
-
-          // Height of right zone drives the card height when current.
-          const succH = isCurrent && !isTerminal && canEdit
-            ? successors.length * ROW_H + (successors.length - 1) * ROW_GAP
-            : ROW_H;
 
           return (
             <Box

--- a/web/src/components/StateCarousel.tsx
+++ b/web/src/components/StateCarousel.tsx
@@ -433,7 +433,7 @@ export default function StateCarousel({
                   {!isTerminal && canEdit ? (
                     <>
                       <BranchConnector count={successors.length} />
-                      <Box sx={{ display: "flex", flexDirection: "column", gap: `${ROW_GAP}px`, pl: "4px", minWidth: 0, overflow: "hidden", flex: 1 }}>
+                      <Box role="group" aria-label="State flow" sx={{ display: "flex", flexDirection: "column", gap: `${ROW_GAP}px`, pl: "4px", minWidth: 0, overflow: "hidden", flex: 1 }}>
                         {successors.map((next) => (
                           <Box key={next} sx={{ height: ROW_H, display: "flex", alignItems: "center", minWidth: 0, overflow: "hidden" }}>
                             <StateChip

--- a/web/src/components/StateChip.tsx
+++ b/web/src/components/StateChip.tsx
@@ -13,7 +13,10 @@ export interface StateChipProps {
   description?: string;
   variant: StateChipVariant;
   isTerminal: boolean;
+  /** Past chip highlighted as the rewind target; current chip displaced by a rewind. */
   muted?: boolean;
+  /** This chip is the actively selected rewind target (only meaningful on past chips). */
+  rewindSelected?: boolean;
   disabled?: boolean;
   onClick?: () => void;
   onHoverStart?: () => void;
@@ -37,14 +40,20 @@ export default function StateChip({
   variant,
   isTerminal,
   muted = false,
+  rewindSelected = false,
   disabled = false,
   onClick,
   onHoverStart,
   onHoverEnd,
 }: StateChipProps) {
-  const interactive = variant === "future" && !!onClick;
+  const interactive = !!onClick;
+
+  // rewindSelected past chips use the actual state color, not grey.
   const baseColor =
-    variant === "past" ? PAST_STATE_COLOR : getStateColor(state, isTerminal);
+    variant === "past" && !rewindSelected
+      ? PAST_STATE_COLOR
+      : getStateColor(state, isTerminal);
+
   const outlineColor = muted
     ? `color-mix(in oklab, ${PAST_STATE_COLOR} 55%, transparent)`
     : baseColor;
@@ -56,7 +65,9 @@ export default function StateChip({
         : `color-mix(in oklab, ${baseColor} 18%, transparent)`;
     }
     if (variant === "past") {
-      return `color-mix(in oklab, ${PAST_STATE_COLOR} 10%, transparent)`;
+      return rewindSelected
+        ? `color-mix(in oklab, ${baseColor} 16%, transparent)`
+        : `color-mix(in oklab, ${PAST_STATE_COLOR} 10%, transparent)`;
     }
     return "transparent";
   })();
@@ -68,13 +79,17 @@ export default function StateChip({
         : baseColor;
     }
     if (variant === "past") {
-      return `color-mix(in oklab, ${PAST_STATE_COLOR} 18%, white)`;
+      return rewindSelected
+        ? baseColor
+        : `color-mix(in oklab, ${PAST_STATE_COLOR} 18%, white)`;
     }
     return "transparent";
   })();
 
+  const actualStateColor = getStateColor(state, isTerminal);
+
   const chipSx: SxProps<Theme> = {
-    borderRadius: "6px",
+    borderRadius: 999,
     border: "1px solid",
     borderColor: outlineColor,
     display: "inline-flex",
@@ -88,16 +103,54 @@ export default function StateChip({
     textTransform: "none",
     whiteSpace: "nowrap",
     width: "fit-content",
+    position: "relative",
     color: muted
       ? `color-mix(in oklab, ${PAST_STATE_COLOR} 80%, black)`
       : baseColor,
     backgroundColor,
     borderStyle: variant === "future" ? "dashed" : "solid",
     fontSize: variant === "current" ? "0.85rem" : "0.8125rem",
-    boxShadow: "none",
     opacity: disabled ? 0.6 : 1,
     transition:
       "background-color 120ms ease, border-color 120ms ease, color 120ms ease, transform 180ms ease, box-shadow 180ms ease",
+
+    // Rewind-selected past chip: pulsing glow to show "you are here (in the past)".
+    ...(rewindSelected
+      ? {
+          "@keyframes rewindGlow": {
+            "0%, 100%": {
+              boxShadow: `0 0 0 1.5px ${baseColor}, 0 0 8px color-mix(in oklab, ${baseColor} 30%, transparent)`,
+            },
+            "50%": {
+              boxShadow: `0 0 0 2px ${baseColor}, 0 0 20px color-mix(in oklab, ${baseColor} 60%, transparent)`,
+            },
+          },
+          animation: "rewindGlow 2s ease-in-out infinite",
+        }
+      : { boxShadow: "none" }),
+
+    // Muted current chip: small live-dot badge at top-right to mark the real current state.
+    ...(variant === "current" && muted
+      ? {
+          "&::after": {
+            content: '""',
+            position: "absolute",
+            top: -3,
+            right: -3,
+            width: 7,
+            height: 7,
+            borderRadius: "50%",
+            backgroundColor: actualStateColor,
+            boxShadow: `0 0 5px ${actualStateColor}`,
+            "@keyframes liveDot": {
+              "0%, 100%": { opacity: 0.45, transform: "scale(0.8)" },
+              "50%": { opacity: 1, transform: "scale(1.15)" },
+            },
+            animation: "liveDot 2.2s ease-in-out infinite",
+          },
+        }
+      : {}),
+
     ...(interactive
       ? {
           "&:hover": {
@@ -130,7 +183,7 @@ export default function StateChip({
           overflow: "hidden",
           flexShrink: 0,
           transition: "background-color 120ms ease, border-color 120ms ease",
-          ...(interactive
+          ...(interactive && variant === "future"
             ? {
                 backgroundColor: "transparent",
                 "&::after": {

--- a/web/src/components/__tests__/PieceDetail.test.tsx
+++ b/web/src/components/__tests__/PieceDetail.test.tsx
@@ -721,7 +721,7 @@ describe("PieceDetail", () => {
     await waitFor(() => expect(onPieceUpdated).toHaveBeenCalledWith(updated));
   });
 
-  it("history panel hidden by default", async () => {
+  it("past state chips visible in carousel for multi-state piece", async () => {
     const piece = makePiece({
       history: [
         makeState({ state: "designed" }),
@@ -730,12 +730,13 @@ describe("PieceDetail", () => {
       current_state: makeState({ state: "wheel_thrown" }),
     });
     await renderPieceDetail(piece);
+    // Past state chip is always visible in the carousel (clickable to enter rewind)
     expect(
-      screen.getByRole("button", { name: /show history/i }),
+      screen.getByRole("button", { name: "Designing" }),
     ).toBeInTheDocument();
   });
 
-  it("history panel toggles on click", async () => {
+  it("past state chips are already visible without toggling", async () => {
     const piece = makePiece({
       history: [
         makeState({
@@ -753,12 +754,13 @@ describe("PieceDetail", () => {
       }),
     });
     await renderPieceDetail(piece);
-    fireEvent.click(screen.getByRole("button", { name: /show history/i }));
-    expect(screen.getByText("Designed")).toBeInTheDocument();
+    // Carousel renders all cards immediately — no toggle required
+    expect(screen.getByRole("button", { name: "Designing" })).toBeInTheDocument();
   });
 
-  it("no history panel when piece has only one state", async () => {
+  it("no past state chips for single-state piece", async () => {
     await renderPieceDetail();
+    // Default piece has one state (designed); no past chips, no show-history button
     expect(
       screen.queryByRole("button", { name: /show history/i }),
     ).not.toBeInTheDocument();
@@ -1115,22 +1117,16 @@ describe("PieceDetail", () => {
 
       await renderPieceDetail(piece);
 
-      fireEvent.click(screen.getByRole("button", { name: /show history/i }));
+      // Click the past "Designing" chip in the carousel to enter rewind mode
+      fireEvent.click(screen.getByRole("button", { name: "Designing" }));
 
-      const historicalItem = screen.getByText("Designed").closest("li")!;
-      fireEvent.click(historicalItem);
+      expect(screen.getByText(/viewing: designing/i)).toBeInTheDocument();
 
-      expect(screen.getByText(/rewound to: designing/i)).toBeInTheDocument();
-
-      // Clear rewind mode via the Chip's delete button
-      const chip = screen.getByRole("button", {
-        name: /rewound to: designing/i,
-      });
-      const clearButton = within(chip).getByTestId("CancelIcon");
-      fireEvent.click(clearButton);
+      // Clear rewind mode via the integrated rewind chip's delete button
+      fireEvent.click(screen.getByTestId("CancelIcon"));
 
       expect(
-        screen.queryByText(/rewound to: designing/i),
+        screen.queryByText(/viewing: designing/i),
       ).not.toBeInTheDocument();
     });
 

--- a/web/src/components/__tests__/PieceDetail.test.tsx
+++ b/web/src/components/__tests__/PieceDetail.test.tsx
@@ -395,19 +395,17 @@ describe("PieceDetail", () => {
 
   it("renders successor state buttons for non-terminal state", async () => {
     await renderPieceDetail();
-    const stateFlow = screen.getByRole("group", { name: "State flow" });
-    expect(within(stateFlow).getByText("Designing")).toBeInTheDocument();
-    expect(
-      within(stateFlow).getByRole("button", { name: "Throwing" }),
-    ).toBeInTheDocument();
-    expect(
-      within(stateFlow).getByRole("button", { name: "Handbuilding" }),
-    ).toBeInTheDocument();
+    // Current state chip shows "Designing"; successor chips are in the carousel
+    expect(screen.getByRole("button", { name: "Designing" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Throwing" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Handbuilding" })).toBeInTheDocument();
   });
 
   it("renders completed before recycled at the end of the successor list", async () => {
+    const glazeFired = makeState({ state: "glaze_fired" });
     const piece = makePiece({
-      current_state: makeState({ state: "glaze_fired" }),
+      current_state: glazeFired,
+      history: [glazeFired],
     });
     await renderPieceDetail(piece);
 
@@ -1147,15 +1145,11 @@ describe("PieceDetail", () => {
 
       await renderPieceDetail(piece, onPieceUpdated);
 
-      fireEvent.click(screen.getByRole("button", { name: /show history/i }));
-      const historicalItem = screen.getByText("Designed").closest("li")!;
-      fireEvent.click(historicalItem);
+      // Enter rewind mode by clicking the past "Designing" chip in the carousel
+      fireEvent.click(screen.getByRole("button", { name: "Designing" }));
 
-      // Find the Notes input within the active historical editor
-      // It's in the section card that has "Rewound to: ..."
-      const historicalEditor = screen.getByText(/Editing historical state/i)
-        .parentElement!.parentElement!;
-      const notesInput = within(historicalEditor).getByLabelText("Notes");
+      // The historical Notes input appears in the rewind editor below the carousel
+      const notesInput = screen.getByLabelText("Notes");
       fireEvent.change(notesInput, { target: { value: "new" } });
 
       await waitFor(

--- a/web/src/components/__tests__/PieceDetail.test.tsx
+++ b/web/src/components/__tests__/PieceDetail.test.tsx
@@ -730,7 +730,7 @@ describe("PieceDetail", () => {
     await renderPieceDetail(piece);
     // Past state chip is always visible in the carousel (clickable to enter rewind)
     expect(
-      screen.getByRole("button", { name: "Designing" }),
+      screen.getByRole("button", { name: "Designed" }),
     ).toBeInTheDocument();
   });
 
@@ -753,7 +753,7 @@ describe("PieceDetail", () => {
     });
     await renderPieceDetail(piece);
     // Carousel renders all cards immediately — no toggle required
-    expect(screen.getByRole("button", { name: "Designing" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Designed" })).toBeInTheDocument();
   });
 
   it("no past state chips for single-state piece", async () => {
@@ -1115,8 +1115,8 @@ describe("PieceDetail", () => {
 
       await renderPieceDetail(piece);
 
-      // Click the past "Designing" chip in the carousel to enter rewind mode
-      fireEvent.click(screen.getByRole("button", { name: "Designing" }));
+      // Click the past "Designed" chip in the carousel to enter rewind mode
+      fireEvent.click(screen.getByRole("button", { name: "Designed" }));
 
       expect(screen.getByText(/viewing: designing/i)).toBeInTheDocument();
 
@@ -1145,8 +1145,8 @@ describe("PieceDetail", () => {
 
       await renderPieceDetail(piece, onPieceUpdated);
 
-      // Enter rewind mode by clicking the past "Designing" chip in the carousel
-      fireEvent.click(screen.getByRole("button", { name: "Designing" }));
+      // Enter rewind mode by clicking the past "Designed" chip in the carousel
+      fireEvent.click(screen.getByRole("button", { name: "Designed" }));
 
       // The historical Notes input appears in the rewind editor below the carousel
       const notesInput = screen.getByLabelText("Notes");


### PR DESCRIPTION
## Summary

Replaces the separate `StateTransition` picker and `Timeline` `SectionCard` in `PieceDetail` with a single integrated **`StateCarousel`** component — a horizontal snap carousel over the full state history.

- **StateCarousel**: snap-scroll rail, one card per `statesHistory` entry. Each card shows:
  - Predecessor pill (left zone, current non-terminal only)
  - Center state `StateChip` — clicking current clears rewind, clicking past sets/clears rewind
  - Successor chips with Bezier-fan `BranchConnector` SVG (right zone, current non-terminal)
  - Past/terminal cards: centered grid layout
  - Integrated rewind status chip below pager dots (no separate `SectionCard`)
  - Mouse drag (5 px threshold to avoid blocking clicks) + touch scroll
- **StateChip** updates:
  - `borderRadius: 999` (pill)
  - `interactive = !!onClick` — hover affordance on all clickable chips, not just future
  - Pulsing dot restricted to `variant === "future" && interactive`
  - New `rewindSelected` prop: pulsing glow on the active past chip
  - `muted` current chip: live-dot badge at top-right marks real current state
- **PieceDetail** cleanup:
  - `StateTransition` import and component removed
  - `Timeline` `SectionCard` removed
  - Standalone rewind header `Chip` removed (carousel shows it)
  - Location field: bare `Box` (no `SectionCard` border)
  - `gridArea: "info"` Box: `minWidth: 0` (proper grid overflow fix)
- **Active-pane focus bugs fixed**:
  - `useLayoutEffect` instant-scrolls to the correct card before first paint — current state, or rewound state if `rewindedStateId` is set on load
  - Post-mount `useEffect` keyed on `rewindedStateId` smoothly animates back to current state when rewind chip is dismissed
- **Review feedback addressed**:
  - Historical cards now use `formatPastState` (e.g. "Designed" not "Designing") for card chips, predecessor pills, and pager dot aria-labels; tests updated to match
  - `activeIdx` clamped to ≥ 0 on init so the pager dot is highlighted during the history-loading phase

## Test plan

- [ ] Fresh page load on a multi-state piece — carousel opens on the current state card (not card 0)
- [ ] Navigate to a piece URL with a rewind param — carousel opens on the rewound card
- [ ] Click a past state chip — chip glows, carousel pane stays, rewind indicator appears
- [ ] Dismiss rewind chip — carousel animates back to current state
- [ ] Confirm drag-to-scroll works without blocking chip clicks
- [ ] Confirm successor chips use `StateChip` design (pill, dashed border, pulsing dot)
- [ ] Terminal state (completed/recycled) — center-grid layout, no successor zone
- [ ] Multi-state piece: verify past cards show past-tense labels (e.g. "Designed", not "Designing")
- [ ] While history is loading (spinner visible): verify the pager dot highlights the current-state card

🤖 Generated with [Claude Code](https://claude.com/claude-code)