### PR TITLE
fix: skip npm scripts during gz_start setup

### DIFF
--- a/tools/gz_start_launcher.py
+++ b/tools/gz_start_launcher.py
@@ -246,8 +246,12 @@ def ensure_local_web_node_modules(roots: Roots) -> None:
     if worktree_nm.exists():
         return
 
-    print("web: installing local node_modules via npm install...")
-    subprocess.run(["npm", "install"], cwd=str(roots.workspace / "web"), check=True)
+    print("web: installing local node_modules via npm install --ignore-scripts...")
+    subprocess.run(
+        ["npm", "install", "--ignore-scripts"],
+        cwd=str(roots.workspace / "web"),
+        check=True,
+    )
 
 
 def sync_generated_types(roots: Roots, env: dict[str, str]) -> None:

--- a/tools/tests/test_gz_start_launcher.py
+++ b/tools/tests/test_gz_start_launcher.py
@@ -450,7 +450,29 @@ def test_ensure_local_web_node_modules_replaces_shared_symlink(
 
     assert not local_nm.is_symlink()
     assert local_nm.exists()
-    assert install_calls == [(["npm", "install"], str(local_web))]
+    assert install_calls == [(["npm", "install", "--ignore-scripts"], str(local_web))]
+
+
+def test_ensure_local_web_node_modules_skips_dependency_scripts(
+    monkeypatch, tmp_path: Path
+) -> None:
+    shared = tmp_path / "shared"
+    workspace = tmp_path / "worktree"
+    local_web = workspace / "web"
+    local_web.mkdir(parents=True)
+
+    roots = launcher.Roots(workspace=workspace, shared=shared)
+    install_calls: list[list[str]] = []
+
+    def fake_run(args, cwd, check):
+        install_calls.append(args)
+        return object()
+
+    monkeypatch.setattr(launcher.subprocess, "run", fake_run)
+
+    launcher.ensure_local_web_node_modules(roots)
+
+    assert install_calls == [["npm", "install", "--ignore-scripts"]]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Fresh worktrees fail during `gz_start` because the automatic `npm install` runs the native build script for the unrelated `better-sqlite3` coverage-audit dependency. See [issue #1010](https://github.com/shaoster/glaze/issues/1010).

## Fix

Install worktree-local web dependencies with `npm install --ignore-scripts`. The Vite dependencies needed for startup are still installed, while unrelated native addon scripts no longer block startup.

## Regression Test

Added `test_ensure_local_web_node_modules_skips_dependency_scripts` in `tools/tests/test_gz_start_launcher.py`. It verifies the fresh-worktree installation path invokes npm with `--ignore-scripts`; it failed on the buggy baseline and passes with the fix.

## Verification

- `bazel test //... --test_output=errors` — 80 test targets pass
- `bazel build --config=ci --config=lint //...` — passes
- `bazel test --config=ci --config=lint --test_tag_filters=lint //...` — 5 lint test targets pass
- Ruff formatting and checks on both changed Python files — pass
- `git diff --check` — passes

Closes #1010
