### PR TITLE
fix(web): preserve notes typed while a previous autosave resolves

### DIFF
--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -138,12 +138,13 @@ export default function WorkflowState({
 
   const saveWorkflowState = useCallback(async () => {
     const saveFn = saveStateFn ?? ((p) => updateCurrentState(pieceId, p));
+    const sentNotes = currentPayload.notes;
     const result = await saveFn(currentPayload);
     const savedState = saveStateFn
       ? (result.history.find((ps) => ps.id === initialPieceState.id) ??
         result.current_state)
       : result.current_state;
-    dispatch({ type: "replace_base_state", pieceState: savedState });
+    dispatch({ type: "replace_base_state", pieceState: savedState, sentNotes });
     onSaved(result);
   }, [pieceId, initialPieceState.id, onSaved, saveStateFn, currentPayload]);
 

--- a/web/src/components/WorkflowState.tsx
+++ b/web/src/components/WorkflowState.tsx
@@ -139,14 +139,30 @@ export default function WorkflowState({
   const saveWorkflowState = useCallback(async () => {
     const saveFn = saveStateFn ?? ((p) => updateCurrentState(pieceId, p));
     const sentNotes = currentPayload.notes;
+    const sentCustomFieldInputs = customFieldInputs;
+    const sentGlobalRefPks = globalRefPks;
     const result = await saveFn(currentPayload);
     const savedState = saveStateFn
       ? (result.history.find((ps) => ps.id === initialPieceState.id) ??
         result.current_state)
       : result.current_state;
-    dispatch({ type: "replace_base_state", pieceState: savedState, sentNotes });
+    dispatch({
+      type: "replace_base_state",
+      pieceState: savedState,
+      sentNotes,
+      sentCustomFieldInputs,
+      sentGlobalRefPks,
+    });
     onSaved(result);
-  }, [pieceId, initialPieceState.id, onSaved, saveStateFn, currentPayload]);
+  }, [
+    pieceId,
+    initialPieceState.id,
+    onSaved,
+    saveStateFn,
+    currentPayload,
+    customFieldInputs,
+    globalRefPks,
+  ]);
 
   const autosave = useAutosave({
     dirty: !readOnly && isDirty && !disableAutosave,

--- a/web/src/components/__tests__/WorkflowState.test.tsx
+++ b/web/src/components/__tests__/WorkflowState.test.tsx
@@ -805,6 +805,90 @@ describe("WorkflowState", () => {
     }
   });
 
+  it("preserves a custom field edited while a previous autosave is still resolving", async () => {
+    vi.useFakeTimers();
+    try {
+      let resolveFirstSave!: (value: PieceDetail) => void;
+      const firstSavePromise = new Promise<PieceDetail>((resolve) => {
+        resolveFirstSave = resolve;
+      });
+      vi.mocked(api.updateCurrentState)
+        .mockReturnValueOnce(firstSavePromise)
+        .mockResolvedValueOnce(
+          makePieceDetail({
+            current_state: makeState({
+              state: "trimmed",
+              custom_fields: { trimmed_weight_lbs: 975 },
+            }),
+          }),
+        );
+
+      render(
+        <WorkflowState
+          {...defaultProps}
+          autosaveDelayMs={1000}
+          initialPieceState={makeState({
+            state: "trimmed",
+            custom_fields: { trimmed_weight_lbs: 900 },
+          })}
+        />,
+      );
+
+      fireEvent.change(screen.getByLabelText("Trimmed Weight Lbs"), {
+        target: { value: "950" },
+      });
+
+      // The first debounce fires; the request for 950 is now in flight.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(api.updateCurrentState).toHaveBeenCalledWith(
+        "test-piece-id",
+        expect.objectContaining({
+          custom_fields: { trimmed_weight_lbs: 950 },
+        }),
+      );
+
+      // The user keeps editing the field while that save is still pending —
+      // this reschedules a fresh 1000ms debounce window that hasn't elapsed
+      // yet. Notes is untouched throughout.
+      fireEvent.change(screen.getByLabelText("Trimmed Weight Lbs"), {
+        target: { value: "975" },
+      });
+
+      // The first (now-stale) request resolves, echoing back exactly what
+      // was sent (950), before the rescheduled debounce window elapses.
+      await act(async () => {
+        resolveFirstSave(
+          makePieceDetail({
+            current_state: makeState({
+              state: "trimmed",
+              custom_fields: { trimmed_weight_lbs: 950 },
+            }),
+          }),
+        );
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      // The newer field edit must not be clobbered by the stale response.
+      expect(screen.getByLabelText("Trimmed Weight Lbs")).toHaveValue(975);
+
+      // ...and the rescheduled debounce must still fire with the latest
+      // field value once its window elapses, not the stale reverted one.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(api.updateCurrentState).toHaveBeenCalledWith(
+        "test-piece-id",
+        expect.objectContaining({
+          custom_fields: { trimmed_weight_lbs: 975 },
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("shows error message on save failure", async () => {
     vi.mocked(api.updateCurrentState).mockRejectedValue(
       new Error("Network error"),

--- a/web/src/components/__tests__/WorkflowState.test.tsx
+++ b/web/src/components/__tests__/WorkflowState.test.tsx
@@ -739,6 +739,72 @@ describe("WorkflowState", () => {
     );
   });
 
+  it("preserves notes typed while a previous autosave is still resolving", async () => {
+    // Real timers make the ordering between the "abcd" debounce timer and
+    // the stale save's promise-resolution microtasks nondeterministic (it
+    // varies with the effect-flush scheduling of the test environment).
+    // Fake timers give explicit control over both, so we can pin down the
+    // exact race Codex described: the stale save resolves before the
+    // rescheduled debounce window elapses.
+    vi.useFakeTimers();
+    try {
+      let resolveFirstSave!: (value: PieceDetail) => void;
+      const firstSavePromise = new Promise<PieceDetail>((resolve) => {
+        resolveFirstSave = resolve;
+      });
+      vi.mocked(api.updateCurrentState)
+        .mockReturnValueOnce(firstSavePromise)
+        .mockResolvedValueOnce(
+          makePieceDetail({ current_state: makeState({ notes: "abcd" }) }),
+        );
+
+      render(<WorkflowState {...defaultProps} autosaveDelayMs={1000} />);
+
+      fireEvent.change(screen.getByLabelText("Notes"), {
+        target: { value: "abc" },
+      });
+
+      // The first debounce fires; the request for "abc" is now in flight.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(api.updateCurrentState).toHaveBeenCalledWith(
+        "test-piece-id",
+        expect.objectContaining({ notes: "abc" }),
+      );
+
+      // The user keeps typing while that save is still pending — this
+      // reschedules a fresh 1000ms debounce window that hasn't elapsed yet.
+      fireEvent.change(screen.getByLabelText("Notes"), {
+        target: { value: "abcd" },
+      });
+
+      // The first (now-stale) request resolves, echoing back exactly what
+      // was sent ("abc"), before the rescheduled debounce window elapses.
+      await act(async () => {
+        resolveFirstSave(
+          makePieceDetail({ current_state: makeState({ notes: "abc" }) }),
+        );
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      // The newer keystroke must not be clobbered by the stale response.
+      expect(screen.getByLabelText("Notes")).toHaveValue("abcd");
+
+      // ...and the rescheduled debounce must still fire with the latest
+      // content once its window elapses.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(api.updateCurrentState).toHaveBeenCalledWith(
+        "test-piece-id",
+        expect.objectContaining({ notes: "abcd" }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("shows error message on save failure", async () => {
     vi.mocked(api.updateCurrentState).mockRejectedValue(
       new Error("Network error"),

--- a/web/src/components/workflowStateDraft.ts
+++ b/web/src/components/workflowStateDraft.ts
@@ -28,7 +28,13 @@ export type DraftState = {
 };
 
 export type DraftAction =
-  | { type: "replace_base_state"; pieceState: PieceState; sentNotes?: string }
+  | {
+      type: "replace_base_state";
+      pieceState: PieceState;
+      sentNotes?: string;
+      sentCustomFieldInputs?: CustomFieldInputMap;
+      sentGlobalRefPks?: GlobalRefPkMap;
+    }
   | { type: "set_notes"; notes: string }
   | { type: "set_custom_field"; name: string; value: string }
   | { type: "set_global_ref_pks"; globalRefPks: GlobalRefPkMap };
@@ -171,12 +177,25 @@ export function draftReducer(
     case "replace_base_state": {
       const rebuilt = buildDraftState(action.pieceState);
       // If a newer edit has arrived since this save was dispatched (the
-      // live notes no longer match what was actually sent), keep it
+      // live value no longer matches what was actually sent), keep it
       // instead of clobbering it with this now-stale response.
-      if (action.sentNotes !== undefined && state.notes !== action.sentNotes) {
-        return { ...rebuilt, notes: state.notes };
-      }
-      return rebuilt;
+      const notes =
+        action.sentNotes !== undefined && state.notes !== action.sentNotes
+          ? state.notes
+          : rebuilt.notes;
+      const customFieldInputs =
+        action.sentCustomFieldInputs !== undefined &&
+        JSON.stringify(state.customFieldInputs) !==
+          JSON.stringify(action.sentCustomFieldInputs)
+          ? state.customFieldInputs
+          : rebuilt.customFieldInputs;
+      const globalRefPks =
+        action.sentGlobalRefPks !== undefined &&
+        JSON.stringify(state.globalRefPks) !==
+          JSON.stringify(action.sentGlobalRefPks)
+          ? state.globalRefPks
+          : rebuilt.globalRefPks;
+      return { ...rebuilt, notes, customFieldInputs, globalRefPks };
     }
     case "set_notes":
       return { ...state, notes: action.notes };

--- a/web/src/components/workflowStateDraft.ts
+++ b/web/src/components/workflowStateDraft.ts
@@ -28,7 +28,7 @@ export type DraftState = {
 };
 
 export type DraftAction =
-  | { type: "replace_base_state"; pieceState: PieceState }
+  | { type: "replace_base_state"; pieceState: PieceState; sentNotes?: string }
   | { type: "set_notes"; notes: string }
   | { type: "set_custom_field"; name: string; value: string }
   | { type: "set_global_ref_pks"; globalRefPks: GlobalRefPkMap };
@@ -168,8 +168,16 @@ export function draftReducer(
   action: DraftAction,
 ): DraftState {
   switch (action.type) {
-    case "replace_base_state":
-      return buildDraftState(action.pieceState);
+    case "replace_base_state": {
+      const rebuilt = buildDraftState(action.pieceState);
+      // If a newer edit has arrived since this save was dispatched (the
+      // live notes no longer match what was actually sent), keep it
+      // instead of clobbering it with this now-stale response.
+      if (action.sentNotes !== undefined && state.notes !== action.sentNotes) {
+        return { ...rebuilt, notes: state.notes };
+      }
+      return rebuilt;
+    }
     case "set_notes":
       return { ...state, notes: action.notes };
     case "set_custom_field":


### PR DESCRIPTION
## Problem

[Codex review comment on #1014](https://github.com/shaoster/glaze/pull/1014#discussion_r3686502961), filed after that PR merged:

> When a user edits `WorkflowState` while an autosave is in flight, adding `save` here schedules the next debounce, but if the older request resolves before that debounce fires, `saveWorkflowState` dispatches `replace_base_state` with the older server payload and `dirty` becomes false. That rerender runs this effect's cleanup and clears the pending timer for the newer edit, so the field is reset to the stale saved value and the latest keystrokes are still dropped in the common case where the first save finishes within the debounce window.

Confirmed and worse than described: `replace_base_state` fully rebuilds the draft (`buildDraftState`) from the server response, including `notes` — so a keystroke typed after a save request went out but before its response arrived doesn't just fail to persist, it visibly disappears from the Notes field the instant the stale response lands.

**Update:** a [follow-up Codex comment on this PR](https://github.com/shaoster/glaze/pull/1015#discussion_r3686690212) caught that the first fix here only protected `notes` — `customFieldInputs`/`globalRefPks` were still unconditionally clobbered by the same stale response, and since the draft stays dirty, the *next* autosave would then post those reverted custom-field values, silently overwriting the server with stale data. Generalized below.

## Fix

The only thing that can tell "the server transformed the value" (should adopt it) apart from "the user edited more after sending" (should not) is knowing exactly what was sent in the specific request that's resolving — that's only known at `WorkflowState.tsx`'s `saveWorkflowState` call site, not in the reducer or in `ImageUploader.tsx`.

- `workflowStateDraft.ts`: `replace_base_state` now accepts optional `sentNotes`, `sentCustomFieldInputs`, and `sentGlobalRefPks`. For each, if provided and it no longer matches the live draft value when the response lands, a newer edit has arrived since the request was sent — keep it (stay dirty) instead of adopting the stale response.
- `WorkflowState.tsx`: `saveWorkflowState` captures `currentPayload.notes`, `customFieldInputs`, and `globalRefPks` before awaiting the save and passes them through.
- `ImageUploader.tsx` is untouched — its `replace_base_state` dispatch omits all three `sent*` fields, so it keeps today's full-adopt behavior (it has no other mechanism to get newly-uploaded images into the draft).

Two approaches were tried and rejected for the `notes` case before landing on this one (both broke the existing `"adopts the server-returned current state as the new base after save"` test, which correctly expects the Notes field to snap to a server-canonicalized value when there's no interim edit): only updating `baseState` and leaving `notes` untouched, and comparing live `notes` against the server's *returned* `notes` instead of what was actually *sent*. The same reasoning is why `customFieldInputs`/`globalRefPks` are compared against what was *sent*, not the response.

## Regression Tests

Both in `WorkflowState.test.tsx`, using fake timers for deterministic control over the race (real timers made the ordering between the debounce timer and the stale save's resolution nondeterministic in this test environment):

- *"preserves notes typed while a previous autosave is still resolving"*: fires a save for `"abc"`, types `"abcd"` while it's in flight, resolves the first save with a response echoing back `"abc"` before the rescheduled debounce window elapses, and asserts the Notes field still shows `"abcd"` — then that a second save eventually fires with `"abcd"`.
- *"preserves a custom field edited while a previous autosave is still resolving"*: same shape, but for a custom field (`trimmed_weight_lbs`) instead of notes — edits `950` → `975` mid-flight, resolves the stale `950` response, asserts the field still shows `975` and the rescheduled save posts `975`, not the reverted `950`.

Each fails on the code that doesn't yet guard that specific field (verified by temporarily reverting just the production changes) and passes with the fix. The existing "adopts the server-returned current state" and "replaces saved additional fields from the server" tests continue to pass unchanged.

## Verification

```
rtk bazel test //web:web_workflow_state_test --test_output=all   # both new tests: FAIL pre-fix, PASS post-fix; no other regressions
rtk bazel test //web:web_test --test_output=errors                # 53/53 pass
rtk bazel build --config=lint //web/...                           # clean
```
