### PR TITLE
fix: apply context-appropriate sizing to AppImage <img> element (#997)

### DIFF
--- a/web/src/components/AppImage.tsx
+++ b/web/src/components/AppImage.tsx
@@ -191,7 +191,15 @@ function AppImageRenderer({
     pointerEvents: "none",
   };
 
+  const contextImageStyle: React.CSSProperties =
+    context === "lightbox"
+      ? { maxWidth: "90vw", maxHeight: "80vh", objectFit: "contain" }
+      : context === "gallery" || context === "detail"
+        ? { width: "100%", height: "100%", objectFit: "cover" }
+        : { width: THUMBNAIL_SIZE, height: THUMBNAIL_SIZE, objectFit: "cover" };
+
   const imageStyle: React.CSSProperties = {
+    ...contextImageStyle,
     ...style,
     opacity: isLoading ? 0 : 1,
   };

--- a/web/src/components/__tests__/AppImage.test.tsx
+++ b/web/src/components/__tests__/AppImage.test.tsx
@@ -128,6 +128,22 @@ describe("AppImage", () => {
     expect(screen.getByTestId("app-image")).toHaveAttribute("src", CROPPED_URL);
   });
 
+  it("thumbnail context: img has cover sizing by default", () => {
+    render(
+      <AppImage url={ORIGINAL_URL} context="thumbnail" data-testid="app-image" />,
+    );
+    const img = screen.getByTestId("app-image");
+    expect(img).toHaveStyle({ width: "64px", height: "64px", objectFit: "cover" });
+  });
+
+  it("gallery context: img fills container by default", () => {
+    render(
+      <AppImage url={ORIGINAL_URL} context="gallery" data-testid="app-image" />,
+    );
+    const img = screen.getByTestId("app-image");
+    expect(img).toHaveStyle({ width: "100%", height: "100%", objectFit: "cover" });
+  });
+
   it("clears the loading spinner once the image load event fires", () => {
     const onLoad = vi.fn();
     render(


### PR DESCRIPTION
## Problem

Analysis view images were megazoomed after the Cloudinary → R2 migration ([#997](https://github.com/shaoster/glaze/issues/997)). `AppImageRenderer` applied context-specific sizing to the wrapper `<Box>` but left the `<img>` element unconstrained. Cloudinary URL transforms pre-resized images before delivery, masking this gap; R2 serves originals at full resolution.

## Fix

Added a `contextImageStyle` lookup in `AppImageRenderer` that maps each `AppImageContext` to default `<img>` sizing:

| Context | Default img style |
|---|---|
| `thumbnail` / `preview` | `width: 64px; height: 64px; objectFit: cover` |
| `gallery` / `detail` | `width: 100%; height: 100%; objectFit: cover` |
| `lightbox` | `maxWidth: 90vw; maxHeight: 80vh; objectFit: contain` |

Caller-supplied `style` props are spread after the defaults, so existing callers (`PieceList`, `PiecePhotoGalleryGrid`, `PieceDetail`, `SelectablePhotoMasonry`, `ImageLightbox`) that already pass explicit sizing continue to work unchanged — their values override the new defaults.

## Regression Test

`web/src/components/__tests__/AppImage.test.tsx` — two new tests:
- `"thumbnail context: img has cover sizing by default"` — asserts `width: 64px; height: 64px; objectFit: cover`
- `"gallery context: img fills container by default"` — asserts `width: 100%; height: 100%; objectFit: cover`

Both tests failed on the buggy baseline (confirmed before applying the fix) and pass with the fix.

## Verification

```
rtk bazel test //web:web_app_image_test  → 13 passed
rtk bazel test //web:web_test            → 52 passed
rtk bazel build --config=lint //web/... → build completed successfully
```

Closes #997
