### PR TITLE
fix(r2): switch browser uploads from presigned POST to PUT

### DIFF
--- a/api/r2.py
+++ b/api/r2.py
@@ -29,9 +29,11 @@ _REQUIRED_ENV_VARS = (
 # Default presigned-PUT expiry, in seconds.
 PRESIGNED_PUT_EXPIRES_SECONDS = 600
 
-# Maximum file size accepted by the presigned-POST endpoint (50 MiB).
-# This is enforced server-side via R2's content-length-range condition so
-# clients cannot bypass it by sending a malformed Content-Length header.
+# Maximum file size accepted by the presigned-PUT upload flow (50 MiB).
+# R2 presigned PUT URLs have no content-length-range condition (unlike S3
+# presigned POST), so this is enforced after the fact: the confirm-upload
+# endpoint HEADs the object once the client's PUT completes and deletes it
+# if it exceeds this cap.
 MAX_UPLOAD_BYTES = 50 * 1024 * 1024
 
 
@@ -93,30 +95,17 @@ def generate_presigned_put(
     )
 
 
-def generate_presigned_post(
-    key: str,
-    content_type: str,
-    *,
-    max_bytes: int = MAX_UPLOAD_BYTES,
-    expires: int = PRESIGNED_PUT_EXPIRES_SECONDS,
-) -> dict:
-    """Return a presigned POST payload for *key* with a server-enforced size cap.
+def get_object_content_length(key: str) -> int:
+    """Return the size in bytes of an already-uploaded object.
 
-    Returns a dict with ``url`` and ``fields`` suitable for a multipart POST.
-    The ``content-length-range`` condition is embedded in the policy so R2
-    rejects uploads larger than *max_bytes* without involving our server.
+    Used to enforce ``MAX_UPLOAD_BYTES`` after a browser PUT completes: R2's
+    presigned PUT URLs (unlike S3 presigned POST policies) have no
+    ``content-length-range`` condition, so the cap can only be checked after
+    the fact via a HEAD request.
     """
     client = get_r2_client()
-    return client.generate_presigned_post(
-        Bucket=get_bucket_name(),
-        Key=key,
-        Fields={"Content-Type": content_type},
-        Conditions=[
-            {"Content-Type": content_type},
-            ["content-length-range", 1, max_bytes],
-        ],
-        ExpiresIn=expires,
-    )
+    response = client.head_object(Bucket=get_bucket_name(), Key=key)
+    return response["ContentLength"]
 
 
 def public_url_for_key(key: str) -> str:

--- a/api/static/admin/js/r2_image_widget.js
+++ b/api/static/admin/js/r2_image_widget.js
@@ -76,6 +76,22 @@
   var CONVERT_POLL_INTERVAL = 2000;
   var CONVERT_POLL_TIMEOUT = 120000;
 
+  function confirmUpload(key) {
+    return fetch('/api/uploads/r2/confirm-upload/', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json', 'X-CSRFToken': getCsrfToken() },
+      body: JSON.stringify({ key: key }),
+    }).then(function (r) {
+      if (!r.ok) {
+        return r.json().catch(function () { return {}; }).then(function (body) {
+          throw new Error(body.detail || ('Upload confirmation failed with status ' + r.status));
+        });
+      }
+      return r.json();
+    });
+  }
+
   function triggerConversion(key) {
     return fetch('/api/uploads/r2/convert-image/', {
       method: 'POST',
@@ -108,17 +124,17 @@
 
     fetchPresignedUrl(mimeType)
       .then(function (presign) {
-        // Multipart POST so R2 enforces the server-signed content-length-range.
-        var form = new FormData();
-        Object.entries(presign.fields || {}).forEach(function (entry) {
-          form.append(entry[0], entry[1]);
-        });
-        form.append('file', file);
         return fetch(presign.upload_url, {
-          method: 'POST',
-          body: form,
+          method: 'PUT',
+          headers: { 'Content-Type': mimeType },
+          body: file,
         }).then(function (r) {
           if (!r.ok) { throw new Error('Upload failed with status ' + r.status); }
+          // R2 presigned PUT URLs can't enforce a size cap at signature
+          // time, so the server checks it here and deletes the object if
+          // oversized.
+          return confirmUpload(presign.key);
+        }).then(function () {
           // For non-browser-renderable formats (HEIC/HEIF/AVIF), trigger
           // server-side JPEG conversion and wait for the JPEG URL.
           if (NON_BROWSER_TYPES.indexOf(mimeType) !== -1) {

--- a/api/tests/test_r2_uploads.py
+++ b/api/tests/test_r2_uploads.py
@@ -23,11 +23,8 @@ def r2_env(monkeypatch):
 @pytest.fixture
 def presign_mock():
     with mock.patch(
-        "api.r2.generate_presigned_post",
-        return_value={
-            "url": "https://test-account.r2.cloudflarestorage.com/test-bucket",
-            "fields": {"key": "images/1/x.jpg", "Content-Type": "image/jpeg"},
-        },
+        "api.r2.generate_presigned_put",
+        return_value="https://test-account.r2.cloudflarestorage.com/test-bucket",
     ) as presign:
         yield presign
 
@@ -62,7 +59,7 @@ class TestR2PresignedUploadUrl:
         assert body["upload_url"] == (
             "https://test-account.r2.cloudflarestorage.com/test-bucket"
         )
-        assert isinstance(body["fields"], dict)
+        assert "fields" not in body
         assert body["public_url"] == f"https://media.example.com/{body['key']}"
         assert body["expires_in"] == 600
         assert body["max_bytes"] > 0
@@ -148,6 +145,73 @@ class TestR2PresignedUploadUrl:
         )
         assert response.status_code == 400
         presign_mock.assert_not_called()
+
+
+CONFIRM_ENDPOINT = "/api/uploads/r2/confirm-upload/"
+
+
+@pytest.mark.django_db
+class TestR2ConfirmUpload:
+    def test_returns_401_when_not_authenticated(self, client, r2_env):
+        client.force_authenticate(user=None)
+        response = client.post(
+            CONFIRM_ENDPOINT, {"key": "images/1/x.jpg"}, format="json"
+        )
+        assert response.status_code == 401
+
+    def test_returns_503_when_not_configured(self, client, monkeypatch):
+        for key in R2_ENV:
+            monkeypatch.delenv(key, raising=False)
+        response = client.post(
+            CONFIRM_ENDPOINT, {"key": "images/1/x.jpg"}, format="json"
+        )
+        assert response.status_code == 503
+
+    def test_rejects_malformed_key(self, client, user, r2_env):
+        response = client.post(
+            CONFIRM_ENDPOINT, {"key": "not-a-valid-prefix/x.jpg"}, format="json"
+        )
+        assert response.status_code == 400
+
+    def test_rejects_key_belonging_to_another_user(
+        self, client, user, other_user, r2_env
+    ):
+        response = client.post(
+            CONFIRM_ENDPOINT,
+            {"key": f"images/{other_user.id}/x.jpg"},
+            format="json",
+        )
+        assert response.status_code == 403
+
+    def test_confirms_upload_under_size_cap(self, client, user, r2_env):
+        key = f"images/{user.id}/x.jpg"
+        with (
+            mock.patch(
+                "api.r2.get_object_content_length", return_value=1024
+            ) as head_mock,
+            mock.patch("api.r2.delete_object") as delete_mock,
+        ):
+            response = client.post(CONFIRM_ENDPOINT, {"key": key}, format="json")
+
+        assert response.status_code == 200
+        head_mock.assert_called_once_with(key)
+        delete_mock.assert_not_called()
+
+    def test_deletes_and_rejects_upload_over_size_cap(self, client, user, r2_env):
+        from api import r2
+
+        key = f"images/{user.id}/x.jpg"
+        with (
+            mock.patch(
+                "api.r2.get_object_content_length",
+                return_value=r2.MAX_UPLOAD_BYTES + 1,
+            ),
+            mock.patch("api.r2.delete_object") as delete_mock,
+        ):
+            response = client.post(CONFIRM_ENDPOINT, {"key": key}, format="json")
+
+        assert response.status_code == 413
+        delete_mock.assert_called_once_with(key)
 
 
 class TestR2Helpers:

--- a/api/uploads/views.py
+++ b/api/uploads/views.py
@@ -77,10 +77,6 @@ _STAFF_ONLY_RESOURCE_TYPES = {"video", "audio"}
             "type": "object",
             "properties": {
                 "upload_url": {"type": "string"},
-                "fields": {
-                    "type": "object",
-                    "additionalProperties": {"type": "string"},
-                },
                 "key": {"type": "string"},
                 "public_url": {"type": "string"},
                 "expires_in": {"type": "integer"},
@@ -88,7 +84,6 @@ _STAFF_ONLY_RESOURCE_TYPES = {"video", "audio"}
             },
             "required": [
                 "upload_url",
-                "fields",
                 "key",
                 "public_url",
                 "expires_in",
@@ -104,7 +99,13 @@ _STAFF_ONLY_RESOURCE_TYPES = {"video", "audio"}
 @permission_classes([IsAuthenticated])
 @traced
 def r2_presigned_upload_url(request: Request) -> Response:
-    """Issue a presigned R2 PUT URL with a server-generated object key."""
+    """Issue a presigned R2 PUT URL with a server-generated object key.
+
+    The client must call ``r2_confirm_upload`` immediately after the PUT
+    completes — R2's presigned PUT URLs cannot enforce ``MAX_UPLOAD_BYTES``
+    at signature time (unlike S3 presigned POST policies), so the size cap
+    is checked and enforced there instead.
+    """
     if not r2.is_r2_configured():
         return Response(
             {"detail": "Object storage is not configured on the server."},
@@ -147,21 +148,102 @@ def r2_presigned_upload_url(request: Request) -> Response:
     # never reach the key, so collisions/overwrites/traversal are impossible.
     key = f"{resource_config.prefix}/{request.user.id}/{uuid.uuid4()}.{extension}"
 
-    presigned = r2.generate_presigned_post(
+    upload_url = r2.generate_presigned_put(
         key,
         content_type,
         expires=r2.PRESIGNED_PUT_EXPIRES_SECONDS,
     )
     return Response(
         {
-            "upload_url": presigned["url"],
-            "fields": presigned["fields"],
+            "upload_url": upload_url,
             "key": key,
             "public_url": r2.public_url_for_key(key),
             "expires_in": r2.PRESIGNED_PUT_EXPIRES_SECONDS,
             "max_bytes": r2.MAX_UPLOAD_BYTES,
         }
     )
+
+
+# Object-key prefixes that a browser upload may target, matching
+# ``_RESOURCE_TYPES``' ``prefix`` values.
+_UPLOAD_KEY_PREFIXES = {config.prefix for config in _RESOURCE_TYPES.values()}
+
+
+@extend_schema(
+    request={
+        "application/json": {
+            "type": "object",
+            "properties": {
+                "key": {
+                    "type": "string",
+                    "description": "R2 key returned by the presigned-url endpoint",
+                },
+            },
+            "required": ["key"],
+        }
+    },
+    responses={
+        200: {
+            "type": "object",
+            "properties": {
+                "key": {"type": "string"},
+                "size": {"type": "integer"},
+            },
+            "required": ["key", "size"],
+        },
+        400: {"type": "object"},
+        403: {"type": "object"},
+        413: {"type": "object"},
+        503: {"type": "object"},
+    },
+)
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+@traced
+def r2_confirm_upload(request: Request) -> Response:
+    """Verify a completed browser PUT upload against the size cap.
+
+    R2 presigned PUT URLs cannot embed a content-length-range condition, so
+    the cap enforced by ``MAX_UPLOAD_BYTES`` is checked here instead: HEAD
+    the object the client just uploaded, and delete it if it is oversized.
+    """
+    if not r2.is_r2_configured():
+        return Response(
+            {"detail": "Object storage is not configured on the server."},
+            status=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    key = request.data.get("key")
+    if not isinstance(key, str) or not key.strip():
+        return Response(
+            {"detail": "key is required."}, status=status.HTTP_400_BAD_REQUEST
+        )
+    key = key.strip()
+
+    prefix = key.split("/", 1)[0]
+    if prefix not in _UPLOAD_KEY_PREFIXES:
+        return Response(
+            {"detail": "key does not match a known upload prefix."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    # [SECURITY] Only allow confirming keys that belong to this user.
+    user_prefix = f"{prefix}/{request.user.id}/"
+    if not key.startswith(user_prefix):
+        return Response(
+            {"detail": "Key does not belong to your account."},
+            status=status.HTTP_403_FORBIDDEN,
+        )
+
+    size = r2.get_object_content_length(key)
+    if size > r2.MAX_UPLOAD_BYTES:
+        r2.delete_object(key)
+        return Response(
+            {"detail": f"Upload exceeds the maximum allowed size of {r2.MAX_UPLOAD_BYTES} bytes."},
+            status=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+        )
+
+    return Response({"key": key, "size": size})
 
 
 _JPEG_EXTENSIONS = {"jpg", "jpeg"}
@@ -307,4 +389,9 @@ def r2_convert_image_status(request: Request, task_id: str) -> Response:
     )
 
 
-__all__ = ["r2_presigned_upload_url", "r2_convert_image", "r2_convert_image_status"]
+__all__ = [
+    "r2_presigned_upload_url",
+    "r2_confirm_upload",
+    "r2_convert_image",
+    "r2_convert_image_status",
+]

--- a/api/urls.py
+++ b/api/urls.py
@@ -158,6 +158,11 @@ urlpatterns = [
         name="r2-presigned-upload-url",
     ),
     path(
+        "uploads/r2/confirm-upload/",
+        views.r2_confirm_upload,
+        name="r2-confirm-upload",
+    ),
+    path(
         "uploads/r2/convert-image/",
         views.r2_convert_image,
         name="r2-convert-image",

--- a/api/views.py
+++ b/api/views.py
@@ -62,6 +62,7 @@ from .piece.views import (
 from .task_views import report_task_progress, submit_task, task_detail
 from .telemetry_views import browser_traces
 from .uploads.views import (
+    r2_confirm_upload,
     r2_convert_image,
     r2_convert_image_status,
     r2_presigned_upload_url,
@@ -109,6 +110,7 @@ __all__ = [
     "piece_showcase_video",
     "piece_states",
     "pieces",
+    "r2_confirm_upload",
     "r2_convert_image",
     "r2_convert_image_status",
     "r2_presigned_upload_url",

--- a/web/src/pages/GlazeImportToolPage.tsx
+++ b/web/src/pages/GlazeImportToolPage.tsx
@@ -19,6 +19,7 @@ import CloudUploadIcon from "@mui/icons-material/CloudUpload";
 import MergeIcon from "@mui/icons-material/MergeType";
 import axios from "axios";
 import {
+  confirmR2Upload,
   extractErrorMessage,
   fetchR2PresignedUrl,
   importManualSquareCropRecords,
@@ -405,10 +406,10 @@ export default function GlazeImportToolPage({
           ),
         );
         const presigned = await fetchR2PresignedUrl("image/webp");
-        const form = new FormData();
-        Object.entries(presigned.fields).forEach(([k, v]) => form.append(k, v));
-        form.append("file", cropFile);
-        await axios.post(presigned.upload_url, form);
+        await axios.put(presigned.upload_url, cropFile, {
+          headers: { "Content-Type": "image/webp" },
+        });
+        await confirmR2Upload(presigned.key);
         r2Keys[record.id] = presigned.key;
       }
       const result = await importManualSquareCropRecords(

--- a/web/src/pages/__tests__/GlazeImportToolPage.test.tsx
+++ b/web/src/pages/__tests__/GlazeImportToolPage.test.tsx
@@ -13,7 +13,7 @@ import { importManualSquareCropRecords } from "../../util/api";
 import { uploadImageToR2 } from "../../util/r2Upload";
 
 vi.mock("axios", () => ({
-  default: { post: vi.fn().mockResolvedValue({}) },
+  default: { post: vi.fn().mockResolvedValue({}), put: vi.fn().mockResolvedValue({}) },
 }));
 
 vi.mock("../../util/api", () => ({
@@ -30,11 +30,14 @@ vi.mock("../../util/api", () => ({
   }),
   fetchR2PresignedUrl: vi.fn().mockResolvedValue({
     upload_url: "https://r2.example.com/upload",
-    fields: {},
     key: "images/test/crop.webp",
     public_url: "https://media.example.com/images/test/crop.webp",
     expires_in: 3600,
     max_bytes: 10485760,
+  }),
+  confirmR2Upload: vi.fn().mockResolvedValue({
+    key: "images/test/crop.webp",
+    size: 1024,
   }),
   importManualSquareCropRecords: vi.fn(),
 }));

--- a/web/src/util/__tests__/api.test.ts
+++ b/web/src/util/__tests__/api.test.ts
@@ -1293,6 +1293,21 @@ describe("piece history and schema endpoints", () => {
     expect(result.status).toBe("success");
   });
 
+  it("confirmR2Upload posts the key to the confirm-upload endpoint", async () => {
+    const { confirmR2Upload } = await loadApiModule();
+    mockClient.post.mockResolvedValue({
+      data: { key: "images/abc.jpg", size: 1024 },
+    });
+
+    const result = await confirmR2Upload("images/abc.jpg");
+
+    expect(mockClient.post).toHaveBeenCalledWith(
+      "uploads/r2/confirm-upload/",
+      { key: "images/abc.jpg" },
+    );
+    expect(result.size).toBe(1024);
+  });
+
   it("listAgentTokens fetches the agent token list", async () => {
     const { listAgentTokens } = await loadApiModule();
     mockClient.get.mockResolvedValue({

--- a/web/src/util/__tests__/r2Upload.test.ts
+++ b/web/src/util/__tests__/r2Upload.test.ts
@@ -5,26 +5,28 @@ vi.mock("../api", () => ({
   fetchR2PresignedUrl: vi.fn(),
   getR2ConversionStatus: vi.fn(),
   triggerR2ImageConversion: vi.fn(),
+  confirmR2Upload: vi.fn(),
 }));
 
 import axios from "axios";
 import {
+  confirmR2Upload,
   fetchR2PresignedUrl,
   getR2ConversionStatus,
   triggerR2ImageConversion,
 } from "../api";
 import { MAX_UPLOAD_LONG_EDGE, uploadImageToR2 } from "../r2Upload";
 
-const mockAxiosPost = vi.mocked(axios.post);
+const mockAxiosPut = vi.mocked(axios.put);
 const mockFetchPresigned = vi.mocked(fetchR2PresignedUrl);
 const mockGetConversionStatus = vi.mocked(getR2ConversionStatus);
 const mockTriggerConversion = vi.mocked(triggerR2ImageConversion);
+const mockConfirmUpload = vi.mocked(confirmR2Upload);
 
 const PRESIGNED = {
   upload_url: "https://r2.example.com/upload",
   public_url: "https://cdn.example.com/image.jpg",
   key: "images/abc.jpg",
-  fields: { key: "images/abc.jpg", policy: "base64policy" },
 };
 
 function makeJpegFile(name = "photo.jpg", size = 100): File {
@@ -37,8 +39,9 @@ function makeFile(name: string, type: string): File {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockAxiosPost.mockResolvedValue({});
+  mockAxiosPut.mockResolvedValue({});
   mockFetchPresigned.mockResolvedValue(PRESIGNED);
+  mockConfirmUpload.mockResolvedValue({ key: PRESIGNED.key, size: 1024 });
 });
 
 describe("MAX_UPLOAD_LONG_EDGE", () => {
@@ -48,7 +51,7 @@ describe("MAX_UPLOAD_LONG_EDGE", () => {
 });
 
 describe("uploadImageToR2 — browser-decodable JPEG within size cap", () => {
-  it("uploads via presigned POST and returns the public URL without conversion", async () => {
+  it("uploads via presigned PUT, confirms, and returns the public URL without conversion", async () => {
     const bitmap = {
       width: 800,
       height: 600,
@@ -81,11 +84,53 @@ describe("uploadImageToR2 — browser-decodable JPEG within size cap", () => {
     const result = await uploadImageToR2(file);
 
     expect(mockFetchPresigned).toHaveBeenCalledWith("image/jpeg");
-    expect(mockAxiosPost).toHaveBeenCalledWith(
+    expect(mockAxiosPut).toHaveBeenCalledWith(
       PRESIGNED.upload_url,
-      expect.any(FormData),
+      expect.any(Blob),
+      { headers: { "Content-Type": "image/jpeg" } },
     );
+    expect(mockConfirmUpload).toHaveBeenCalledWith(PRESIGNED.key);
     expect(result.url).toBe(PRESIGNED.public_url);
+    vi.unstubAllGlobals();
+  });
+
+  it("propagates a rejection when the confirm step reports the upload exceeded the size cap", async () => {
+    const bitmap = {
+      width: 800,
+      height: 600,
+      close: vi.fn(),
+    } as unknown as ImageBitmap;
+    vi.stubGlobal("createImageBitmap", vi.fn().mockResolvedValue(bitmap));
+
+    const canvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn().mockReturnValue({
+        fillStyle: "",
+        fillRect: vi.fn(),
+        drawImage: vi.fn(),
+      }),
+      toBlob: vi.fn(
+        (cb: (b: Blob | null) => void) =>
+          cb(new Blob(["img"], { type: "image/jpeg" })),
+      ),
+    };
+    vi.stubGlobal(
+      "document",
+      Object.assign({}, globalThis.document, {
+        createElement: () => canvas,
+        cookie: "",
+      }),
+    );
+
+    mockConfirmUpload.mockRejectedValue(
+      new Error("Upload exceeds the maximum allowed size."),
+    );
+
+    const file = makeJpegFile();
+    await expect(uploadImageToR2(file)).rejects.toThrow(
+      "Upload exceeds the maximum allowed size.",
+    );
     vi.unstubAllGlobals();
   });
 });

--- a/web/src/util/api.ts
+++ b/web/src/util/api.ts
@@ -198,7 +198,6 @@ client.interceptors.response.use(
 
 export type R2PresignedUpload = {
   upload_url: string;
-  fields: Record<string, string>;
   key: string;
   public_url: string;
   expires_in: number;
@@ -891,6 +890,22 @@ export async function fetchR2PresignedUrl(
       content_type: contentType,
       resource_type: resourceType,
     },
+  );
+  return data;
+}
+
+/**
+ * Confirm a completed presigned-PUT upload. R2's presigned PUT URLs cannot
+ * enforce a size cap at signature time, so the server checks it here and
+ * deletes the object if it's oversized — this must be called right after
+ * the PUT resolves, before the uploaded URL is used anywhere else.
+ */
+export async function confirmR2Upload(
+  key: string,
+): Promise<{ key: string; size: number }> {
+  const { data } = await client.post<{ key: string; size: number }>(
+    "uploads/r2/confirm-upload/",
+    { key },
   );
   return data;
 }

--- a/web/src/util/r2Upload.ts
+++ b/web/src/util/r2Upload.ts
@@ -12,6 +12,7 @@
  */
 import axios from "axios";
 import {
+  confirmR2Upload,
   fetchR2PresignedUrl,
   getR2ConversionStatus,
   triggerR2ImageConversion,
@@ -191,12 +192,14 @@ export async function uploadImageToR2(
 
   const presigned = await fetchR2PresignedUrl(prepared.contentType);
 
-  // Use multipart POST so R2 enforces the server-signed content-length-range
-  // condition. The 'file' field must come last per the S3 presigned POST spec.
-  const form = new FormData();
-  Object.entries(presigned.fields).forEach(([k, v]) => form.append(k, v));
-  form.append("file", prepared.blob);
-  await axios.post(presigned.upload_url, form);
+  await axios.put(presigned.upload_url, prepared.blob, {
+    headers: { "Content-Type": prepared.contentType },
+  });
+
+  // R2 presigned PUT URLs can't enforce a size cap at signature time, so the
+  // server checks it here (and deletes the object if oversized) right after
+  // the PUT completes.
+  await confirmR2Upload(presigned.key);
 
   // Already a JPEG — return immediately, no server conversion needed.
   if (prepared.isJpeg) {


### PR DESCRIPTION
## Problem

Piece image uploads fail in production with a `501` response and a missing
`Access-Control-Allow-Origin` header from R2 ([#1009](https://github.com/shaoster/glaze/issues/1009)). The 501 is the real signal: Cloudflare R2 does not implement the S3 "POST Object" operation at all, and `api/uploads/views.py` was issuing presigned-POST uploads (`r2.generate_presigned_post`) from every direct-to-R2 caller — `ImageUploader`, the glaze import tool, and the Django admin image widget. No CORS policy can fix a request type the storage backend doesn't support.

Git history shows this flow originally used presigned PUT and worked; a later commit (`59759f28`) deliberately switched to POST to gain a `content-length-range` condition enforcing a 50 MiB upload cap server-side — a real security fix, just one that also happens to depend on an R2-unsupported operation.

## Fix

- Revert the upload flow to presigned PUT (`r2.generate_presigned_put`), which R2 does support, across all three callers.
- Restore the size cap via a new `POST /api/uploads/r2/confirm-upload/` endpoint: right after the client's PUT completes, it HEADs the object and deletes it if it exceeds `MAX_UPLOAD_BYTES` (50 MiB), returning 413. R2 presigned PUT URLs have no `content-length-range` equivalent, so this after-the-fact check is the closest available guarantee — not atomic, but it removes any object that violates the cap.
- Removed `r2.generate_presigned_post`, now dead code with no callers.

Still entirely direct-to-R2 (no application-proxied uploads), per the issue's stated out-of-scope constraint.

## Regression Tests

- `api/tests/test_r2_uploads.py`: `TestR2PresignedUploadUrl` updated to assert the endpoint calls `generate_presigned_put` and returns no `fields`; new `TestR2ConfirmUpload` covers auth, config, malformed/foreign keys, ownership, under-cap (200, no delete), and over-cap (413 + delete).
- `web/src/util/__tests__/r2Upload.test.ts`: asserts `axios.put` with a `Content-Type` header instead of `axios.post`/`FormData`, and a new test asserting a `confirmR2Upload` rejection propagates out of `uploadImageToR2`.
- `web/src/util/__tests__/api.test.ts`: new test for `confirmR2Upload`.

Confirmed both new/updated test files fail before the fix (wrong R2 API family — `generate_presigned_post` still mocked/called, `axios.post` still asserted) and pass after.

## Verification

```
rtk bazel test //... --test_output=errors   # 80/80 pass
rtk bazel build --config=lint //...         # ruff, eslint, tsc, mypy all pass
```

## Follow-up (not in this PR)

The Cloudflare R2 bucket's CORS policy still needs a dashboard update for the new PUT-based flow — `AllowedMethods: PUT`, `AllowedOrigins: <production origin>`, `AllowedHeaders: content-type` (R2 rejects a bare `*` wildcard here even though S3 accepts it). This is Cloudflare-dashboard-only config, not tracked in this repo, and is the user's manual step after this PR merges.

Closes #1009
