### PR TITLE
fix(web): reschedule autosave debounce on edits made mid-save

### DIFF
--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -1612,6 +1612,23 @@ vitest_test(
 )
 
 vitest_test(
+    name = "web_autosave_test",
+    srcs = [
+        "src/components/__tests__/useAutosave.test.ts",
+    ],
+    tags = ["ibazel_notify_changes"],
+    deps = [
+        ":autosave_src",
+        ":node_modules/@tanstack/react-query",
+        ":node_modules/@testing-library/react",
+        ":node_modules/react",
+    ],
+    expected_coverage = [
+        "web/src/components/useAutosave*",
+    ],
+)
+
+vitest_test(
     name = "web_query_keys_test",
     srcs = [
         "src/util/__tests__/queryKeys.test.ts",
@@ -1684,6 +1701,7 @@ test_suite(
         ":web_r2_upload_test",
         ":web_use_toggle_global_entry_favorite_test",
         ":web_query_keys_test",
+        ":web_autosave_test",
     ],
 )
 

--- a/web/src/components/__tests__/useAutosave.test.ts
+++ b/web/src/components/__tests__/useAutosave.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+import { useAutosave } from "../useAutosave";
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useAutosave", () => {
+  it("schedules a fresh save for edits made while the previous save is still in flight", async () => {
+    const wrapper = makeWrapper();
+
+    let resolveFirstSave: () => void = () => {};
+    const firstSavePromise = new Promise<void>((resolve) => {
+      resolveFirstSave = resolve;
+    });
+    const save1 = () => firstSavePromise;
+    const save2 = async () => {};
+    let save2CallCount = 0;
+    const trackedSave2 = async () => {
+      save2CallCount += 1;
+      await save2();
+    };
+
+    const { result, rerender } = renderHook(
+      ({ save }: { save: () => Promise<void> }) =>
+        useAutosave({
+          dirty: true,
+          save,
+          delayMs: 10,
+          mutationKey: ["test-autosave"],
+        }),
+      { wrapper, initialProps: { save: save1 } },
+    );
+
+    // The initial debounce window elapses and the first save fires.
+    await waitFor(() => expect(result.current.status).toBe("saving"));
+
+    // While that save is still in flight, the user keeps typing. `dirty`
+    // stays true throughout (base state hasn't caught up yet), but the
+    // save callback closes over the newer content — exactly like
+    // WorkflowState/PieceHistory rebuilding `save` via useCallback on
+    // every keystroke.
+    rerender({ save: trackedSave2 });
+
+    // The in-flight save finally completes.
+    resolveFirstSave();
+    await waitFor(() => expect(result.current.lastSavedAt).not.toBeNull());
+
+    // A fresh debounce window must be scheduled for the edit that arrived
+    // during the first save — otherwise it is silently dropped.
+    await waitFor(() => expect(save2CallCount).toBe(1));
+  });
+});

--- a/web/src/components/useAutosave.ts
+++ b/web/src/components/useAutosave.ts
@@ -37,7 +37,7 @@ export function useAutosave({
     if (!dirty) return;
     const timer = window.setTimeout(() => mutate(), delayMs);
     return () => window.clearTimeout(timer);
-  }, [dirty, delayMs, mutate]);
+  }, [dirty, delayMs, mutate, save]);
 
   const displayStatus: AutosaveStatus =
     dirty && status === "idle"


### PR DESCRIPTION
## Problem

[Autosave debouncing drops the user's most recent edits](https://github.com/shaoster/glaze/issues/1005) when typing quickly, e.g. in the Notes field.

## Fix

`useAutosave`'s debounce `useEffect` was keyed on `[dirty, delayMs, mutate]`. `mutate` (from `useMutation`) is referentially stable across renders, and `dirty` only *transitions* `false → true` once per save cycle. So once a save was in flight, further edits kept `dirty` at `true` (no transition) and the effect never re-ran — no new timer was ever scheduled for those edits, and they were silently lost with no other mechanism (`saveNow` isn't wired to blur/unmount anywhere) to save them.

The fix adds `save` to the dependency array. Both existing consumers (`WorkflowState.tsx`, `PieceHistory.tsx`) already rebuild their `save` callback via `useCallback` keyed on the live field content, so this makes the debounce timer reschedule on every edit — including edits typed while a previous save is still in flight — restoring standard debounce semantics.

## Regression Test

`web/src/components/__tests__/useAutosave.test.ts` — *"schedules a fresh save for edits made while the previous save is still in flight"*. Starts a save, keeps it pending, rerenders the hook with a new `save` closure while `dirty` stays `true` (simulating a keystroke that arrives mid-save), resolves the first save, and asserts the second `save` closure eventually fires too.

Confirmed this fails on the pre-fix code (times out waiting for the second save) and passes after the fix.

## Verification

```
rtk bazel test //web:web_autosave_test --test_output=all   # new test: FAIL pre-fix, PASS post-fix
rtk bazel test //web:web_test --test_output=errors         # 53/53 pass, no regressions
rtk bazel build --config=lint //web/...                    # clean
```

Closes #1005
