### PR TITLE
feat(web): add Storybook coverage for 11 uncovered components

### DIFF
--- a/web/src/stories/AppFooterLinks.stories.tsx
+++ b/web/src/stories/AppFooterLinks.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import AppFooterLinks from "../components/AppFooterLinks";
+
+/**
+ * AppFooterLinks renders the "About Us · Privacy Policy · Terms of Service"
+ * link row shown at the bottom of app pages.
+ *
+ * Rationale ("Switch support flow to django-helpdesk"):
+ * - Originally included an in-app support/contact link backed by a bespoke
+ *   support-thread API. That flow was migrated to django-helpdesk (mounted
+ *   under `/support/`, linked from the authenticated user dropdown instead),
+ *   leaving this component with just the lightweight legal/info links.
+ * - `sticky` pins the footer to the viewport bottom with a blurred backdrop —
+ *   used on pages (e.g. the public piece showcase) that don't otherwise
+ *   scroll far enough to reach a static footer.
+ */
+const meta = {
+  title: "Components/AppFooterLinks",
+  component: AppFooterLinks,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof AppFooterLinks>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Static: Story = {
+  args: {
+    sticky: false,
+  },
+};
+
+export const Sticky: Story = {
+  args: {
+    sticky: true,
+  },
+  render: (args) => (
+    <Box sx={{ height: 240, display: "flex", flexDirection: "column" }}>
+      <Typography variant="body2" color="text.secondary" sx={{ flex: 1 }}>
+        Page content scrolls above; the footer stays pinned to the bottom of
+        this container with a blurred backdrop.
+      </Typography>
+      <AppFooterLinks {...args} />
+    </Box>
+  ),
+};

--- a/web/src/stories/DeveloperTokensDialog.stories.tsx
+++ b/web/src/stories/DeveloperTokensDialog.stories.tsx
@@ -1,0 +1,158 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import Button from "@mui/material/Button";
+import { http, HttpResponse, delay } from "msw";
+import { DeveloperTokensDialog } from "../components/DeveloperTokensDialog";
+import type { AgentToken } from "../util/types";
+
+/**
+ * DeveloperTokensDialog manages `pdagent_…` bearer tokens for external agent
+ * access (MCP servers, ChatGPT actions).
+ *
+ * Rationale (PR #879 — "feat(auth): API token authentication for external
+ * agents"; documented further in PR #1007):
+ * - Tokens carry standard user permissions only — staff privileges are never
+ *   granted, called out directly in the dialog body copy.
+ * - The raw token value is returned exactly once, from the create response —
+ *   the list endpoint never re-exposes it, so the dialog shows a one-time
+ *   "copy this now" warning banner immediately after creation.
+ * - `useQuery` is `enabled: open` so the token list isn't fetched until the
+ *   dialog is actually opened.
+ *
+ * Edge cases:
+ * - Empty state: "No active tokens. Create one above." replaces the table.
+ * - Loading: a `LinearProgress` bar renders under the title while fetching.
+ * - Create failure: an inline `Alert` appears under the create form; the
+ *   typed name is only cleared on success, so a failed submission is easy to retry.
+ */
+const meta = {
+  title: "Components/DeveloperTokensDialog",
+  component: DeveloperTokensDialog,
+  parameters: {
+    layout: "centered",
+    docs: {
+      inlineStories: false,
+      iframeHeight: 500,
+      source: {
+        code: `
+<DeveloperTokensDialog
+  open={true}
+  onClose={() => {}}
+  userId={1}
+/>`,
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    open: { table: { disable: true } },
+  },
+  render: (args) => <DeveloperTokensDialogWithState {...args} />,
+} satisfies Meta<typeof DeveloperTokensDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function DeveloperTokensDialogWithState(
+  args: React.ComponentProps<typeof DeveloperTokensDialog>,
+) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button variant="contained" onClick={() => setOpen(true)}>
+        Manage Developer Tokens
+      </Button>
+      <DeveloperTokensDialog
+        {...args}
+        open={open}
+        onClose={() => {
+          setOpen(false);
+          args.onClose();
+        }}
+      />
+    </>
+  );
+}
+
+const mockTokens: AgentToken[] = [
+  {
+    id: "tok-1",
+    name: "Claude MCP",
+    created_at: new Date("2026-06-01T10:00:00Z"),
+    last_used_at: new Date("2026-07-09T08:30:00Z"),
+  },
+  {
+    id: "tok-2",
+    name: "ChatGPT Actions",
+    created_at: new Date("2026-06-15T14:00:00Z"),
+    last_used_at: undefined,
+  },
+];
+
+export const WithTokens: Story = {
+  args: { open: false, onClose: () => {}, userId: 1 },
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("/api/auth/agent-tokens/", () => HttpResponse.json(mockTokens)),
+      ],
+    },
+  },
+};
+
+export const Empty: Story = {
+  args: { open: false, onClose: () => {}, userId: 1 },
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("/api/auth/agent-tokens/", () => HttpResponse.json([])),
+      ],
+    },
+  },
+};
+
+export const Loading: Story = {
+  args: { open: false, onClose: () => {}, userId: 1 },
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("/api/auth/agent-tokens/", async () => {
+          await delay("infinite");
+          return HttpResponse.json([]);
+        }),
+      ],
+    },
+  },
+};
+
+export const TokenJustCreated: Story = {
+  args: { open: false, onClose: () => {}, userId: 1 },
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("/api/auth/agent-tokens/", () => HttpResponse.json(mockTokens)),
+        http.post("/api/auth/agent-tokens/", () =>
+          HttpResponse.json({
+            id: "tok-3",
+            name: "New Agent",
+            created_at: new Date().toISOString(),
+            last_used_at: null,
+            token: "pdagent_live_a1b2c3d4e5f6g7h8i9j0",
+          }),
+        ),
+      ],
+    },
+  },
+};
+
+export const CreateFailed: Story = {
+  args: { open: false, onClose: () => {}, userId: 1 },
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("/api/auth/agent-tokens/", () => HttpResponse.json(mockTokens)),
+        http.post("/api/auth/agent-tokens/", () => HttpResponse.json({}, { status: 500 })),
+      ],
+    },
+  },
+};

--- a/web/src/stories/DeveloperTokensDialog.stories.tsx
+++ b/web/src/stories/DeveloperTokensDialog.stories.tsx
@@ -74,6 +74,8 @@ function DeveloperTokensDialogWithState(
   );
 }
 
+const csrfHandler = http.get("/api/auth/csrf/", () => HttpResponse.json({}));
+
 const mockTokens: AgentToken[] = [
   {
     id: "tok-1",
@@ -94,7 +96,9 @@ export const WithTokens: Story = {
   parameters: {
     msw: {
       handlers: [
+        csrfHandler,
         http.get("/api/auth/agent-tokens/", () => HttpResponse.json(mockTokens)),
+        http.delete("/api/auth/agent-tokens/:id/", () => new HttpResponse(null, { status: 204 })),
       ],
     },
   },
@@ -105,6 +109,7 @@ export const Empty: Story = {
   parameters: {
     msw: {
       handlers: [
+        csrfHandler,
         http.get("/api/auth/agent-tokens/", () => HttpResponse.json([])),
       ],
     },
@@ -116,6 +121,7 @@ export const Loading: Story = {
   parameters: {
     msw: {
       handlers: [
+        csrfHandler,
         http.get("/api/auth/agent-tokens/", async () => {
           await delay("infinite");
           return HttpResponse.json([]);
@@ -130,6 +136,7 @@ export const TokenJustCreated: Story = {
   parameters: {
     msw: {
       handlers: [
+        csrfHandler,
         http.get("/api/auth/agent-tokens/", () => HttpResponse.json(mockTokens)),
         http.post("/api/auth/agent-tokens/", () =>
           HttpResponse.json({
@@ -150,6 +157,7 @@ export const CreateFailed: Story = {
   parameters: {
     msw: {
       handlers: [
+        csrfHandler,
         http.get("/api/auth/agent-tokens/", () => HttpResponse.json(mockTokens)),
         http.post("/api/auth/agent-tokens/", () => HttpResponse.json({}, { status: 500 })),
       ],

--- a/web/src/stories/DeveloperTokensDialog.stories.tsx
+++ b/web/src/stories/DeveloperTokensDialog.stories.tsx
@@ -75,6 +75,15 @@ function DeveloperTokensDialogWithState(
 }
 
 const csrfHandler = http.get("/api/auth/csrf/", () => HttpResponse.json({}));
+const createTokenHandler = http.post("/api/auth/agent-tokens/", () =>
+  HttpResponse.json({
+    id: "tok-3",
+    name: "New Agent",
+    created_at: new Date().toISOString(),
+    last_used_at: null,
+    token: "pdagent_live_a1b2c3d4e5f6g7h8i9j0",
+  }),
+);
 
 const mockTokens: AgentToken[] = [
   {
@@ -97,6 +106,7 @@ export const WithTokens: Story = {
     msw: {
       handlers: [
         csrfHandler,
+        createTokenHandler,
         http.get("/api/auth/agent-tokens/", () => HttpResponse.json(mockTokens)),
         http.delete("/api/auth/agent-tokens/:id/", () => new HttpResponse(null, { status: 204 })),
       ],
@@ -110,6 +120,7 @@ export const Empty: Story = {
     msw: {
       handlers: [
         csrfHandler,
+        createTokenHandler,
         http.get("/api/auth/agent-tokens/", () => HttpResponse.json([])),
       ],
     },
@@ -122,6 +133,7 @@ export const Loading: Story = {
     msw: {
       handlers: [
         csrfHandler,
+        createTokenHandler,
         http.get("/api/auth/agent-tokens/", async () => {
           await delay("infinite");
           return HttpResponse.json([]);
@@ -137,16 +149,8 @@ export const TokenJustCreated: Story = {
     msw: {
       handlers: [
         csrfHandler,
+        createTokenHandler,
         http.get("/api/auth/agent-tokens/", () => HttpResponse.json(mockTokens)),
-        http.post("/api/auth/agent-tokens/", () =>
-          HttpResponse.json({
-            id: "tok-3",
-            name: "New Agent",
-            created_at: new Date().toISOString(),
-            last_used_at: null,
-            token: "pdagent_live_a1b2c3d4e5f6g7h8i9j0",
-          }),
-        ),
       ],
     },
   },

--- a/web/src/stories/DynamicPreferenceField.stories.tsx
+++ b/web/src/stories/DynamicPreferenceField.stories.tsx
@@ -1,0 +1,118 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { fn } from "@storybook/test";
+import { DynamicPreferenceField } from "../components/DynamicPreferenceField";
+import type { PreferenceField } from "../util/preferences";
+import type { ProcessSummaryFieldOption } from "../util/workflow";
+
+/**
+ * DynamicPreferenceField renders a single preference input, dispatched purely
+ * on `field.type` — the field-level counterpart to `PREFERENCES_SCHEMA`
+ * (driven by `user_preferences.yml`), the same "schema drives the UI"
+ * pattern `workflow.yml` uses for per-state forms.
+ *
+ * Rationale:
+ * - Kept prop-driven and context-free on purpose so `UserPreferencesDialog`
+ *   can render one per schema field without each field needing its own data
+ *   fetching or mutation wiring — the parent owns all form state.
+ * - `field-list` groups its options by `option.group` (e.g. "Piece",
+ *   "Current State") and renders a `Divider` between groups.
+ *
+ * Edge cases:
+ * - `string`: value is hard-truncated to `field.max_length` on every keystroke.
+ * - `boolean`: defaults to `true` when `value` is `undefined` (tutorial
+ *   preferences are opt-out, not opt-in).
+ * - Unknown `field.type`: renders nothing.
+ */
+const meta = {
+  title: "Components/DynamicPreferenceField",
+  component: DynamicPreferenceField,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof DynamicPreferenceField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const stringField: PreferenceField = {
+  type: "string",
+  label: "Alias",
+  hint: "How you'd like to identify yourself in the app. Not visible to others.",
+  storage: "UserProfile",
+  max_length: 50,
+};
+
+const booleanField: PreferenceField = {
+  type: "boolean",
+  label: 'Show the "Change your alias!" tip',
+  hint: "Controls the alias guidance shown on the piece list.",
+  storage: "UserProfile.preferences",
+};
+
+const fieldListField: PreferenceField = {
+  type: "field-list",
+  label: "Process Summary Fields",
+  hint: "Select fields to show. Images excluded.",
+  storage: "UserProfile.preferences",
+  provider: "workflow_summary_fields",
+};
+
+const mockOptions: ProcessSummaryFieldOption[] = [
+  { ref: "piece.name", label: "Name", group: "Piece" },
+  { ref: "piece.created", label: "Created", group: "Piece" },
+  { ref: "current_state.state", label: "Current state", group: "Current State" },
+  { ref: "glazed.glaze_combination", label: "Glaze combination", group: "Glazed" },
+];
+
+function StringFieldHarness(
+  args: React.ComponentProps<typeof DynamicPreferenceField>,
+) {
+  const [value, setValue] = useState(args.value);
+  return <DynamicPreferenceField {...args} value={value} onChange={setValue} />;
+}
+
+export const StringInput: Story = {
+  args: {
+    fieldId: "alias",
+    field: stringField,
+    value: "clay-wrangler",
+    onChange: fn(),
+    isSaving: false,
+    options: [],
+  },
+  render: (args) => <StringFieldHarness {...args} />,
+};
+
+export const BooleanCheckbox: Story = {
+  args: {
+    fieldId: "change_alias_prompt",
+    field: booleanField,
+    value: true,
+    onChange: fn(),
+    isSaving: false,
+    options: [],
+  },
+  render: (args) => <StringFieldHarness {...args} />,
+};
+
+export const FieldListGrouped: Story = {
+  args: {
+    fieldId: "process_summary_fields",
+    field: fieldListField,
+    value: ["piece.name", "glazed.glaze_combination"],
+    onChange: fn(),
+    isSaving: false,
+    options: mockOptions,
+  },
+  render: (args) => <StringFieldHarness {...args} />,
+};
+
+export const SavingDisablesInput: Story = {
+  args: {
+    ...StringInput.args,
+    isSaving: true,
+  },
+  render: (args) => <StringFieldHarness {...args} />,
+};

--- a/web/src/stories/LargeTutorialInlay.stories.tsx
+++ b/web/src/stories/LargeTutorialInlay.stories.tsx
@@ -1,0 +1,133 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import Button from "@mui/material/Button";
+import { fn } from "@storybook/test";
+import LargeTutorialInlay from "../components/LargeTutorialInlay";
+
+/**
+ * LargeTutorialInlay is a full-screen, multi-page onboarding modal — the
+ * "modal" inlay type in the declarative tutorials system.
+ *
+ * Rationale (Issue #911 — "feat(tutorials): add LargeTutorialInlay modal and
+ * extend schema"):
+ * - Scaffolded alongside `SmallTutorialInlay` (anchored popovers) so
+ *   `tutorials.yml` can declare either an anchored tip or a full walkthrough
+ *   modal gated by `route`, dispatched by `TutorialManager` on `inlay.type`.
+ * - Internally owns its own page index and "Don't show this again" checkbox
+ *   state; callers only supply the page content and two terminal callbacks.
+ * - `<em>...</em>` markup inside `title` renders as an italic, muted span
+ *   (see `renderTitle`) so tutorial copy can emphasize a word without HTML risk.
+ *
+ * Edge cases:
+ * - First page: no "Back" button.
+ * - Last page: the primary button becomes `completeLabel` and calls `onComplete`
+ *   instead of `onClose`/advancing.
+ * - Bullets are optional per-page — pages can mix prose-only and bulleted content.
+ * - Checking "Don't show this again" is passed through to whichever of
+ *   `onComplete`/`onClose` fires, so the caller decides how to persist it
+ *   (e.g. saving a `false` tutorial preference).
+ */
+const meta = {
+  title: "Components/LargeTutorialInlay",
+  component: LargeTutorialInlay,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      inlineStories: false,
+      iframeHeight: 600,
+      source: {
+        code: `
+<LargeTutorialInlay
+  pages={pages}
+  onComplete={({ dontShow }) => console.log('complete', dontShow)}
+  onClose={({ dontShow }) => console.log('close', dontShow)}
+/>`,
+      },
+    },
+  },
+  tags: ["autodocs"],
+  render: (args) => <LargeTutorialInlayWithToggle {...args} />,
+} satisfies Meta<typeof LargeTutorialInlay>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function LargeTutorialInlayWithToggle(
+  args: React.ComponentProps<typeof LargeTutorialInlay>,
+) {
+  const [open, setOpen] = useState(false);
+  if (!open) {
+    return (
+      <Button variant="contained" onClick={() => setOpen(true)}>
+        Open Tutorial
+      </Button>
+    );
+  }
+  return (
+    <LargeTutorialInlay
+      {...args}
+      onClose={(opts) => {
+        args.onClose(opts);
+        setOpen(false);
+      }}
+      onComplete={(opts) => {
+        args.onComplete(opts);
+        setOpen(false);
+      }}
+    />
+  );
+}
+
+const onboardingPages = [
+  {
+    title: "Welcome to <em>PotterDoc</em>",
+    body: "Track every piece you throw, from wet clay to the final glaze fire, in one place.",
+  },
+  {
+    title: "Log each <em>state</em> as you go",
+    body: "PotterDoc's workflow mirrors your studio process — capture notes and photos as a piece moves through it.",
+    bullets: [
+      "Attach photos at any state",
+      "Record glaze combinations and kiln locations",
+      "Rewind the timeline to see how a piece looked earlier",
+    ],
+  },
+  {
+    title: "Share your <em>finished work</em>",
+    body: "Completed pieces get a public showcase page you can send to customers or post online.",
+    bullets: ["Custom showcase story", "Optional video embed", "One-click share link"],
+  },
+];
+
+export const Default: Story = {
+  args: {
+    pages: onboardingPages,
+    onComplete: fn(),
+    onClose: fn(),
+  },
+};
+
+export const SinglePageNoBullets: Story = {
+  args: {
+    pages: [
+      {
+        title: "New: <em>Timeline Rewind</em>",
+        body: "You can now click any past state on a piece's carousel to view it exactly as it looked at that point in the workflow.",
+      },
+    ],
+    eyebrow: "What's new",
+    completeLabel: "Got it",
+    onComplete: fn(),
+    onClose: fn(),
+  },
+};
+
+export const CustomEyebrowAndCompleteLabel: Story = {
+  args: {
+    pages: onboardingPages.slice(0, 2),
+    eyebrow: "Glaze Combinations · 2 min",
+    completeLabel: "Start logging glazes",
+    onComplete: fn(),
+    onClose: fn(),
+  },
+};

--- a/web/src/stories/ReportBadCropDialog.stories.tsx
+++ b/web/src/stories/ReportBadCropDialog.stories.tsx
@@ -1,0 +1,129 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import Button from "@mui/material/Button";
+import { http, HttpResponse, delay } from "msw";
+import ReportBadCropDialog from "../components/ReportBadCropDialog";
+
+/**
+ * ReportBadCropDialog lets a user flag a piece-state image whose
+ * auto-segmented crop is wrong, optionally editing the crop box and adding
+ * notes before submitting a human crop run for review.
+ *
+ * Rationale (PR #421 — "feat: bad-crop tagging and inference-run persistence";
+ * hardened in follow-ups "clarify crop vs mask flow" and "make piece-state
+ * image authoritative"):
+ * - `crop` fields are normalized `0..1` fractions (not pixels) so they stay
+ *   valid across any image's actual resolution.
+ * - Submitting posts a `crop-runs/` record for downstream model review/retraining,
+ *   distinct from the crop actually applied to the image.
+ *
+ * Edge cases:
+ * - Success: shows a confirmation `Alert` and auto-closes after 1s.
+ * - Error: shows the extracted error message and keeps the dialog open with
+ *   the form re-enabled so the user can retry.
+ * - `open` toggling resets `notes`/`error`/`success`/`crop` back to `initialCrop`
+ *   (or the full-frame default) every time the dialog reopens.
+ */
+const meta = {
+  title: "Components/ReportBadCropDialog",
+  component: ReportBadCropDialog,
+  parameters: {
+    layout: "centered",
+    docs: {
+      inlineStories: false,
+      iframeHeight: 500,
+      source: {
+        code: `
+<ReportBadCropDialog
+  open={true}
+  onClose={() => {}}
+  pieceStateImageId={42}
+  initialCrop={{ x: 0.1, y: 0.1, width: 0.8, height: 0.8 }}
+/>`,
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    open: { table: { disable: true } },
+  },
+  render: (args) => <ReportBadCropDialogWithState {...args} />,
+} satisfies Meta<typeof ReportBadCropDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function ReportBadCropDialogWithState(
+  args: React.ComponentProps<typeof ReportBadCropDialog>,
+) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button variant="outlined" color="warning" onClick={() => setOpen(true)}>
+        Report Bad Crop
+      </Button>
+      <ReportBadCropDialog
+        {...args}
+        open={open}
+        onClose={() => {
+          setOpen(false);
+          args.onClose();
+        }}
+      />
+    </>
+  );
+}
+
+export const Default: Story = {
+  args: {
+    open: false,
+    onClose: () => {},
+    pieceStateImageId: 42,
+    initialCrop: { x: 0.1, y: 0.1, width: 0.8, height: 0.8 },
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        http.post("/api/crop-runs/", () =>
+          HttpResponse.json({
+            id: 1,
+            piece_state_image_id: 42,
+            crop: { x: 0.1, y: 0.1, width: 0.8, height: 0.8 },
+            notes: "",
+            status: "pending",
+          }),
+        ),
+      ],
+    },
+  },
+};
+
+export const Submitting: Story = {
+  args: { ...Default.args },
+  parameters: {
+    msw: {
+      handlers: [
+        http.post("/api/crop-runs/", async () => {
+          await delay("infinite");
+          return HttpResponse.json({});
+        }),
+      ],
+    },
+  },
+};
+
+export const SubmitFailed: Story = {
+  args: { ...Default.args },
+  parameters: {
+    msw: {
+      handlers: [
+        http.post("/api/crop-runs/", () =>
+          HttpResponse.json(
+            { detail: "This image already has a pending crop review." },
+            { status: 400 },
+          ),
+        ),
+      ],
+    },
+  },
+};

--- a/web/src/stories/RoutedGlobalEntryField.stories.tsx
+++ b/web/src/stories/RoutedGlobalEntryField.stories.tsx
@@ -1,0 +1,126 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+import { http, HttpResponse } from "msw";
+import RoutedGlobalEntryField from "../components/RoutedGlobalEntryField";
+
+/**
+ * RoutedGlobalEntryField wraps `GlobalEntryField` with URL-driven open/tab
+ * state via `useGlobalFieldRouting`, so the browse/create dialog for a
+ * workflow global field is deep-linkable at
+ * `/pieces/:id/state/fields/:fieldName[/new]`.
+ *
+ * Rationale:
+ * - `fieldName` defaults to `globalName` but must be set explicitly when two
+ *   fields on the same state reference the same global (e.g. both
+ *   `current_location` and `kiln_location` reference the `location` global) —
+ *   otherwise both fields would share one URL slot and open in lockstep.
+ * - Falls back to the plain, unrouted `GlobalEntryField` when rendered
+ *   outside a Router context (`useInRouterContext()` is false), which is how
+ *   the same field components stay usable embedded in Django admin forms.
+ * - An inner component (`RoutedGlobalEntryFieldInner`) keeps
+ *   `useGlobalFieldRouting` unconditional even though the router check
+ *   happens in the outer default export — hooks can't be called conditionally.
+ *
+ * Edge cases:
+ * - Landing directly on `/pieces/:id/state/fields/:fieldName` opens the
+ *   dialog on mount with the "browse" tab selected.
+ * - Landing on the `/new` suffix opens directly to the "create" tab.
+ * - Rendered with no ancestor Router (e.g. mounted standalone in Django
+ *   admin) it silently drops routing and behaves like a plain `GlobalEntryField`.
+ */
+const meta = {
+  title: "Components/RoutedGlobalEntryField",
+  component: RoutedGlobalEntryField,
+  parameters: {
+    layout: "centered",
+    noGlobalRouter: true,
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof RoutedGlobalEntryField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const mockHandlers = [
+  http.get("/api/globals/location/", () =>
+    HttpResponse.json([
+      { id: "l1", name: "Studio Shelf A", is_public: false },
+      { id: "l2", name: "Kiln Room", is_public: false },
+    ]),
+  ),
+];
+
+function withMemoryRouter(initialPath: string) {
+  return [
+    (Story: React.ComponentType) => {
+      const router = createMemoryRouter(
+        [{ path: "/pieces/:id/*", element: <Story /> }],
+        { initialEntries: [initialPath] },
+      );
+      return <RouterProvider router={router} />;
+    },
+  ];
+}
+
+export const Closed: Story = {
+  args: {
+    pieceId: "p1",
+    globalName: "location",
+    label: "Location",
+    value: "",
+    onSelect: () => {},
+  },
+  decorators: withMemoryRouter("/pieces/p1"),
+  parameters: {
+    msw: { handlers: mockHandlers },
+  },
+};
+
+export const OpenFromUrlBrowseTab: Story = {
+  args: {
+    ...Closed.args,
+  },
+  decorators: withMemoryRouter("/pieces/p1/state/fields/location"),
+  parameters: {
+    msw: { handlers: mockHandlers },
+  },
+};
+
+export const OpenFromUrlCreateTab: Story = {
+  args: {
+    ...Closed.args,
+  },
+  decorators: withMemoryRouter("/pieces/p1/state/fields/location/new"),
+  parameters: {
+    msw: { handlers: mockHandlers },
+  },
+};
+
+export const DisambiguatedFieldName: Story = {
+  args: {
+    pieceId: "p1",
+    globalName: "location",
+    fieldName: "kiln_location",
+    label: "Kiln Location",
+    value: "",
+    onSelect: () => {},
+  },
+  decorators: withMemoryRouter("/pieces/p1/state/fields/kiln_location"),
+  parameters: {
+    msw: { handlers: mockHandlers },
+  },
+};
+
+export const OutsideRouterFallsBackToPlainField: Story = {
+  args: {
+    pieceId: "p1",
+    globalName: "location",
+    label: "Location (no Router ancestor, e.g. Django admin)",
+    value: "",
+    onSelect: () => {},
+  },
+  // No router decorator: exercises the useInRouterContext() === false fallback.
+  parameters: {
+    msw: { handlers: mockHandlers },
+  },
+};

--- a/web/src/stories/RoutedGlobalEntryField.stories.tsx
+++ b/web/src/stories/RoutedGlobalEntryField.stories.tsx
@@ -89,10 +89,18 @@ export const OpenFromUrlBrowseTab: Story = {
 export const OpenFromUrlCreateTab: Story = {
   args: {
     ...Closed.args,
+    canCreate: true,
   },
   decorators: withMemoryRouter("/pieces/p1/state/fields/location/new"),
   parameters: {
-    msw: { handlers: mockHandlers },
+    msw: {
+      handlers: [
+        ...mockHandlers,
+        http.post("/api/globals/location/", () =>
+          HttpResponse.json({ id: "l3", name: "New Location", is_public: false }),
+        ),
+      ],
+    },
   },
 };
 

--- a/web/src/stories/SelectablePhotoMasonry.stories.tsx
+++ b/web/src/stories/SelectablePhotoMasonry.stories.tsx
@@ -1,0 +1,97 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import SelectablePhotoMasonry, {
+  type SelectablePhotoItem,
+} from "../components/SelectablePhotoMasonry";
+
+/**
+ * SelectablePhotoMasonry renders a checkbox-selectable CSS-column masonry
+ * grid of a piece's photos across its history.
+ *
+ * Rationale (PR #776–781 — "showcase video UX improvements"; extended in
+ * PR #827 phase 5 for direct-to-R2 uploads / `AppImage`):
+ * - Built for `ShowcaseVideoInputPicker`, where a user picks which photos to
+ *   include when generating a showcase video from a piece's timeline.
+ * - `locked` items (typically an auto-selected cover frame) render a "Cover"
+ *   badge and a disabled, tooltip-explained checkbox instead of letting the
+ *   user exclude them.
+ * - Uses CSS multi-column layout (`columnCount` responsive 2→5) rather than
+ *   a JS masonry library, so tile heights can vary freely by aspect ratio.
+ *
+ * Edge cases:
+ * - Empty: renders `emptyLabel` instead of the grid.
+ * - `disabled`: every checkbox (including unlocked ones) is disabled, e.g.
+ *   while a video is already encoding.
+ */
+const meta = {
+  title: "Components/SelectablePhotoMasonry",
+  component: SelectablePhotoMasonry,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof SelectablePhotoMasonry>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function makeItems(): SelectablePhotoItem[] {
+  const specs: Array<[string, string, string, boolean]> = [
+    ["mug.svg", "Designed", "May 1", false],
+    ["bowl.svg", "Wheel Thrown", "May 2", false],
+    ["plate.svg", "Trimmed", "May 5", false],
+    ["teapot.svg", "Bisque Fired", "May 10", false],
+    ["vase.svg", "Glazed", "May 12", true],
+    ["question-mark.svg", "Glaze Fired", "May 20", false],
+  ];
+  return specs.map(([file, stateLabel, whenLabel, locked], i) => ({
+    key: `photo-${i}`,
+    url: `/thumbnails/${file}`,
+    stateLabel,
+    whenLabel,
+    cropped_url: null,
+    crop: null,
+    checked: !locked,
+    locked,
+  }));
+}
+
+function MasonryHarness(args: React.ComponentProps<typeof SelectablePhotoMasonry>) {
+  const [items, setItems] = useState(args.items);
+  return (
+    <SelectablePhotoMasonry
+      {...args}
+      items={items.map((item) => ({
+        ...item,
+        onToggle: () =>
+          setItems((prev) =>
+            prev.map((i) => (i.key === item.key ? { ...i, checked: !i.checked } : i)),
+          ),
+      }))}
+    />
+  );
+}
+
+export const Default: Story = {
+  args: {
+    items: makeItems(),
+    emptyLabel: "No photos available.",
+  },
+  render: (args) => <MasonryHarness {...args} />,
+};
+
+export const Empty: Story = {
+  args: {
+    items: [],
+    emptyLabel: "No photos available for this piece yet.",
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    items: makeItems(),
+    emptyLabel: "No photos available.",
+    disabled: true,
+  },
+  render: (args) => <MasonryHarness {...args} />,
+};

--- a/web/src/stories/SmallTutorialInlay.stories.tsx
+++ b/web/src/stories/SmallTutorialInlay.stories.tsx
@@ -9,7 +9,7 @@ import {
   PreferencesDialogProvider,
 } from "../components/CurrentUserContext";
 import { SMALL_TUTORIAL_INLAY_PLACEMENTS } from "../components/SmallTutorialInlayConfig";
-import type { AuthUser } from "../util/api";
+import type { AuthUser, UserPreferences } from "../util/api";
 
 /**
  * SmallTutorialInlay is an anchored, always-visible popover tip attached to a
@@ -48,7 +48,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const mockUser: AuthUser = {
+const initialUser: AuthUser = {
   id: 1,
   is_staff: false,
   openid_subject: "sub-1",
@@ -60,12 +60,20 @@ function SmallTutorialInlayHarness(
   args: React.ComponentProps<typeof SmallTutorialInlay>,
 ) {
   const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
+  // Mirrors App.tsx's real saveUserPreferences wrapper: persist the merged
+  // preferences back onto the in-memory user so dismissing the tip (which
+  // sets preferences[tutorialKey] = false) actually hides it, the same way
+  // it would once TutorialManager re-renders with the updated currentUser.
+  const [user, setUser] = useState(initialUser);
 
   return (
-    <CurrentUserProvider currentUser={mockUser}>
+    <CurrentUserProvider currentUser={user}>
       <PreferencesDialogProvider
         openPreferencesDialog={fn()}
-        saveUserPreferences={async (p) => p}
+        saveUserPreferences={async (p: UserPreferences) => {
+          setUser((prev) => ({ ...prev, preferences: p }));
+          return p;
+        }}
       >
         <Box sx={{ display: "flex", justifyContent: "center", pt: 6, pb: 10 }}>
           <Box ref={setAnchorEl}>

--- a/web/src/stories/SmallTutorialInlay.stories.tsx
+++ b/web/src/stories/SmallTutorialInlay.stories.tsx
@@ -1,0 +1,108 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import { fn } from "@storybook/test";
+import SmallTutorialInlay from "../components/SmallTutorialInlay";
+import {
+  CurrentUserProvider,
+  PreferencesDialogProvider,
+} from "../components/CurrentUserContext";
+import { SMALL_TUTORIAL_INLAY_PLACEMENTS } from "../components/SmallTutorialInlayConfig";
+import type { AuthUser } from "../util/api";
+
+/**
+ * SmallTutorialInlay is an anchored, always-visible popover tip attached to a
+ * live DOM element — the "anchored" inlay type in the declarative tutorials
+ * system (`tutorials.yml`), dispatched by `TutorialManager`.
+ *
+ * Rationale (Issue #692 — "single declarative location for tutorials";
+ * extended in Issue #911 for the anchored/modal split):
+ * - `TutorialManager` resolves `attachment.selector` via `document.querySelector`
+ *   and passes the live `HTMLElement` in as `attachedElement`; this story
+ *   simulates that by handing the component a ref to a rendered anchor.
+ * - Visibility (`shouldShow`) requires an attached element, a signed-in user,
+ *   a `saveUserPreferences` function, AND the tutorial's preference key not
+ *   already being explicitly `false` — any missing piece hides the tip
+ *   entirely rather than rendering in a degraded state.
+ * - A gentle infinite bounce animation draws the eye without being disruptive;
+ *   respects `prefers-reduced-motion`.
+ *
+ * Edge cases:
+ * - Clicking the tip body dismisses the tutorial (persists the preference)
+ *   THEN fires `onClick` — e.g. opening the relevant settings section.
+ * - The dedicated close (X) button dismisses without firing `onClick`.
+ * - `placement` drives both Popper positioning and the tail/arrow's rotation
+ *   and border sides so the tail always points at the anchor.
+ */
+const meta = {
+  title: "Components/SmallTutorialInlay",
+  component: SmallTutorialInlay,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+  render: (args) => <SmallTutorialInlayHarness {...args} />,
+} satisfies Meta<typeof SmallTutorialInlay>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const mockUser: AuthUser = {
+  id: 1,
+  is_staff: false,
+  openid_subject: "sub-1",
+  alias: "test-potter",
+  preferences: { process_summary_fields: [] },
+};
+
+function SmallTutorialInlayHarness(
+  args: React.ComponentProps<typeof SmallTutorialInlay>,
+) {
+  const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
+
+  return (
+    <CurrentUserProvider currentUser={mockUser}>
+      <PreferencesDialogProvider
+        openPreferencesDialog={fn()}
+        saveUserPreferences={async (p) => p}
+      >
+        <Box sx={{ display: "flex", justifyContent: "center", pt: 6, pb: 10 }}>
+          <Box ref={setAnchorEl}>
+            <Button variant="outlined">Anchor element</Button>
+          </Box>
+          <SmallTutorialInlay {...args} attachedElement={anchorEl} />
+        </Box>
+      </PreferencesDialogProvider>
+    </CurrentUserProvider>
+  );
+}
+
+export const RightPlacement: Story = {
+  args: {
+    attachedElement: null,
+    tutorialKey: "change_alias_prompt",
+    label: "Change your alias!",
+    dismissLabel: "Dismiss alias tip",
+    placement: SMALL_TUTORIAL_INLAY_PLACEMENTS.RIGHT,
+    onClick: fn(),
+  },
+};
+
+export const LeftPlacement: Story = {
+  args: {
+    ...RightPlacement.args,
+    placement: SMALL_TUTORIAL_INLAY_PLACEMENTS.LEFT,
+  },
+};
+
+export const TopPlacement: Story = {
+  args: {
+    attachedElement: null,
+    tutorialKey: "summary_customize_popover",
+    label: "Customize this summary!",
+    dismissLabel: "Dismiss summary customization tip",
+    placement: SMALL_TUTORIAL_INLAY_PLACEMENTS.TOP,
+    onClick: fn(),
+  },
+};

--- a/web/src/stories/StateCarousel.stories.tsx
+++ b/web/src/stories/StateCarousel.stories.tsx
@@ -1,7 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { http, HttpResponse } from "msw";
 import StateCarousel from "../components/StateCarousel";
 import { fn } from "@storybook/test";
-import type { PieceDetail, PieceState } from "../util/types";
+import type { PieceDetail, PieceState, StateEnum } from "../util/types";
+import { STATES, SUCCESSORS, isTerminalState } from "../util/workflow";
 
 /**
  * StateCarousel renders a piece's full state history as a horizontal snap-scroll
@@ -52,21 +54,52 @@ function makeState(overrides: Partial<PieceState> & Pick<PieceState, "id" | "sta
   };
 }
 
-const midFlowHistory: PieceState[] = [
-  makeState({ id: "s1", state: "designed", created: new Date("2026-05-01T10:00:00Z"), previous_state: null, next_state: "wheel_thrown" }),
-  makeState({ id: "s2", state: "wheel_thrown", created: new Date("2026-05-02T14:00:00Z"), previous_state: "designed", next_state: "trimmed" }),
-  makeState({ id: "s3", state: "trimmed", created: new Date("2026-05-05T09:00:00Z"), previous_state: "wheel_thrown", next_state: "bisque_fired" }),
-  makeState({ id: "s4", state: "bisque_fired", created: new Date("2026-05-10T09:00:00Z"), previous_state: "trimmed", next_state: "glazed" }),
-  makeState({ id: "s5", state: "glazed", created: new Date(), previous_state: "bisque_fired", next_state: null }),
-];
+// Walks SUCCESSORS from the initial workflow state, always preferring a
+// non-terminal, non-"recycled" successor, so the sample history stays a
+// valid path through whatever workflow.yml currently defines rather than a
+// hardcoded chain that could drift out of sync with real transitions.
+function walkHappyPath(steps: number): StateEnum[] {
+  const path: StateEnum[] = [STATES[0] as StateEnum];
+  while (path.length < steps) {
+    const successors = SUCCESSORS[path[path.length - 1]] ?? [];
+    const next = successors.find((s) => s !== "recycled" && !isTerminalState(s));
+    if (!next) break;
+    path.push(next as StateEnum);
+  }
+  return path;
+}
 
-const terminalHistory: PieceState[] = [
-  ...midFlowHistory.slice(0, 4),
-  makeState({ id: "s5", state: "glazed", created: new Date("2026-05-12T09:00:00Z"), previous_state: "bisque_fired", next_state: "submitted_to_glaze_fire" }),
-  makeState({ id: "s6", state: "submitted_to_glaze_fire", created: new Date("2026-05-13T09:00:00Z"), previous_state: "glazed", next_state: "glaze_fired" }),
-  makeState({ id: "s7", state: "glaze_fired", created: new Date("2026-05-20T09:00:00Z"), previous_state: "submitted_to_glaze_fire", next_state: "completed" }),
-  makeState({ id: "s8", state: "completed", created: new Date(), previous_state: "glaze_fired", next_state: null }),
-];
+// Extends a happy-path state sequence to its first terminal state (e.g.
+// "completed"), again derived from SUCCESSORS rather than hardcoded.
+function walkToTerminal(path: StateEnum[]): StateEnum[] {
+  const extended = [...path];
+  while (!isTerminalState(extended[extended.length - 1])) {
+    const successors = SUCCESSORS[extended[extended.length - 1]] ?? [];
+    const next = successors.find((s) => s !== "recycled") ?? successors[0];
+    if (!next) break;
+    extended.push(next as StateEnum);
+  }
+  return extended;
+}
+
+function statesToHistory(path: StateEnum[]): PieceState[] {
+  let created = new Date("2026-05-01T10:00:00Z");
+  return path.map((state, i) => {
+    const entry = makeState({
+      id: `s${i + 1}`,
+      state,
+      created: new Date(created),
+      previous_state: i > 0 ? path[i - 1] : null,
+      next_state: i < path.length - 1 ? path[i + 1] : null,
+    });
+    created = new Date(created.getTime() + 4 * 24 * 60 * 60 * 1000);
+    return entry;
+  });
+}
+
+const midFlowPath = walkHappyPath(5);
+const midFlowHistory: PieceState[] = statesToHistory(midFlowPath);
+const terminalHistory: PieceState[] = statesToHistory(walkToTerminal(midFlowPath));
 
 function makePiece(history: PieceState[], overrides: Partial<PieceDetail> = {}): PieceDetail {
   const current = history[history.length - 1];
@@ -117,10 +150,25 @@ export const Rewinded: Story = {
   },
 };
 
+const editablePiece = makePiece(midFlowHistory, { is_editable: true });
+
 export const EditableWithHistoryModal: Story = {
   args: {
     ...Default.args,
-    piece: makePiece(midFlowHistory, { is_editable: true }),
+    piece: editablePiece,
+  },
+  parameters: {
+    // The "Edit history" modal (PieceHistory) can edit a date, delete a
+    // state, or insert a missing one — each hits a real pieces/:id/states/...
+    // endpoint, so all three must be mocked or those controls fail against
+    // an unhandled request instead of demonstrating editable history.
+    msw: {
+      handlers: [
+        http.patch("/api/pieces/p1/states/:stateId/", () => HttpResponse.json(editablePiece)),
+        http.delete("/api/pieces/p1/states/:stateId/", () => HttpResponse.json(editablePiece)),
+        http.post("/api/pieces/p1/states/", () => HttpResponse.json(editablePiece)),
+      ],
+    },
   },
 };
 

--- a/web/src/stories/StateCarousel.stories.tsx
+++ b/web/src/stories/StateCarousel.stories.tsx
@@ -1,0 +1,148 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import StateCarousel from "../components/StateCarousel";
+import { fn } from "@storybook/test";
+import type { PieceDetail, PieceState } from "../util/types";
+
+/**
+ * StateCarousel renders a piece's full state history as a horizontal snap-scroll
+ * carousel, replacing the old side-by-side StateTransition picker + Timeline
+ * SectionCard.
+ *
+ * Rationale (Issue/PR #994 — "replace StateTransition + Timeline with StateCarousel"):
+ * - One card per history entry; the current card additionally renders a
+ *   Bezier-fan `BranchConnector` fanning out to all valid successor states.
+ * - Clicking a past card's StateChip sets/clears "rewind" (viewing the piece
+ *   as it existed at that point in history); the current card's chip always
+ *   clears rewind.
+ * - `useLayoutEffect` instant-scrolls to the correct card before first paint
+ *   (current state, or the rewound state if `rewindedStateId` is set on
+ *   load) to avoid a visible flash of card 0.
+ * - Mouse drag-to-scroll uses a 5px threshold so drags don't suppress the
+ *   click that starts them.
+ *
+ * Edge cases:
+ * - Terminal state (`completed`/`recycled`): centered grid, no successor zone, "end" label.
+ * - Rewinded: past chip glows (`rewindSelected`), integrated status Chip appears below the pager dots.
+ * - Editable (`piece.is_editable`): reveals an "Edit history" icon button opening a `PieceHistory` modal.
+ * - Loading / error: history fetch spinner or retry banner render below the rail without blocking transitions.
+ */
+const meta = {
+  title: "Components/StateCarousel",
+  component: StateCarousel,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof StateCarousel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function makeState(overrides: Partial<PieceState> & Pick<PieceState, "id" | "state">): PieceState {
+  return {
+    notes: "",
+    created: new Date("2026-05-01T10:00:00Z"),
+    last_modified: new Date("2026-05-01T10:00:00Z"),
+    images: [],
+    previous_state: null,
+    next_state: null,
+    custom_fields: {},
+    has_been_edited: false,
+    ...overrides,
+  };
+}
+
+const midFlowHistory: PieceState[] = [
+  makeState({ id: "s1", state: "designed", created: new Date("2026-05-01T10:00:00Z"), previous_state: null, next_state: "wheel_thrown" }),
+  makeState({ id: "s2", state: "wheel_thrown", created: new Date("2026-05-02T14:00:00Z"), previous_state: "designed", next_state: "trimmed" }),
+  makeState({ id: "s3", state: "trimmed", created: new Date("2026-05-05T09:00:00Z"), previous_state: "wheel_thrown", next_state: "bisque_fired" }),
+  makeState({ id: "s4", state: "bisque_fired", created: new Date("2026-05-10T09:00:00Z"), previous_state: "trimmed", next_state: "glazed" }),
+  makeState({ id: "s5", state: "glazed", created: new Date(), previous_state: "bisque_fired", next_state: null }),
+];
+
+const terminalHistory: PieceState[] = [
+  ...midFlowHistory.slice(0, 4),
+  makeState({ id: "s5", state: "glazed", created: new Date("2026-05-12T09:00:00Z"), previous_state: "bisque_fired", next_state: "submitted_to_glaze_fire" }),
+  makeState({ id: "s6", state: "submitted_to_glaze_fire", created: new Date("2026-05-13T09:00:00Z"), previous_state: "glazed", next_state: "glaze_fired" }),
+  makeState({ id: "s7", state: "glaze_fired", created: new Date("2026-05-20T09:00:00Z"), previous_state: "submitted_to_glaze_fire", next_state: "completed" }),
+  makeState({ id: "s8", state: "completed", created: new Date(), previous_state: "glaze_fired", next_state: null }),
+];
+
+function makePiece(history: PieceState[], overrides: Partial<PieceDetail> = {}): PieceDetail {
+  const current = history[history.length - 1];
+  return {
+    id: "p1",
+    name: "Test Piece",
+    created: history[0].created,
+    last_modified: current.created,
+    photo_count: 0,
+    thumbnail: null,
+    shared: false,
+    is_editable: false,
+    can_edit: true,
+    tags: [],
+    current_location: "Studio",
+    showcase_story: "",
+    showcase_fields: [],
+    showcase_video_url: null,
+    owner_alias: null,
+    current_state: current,
+    history,
+    ...overrides,
+  };
+}
+
+export const Default: Story = {
+  args: {
+    statesHistory: midFlowHistory,
+    piece: makePiece(midFlowHistory),
+    onPieceUpdated: fn(),
+    onRewind: fn(),
+    onTransition: fn(),
+  },
+};
+
+export const TerminalState: Story = {
+  args: {
+    ...Default.args,
+    statesHistory: terminalHistory,
+    piece: makePiece(terminalHistory),
+  },
+};
+
+export const Rewinded: Story = {
+  args: {
+    ...Default.args,
+    rewindedStateId: "s2",
+  },
+};
+
+export const EditableWithHistoryModal: Story = {
+  args: {
+    ...Default.args,
+    piece: makePiece(midFlowHistory, { is_editable: true }),
+  },
+};
+
+export const HistoryLoading: Story = {
+  args: {
+    ...Default.args,
+    historyLoading: true,
+  },
+};
+
+export const HistoryLoadFailed: Story = {
+  args: {
+    ...Default.args,
+    historyError: new Error("Network error"),
+    refetchHistory: fn(),
+  },
+};
+
+export const AutosaveFailedBlocksTransition: Story = {
+  args: {
+    ...Default.args,
+    hasSaveError: true,
+    transitionError: "Auto-save failed. Your changes may not be saved.",
+  },
+};

--- a/web/src/stories/StateCarousel.stories.tsx
+++ b/web/src/stories/StateCarousel.stories.tsx
@@ -54,30 +54,42 @@ function makeState(overrides: Partial<PieceState> & Pick<PieceState, "id" | "sta
   };
 }
 
-// Walks SUCCESSORS from the initial workflow state, always preferring a
-// non-terminal, non-"recycled" successor, so the sample history stays a
-// valid path through whatever workflow.yml currently defines rather than a
-// hardcoded chain that could drift out of sync with real transitions.
+// Walks SUCCESSORS from the initial workflow state, always preferring an
+// unvisited, non-terminal, non-"recycled" successor, so the sample history
+// stays a valid path through whatever workflow.yml currently defines rather
+// than a hardcoded chain that could drift out of sync with real transitions.
+// Some states (e.g. "carved" and "slip_applied") are mutually reachable, so
+// the visited set is required to guarantee forward progress and termination
+// rather than bouncing between the same two states forever.
 function walkHappyPath(steps: number): StateEnum[] {
   const path: StateEnum[] = [STATES[0] as StateEnum];
+  const visited = new Set<StateEnum>(path);
   while (path.length < steps) {
-    const successors = SUCCESSORS[path[path.length - 1]] ?? [];
-    const next = successors.find((s) => s !== "recycled" && !isTerminalState(s));
+    const successors = (SUCCESSORS[path[path.length - 1]] ?? []) as StateEnum[];
+    const next = successors.find(
+      (s) => s !== "recycled" && !isTerminalState(s) && !visited.has(s),
+    );
     if (!next) break;
-    path.push(next as StateEnum);
+    path.push(next);
+    visited.add(next);
   }
   return path;
 }
 
 // Extends a happy-path state sequence to its first terminal state (e.g.
-// "completed"), again derived from SUCCESSORS rather than hardcoded.
+// "completed"), again derived from SUCCESSORS rather than hardcoded, using
+// the same visited-set approach to guarantee termination.
 function walkToTerminal(path: StateEnum[]): StateEnum[] {
   const extended = [...path];
+  const visited = new Set<StateEnum>(extended);
   while (!isTerminalState(extended[extended.length - 1])) {
-    const successors = SUCCESSORS[extended[extended.length - 1]] ?? [];
-    const next = successors.find((s) => s !== "recycled") ?? successors[0];
+    const successors = (SUCCESSORS[extended[extended.length - 1]] ?? []) as StateEnum[];
+    const next =
+      successors.find((s) => s !== "recycled" && !visited.has(s)) ??
+      successors.find((s) => !visited.has(s));
     if (!next) break;
-    extended.push(next as StateEnum);
+    extended.push(next);
+    visited.add(next);
   }
   return extended;
 }

--- a/web/src/stories/TutorialManager.stories.tsx
+++ b/web/src/stories/TutorialManager.stories.tsx
@@ -1,0 +1,121 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import Box from "@mui/material/Box";
+import Chip from "@mui/material/Chip";
+import Typography from "@mui/material/Typography";
+import { fn } from "@storybook/test";
+import TutorialManager from "../components/TutorialManager";
+import {
+  CurrentUserProvider,
+  PreferencesDialogProvider,
+} from "../components/CurrentUserContext";
+import type { AuthUser } from "../util/api";
+
+/**
+ * TutorialManager is the app-wide orchestrator for `tutorials.yml`. It takes
+ * no props: it reads the declarative config at build time, watches the DOM
+ * via `MutationObserver` for elements matching each anchored tutorial's
+ * `attachment.selector`, and renders a `SmallTutorialInlay` (or
+ * `LargeTutorialInlay` for `type: modal` tutorials, gated by `route`) per
+ * still-visible tutorial.
+ *
+ * Rationale (Issue #692 — "single declarative location for tutorials";
+ * extended in Issue #911 for anchored/modal dispatch):
+ * - A tutorial is hidden once `currentUser.preferences[key] === false`
+ *   (persisted via `useSaveUserPreferences` when the user dismisses it) or
+ *   once any of its `depends_on` tutorials is still active (not yet dismissed).
+ * - Rendered once near the app root (`App.tsx`) so it can find anchors
+ *   anywhere on the page as routes change.
+ *
+ * This story mounts real elements with the `id`s that the live
+ * `tutorials.yml` selectors target (`#process-summary-title`, `#user-chip`)
+ * so `TutorialManager`'s real `document.querySelector` scan finds them —
+ * exactly like it does in the deployed app.
+ *
+ * Edge cases:
+ * - No signed-in user: renders nothing (`if (!currentUser) return null`).
+ * - A tutorial whose `depends_on` entry hasn't been dismissed yet stays hidden
+ *   until the user dismisses the dependency first (sequential onboarding).
+ */
+const meta = {
+  title: "Components/TutorialManager",
+  component: TutorialManager,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof TutorialManager>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function makeUser(preferences: Record<string, unknown> = {}): AuthUser {
+  return {
+    id: 1,
+    is_staff: false,
+    openid_subject: "sub-1",
+    alias: "test-potter",
+    preferences: { process_summary_fields: [], ...preferences },
+  };
+}
+
+function MockPage() {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 8, maxWidth: 480 }}>
+      <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+        <Chip id="user-chip" label="test-potter" />
+      </Box>
+      <Box>
+        <Typography id="process-summary-title" variant="h6">
+          Process Summary
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Weight loss, glaze coverage, and other computed fields appear here.
+        </Typography>
+      </Box>
+    </Box>
+  );
+}
+
+export const BothTutorialsActive: Story = {
+  render: () => (
+    <CurrentUserProvider currentUser={makeUser()}>
+      <PreferencesDialogProvider
+        openPreferencesDialog={fn()}
+        saveUserPreferences={async (p) => p}
+      >
+        <MockPage />
+        <TutorialManager />
+      </PreferencesDialogProvider>
+    </CurrentUserProvider>
+  ),
+};
+
+export const OneTutorialDismissed: Story = {
+  render: () => (
+    <CurrentUserProvider
+      currentUser={makeUser({ summary_customize_popover: false })}
+    >
+      <PreferencesDialogProvider
+        openPreferencesDialog={fn()}
+        saveUserPreferences={async (p) => p}
+      >
+        <MockPage />
+        <TutorialManager />
+      </PreferencesDialogProvider>
+    </CurrentUserProvider>
+  ),
+};
+
+export const NoSignedInUser: Story = {
+  render: () => (
+    <CurrentUserProvider currentUser={null}>
+      <PreferencesDialogProvider
+        openPreferencesDialog={fn()}
+        saveUserPreferences={async (p) => p}
+      >
+        <MockPage />
+        <TutorialManager />
+      </PreferencesDialogProvider>
+    </CurrentUserProvider>
+  ),
+};

--- a/web/src/stories/TutorialManager.stories.tsx
+++ b/web/src/stories/TutorialManager.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
 import Box from "@mui/material/Box";
 import Chip from "@mui/material/Chip";
 import Typography from "@mui/material/Typography";
@@ -8,7 +9,7 @@ import {
   CurrentUserProvider,
   PreferencesDialogProvider,
 } from "../components/CurrentUserContext";
-import type { AuthUser } from "../util/api";
+import type { AuthUser, UserPreferences } from "../util/api";
 
 /**
  * TutorialManager is the app-wide orchestrator for `tutorials.yml`. It takes
@@ -76,46 +77,40 @@ function MockPage() {
   );
 }
 
-export const BothTutorialsActive: Story = {
-  render: () => (
-    <CurrentUserProvider currentUser={makeUser()}>
+// Mirrors App.tsx's real saveUserPreferences wrapper: persist the merged
+// preferences back onto the in-memory user so dismissing a tip (which sets
+// preferences[tutorialKey] = false) actually hides it, instead of the tip
+// staying visible after a "successful" mutation that never updates context.
+function TutorialManagerHarness({ initialUser }: { initialUser: AuthUser | null }) {
+  const [user, setUser] = useState(initialUser);
+  return (
+    <CurrentUserProvider currentUser={user}>
       <PreferencesDialogProvider
         openPreferencesDialog={fn()}
-        saveUserPreferences={async (p) => p}
+        saveUserPreferences={async (p: UserPreferences) => {
+          setUser((prev) => (prev ? { ...prev, preferences: p } : prev));
+          return p;
+        }}
       >
         <MockPage />
         <TutorialManager />
       </PreferencesDialogProvider>
     </CurrentUserProvider>
-  ),
+  );
+}
+
+export const BothTutorialsActive: Story = {
+  render: () => <TutorialManagerHarness initialUser={makeUser()} />,
 };
 
 export const OneTutorialDismissed: Story = {
   render: () => (
-    <CurrentUserProvider
-      currentUser={makeUser({ summary_customize_popover: false })}
-    >
-      <PreferencesDialogProvider
-        openPreferencesDialog={fn()}
-        saveUserPreferences={async (p) => p}
-      >
-        <MockPage />
-        <TutorialManager />
-      </PreferencesDialogProvider>
-    </CurrentUserProvider>
+    <TutorialManagerHarness
+      initialUser={makeUser({ summary_customize_popover: false })}
+    />
   ),
 };
 
 export const NoSignedInUser: Story = {
-  render: () => (
-    <CurrentUserProvider currentUser={null}>
-      <PreferencesDialogProvider
-        openPreferencesDialog={fn()}
-        saveUserPreferences={async (p) => p}
-      >
-        <MockPage />
-        <TutorialManager />
-      </PreferencesDialogProvider>
-    </CurrentUserProvider>
-  ),
+  render: () => <TutorialManagerHarness initialUser={null} />,
 };

--- a/web/src/stories/UserPreferencesDialog.stories.tsx
+++ b/web/src/stories/UserPreferencesDialog.stories.tsx
@@ -1,0 +1,179 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import Button from "@mui/material/Button";
+import { http, HttpResponse, delay } from "msw";
+import UserPreferencesDialog from "../components/UserPreferencesDialog";
+import {
+  CurrentUserProvider,
+  PreferencesDialogProvider,
+  type PreferencesSectionId,
+} from "../components/CurrentUserContext";
+import {
+  updateUserPreferences,
+  type AuthUser,
+  type UserPreferences,
+} from "../util/api";
+
+/**
+ * UserPreferencesDialog renders one collapsible `Accordion` section per entry
+ * in `user_preferences.yml`, plus a synthesized "Tutorials" section built
+ * from every dismissible tutorial in `tutorials.yml`.
+ *
+ * Rationale:
+ * - `activeSectionId` / `onSectionChange` are lifted to the caller (see
+ *   `RoutedGlobalEntryField`-style routing elsewhere in the app) so a
+ *   `SmallTutorialInlay`'s "open preferences" action can deep-link straight
+ *   to the relevant section (e.g. clicking the alias tip opens "Identity").
+ * - Field values are seeded from the fetched `UserPreferencesResponse`,
+ *   falling back to the in-memory `currentUser` so the dialog isn't blank
+ *   while the network request is in flight.
+ * - The form remounts (via a `JSON.stringify`-keyed `PreferencesForm`) only
+ *   when the *initial* values actually change, so in-progress edits survive
+ *   unrelated re-renders.
+ *
+ * Edge cases:
+ * - Loading or saving: a `LinearProgress` bar renders under the title.
+ * - Load failure: inline error text, but the form still renders with
+ *   fallback values so the dialog isn't stuck.
+ * - Save failure: an `Alert` appears above the form; the dialog stays open.
+ * - Closing while saving is disabled (`onClose={savePending ? undefined : onClose}`).
+ */
+const meta = {
+  title: "Components/UserPreferencesDialog",
+  component: UserPreferencesDialog,
+  parameters: {
+    layout: "centered",
+    docs: {
+      inlineStories: false,
+      iframeHeight: 650,
+      source: {
+        code: `
+<UserPreferencesDialog
+  open={true}
+  activeSectionId={null}
+  onClose={() => {}}
+  onSectionChange={() => {}}
+/>`,
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    open: { table: { disable: true } },
+  },
+  render: (args) => <UserPreferencesDialogWithState {...args} />,
+} satisfies Meta<typeof UserPreferencesDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const mockUser: AuthUser = {
+  id: 1,
+  is_staff: false,
+  openid_subject: "sub-1",
+  alias: "clay-wrangler",
+  preferences: {
+    process_summary_fields: ["piece.name", "glazed.glaze_combination"],
+    change_alias_prompt: true,
+  },
+};
+
+function UserPreferencesDialogWithState(
+  args: React.ComponentProps<typeof UserPreferencesDialog>,
+) {
+  const [open, setOpen] = useState(false);
+  const [activeSectionId, setActiveSectionId] =
+    useState<PreferencesSectionId | null>(args.activeSectionId);
+  return (
+    <CurrentUserProvider currentUser={mockUser}>
+      <PreferencesDialogProvider
+        openPreferencesDialog={() => {}}
+        saveUserPreferences={async (
+          preferences: UserPreferences,
+          alias?: string,
+        ) => {
+          const response = await updateUserPreferences(preferences, alias);
+          return response.preferences;
+        }}
+      >
+        <Button variant="contained" onClick={() => setOpen(true)}>
+          Open Preferences
+        </Button>
+        <UserPreferencesDialog
+          {...args}
+          open={open}
+          activeSectionId={activeSectionId}
+          onSectionChange={setActiveSectionId}
+          onClose={() => {
+            setOpen(false);
+            args.onClose();
+          }}
+        />
+      </PreferencesDialogProvider>
+    </CurrentUserProvider>
+  );
+}
+
+const csrfHandler = http.get("/api/auth/csrf/", () => HttpResponse.json({}));
+const preferencesHandler = http.get("/api/auth/preferences/", () =>
+  HttpResponse.json({ alias: mockUser.alias, preferences: mockUser.preferences }),
+);
+const saveHandler = http.patch("/api/auth/preferences/", async ({ request }) => {
+  const body = (await request.json()) as Record<string, unknown>;
+  return HttpResponse.json({
+    alias: mockUser.alias,
+    preferences: { ...mockUser.preferences, ...(body.preferences as object) },
+  });
+});
+
+export const Default: Story = {
+  args: { open: false, activeSectionId: null, onClose: () => {}, onSectionChange: () => {} },
+  parameters: { msw: { handlers: [csrfHandler, preferencesHandler, saveHandler] } },
+};
+
+export const IdentitySectionExpanded: Story = {
+  args: { ...Default.args, activeSectionId: "identity" },
+  parameters: { msw: { handlers: [csrfHandler, preferencesHandler, saveHandler] } },
+};
+
+export const Loading: Story = {
+  args: { ...Default.args },
+  parameters: {
+    msw: {
+      handlers: [
+        csrfHandler,
+        http.get("/api/auth/preferences/", async () => {
+          await delay("infinite");
+          return HttpResponse.json({});
+        }),
+        saveHandler,
+      ],
+    },
+  },
+};
+
+export const LoadFailed: Story = {
+  args: { ...Default.args },
+  parameters: {
+    msw: {
+      handlers: [
+        csrfHandler,
+        http.get("/api/auth/preferences/", () => HttpResponse.json({}, { status: 500 })),
+        saveHandler,
+      ],
+    },
+  },
+};
+
+export const SaveFailed: Story = {
+  args: { ...Default.args, activeSectionId: "identity" },
+  parameters: {
+    msw: {
+      handlers: [
+        csrfHandler,
+        preferencesHandler,
+        http.patch("/api/auth/preferences/", () => HttpResponse.json({}, { status: 500 })),
+      ],
+    },
+  },
+};


### PR DESCRIPTION
## Summary

Adds Storybook coverage for the 11 components in `web/src/components/` that had none, following the `/stories` workflow (history trawling via `git log`/`gh`, MSW-mocked API dependencies, JSDoc rationale, 3+ variants per component):

- **StateCarousel** — the horizontal snap-carousel that replaced `StateTransition` + Timeline ([#994](https://github.com/shaoster/glaze/pull/994)): mid-flow, terminal state, rewind, editable-with-history-modal, loading, error, and autosave-failure variants.
- **TutorialManager**, **LargeTutorialInlay**, **SmallTutorialInlay** — the declarative `tutorials.yml`-driven onboarding system ([#692](https://github.com/shaoster/glaze/issues/692), [#911](https://github.com/shaoster/glaze/issues/911)). `TutorialManager`'s story mounts real DOM anchors matching the live config's selectors so its actual `document.querySelector` scan finds them, exactly as in the deployed app.
- **DeveloperTokensDialog** — `pdagent_…` bearer token management for external agents ([#879](https://github.com/shaoster/glaze/pull/879)), with MSW handlers for list/create/revoke and a one-time-reveal token variant.
- **UserPreferencesDialog** + **DynamicPreferenceField** — the `user_preferences.yml`-driven preferences form and its per-field-type renderer (string/boolean/field-list).
- **ReportBadCropDialog** — the bad-crop reporting flow ([#421](https://github.com/shaoster/glaze/pull/421)).
- **SelectablePhotoMasonry** — the checkbox-selectable masonry grid used by `ShowcaseVideoInputPicker`.
- **AppFooterLinks** — the legal/info footer link row (support flow now lives in django-helpdesk, not here).
- **RoutedGlobalEntryField** — the URL-driven wrapper around `GlobalEntryField`, including a story exercising its unrouted (Django admin) fallback path.

Excluded from coverage: `AuthTokenContext`, `CurrentUserContext`, `PieceDetailSaveStatusContext` — pure context providers with no rendered UI of their own.

## Verification

- `rtk bazel build //web:storybook_build` — static Storybook build succeeds.
- `rtk bazel build --config=lint //web/...` — all 113 targets pass (tsc typecheck + eslint). Caught and fixed 4 real issues surfaced by the new stories: a `Date | undefined` vs `null` mismatch, two missing-required-prop story args, an incompatible `saveUserPreferences` callback type, and a `react-hooks/refs` violation (reading `ref.current` during render — replaced with a callback-ref-backed `useState`).
- Did not verify interactively in a browser via `rtk bazel run //web:storybook_dev` this session — CI's storybook job will catch any remaining runtime-only issues.

## Test plan

- [ ] CI passes (build, lint, tests)
- [ ] Spot-check a few new stories in the deployed/CI-built Storybook, especially `StateCarousel` (drag/scroll) and `TutorialManager` (DOM-anchor scanning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
