### PR TITLE
fix(otel): drop unused auto-instrumentation metrics to free Grafana series quota

### DIFF
--- a/backend/otel.py
+++ b/backend/otel.py
@@ -123,7 +123,7 @@ def configure_otel() -> bool:
     )
     from opentelemetry.sdk.metrics import MeterProvider
     from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
-    from opentelemetry.sdk.metrics.view import View
+    from opentelemetry.sdk.metrics.view import DropAggregation, View
 
     metric_exporter = OTLPMetricExporter(
         endpoint=os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317"),
@@ -146,6 +146,10 @@ def configure_otel() -> bool:
             ),
             # Active-requests gauge is only queried as a scalar sum — no per-label breakdown needed.
             View(instrument_name="http.server.active_requests", attribute_keys=set()),
+            # Drop everything else (psycopg db.client.*, redis, and any future
+            # auto-instrumentation) — views are first-match-wins, so the two
+            # HTTP entries above are preserved.
+            View(instrument_name="*", aggregation=DropAggregation()),
         ],
     )
     metrics.set_meter_provider(meter_provider)


### PR DESCRIPTION
## Summary

- `PsycopgInstrumentor` and `RedisInstrumentor` emit `db.client.*` and other metrics that are not queried by the dashboard, consuming Grafana Cloud series quota
- Adds a catch-all `View(instrument_name="*", aggregation=DropAggregation())` at the end of the `MeterProvider` views list so all unmatched instruments are silently discarded before export
- The two existing HTTP views (`http.server.duration`, `http.server.active_requests`) are matched first and continue to flow through with their already-trimmed attribute sets

## Test plan

- [ ] Deploy to production and verify the "Metrics Series Quota" pie chart (panel 9) shows a meaningful drop in used series
- [ ] Confirm dashboard panels 1–5 (HTTP request rate, error rate, p95 latency, active requests, status breakdown) still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)