### PR TITLE
fix(mcp): add notes support to transition_piece and add update_current_state tool

### DIFF
--- a/potterdoc_mcp/client.py
+++ b/potterdoc_mcp/client.py
@@ -209,6 +209,7 @@ class PotterDocClient:
         piece_id: str,
         target_state: str,
         custom_fields: dict[str, Any] | None = None,
+        notes: str | None = None,
     ) -> dict[str, Any]:
         mutation = """
         mutation TransitionPiece($id: ID!, $input: TransitionPieceInput!) {
@@ -221,8 +222,33 @@ class PotterDocClient:
         input_payload: dict[str, Any] = {"targetState": target_state}
         if custom_fields:
             input_payload["customFields"] = custom_fields
+        if notes is not None:
+            input_payload["notes"] = notes
         data = await self._graphql(mutation, {"id": piece_id, "input": input_payload})
         return data["transitionPiece"]  # type: ignore[no-any-return]
+
+    async def update_current_state(
+        self,
+        piece_id: str,
+        *,
+        notes: str | None = None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {}
+        if notes is not None:
+            payload["notes"] = notes
+        if not payload:
+            raise _error("No fields provided to update_current_state.")
+        mutation = """
+        mutation UpdateCurrentState($id: ID!, $input: UpdateStateInput!) {
+          updateCurrentState(id: $id, input: $input) {
+            id
+            name
+            currentState { state }
+          }
+        }
+        """
+        data = await self._graphql(mutation, {"id": piece_id, "input": payload})
+        return data["updateCurrentState"]  # type: ignore[no-any-return]
 
     # ------------------------------------------------------------------
     # Images

--- a/potterdoc_mcp/server.py
+++ b/potterdoc_mcp/server.py
@@ -184,6 +184,7 @@ async def transition_piece(
     piece_id: str,
     target_state: str,
     custom_fields: dict[str, Any] | None = None,
+    notes: str | None = None,
     ctx: Context | None = None,
 ) -> dict[str, Any]:
     """Transition a pottery piece to a new workflow state.
@@ -196,6 +197,8 @@ async def transition_piece(
         target_state: The workflow state ID to transition to (e.g. "wheel_thrown", "bisque_fired").
         custom_fields: Dict of field name → value for any fields required by the
             target state schema. Pass null/omit if the state has no required fields.
+        notes: Optional free-text notes to record for this new state (e.g. firing
+            temperature, observations). Can also be set later via update_current_state.
 
     Returns the newly created PieceState record.
     """
@@ -203,6 +206,7 @@ async def transition_piece(
         piece_id=piece_id,
         target_state=target_state,
         custom_fields=custom_fields,
+        notes=notes,
     )
 
 
@@ -240,6 +244,33 @@ async def update_piece_metadata(
         shared=shared,
         tags=tags,
     )
+
+
+# ------------------------------------------------------------------
+# State update tool
+# ------------------------------------------------------------------
+
+
+@mcp.tool()
+async def update_current_state(
+    piece_id: str,
+    notes: str,
+    ctx: Context | None = None,
+) -> dict[str, Any]:
+    """Update the notes on a piece's current workflow state.
+
+    Use this to add or edit free-text notes on a piece that is already past
+    the design step. Notes are stored per state, so this updates only the
+    current (most recent) state.
+
+    Args:
+        piece_id: The piece UUID.
+        notes: Free-text notes to set on the current state (e.g. firing
+            temperature, glaze observations, any relevant details).
+
+    Returns the updated piece detail.
+    """
+    return await _get_client(ctx).update_current_state(piece_id=piece_id, notes=notes)
 
 
 # ------------------------------------------------------------------

--- a/potterdoc_mcp/tests/test_states.py
+++ b/potterdoc_mcp/tests/test_states.py
@@ -63,3 +63,40 @@ def test_transition_piece_invalid_transition(client: PotterDocClient) -> None:
         with pytest.raises(McpError) as exc_info:
             asyncio.run(client.transition_piece("abc", "fired"))
     assert "GraphQL" in str(exc_info.value)
+
+
+def test_transition_piece_with_notes(client: PotterDocClient) -> None:
+    state = {"id": "abc", "currentState": {"state": "bisque_fired"}}
+    with patch.object(
+        client,
+        "_graphql",
+        new_callable=AsyncMock,
+        return_value={"transitionPiece": state},
+    ) as mock_gql:
+        result = asyncio.run(client.transition_piece("abc", "bisque_fired", notes="cone 06"))
+
+    assert result == state
+    _, variables = mock_gql.call_args.args
+    assert variables["input"]["targetState"] == "bisque_fired"
+    assert variables["input"]["notes"] == "cone 06"
+
+
+def test_update_current_state_notes(client: PotterDocClient) -> None:
+    piece = {"id": "abc", "name": "Vase", "currentState": {"state": "bisque_fired"}}
+    with patch.object(
+        client,
+        "_graphql",
+        new_callable=AsyncMock,
+        return_value={"updateCurrentState": piece},
+    ) as mock_gql:
+        result = asyncio.run(client.update_current_state("abc", notes="cone 06"))
+
+    assert result == piece
+    _, variables = mock_gql.call_args.args
+    assert variables["id"] == "abc"
+    assert variables["input"] == {"notes": "cone 06"}
+
+
+def test_update_current_state_no_fields_raises(client: PotterDocClient) -> None:
+    with pytest.raises(McpError, match="No fields"):
+        asyncio.run(client.update_current_state("abc"))


### PR DESCRIPTION
## Problem

The MCP server had no way for agents to add notes to a pottery piece outside the initial creation step. The `create_piece` tool accepted notes, but `transition_piece` silently dropped them and there was no tool to update notes on an existing state. See [#1002](https://github.com/shaoster/glaze/issues/1002).

## Fix

Two wires were missing between the MCP layer and the GraphQL layer:

1. **`transition_piece`** — `TransitionPieceInput.notes` already existed in GraphQL but was never populated. Added `notes: str | None = None` to both the MCP tool and the client method.

2. **`update_current_state`** — the `updateCurrentState` GraphQL mutation was fully implemented but had no MCP binding. Added a new tool and client method that call this mutation.

Notes are stored per `PieceState` row, which is why `update_piece_metadata` (which operates on the `Piece` itself) was the wrong place — no changes there.

## Regression Test

Added three tests to `potterdoc_mcp/tests/test_states.py`:
- `test_transition_piece_with_notes` — verifies `notes` is forwarded in the GraphQL `input` when calling `transition_piece`
- `test_update_current_state_notes` — verifies `updateCurrentState` mutation is called with the correct variables
- `test_update_current_state_no_fields_raises` — verifies the no-fields guard raises `McpError`

All three failed before the fix and pass after.

## Verification

```
//potterdoc_mcp:potterdoc_mcp_test    PASSED in 3.1s  (47/47)
```

Closes #1002
